### PR TITLE
ci: auto-deploy to staging on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,22 @@ jobs:
       - name: Dev server log (on failure)
         if: failure()
         run: cat dev-server.log || true
+
+  # -------------------------------------------------------------------------
+  # Deploy to the staging Fly app. Only on push to main, and only once both
+  # gates above are green. PRs never deploy.
+  # -------------------------------------------------------------------------
+  deploy-staging:
+    name: Deploy (staging)
+    runs-on: ubuntu-latest
+    needs: [test, smoke]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v5
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy -a seazn-club-stg --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy -a seazn-club-stg --remote-only
+      - run: flyctl deploy -c fly.stg.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a `deploy-staging` job to CI that deploys the staging Fly app (`seazn-club-stg`) automatically.

- Runs **only** on push to `main` (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`) — PRs never deploy.
- `needs: [test, smoke]` — deploys only after both existing gates are green.
- Uses `flyctl deploy --remote-only` with the `FLY_TOKEN` repo secret.
- Own concurrency group (`deploy-staging`, no cancel) so overlapping deploys queue instead of racing.

Prod is untouched — no auto-deploy there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)