### PR TITLE
fix(billing): reconcile checkout on return (webhook safety net)

### DIFF
--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: Request) {
         metadata: { org_id: orgId },
       },
       line_items: [{ price: plan.price_id, quantity: 1 }],
-      success_url: `${base}/settings/billing?checkout=success`,
+      success_url: `${base}/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${base}/settings/billing`,
       allow_promotion_codes: true,
       tax_id_collection: { enabled: true },

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -2,64 +2,7 @@ import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Look up our plan_key from a Stripe price ID. */
-async function planKeyForPrice(priceId: string): Promise<string | null> {
-  const [row] = await sql<{ key: string }[]>`
-    select key from plans
-    where stripe_price_id_monthly = ${priceId}
-       or stripe_price_id_annual  = ${priceId}`;
-  return row?.key ?? null;
-}
-
-/** Upsert subscription row from a Stripe Subscription object. */
-async function syncSubscription(
-  orgId: string,
-  stripeSub: Stripe.Subscription,
-): Promise<void> {
-  const priceId = stripeSub.items.data[0]?.price?.id ?? null;
-  const planKey = priceId ? (await planKeyForPrice(priceId)) : null;
-
-  // Map Stripe status to our status enum
-  const statusMap: Record<string, string> = {
-    trialing: "trialing",
-    active: "active",
-    past_due: "past_due",
-    canceled: "canceled",
-    incomplete: "past_due",
-    incomplete_expired: "canceled",
-    unpaid: "past_due",
-    paused: "past_due",
-  };
-  const status = statusMap[stripeSub.status] ?? "past_due";
-
-  // In Stripe v22, current_period_end lives on each subscription item
-  const periodEnd = stripeSub.items.data[0]?.current_period_end ?? null;
-
-  await sql`
-    insert into subscriptions
-      (org_id, plan_key, status, stripe_subscription_id,
-       current_period_end, trial_end, cancel_at_period_end, updated_at)
-    values
-      (${orgId}, ${planKey ?? "community"}, ${status},
-       ${stripeSub.id},
-       ${periodEnd ? new Date(periodEnd * 1000).toISOString() : null},
-       ${stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null},
-       ${stripeSub.cancel_at_period_end},
-       now())
-    on conflict (org_id) do update set
-      plan_key              = excluded.plan_key,
-      status                = excluded.status,
-      stripe_subscription_id = excluded.stripe_subscription_id,
-      current_period_end    = excluded.current_period_end,
-      trial_end             = excluded.trial_end,
-      cancel_at_period_end  = excluded.cancel_at_period_end,
-      updated_at            = now()`;
-}
+import { syncSubscription } from "@/lib/billing";
 
 // ---------------------------------------------------------------------------
 // Event handlers

--- a/src/app/settings/billing/page.tsx
+++ b/src/app/settings/billing/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getActiveOrgId, getCurrentUser, requireOrgRole } from "@/lib/auth";
 import { sql } from "@/lib/db";
+import { reconcileCheckout } from "@/lib/billing";
 import { Nav } from "@/components/nav";
 import { BillingBanner } from "@/components/billing-banner";
 import { UpgradeButton, ManageBillingButton } from "@/components/billing-actions";
@@ -30,7 +31,11 @@ const STATUS_BADGE: Record<string, string> = {
   suspended: "bg-red-100 text-red-700",
 };
 
