### PR TITLE
ci: engine-check + security gate (doc 07)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,33 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit
+      - run: npm run engine:check
       - run: npm test
+
+  # -------------------------------------------------------------------------
+  # Security gate (doc 07 §4): secret scan + dependency audit. Secret leaks
+  # block; the dependency audit is advisory (won't block on a pre-existing
+  # transitive advisory) but stays visible.
+  # -------------------------------------------------------------------------
+  security:
+    name: Security scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Dependency audit (high+)
+        run: npm audit --audit-level=high
+        continue-on-error: true
 
   # -------------------------------------------------------------------------
   # Integration gate: real Postgres container -> real HTTP -> real DB.
@@ -97,7 +123,7 @@ jobs:
   deploy-staging:
     name: Deploy (staging)
     runs-on: ubuntu-latest
-    needs: [test, smoke]
+    needs: [test, smoke, security]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-staging

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:smoke": "node --experimental-strip-types scripts/smoke.ts",
+    "engine:check": "node --experimental-strip-types scripts/engine-check.ts",
     "db:apply": "node --experimental-strip-types scripts/apply-db.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Doc 07 §4 CI hardening.

- Run `scripts/engine-check.ts` (pure pairing/standings correctness) in the fast job.
- New **Security scan** job: gitleaks secret scan (blocks) + `npm audit --audit-level=high` (advisory).
- Gate `deploy-staging` on the security job.

engine-check verified locally (ALL PASS). Independent of PR #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)