### PR TITLE
fix(billing): honour no-card trial in Stripe checkout

### DIFF
--- a/src/app/api/billing/checkout/route.ts
+++ b/src/app/api/billing/checkout/route.ts
@@ -40,8 +40,15 @@ export async function POST(req: Request) {
         ? { customer: existingCustomerId }
         : { customer_email: user.email }),
       metadata: { org_id: orgId },
+      // Honour the "no card required" trial: don't ask for a payment method up
+      // front. If none is added by the time the trial ends, cancel rather than
+      // silently attempting to bill a card we never collected.
+      payment_method_collection: "if_required",
       subscription_data: {
         trial_period_days: 14,
+        trial_settings: {
+          end_behavior: { missing_payment_method: "cancel" },
+        },
         metadata: { org_id: orgId },
       },
       line_items: [{ price: plan.price_id, quantity: 1 }],


### PR DESCRIPTION
## Problem
Landing/pricing/settings copy says the 14-day Pro trial needs **no card**, but Stripe Checkout still asked for card details.

## Cause
Checkout in `subscription` mode collects a payment method up front by default — `trial_period_days` alone does not suppress it.

## Fix
- `payment_method_collection: "if_required"` — no card prompt during the trial.
- `subscription_data.trial_settings.end_behavior.missing_payment_method: "cancel"` — if no card is added before day 14, the subscription cancels instead of attempting a silent charge on a card we never collected.

Field names verified against the Stripe v22 types. `tsc --noEmit` clean.

## Note
`automatic_tax` stays enabled, so Checkout may still request a billing **address** (for tax location) — that is not a card. Can defer tax to the first real invoice if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)