### PR TITLE
fix(admin): impersonate link never renders (wrong payload path)

### DIFF
--- a/src/components/admin-user-actions.tsx
+++ b/src/components/admin-user-actions.tsx
@@ -26,8 +26,9 @@ export function AdminUserActions({
         const d = await res.json().catch(() => ({}));
         throw new Error(d.error ?? "Failed");
       }
-      const data = await res.json();
-      if (path === "impersonate") setImpersonateUrl(data.url);
+      const body = await res.json();
+      // handler() wraps payloads as { ok: true, data: {...} }
+      if (path === "impersonate") setImpersonateUrl(body.data.url);
       else router.refresh();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Error");


### PR DESCRIPTION
## Problem
Clicking **Impersonate** returned 200 but no one-time link appeared.

## Cause
`handler()` wraps every response as `{ ok: true, data: {...} }`. The client read `body.url` (undefined) instead of `body.data.url`, so `impersonateUrl` stayed empty and the link box never rendered. (Billing actions already read `data.data.url` correctly — impersonate was the outlier.)

## Fix
Read `body.data.url`.

`tsc --noEmit` clean.

## Note
By design the link opens in a new tab (`target="_blank"`); open it in a **private/incognito window** so the impersonation session cookie doesn't overwrite your admin login. Can add a "Copy link" + hint as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)