### PR TITLE
fix(oauth): redirect against external base URL (was 0.0.0.0:3000)

### DIFF
--- a/fly.stg.toml
+++ b/fly.stg.toml
@@ -1,6 +1,13 @@
 app = "seazn-club-stg"
 primary_region = "lhr"
 
+# Runtime env (non-secret). OAUTH_BASE_URL makes server-side redirect/base-URL
+# resolution deterministic behind Fly's proxy (req.url is the internal
+# 0.0.0.0:3000 binding; NEXT_PUBLIC_* build args are not in server process.env).
+[env]
+  OAUTH_BASE_URL   = "https://seazn-club-stg.fly.dev"
+  NEXT_PUBLIC_BASE_URL = "https://seazn-club-stg.fly.dev"
+
 [build]
   [build.args]
     NEXT_PUBLIC_SUPABASE_URL           = "https://hoksroegadfdfwererzu.supabase.co"

--- a/src/app/api/auth/google/callback/route.ts
+++ b/src/app/api/auth/google/callback/route.ts
@@ -6,13 +6,17 @@ import {
   GOOGLE_TOKEN_URL,
   GOOGLE_USERINFO_URL,
   OAUTH_STATE_COOKIE,
+  baseUrl,
   googleConfigured,
   googleRedirectUri,
   type GoogleProfile,
 } from "@/lib/oauth";
 
+// Redirect against the external base URL, not req.url — behind Fly's proxy
+// req.url is the internal binding (http://0.0.0.0:3000), which would send the
+// browser to an unreachable address.
 function fail(req: Request, reason: string) {
-  return NextResponse.redirect(new URL(`/login?error=${reason}`, req.url));
+  return NextResponse.redirect(new URL(`/login?error=${reason}`, baseUrl(req)));
 }
 
 /** Handle Google's redirect: verify state, exchange code, upsert user, sign in. */
@@ -65,7 +69,7 @@ export async function GET(req: Request) {
   const next = jar.get("safe_oauth_next")?.value;
   jar.delete("safe_oauth_next");
   const landing = await postAuthLanding(userId, next);
-  return NextResponse.redirect(new URL(landing.redirect, req.url));
+  return NextResponse.redirect(new URL(landing.redirect, baseUrl(req)));
 }
 
 async function upsertGoogleUser(p: GoogleProfile): Promise<string> {

--- a/src/app/api/auth/google/route.ts
+++ b/src/app/api/auth/google/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import {
   GOOGLE_AUTH_URL,
   OAUTH_STATE_COOKIE,
+  baseUrl,
   googleConfigured,
   googleRedirectUri,
 } from "@/lib/oauth";
@@ -12,7 +13,7 @@ import {
 export async function GET(req: Request) {
   if (!googleConfigured()) {
     return NextResponse.redirect(
-      new URL("/login?error=google_not_configured", req.url),
+      new URL("/login?error=google_not_configured", baseUrl(req)),
     );
   }
 


### PR DESCRIPTION
## Problem
After Google login on Fly, users were redirected to `http://0.0.0.0:3000/...` (unreachable).

## Cause
The google routes built redirect URLs with `new URL(path, req.url)`. Behind Fly's proxy, `req.url` is the internal binding `http://0.0.0.0:3000`, so the post-login and error redirects pointed there.

## Fix
- Use `baseUrl(req)` for all internal redirects in `google/route.ts` + `google/callback/route.ts`. `baseUrl` resolves `OAUTH_BASE_URL` / `NEXT_PUBLIC_BASE_URL`, else `x-forwarded-host`.
- Set `OAUTH_BASE_URL` + `NEXT_PUBLIC_BASE_URL` as runtime `[env]` in `fly.stg.toml` so resolution is deterministic (build args aren't in the server's `process.env`; only `x-forwarded-host` was covering it before).

## Verified on staging
- `OAUTH_BASE_URL` present in runtime env.
- `/api/auth/google` → `redirect_uri=https://seazn-club-stg.fly.dev/api/auth/google/callback` (was resolving to 0.0.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)