### PR TITLE
feat(admin): coupons console + admin nav 404 fixes

### DIFF
--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import { sql } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminAuditPage() {
+  const rows = await sql<{
+    id: string; actor_email: string; action: string; target_type: string;
+    target_id: string; detail: unknown; created_at: string;
+  }[]>`
+    select s.id, u.email as actor_email, s.action, s.target_type, s.target_id,
+           s.detail, s.created_at
+    from staff_audit_log s join users u on u.id = s.actor_id
+    order by s.created_at desc
+    limit 200`;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="mb-1 text-xs text-slate-500">
+          <Link href="/admin" className="hover:text-white">Admin</Link> / Audit
+        </p>
+        <h1 className="text-xl font-bold text-white">Audit log</h1>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-800">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-800 text-xs text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">When</th>
+              <th className="px-3 py-2 text-left">Actor</th>
+              <th className="px-3 py-2 text-left">Action</th>
+              <th className="px-3 py-2 text-left">Target</th>
+              <th className="px-3 py-2 text-left">Detail</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {rows.map((r) => (
+              <tr key={r.id} className="hover:bg-slate-800/50 align-top">
+                <td className="px-3 py-2 text-slate-500 text-xs whitespace-nowrap">
+                  {new Date(r.created_at).toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-slate-300">{r.actor_email}</td>
+                <td className="px-3 py-2 font-mono text-purple-300">{r.action}</td>
+                <td className="px-3 py-2 text-slate-400">
+                  {r.target_type === "org" || r.target_type === "user" ? (
+                    <Link
+                      href={`/admin/${r.target_type}s/${r.target_id}`}
+                      className="hover:text-white"
+                    >
+                      {r.target_type}/{r.target_id.slice(0, 8)}…
+                    </Link>
+                  ) : (
+                    <span>{r.target_type}/{r.target_id.slice(0, 8)}…</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-slate-500 text-xs font-mono max-w-md truncate">
+                  {r.detail ? JSON.stringify(r.detail) : "—"}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-3 py-4 text-center text-slate-500">
+                  No staff actions yet
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/coupons/page.tsx
+++ b/src/app/admin/coupons/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { listCoupons } from "@/lib/coupons";
+import {
+  AdminCouponCreate,
+  AdminCouponToggle,
+} from "@/components/admin-coupon-actions";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminCouponsPage() {
+  const coupons = await listCoupons();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="mb-1 text-xs text-slate-500">
+          <Link href="/admin" className="hover:text-white">
+            Admin
+          </Link>{" "}
+          / Coupons
+        </p>
+        <h1 className="text-xl font-bold text-white">Coupons</h1>
+      </div>
+
+      <AdminCouponCreate />
+
+      <div className="overflow-x-auto rounded-lg border border-slate-800">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-800 text-xs text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">Code</th>
+              <th className="px-3 py-2 text-left">Discount</th>
+              <th className="px-3 py-2 text-left">Duration</th>
+              <th className="px-3 py-2 text-left">Redemptions</th>
+              <th className="px-3 py-2 text-left">Expires</th>
+              <th className="px-3 py-2 text-left">Status</th>
+              <th className="px-3 py-2 text-left">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {coupons.map((c) => (
+              <tr key={c.promoId} className="hover:bg-slate-800/50">
+                <td className="px-3 py-2 font-mono text-purple-300">{c.code}</td>
+                <td className="px-3 py-2 text-slate-300">{c.discount}</td>
+                <td className="px-3 py-2 text-slate-400">{c.duration}</td>
+                <td className="px-3 py-2 text-slate-400">{c.redemptions}</td>
+                <td className="px-3 py-2 text-slate-500 text-xs">
+                  {c.expiresAt ? new Date(c.expiresAt).toLocaleDateString() : "—"}
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs ${
+                      c.active
+                        ? "bg-emerald-900 text-emerald-300"
+                        : "bg-slate-700 text-slate-400"
+                    }`}
+                  >
+                    {c.active ? "active" : "inactive"}
+                  </span>
+                </td>
+                <td className="px-3 py-2">
+                  <AdminCouponToggle promoId={c.promoId} active={c.active} />
+                </td>
+              </tr>
+            ))}
+            {coupons.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-4 text-center text-slate-500">
+                  No coupons yet
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -18,6 +18,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <Link href="/admin" className="hover:text-white">Dashboard</Link>
           <Link href="/admin/orgs" className="hover:text-white">Orgs</Link>
           <Link href="/admin/users" className="hover:text-white">Users</Link>
+          <Link href="/admin/coupons" className="hover:text-white">Coupons</Link>
           <Link href="/admin/audit" className="hover:text-white">Audit</Link>
         </nav>
         <div className="ml-auto flex items-center gap-3 text-xs text-slate-500">

--- a/src/app/admin/orgs/page.tsx
+++ b/src/app/admin/orgs/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+import { sql } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminOrgsPage() {
+  const orgs = await sql<{
+    id: string; name: string; slug: string; status: string;
+    plan_key: string | null; members: number; created_at: string;
+  }[]>`
+    select o.id, o.name, o.slug, o.status,
+           s.plan_key,
+           (select count(*)::int from org_members m where m.org_id = o.id) as members,
+           o.created_at
+    from organizations o
+    left join subscriptions s on s.org_id = o.id
+    order by o.created_at desc
+    limit 100`;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="mb-1 text-xs text-slate-500">
+          <Link href="/admin" className="hover:text-white">Admin</Link> / Orgs
+        </p>
+        <h1 className="text-xl font-bold text-white">Organizations</h1>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-800">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-800 text-xs text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">Name</th>
+              <th className="px-3 py-2 text-left">Plan</th>
+              <th className="px-3 py-2 text-left">Members</th>
+              <th className="px-3 py-2 text-left">Status</th>
+              <th className="px-3 py-2 text-left">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {orgs.map((o) => (
+              <tr key={o.id} className="hover:bg-slate-800/50">
+                <td className="px-3 py-2">
+                  <Link href={`/admin/orgs/${o.id}`} className="text-purple-300 hover:text-white">
+                    {o.name}
+                  </Link>
+                  <span className="ml-2 text-xs text-slate-500">/{o.slug}</span>
+                </td>
+                <td className="px-3 py-2 text-slate-400">{o.plan_key ?? "community"}</td>
+                <td className="px-3 py-2 text-slate-400">{o.members}</td>
+                <td className="px-3 py-2">
+                  <span className={`rounded px-2 py-0.5 text-xs ${
+                    o.status === "active" ? "bg-emerald-900 text-emerald-300" :
+                    o.status === "suspended" ? "bg-red-900 text-red-300" :
+                    "bg-slate-700 text-slate-400"
+                  }`}>{o.status}</span>
+                </td>
+                <td className="px-3 py-2 text-slate-500 text-xs">
+                  {new Date(o.created_at).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+            {orgs.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-3 py-4 text-center text-slate-500">
+                  No organizations yet
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -55,12 +55,16 @@ export default async function AdminDashboard() {
                   <td className="px-3 py-2 text-slate-300">{r.actor_email}</td>
                   <td className="px-3 py-2 font-mono text-purple-300">{r.action}</td>
                   <td className="px-3 py-2 text-slate-400">
-                    <Link
-                      href={`/admin/${r.target_type}s/${r.target_id}`}
-                      className="hover:text-white"
-                    >
-                      {r.target_type}/{r.target_id.slice(0, 8)}…
-                    </Link>
+                    {r.target_type === "org" || r.target_type === "user" ? (
+                      <Link
+                        href={`/admin/${r.target_type}s/${r.target_id}`}
+                        className="hover:text-white"
+                      >
+                        {r.target_type}/{r.target_id.slice(0, 8)}…
+                      </Link>
+                    ) : (
+                      <span>{r.target_type}/{r.target_id.slice(0, 8)}…</span>
+                    )}
                   </td>
                   <td className="px-3 py-2 text-slate-500 text-xs">
                     {new Date(r.created_at).toLocaleString()}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { sql } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminUsersPage() {
+  const users = await sql<{
+    id: string; email: string; display_name: string; email_verified: boolean;
+    is_staff: boolean; staff_role: string | null; created_at: string;
+    deleted_at: string | null;
+  }[]>`
+    select id, email, display_name, email_verified, is_staff, staff_role,
+           created_at, deleted_at
+    from users
+    order by created_at desc
+    limit 100`;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="mb-1 text-xs text-slate-500">
+          <Link href="/admin" className="hover:text-white">Admin</Link> / Users
+        </p>
+        <h1 className="text-xl font-bold text-white">Users</h1>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-800">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-800 text-xs text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">Email</th>
+              <th className="px-3 py-2 text-left">Name</th>
+              <th className="px-3 py-2 text-left">Role</th>
+              <th className="px-3 py-2 text-left">Created</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {users.map((u) => (
+              <tr key={u.id} className="hover:bg-slate-800/50">
+                <td className="px-3 py-2">
+                  <Link href={`/admin/users/${u.id}`} className="text-purple-300 hover:text-white">
+                    {u.email}
+                  </Link>
+                  {!u.email_verified && (
+                    <span className="ml-2 text-xs text-amber-400">unverified</span>
+                  )}
+                  {u.deleted_at && (
+                    <span className="ml-2 text-xs text-red-400">deleted</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-slate-400">{u.display_name}</td>
+                <td className="px-3 py-2">
+                  {u.is_staff ? (
+                    <span className="rounded bg-purple-900 px-2 py-0.5 text-xs text-purple-300">
+                      {u.staff_role ?? "support"}
+                    </span>
+                  ) : (
+                    <span className="text-xs text-slate-500">member</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-slate-500 text-xs">
+                  {new Date(u.created_at).toLocaleDateString()}
+                </td>
+              </tr>
+            ))}
+            {users.length === 0 && (
+              <tr>
+                <td colSpan={4} className="px-3 py-4 text-center text-slate-500">
+                  No users yet
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/coupons/[promoId]/route.ts
+++ b/src/app/api/admin/coupons/[promoId]/route.ts
@@ -1,0 +1,27 @@
+import { requireSuperadmin, logStaffAction } from "@/lib/admin";
+import { setCouponActive } from "@/lib/coupons";
+import { handler } from "@/lib/http";
+import { z } from "zod";
+
+const schema = z.object({ active: z.boolean() }).strict();
+
+/** Toggle a promotion code active/inactive. Superadmin only. */
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ promoId: string }> },
+) {
+  return handler(async () => {
+    const { promoId } = await params;
+    const staff = await requireSuperadmin();
+    const { active } = schema.parse(await req.json());
+    const row = await setCouponActive(promoId, active);
+    await logStaffAction(
+      staff.id,
+      active ? "coupon_activate" : "coupon_deactivate",
+      "coupon",
+      promoId,
+      { code: row.code },
+    );
+    return row;
+  });
+}

--- a/src/app/api/admin/coupons/route.ts
+++ b/src/app/api/admin/coupons/route.ts
@@ -1,0 +1,46 @@
+import { requireStaff, requireSuperadmin, logStaffAction } from "@/lib/admin";
+import { listCoupons, createCoupon } from "@/lib/coupons";
+import { handler } from "@/lib/http";
+import { z } from "zod";
+
+/** List promotion codes. Any staff. */
+export async function GET() {
+  return handler(async () => {
+    await requireStaff();
+    return listCoupons();
+  });
+}
+
+const schema = z
+  .object({
+    code: z.string().trim().min(1).max(64),
+    duration: z.enum(["once", "repeating", "forever"]),
+    durationInMonths: z.number().int().min(1).max(60).nullish(),
+    percentOff: z.number().min(0).max(100).nullish(),
+    amountOff: z.number().min(0).nullish(),
+    currency: z.string().length(3).nullish(),
+    maxRedemptions: z.number().int().min(1).nullish(),
+    expiresAt: z.number().int().positive().nullish(),
+  })
+  .strict()
+  .refine((v) => v.percentOff != null || (v.amountOff != null && v.currency), {
+    message: "Provide either a percent or an amount + currency discount",
+  })
+  .refine((v) => v.duration !== "repeating" || v.durationInMonths != null, {
+    message: "durationInMonths is required for repeating coupons",
+  });
+
+/** Create a coupon + promotion code. Superadmin only (billing impact). */
+export async function POST(req: Request) {
+  return handler(async () => {
+    const staff = await requireSuperadmin();
+    const input = schema.parse(await req.json());
+    const row = await createCoupon(input);
+    await logStaffAction(staff.id, "coupon_create", "coupon", row.promoId, {
+      code: row.code,
+      discount: row.discount,
+      duration: row.duration,
+    });
+    return row;
+  });
+}

--- a/src/components/admin-coupon-actions.tsx
+++ b/src/components/admin-coupon-actions.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+/** Create form for a new coupon + promotion code. Superadmin only. */
+export function AdminCouponCreate() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const [code, setCode] = useState("");
+  const [discountKind, setDiscountKind] = useState<"percent" | "amount">("percent");
+  const [percentOff, setPercentOff] = useState("20");
+  const [amountOff, setAmountOff] = useState("10");
+  const [currency, setCurrency] = useState("GBP");
+  const [duration, setDuration] = useState<"once" | "repeating" | "forever">("once");
+  const [durationInMonths, setDurationInMonths] = useState("3");
+  const [maxRedemptions, setMaxRedemptions] = useState("");
+  const [expiresAt, setExpiresAt] = useState(""); // yyyy-mm-dd
+
+  async function submit() {
+    setLoading(true);
+    setError("");
+    try {
+      const body: Record<string, unknown> = {
+        code: code.trim(),
+        duration,
+      };
+      if (discountKind === "percent") {
+        body.percentOff = Number(percentOff);
+      } else {
+        body.amountOff = Number(amountOff);
+        body.currency = currency.trim().toUpperCase();
+      }
+      if (duration === "repeating") body.durationInMonths = Number(durationInMonths);
+      if (maxRedemptions) body.maxRedemptions = Number(maxRedemptions);
+      if (expiresAt) body.expiresAt = Math.floor(new Date(expiresAt).getTime() / 1000);
+
+      const res = await fetch("/api/admin/coupons", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const d = await res.json().catch(() => ({}));
+        throw new Error(d.error ?? "Failed");
+      }
+      setCode("");
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const inputCls =
+    "rounded border border-slate-600 bg-slate-700 px-2 py-1 text-sm text-white placeholder:text-slate-500";
+
+  return (
+    <div className="space-y-3 rounded-lg bg-slate-800 p-4">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+        New coupon
+      </h2>
+
+      <div className="flex flex-wrap gap-2">
+        <input
+          type="text"
+          value={code}
+          onChange={(e) => setCode(e.target.value.toUpperCase())}
+          placeholder="CODE (e.g. LAUNCH20)"
+          className={`${inputCls} w-48 font-mono`}
+        />
+
+        <select
+          value={discountKind}
+          onChange={(e) => setDiscountKind(e.target.value as "percent" | "amount")}
+          className={inputCls}
+        >
+          <option value="percent">% off</option>
+          <option value="amount">amount off</option>
+        </select>
+
+        {discountKind === "percent" ? (
+          <input
+            type="number"
+            value={percentOff}
+            onChange={(e) => setPercentOff(e.target.value)}
+            className={`${inputCls} w-20`}
+            min={0}
+            max={100}
+          />
+        ) : (
+          <>
+            <input
+              type="number"
+              value={amountOff}
+              onChange={(e) => setAmountOff(e.target.value)}
+              className={`${inputCls} w-24`}
+              min={0}
+              step="0.01"
+            />
+            <input
+              type="text"
+              value={currency}
+              onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+              className={`${inputCls} w-16`}
+              maxLength={3}
+            />
+          </>
+        )}
+
+        <select
+          value={duration}
+          onChange={(e) =>
+            setDuration(e.target.value as "once" | "repeating" | "forever")
+          }
+          className={inputCls}
+        >
+          <option value="once">once</option>
+          <option value="repeating">repeating</option>
+          <option value="forever">forever</option>
+        </select>
+
+        {duration === "repeating" && (
+          <input
+            type="number"
+            value={durationInMonths}
+            onChange={(e) => setDurationInMonths(e.target.value)}
+            className={`${inputCls} w-20`}
+            min={1}
+            max={60}
+            title="months"
+          />
+        )}
+
+        <input
+          type="number"
+          value={maxRedemptions}
+          onChange={(e) => setMaxRedemptions(e.target.value)}
+          placeholder="max uses"
+          className={`${inputCls} w-24`}
+          min={1}
+        />
+
+        <input
+          type="date"
+          value={expiresAt}
+          onChange={(e) => setExpiresAt(e.target.value)}
+          className={inputCls}
+          title="expires at"
+        />
+
+        <button
+          onClick={submit}
+          disabled={loading || !code.trim()}
+          className="rounded bg-purple-700 px-4 py-1 text-sm text-white hover:bg-purple-600 disabled:opacity-50"
+        >
+          {loading ? "…" : "Create"}
+        </button>
+      </div>
+
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}
+
+/** Toggle button for a single promotion code's active state. */
+export function AdminCouponToggle({
+  promoId,
+  active,
+}: {
+  promoId: string;
+  active: boolean;
+}) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function toggle() {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/admin/coupons/${promoId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ active: !active }),
+      });
+      if (res.ok) router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={loading}
+      className={`rounded px-2 py-1 text-xs text-white disabled:opacity-50 ${
+        active ? "bg-red-800 hover:bg-red-700" : "bg-emerald-700 hover:bg-emerald-600"
+      }`}
+    >
+      {loading ? "…" : active ? "Deactivate" : "Activate"}
+    </button>
+  );
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -33,7 +33,7 @@ export async function requireSuperadmin(): Promise<StaffUser> {
 export async function logStaffAction(
   actorId: string,
   action: string,
-  targetType: "org" | "user" | "entitlement",
+  targetType: "org" | "user" | "entitlement" | "coupon",
   targetId: string,
   detail?: Record<string, unknown>,
 ): Promise<void> {

--- a/src/lib/coupons.ts
+++ b/src/lib/coupons.ts
@@ -1,0 +1,124 @@
+import "server-only";
+import type Stripe from "stripe";
+import { getStripe } from "@/lib/stripe";
+
+/**
+ * Coupon management for the staff console. A customer-facing "coupon" is a
+ * Stripe promotion code (the string they type) backed by a Stripe coupon (the
+ * discount). Stripe coupons are immutable, so "editing" = deactivate + recreate;
+ * promotion codes can only be toggled active/inactive.
+ */
+
+export interface CouponRow {
+  promoId: string;
+  couponId: string;
+  code: string;
+  active: boolean;
+  discount: string; // "20% off" | "10.00 GBP off"
+  duration: string; // "once" | "forever" | "3 months"
+  redemptions: string; // "3" | "3 / 100"
+  expiresAt: string | null;
+  created: number;
+}
+
+function describeCoupon(c: Stripe.Coupon): { discount: string; duration: string } {
+  const discount =
+    c.percent_off != null
+      ? `${c.percent_off}% off`
+      : c.amount_off != null
+        ? `${(c.amount_off / 100).toFixed(2)} ${(c.currency ?? "").toUpperCase()} off`
+        : "—";
+  const duration =
+    c.duration === "repeating"
+      ? `${c.duration_in_months ?? "?"} months`
+      : c.duration; // once | forever
+  return { discount, duration };
+}
+
+function toRow(p: Stripe.PromotionCode): CouponRow {
+  const c = p.promotion.coupon;
+  if (c == null || typeof c === "string") {
+    // Only happens if the caller forgot to expand promotion.coupon.
+    throw new Error("Promotion code was returned without an expanded coupon");
+  }
+  const { discount, duration } = describeCoupon(c);
+  return {
+    promoId: p.id,
+    couponId: c.id,
+    code: p.code,
+    active: p.active,
+    discount,
+    duration,
+    redemptions: p.max_redemptions
+      ? `${p.times_redeemed} / ${p.max_redemptions}`
+      : String(p.times_redeemed),
+    expiresAt: p.expires_at ? new Date(p.expires_at * 1000).toISOString() : null,
+    created: p.created,
+  };
+}
+
+/** List the most recent promotion codes (with their coupon expanded). */
+export async function listCoupons(): Promise<CouponRow[]> {
+  const res = await getStripe().promotionCodes.list({
+    limit: 100,
+    expand: ["data.promotion.coupon"],
+  });
+  return res.data.map(toRow).sort((a, b) => b.created - a.created);
+}
+
+export interface CreateCouponInput {
+  code: string;
+  duration: "once" | "repeating" | "forever";
+  durationInMonths?: number | null;
+  percentOff?: number | null;
+  amountOff?: number | null; // major units (e.g. dollars); converted to cents
+  currency?: string | null;
+  maxRedemptions?: number | null;
+  expiresAt?: number | null; // unix seconds
+}
+
+/** Create a coupon + a promotion code that points at it. Returns the row. */
+export async function createCoupon(input: CreateCouponInput): Promise<CouponRow> {
+  const stripe = getStripe();
+
+  const couponParams: Stripe.CouponCreateParams = {
+    name: input.code,
+    duration: input.duration,
+  };
+  if (input.duration === "repeating") {
+    couponParams.duration_in_months = input.durationInMonths ?? 1;
+  }
+  if (input.percentOff != null) {
+    couponParams.percent_off = input.percentOff;
+  } else if (input.amountOff != null && input.currency) {
+    couponParams.amount_off = Math.round(input.amountOff * 100);
+    couponParams.currency = input.currency.toLowerCase();
+  } else {
+    throw new Error("Provide either a percent or an amount discount");
+  }
+
+  const coupon = await stripe.coupons.create(couponParams);
+
+  const promoParams: Stripe.PromotionCodeCreateParams = {
+    promotion: { type: "coupon", coupon: coupon.id },
+    code: input.code,
+    expand: ["promotion.coupon"],
+  };
+  if (input.maxRedemptions) promoParams.max_redemptions = input.maxRedemptions;
+  if (input.expiresAt) promoParams.expires_at = input.expiresAt;
+
+  const promo = await stripe.promotionCodes.create(promoParams);
+  return toRow(promo);
+}
+
+/** Activate or deactivate a promotion code (coupons themselves are immutable). */
+export async function setCouponActive(
+  promoId: string,
+  active: boolean,
+): Promise<CouponRow> {
+  const promo = await getStripe().promotionCodes.update(promoId, {
+    active,
+    expand: ["promotion.coupon"],
+  });
+  return toRow(promo);
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -4,7 +4,7 @@ import { sql } from "@/lib/db";
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
 
 function from(): string {
-  return process.env.EMAIL_FROM || "Seazn Club <onboarding@resend.dev>";
+  return process.env.EMAIL_FROM || "Seazn Club <noreply@mail.seazn.club>";
 }
 
 function replyTo(): string | undefined {


### PR DESCRIPTION
## Summary
- **Coupons console** — staff can list, create, and activate/deactivate Stripe promotion codes.
  - `src/lib/coupons.ts` — list/create/toggle, adapted to **Stripe v22** breaking changes (`promotion.coupon` nesting, `expand` in params).
  - `api/admin/coupons` — GET list (staff), POST create + PATCH toggle (superadmin), audit-logged (`coupon_create` / `coupon_activate` / `coupon_deactivate`).
  - `admin/coupons` page — list table + create form.
  - `admin.ts` — new `"coupon"` audit target type.
- **Fix admin nav 404s** — `Orgs`, `Users`, `Audit` tabs linked to index routes that didn't exist (only `[id]` detail pages were present). Added index pages for orgs, users, audit. Gated dashboard target links to `org`/`user` so entitlement/coupon rows no longer build 404 URLs.
- **Email from-address** — set `EMAIL_FROM` default to verified Resend subdomain `noreply@mail.seazn.club` (fixes 403 `validation_error` from stale `onryde.com`).

## Test
- `tsc --noEmit` clean.
- Local dev probe: `/admin/orgs`, `/admin/users`, `/admin/audit`, `/admin/coupons` now resolve (307 → login) instead of 404.
- Coupon Stripe calls not exercised against live Stripe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)