-export default async function BillingPage() {
+export default async function BillingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ checkout?: string; session_id?: string }>;
+}) {
   const user = await getCurrentUser();
   if (!user) redirect("/login");
 
@@ -39,6 +44,14 @@ export default async function BillingPage() {
 
   const { role } = await requireOrgRole(orgId, ORG_ROLES);
   const isOwner = role === "owner";
+
+  // Reconcile straight from Stripe on return from checkout, so the plan updates
+  // even if the webhook is delayed or missing (best-effort, never throws).
+  const sp = await searchParams;
+  const justCheckedOut = sp.checkout === "success";
+  if (justCheckedOut && sp.session_id) {
+    await reconcileCheckout(orgId, sp.session_id);
+  }
 
   const [sub] = await sql<Subscription[]>`
     select * from subscriptions where org_id = ${orgId}`;
@@ -66,6 +79,13 @@ export default async function BillingPage() {
             ← Settings
           </Link>
         </div>
+
+        {justCheckedOut && (
+          <div className="mb-6 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+            Checkout complete — your plan is now <span className="font-semibold capitalize">{planKey}</span>
+            {status === "trialing" ? " (trial)" : ""}.
+          </div>
+        )}
 
         {/* Current plan */}
         <section className="card mb-6 p-5">

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,96 @@
+import "server-only";
+import type Stripe from "stripe";
+import { getStripe } from "@/lib/stripe";
+import { sql } from "@/lib/db";
+
+/** Map a Stripe subscription status to our subscription status enum. */
+const STATUS_MAP: Record<string, string> = {
+  trialing: "trialing",
+  active: "active",
+  past_due: "past_due",
+  canceled: "canceled",
+  incomplete: "past_due",
+  incomplete_expired: "canceled",
+  unpaid: "past_due",
+  paused: "past_due",
+};
+
+/** Look up our plan_key from a Stripe price ID. */
+export async function planKeyForPrice(priceId: string): Promise<string | null> {
+  const [row] = await sql<{ key: string }[]>`
+    select key from plans
+    where stripe_price_id_monthly = ${priceId}
+       or stripe_price_id_annual  = ${priceId}`;
+  return row?.key ?? null;
+}
+
+/**
+ * Upsert an org's subscription row from a Stripe Subscription object. Shared by
+ * the webhook handler and the reconcile-on-return path so both stay in sync.
+ */
+export async function syncSubscription(
+  orgId: string,
+  stripeSub: Stripe.Subscription,
+): Promise<void> {
+  const priceId = stripeSub.items.data[0]?.price?.id ?? null;
+  const planKey = priceId ? await planKeyForPrice(priceId) : null;
+  const status = STATUS_MAP[stripeSub.status] ?? "past_due";
+  // In Stripe v22, current_period_end lives on each subscription item.
+  const periodEnd = stripeSub.items.data[0]?.current_period_end ?? null;
+
+  await sql`
+    insert into subscriptions
+      (org_id, plan_key, status, stripe_subscription_id,
+       current_period_end, trial_end, cancel_at_period_end, updated_at)
+    values
+      (${orgId}, ${planKey ?? "community"}, ${status},
+       ${stripeSub.id},
+       ${periodEnd ? new Date(periodEnd * 1000).toISOString() : null},
+       ${stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null},
+       ${stripeSub.cancel_at_period_end},
+       now())
+    on conflict (org_id) do update set
+      plan_key               = excluded.plan_key,
+      status                 = excluded.status,
+      stripe_subscription_id = excluded.stripe_subscription_id,
+      current_period_end     = excluded.current_period_end,
+      trial_end              = excluded.trial_end,
+      cancel_at_period_end   = excluded.cancel_at_period_end,
+      updated_at             = now()`;
+}
+
+/**
+ * Reconcile a completed checkout directly from Stripe, so a paid org's plan
+ * updates even if the webhook is delayed, missed, or (as happened) the endpoint
+ * was deleted. Best-effort and idempotent; never throws.
+ */
+export async function reconcileCheckout(
+  orgId: string,
+  sessionId: string,
+): Promise<boolean> {
+  try {
+    const session = await getStripe().checkout.sessions.retrieve(sessionId, {
+      expand: ["subscription", "subscription.items.data.price"],
+    });
+
+    // Only trust a session that belongs to this org.
+    if (session.metadata?.org_id && session.metadata.org_id !== orgId) {
+      return false;
+    }
+
+    if (session.customer) {
+      await sql`
+        update subscriptions set stripe_customer_id = ${session.customer as string}
+        where org_id = ${orgId}`;
+    }
+
+    const subObj = session.subscription;
+    if (subObj && typeof subObj !== "string") {
+      await syncSubscription(orgId, subObj);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Problem
Plan upgrades depended solely on the Stripe webhook. When the webhook endpoint was deleted, paid orgs stayed on `community` — checkout succeeded but the plan never updated.

## Fix
- `src/lib/billing.ts`: shared `syncSubscription` + `planKeyForPrice` (webhook now imports them) + `reconcileCheckout(orgId, sessionId)` — retrieves the checkout session from Stripe (subscription expanded), verifies `metadata.org_id`, links the customer, upserts the subscription. Idempotent, never throws.
- `success_url` carries `&session_id={CHECKOUT_SESSION_ID}`.
- Billing page reconciles on `?checkout=success` before render + shows a confirmation.

The webhook stays the primary path; this is the safety net so a missed/deleted/mis-secreted endpoint can't strand a paying customer.

## Verified
tsc clean; 587 unit tests unaffected. Live staging verification to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)