### PR TITLE
feat: enterprise hardening — RLS denormalization, tamper-evident audit, CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,9 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # ── Future: Upstash Redis ─────────────────────────────────────────────────────
 # UPSTASH_REDIS_REST_URL=https://xxxx.upstash.io
 # UPSTASH_REDIS_REST_TOKEN=xxxx
+
+# ── Security ───────────────────────────────────────────────────────────────────
+# CSP is emitted as Report-Only by default (observe violations in the browser
+# console). Set to "enforce" to block — only after verifying on staging, since
+# enforcing nonce CSP forces dynamic rendering (no static/CDN caching).
+CSP_MODE=report-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Bootstrap database (schema + migrations)
         run: npm run db:apply
 
+      - name: RLS guard (every org_id table isolated)
+        run: npm run check:rls
+
       - name: Start dev server
         run: |
           npm run dev > dev-server.log 2>&1 &

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:smoke": "node --experimental-strip-types scripts/smoke.ts",
-    "db:apply": "node --experimental-strip-types scripts/apply-db.ts"
+    "db:apply": "node --experimental-strip-types scripts/apply-db.ts",
+    "check:rls": "node --experimental-strip-types scripts/check-rls.ts"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.62.0",

--- a/scripts/check-rls.ts
+++ b/scripts/check-rls.ts
@@ -1,0 +1,83 @@
+// RLS guard (doc 03 §9): fail CI if any tenant table with an `org_id` column
+// lacks Row-Level Security + at least one policy. Catches a new table that
+// forgets isolation. Run against a bootstrapped DB:
+//   node --experimental-strip-types scripts/check-rls.ts
+import postgres from "postgres";
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error("DATABASE_URL is not set.");
+  process.exit(1);
+}
+
+// Tables that carry org_id but are intentionally accessed only via the
+// superuser connection (billing/admin), never as app_user, so they are exempt
+// from RLS. Keep this list tight — everything else with org_id must be isolated.
+const SUPERUSER_ONLY = new Set([
+  "subscriptions",
+  "org_entitlement_overrides",
+  "billing_events",
+  "impersonation_sessions",
+  "activation_events",
+]);
+
+const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
+const sql = postgres(url, {
+  ssl: process.env.DATABASE_SSL === "disable" ? false : isLocal ? false : "require",
+  prepare: !url.includes(":6543"),
+  max: 1,
+});
+
+try {
+  const rows = await sql<{
+    table_name: string;
+    rls_enabled: boolean;
+    rls_forced: boolean;
+    policies: number;
+  }[]>`
+    select
+      c.relname                                   as table_name,
+      c.relrowsecurity                            as rls_enabled,
+      c.relforcerowsecurity                       as rls_forced,
+      (select count(*)::int from pg_policies p
+        where p.schemaname = 'public' and p.tablename = c.relname) as policies
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relkind = 'r'
+      and exists (
+        select 1 from information_schema.columns col
+        where col.table_schema = 'public'
+          and col.table_name = c.relname
+          and col.column_name = 'org_id'
+      )
+    order by c.relname`;
+
+  const failures: string[] = [];
+  for (const r of rows) {
+    if (SUPERUSER_ONLY.has(r.table_name)) continue;
+    if (!r.rls_enabled) failures.push(`${r.table_name}: RLS not enabled`);
+    else if (!r.rls_forced) failures.push(`${r.table_name}: RLS not FORCEd (owner bypasses)`);
+    else if (r.policies === 0) failures.push(`${r.table_name}: no policy`);
+  }
+
+  const checked = rows.filter((r) => !SUPERUSER_ONLY.has(r.table_name)).map((r) => r.table_name);
+  console.log(`RLS guard: checked ${checked.length} tenant tables: ${checked.join(", ")}`);
+
+  if (failures.length) {
+    console.error("\nRLS guard FAILED:");
+    for (const f of failures) console.error(`  ✗ ${f}`);
+    console.error(
+      "\nEvery table with an org_id column must enable+force RLS and have a" +
+        " policy, or be added to SUPERUSER_ONLY in scripts/check-rls.ts with a reason.",
+    );
+    process.exitCode = 1;
+  } else {
+    console.log("RLS guard OK: all tenant tables isolated.");
+  }
+} catch (err) {
+  console.error("RLS guard error:", err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+} finally {
+  await sql.end();
+}

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -11,8 +11,12 @@ export default async function AdminAuditPage() {
     select s.id, u.email as actor_email, s.action, s.target_type, s.target_id,
            s.detail, s.created_at
     from staff_audit_log s join users u on u.id = s.actor_id
-    order by s.created_at desc
+    order by s.chain_seq desc nulls last, s.created_at desc
     limit 200`;
+
+  // Tamper-evidence: re-walk the hash chain (doc 04 §6). null = intact.
+  const [{ broken }] = await sql<{ broken: string | null }[]>`
+    select verify_staff_audit_log_chain() as broken`;
 
   return (
     <div className="space-y-6">
@@ -21,6 +25,18 @@ export default async function AdminAuditPage() {
           <Link href="/admin" className="hover:text-white">Admin</Link> / Audit
         </p>
         <h1 className="text-xl font-bold text-white">Audit log</h1>
+      </div>
+
+      <div
+        className={`rounded-lg border px-3 py-2 text-sm ${
+          broken
+            ? "border-red-700 bg-red-900/30 text-red-300"
+            : "border-emerald-800 bg-emerald-900/20 text-emerald-300"
+        }`}
+      >
+        {broken
+          ? `⚠ Hash chain broken at row ${broken} — the audit log may have been tampered with.`
+          : "✓ Hash chain verified — no tampering detected."}
       </div>
 
       <div className="overflow-x-auto rounded-lg border border-slate-800">

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,45 @@ import { NextRequest, NextResponse } from "next/server";
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 /**
+ * Build the Content-Security-Policy for a page request (doc 04 §5).
+ *
+ * script-src uses a per-request nonce + 'strict-dynamic'; Next.js reads the
+ * enforcing CSP header and automatically stamps the nonce onto its framework
+ * and page scripts, so no per-tag wiring is needed. connect-src allows Supabase
+ * (realtime websockets) and Sentry ingest; img-src allows arbitrary https for
+ * player/org avatars.
+ *
+ * Default is Content-Security-Policy-Report-Only so a missing directive can
+ * never break the running app — set CSP_MODE=enforce (after verifying the
+ * browser console on staging) to switch to blocking. Enforcing nonce CSP forces
+ * dynamic rendering (no static/CDN caching), which is why it is opt-in.
+ */
+function cspHeader(nonce: string): { name: string; value: string } {
+  const isDev = process.env.NODE_ENV === "development";
+  const enforce = process.env.CSP_MODE === "enforce";
+  const value = [
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    // Tailwind ships an external stylesheet; 'unsafe-inline' covers the small
+    // inline styles Next injects. Styles are low-risk vs script injection.
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src 'self' blob: data: https:`,
+    `font-src 'self' data:`,
+    `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.ingest.sentry.io https://*.sentry.io`,
+    `frame-src 'self'`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `frame-ancestors 'self'`,
+    `upgrade-insecure-requests`,
+  ].join("; ");
+  return {
+    name: enforce ? "Content-Security-Policy" : "Content-Security-Policy-Report-Only",
+    value,
+  };
+}
+
+/**
  * CSRF protection: for every mutating API call, the Origin header must match
  * the app host. Browsers always send Origin on cross-origin requests, so a
  * mismatch means a third-party site is trying to trigger an action on behalf
@@ -13,37 +52,56 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
  * matches the host the app is running on.
  */
 export function proxy(request: NextRequest) {
-  if (
-    request.nextUrl.pathname.startsWith("/api/") &&
-    !request.nextUrl.pathname.startsWith("/api/webhooks/") &&
-    !SAFE_METHODS.has(request.method)
-  ) {
-    const origin = request.headers.get("origin");
-    // Session cookies are SameSite=Lax — browsers won't attach them on
-    // cross-origin mutations, so CSRF is already blocked at the cookie layer.
-    // Only do an explicit host check when the browser sends Origin so we catch
-    // any cross-origin request that somehow carries credentials.
-    // Absent Origin (same-origin fetch in some browsers/curl) → allow through.
-    if (origin) {
-      // Prefer X-Forwarded-Host (Fly.io / reverse proxy). Fall back to Host
-      // header, stripping port so "localhost:3000" → "localhost".
-      const appHost =
-        request.headers.get("x-forwarded-host")?.split(",")[0].trim() ??
-        request.headers.get("host")?.split(":")[0] ??
-        request.nextUrl.hostname;
-      try {
-        const originHostname = new URL(origin).hostname;
-        if (originHostname !== appHost) {
+  const isApi = request.nextUrl.pathname.startsWith("/api/");
+
+  if (isApi) {
+    if (
+      !request.nextUrl.pathname.startsWith("/api/webhooks/") &&
+      !SAFE_METHODS.has(request.method)
+    ) {
+      const origin = request.headers.get("origin");
+      // Session cookies are SameSite=Lax — browsers won't attach them on
+      // cross-origin mutations, so CSRF is already blocked at the cookie layer.
+      // Only do an explicit host check when the browser sends Origin so we catch
+      // any cross-origin request that somehow carries credentials.
+      // Absent Origin (same-origin fetch in some browsers/curl) → allow through.
+      if (origin) {
+        // Prefer X-Forwarded-Host (Fly.io / reverse proxy). Fall back to Host
+        // header, stripping port so "localhost:3000" → "localhost".
+        const appHost =
+          request.headers.get("x-forwarded-host")?.split(",")[0].trim() ??
+          request.headers.get("host")?.split(":")[0] ??
+          request.nextUrl.hostname;
+        try {
+          const originHostname = new URL(origin).hostname;
+          if (originHostname !== appHost) {
+            return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+          }
+        } catch {
           return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
         }
-      } catch {
-        return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
       }
     }
+    // API responses don't render HTML — no CSP needed.
+    return NextResponse.next();
   }
-  return NextResponse.next();
+
+  // Page requests: attach a per-request nonce + CSP.
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = cspHeader(nonce);
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  // Next reads the enforcing CSP header on the request to stamp script nonces.
+  requestHeaders.set(csp.name, csp.value);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set(csp.name, csp.value);
+  return response;
 }
 
 export const config = {
-  matcher: "/api/:path*",
+  // Run on API routes (CSRF) and all page routes (CSP), but skip Next's static
+  // assets, image optimizer, and the favicon — they don't need either.
+  matcher: ["/api/:path*", "/((?!_next/static|_next/image|favicon.ico).*)"],
 };

--- a/supabase/migrations/010_rls_denormalize_org_id.sql
+++ b/supabase/migrations/010_rls_denormalize_org_id.sql
@@ -1,0 +1,79 @@
+-- 010 — RLS: denormalize org_id onto hot child tables
+-- =============================================================================
+-- schema.sql enables + forces RLS on players/rounds/matches/match_events/
+-- audit_log but their policies sub-select into `tournaments` on every row.
+-- Denormalize `org_id` onto these tables so each policy is a cheap, indexable
+-- `org_id = current_org_id()` comparison. A BEFORE INSERT trigger fills org_id
+-- from the parent tournament, so application inserts don't change and the value
+-- can never drift from the tournament it belongs to.
+-- Idempotent: safe to re-run and safe on both fresh (CI) and populated (prod) DBs.
+-- =============================================================================
+
+-- 1. Columns (nullable first so the backfill can run).
+alter table players       add column if not exists org_id uuid references organizations(id) on delete cascade;
+alter table rounds        add column if not exists org_id uuid references organizations(id) on delete cascade;
+alter table matches       add column if not exists org_id uuid references organizations(id) on delete cascade;
+alter table match_events  add column if not exists org_id uuid references organizations(id) on delete cascade;
+alter table audit_log     add column if not exists org_id uuid references organizations(id) on delete cascade;
+
+-- 2. Backfill from the parent tournament. audit_log.tournament_id is nullable
+--    (system rows); those keep org_id null and are only ever written by the
+--    superuser connection, which bypasses RLS.
+update players       p set org_id = t.org_id from tournaments t where p.tournament_id = t.id and p.org_id is null;
+update rounds        r set org_id = t.org_id from tournaments t where r.tournament_id = t.id and r.org_id is null;
+update matches       m set org_id = t.org_id from tournaments t where m.tournament_id = t.id and m.org_id is null;
+update match_events  e set org_id = t.org_id from tournaments t where e.tournament_id = t.id and e.org_id is null;
+update audit_log     a set org_id = t.org_id from tournaments t where a.tournament_id = t.id and a.org_id is null;
+
+-- 3. Indexes for the policy predicate.
+create index if not exists players_org_idx      on players(org_id);
+create index if not exists rounds_org_idx       on rounds(org_id);
+create index if not exists matches_org_idx      on matches(org_id);
+create index if not exists match_events_org_idx on match_events(org_id);
+create index if not exists audit_log_org_idx    on audit_log(org_id);
+
+-- 4. Trigger: populate org_id from the parent tournament on insert.
+--    SECURITY INVOKER (default) means the lookup runs under the caller's RLS,
+--    so inserting a child row for a tournament outside the current org finds no
+--    tournament, leaves org_id null, and the WITH CHECK below then rejects it.
+create or replace function set_org_from_tournament() returns trigger
+  language plpgsql as $$
+begin
+  if new.org_id is null and new.tournament_id is not null then
+    select org_id into new.org_id from tournaments where id = new.tournament_id;
+  end if;
+  return new;
+end $$;
+
+do $$
+declare tbl text;
+begin
+  foreach tbl in array array['players','rounds','matches','match_events','audit_log'] loop
+    execute format('drop trigger if exists trg_set_org on %I', tbl);
+    execute format(
+      'create trigger trg_set_org before insert on %I
+         for each row execute function set_org_from_tournament()', tbl);
+  end loop;
+end $$;
+
+-- 5. Replace the sub-select policies with direct org_id comparisons.
+--    WITH CHECK on writes prevents inserting/updating a row into another tenant.
+drop policy if exists players_tenant on players;
+create policy players_tenant on players for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+
+drop policy if exists rounds_tenant on rounds;
+create policy rounds_tenant on rounds for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+
+drop policy if exists matches_tenant on matches;
+create policy matches_tenant on matches for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+
+drop policy if exists match_events_tenant on match_events;
+create policy match_events_tenant on match_events for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+
+drop policy if exists audit_log_tenant on audit_log;
+create policy audit_log_tenant on audit_log for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());

--- a/supabase/migrations/011_audit_hash_chain.sql
+++ b/supabase/migrations/011_audit_hash_chain.sql
@@ -1,0 +1,122 @@
+-- 011 — Tamper-evident audit trail (hash chain)
+-- =============================================================================
+-- Doc 04 §6. Each row in audit_log and staff_audit_log stores row_hash =
+-- sha256(prev_hash || canonical row fields). prev_hash links to the previous
+-- row's row_hash, so deleting or editing any row breaks every hash after it and
+-- is detectable by re-walking the chain (verify_*_chain).
+--
+-- Chain order is a dedicated `chain_seq` assigned from a sequence *inside* the
+-- trigger while holding a per-table transaction advisory lock. The lock is held
+-- until commit, so a concurrent inserter blocks until the previous row is
+-- committed and visible — giving a single, deterministic, linear chain
+-- independent of clock ties. Trigger is SECURITY DEFINER so it reads the whole
+-- table for the tip regardless of the caller's RLS. Idempotent.
+-- =============================================================================
+
+create extension if not exists pgcrypto;
+
+alter table audit_log        add column if not exists prev_hash text;
+alter table audit_log        add column if not exists row_hash  text;
+alter table audit_log        add column if not exists chain_seq bigint;
+alter table staff_audit_log  add column if not exists prev_hash text;
+alter table staff_audit_log  add column if not exists row_hash  text;
+alter table staff_audit_log  add column if not exists chain_seq bigint;
+
+create sequence if not exists audit_log_chain_seq;
+create sequence if not exists staff_audit_log_chain_seq;
+
+create index if not exists audit_log_chain_idx       on audit_log(chain_seq);
+create index if not exists staff_audit_log_chain_idx on staff_audit_log(chain_seq);
+
+-- Canonical hash input for a row.
+create or replace function audit_row_hash(prev text, canonical text) returns text
+  language sql immutable as $$
+    select encode(digest(coalesce(prev, '') || '|' || canonical, 'sha256'), 'hex')
+  $$;
+
+-- audit_log chain
+create or replace function audit_log_hash_chain() returns trigger
+  language plpgsql security definer set search_path = public, pg_temp as $$
+declare
+  prev text;
+  canonical text;
+begin
+  perform pg_advisory_xact_lock(hashtext('audit_log_chain'));
+  new.chain_seq := nextval('audit_log_chain_seq');
+  select row_hash into prev from audit_log order by chain_seq desc limit 1;
+  canonical := concat_ws('|',
+    new.id::text, coalesce(new.tournament_id::text, ''), coalesce(new.actor, ''),
+    new.action, new.summary, coalesce(new.detail::text, ''), new.created_at::text);
+  new.prev_hash := prev;
+  new.row_hash  := audit_row_hash(prev, canonical);
+  return new;
+end $$;
+
+-- staff_audit_log chain
+create or replace function staff_audit_log_hash_chain() returns trigger
+  language plpgsql security definer set search_path = public, pg_temp as $$
+declare
+  prev text;
+  canonical text;
+begin
+  perform pg_advisory_xact_lock(hashtext('staff_audit_log_chain'));
+  new.chain_seq := nextval('staff_audit_log_chain_seq');
+  select row_hash into prev from staff_audit_log order by chain_seq desc limit 1;
+  canonical := concat_ws('|',
+    new.id::text, new.actor_id::text, new.action, new.target_type, new.target_id,
+    coalesce(new.detail::text, ''), new.created_at::text);
+  new.prev_hash := prev;
+  new.row_hash  := audit_row_hash(prev, canonical);
+  return new;
+end $$;
+
+-- trg_zhash fires after trg_set_org (alphabetical) so org_id is set first.
+drop trigger if exists trg_zhash on audit_log;
+create trigger trg_zhash before insert on audit_log
+  for each row execute function audit_log_hash_chain();
+
+drop trigger if exists trg_zhash on staff_audit_log;
+create trigger trg_zhash before insert on staff_audit_log
+  for each row execute function staff_audit_log_hash_chain();
+
+-- Verifiers: return the id of the first row (in chain order) whose recomputed
+-- hash or prev-link doesn't match; null = chain intact.
+create or replace function verify_audit_log_chain() returns uuid
+  language plpgsql stable security definer set search_path = public, pg_temp as $$
+declare
+  r audit_log%rowtype;
+  expect_prev text := null;
+  canonical text;
+begin
+  for r in select * from audit_log order by chain_seq loop
+    if r.prev_hash is distinct from expect_prev then return r.id; end if;
+    canonical := concat_ws('|',
+      r.id::text, coalesce(r.tournament_id::text, ''), coalesce(r.actor, ''),
+      r.action, r.summary, coalesce(r.detail::text, ''), r.created_at::text);
+    if r.row_hash is distinct from audit_row_hash(r.prev_hash, canonical) then
+      return r.id;
+    end if;
+    expect_prev := r.row_hash;
+  end loop;
+  return null;
+end $$;
+
+create or replace function verify_staff_audit_log_chain() returns uuid
+  language plpgsql stable security definer set search_path = public, pg_temp as $$
+declare
+  r staff_audit_log%rowtype;
+  expect_prev text := null;
+  canonical text;
+begin
+  for r in select * from staff_audit_log order by chain_seq loop
+    if r.prev_hash is distinct from expect_prev then return r.id; end if;
+    canonical := concat_ws('|',
+      r.id::text, r.actor_id::text, r.action, r.target_type, r.target_id,
+      coalesce(r.detail::text, ''), r.created_at::text);
+    if r.row_hash is distinct from audit_row_hash(r.prev_hash, canonical) then
+      return r.id;
+    end if;
+    expect_prev := r.row_hash;
+  end loop;
+  return null;
+end $$;


### PR DESCRIPTION
Implements the remaining gaps from development docs 02–05 (all except OTP/MFA).

## 1. RLS: org_id denormalization + CI guard (doc 03 §4/§9)
- Migration `010`: add `org_id` to `players/rounds/matches/match_events/audit_log`, backfill from the parent tournament, index it, and a BEFORE INSERT trigger that fills it (so the many `tournament.ts` inserts are unchanged and org_id can't drift).
- Swap the per-row sub-select policies for direct `org_id = current_org_id()` checks with `WITH CHECK` on writes.
- `scripts/check-rls.ts` + CI step: fails if any table with an `org_id` column lacks enforced RLS + a policy (superuser-only billing tables allow-listed).

## 2. Tamper-evident audit log (doc 04 §6)
- Migration `011`: `prev_hash` + `row_hash = sha256(prev || canonical fields)` on `audit_log` and `staff_audit_log`, ordered by a `chain_seq` assigned under a per-table advisory lock (deterministic linear chain under concurrency).
- `verify_*_chain()` SQL functions; `/admin/audit` shows a verified/broken banner.

## 3. Nonce-based CSP (doc 04 §5)
- Extend `proxy.ts` (Next 16's `middleware`) with a per-request nonce + `Content-Security-Policy`, alongside the existing CSRF check. `connect-src` allows Supabase realtime + Sentry; `img-src` allows https avatars.
- Ships **Report-Only** (`CSP_MODE=report-only`); flip to `enforce` after checking the browser console on staging (enforcing forces dynamic rendering).

## Validation
- `tsc --noEmit` clean.
- No local Postgres — **CI is the schema validator**: the smoke job bootstraps postgres:16, runs `db:apply` (schema + all migrations), the new RLS guard, then exercises tournament create/score through `withTenant` (covers the new org_id trigger + WITH CHECK policies).
- Not deployed. Migrations are idempotent and backfill, safe on fresh + populated DBs, but enabling should be a reviewed rollout.

## Decisions applied (open questions)
- **03:** denormalize org_id (recommended) — via trigger, not app changes.
- **CSP:** Report-Only first (reversible) rather than blind enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)