### PR TITLE
feat(cache): Redis (Upstash) cache-aside + rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,9 +48,11 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 # INNGEST_EVENT_KEY=xxxx
 # INNGEST_SIGNING_KEY=signkey-xxxx
 
-# ── Future: Upstash Redis ─────────────────────────────────────────────────────
-# UPSTASH_REDIS_REST_URL=https://xxxx.upstash.io
-# UPSTASH_REDIS_REST_TOKEN=xxxx
+# ── Redis (Upstash) ───────────────────────────────────────────────────────────
+# Cache-aside for entitlements + Redis-backed rate limiting. Fail-open: unset =
+# app falls back to Postgres. RESP URL (Fly/Upstash), e.g.
+# redis://default:<password>@fly-<db>.upstash.io:6379
+# REDIS_URL=redis://default:xxxx@fly-xxxx.upstash.io:6379
 
 # ── Security ───────────────────────────────────────────────────────────────────
 # CSP is emitted as Report-Only by default (observe violations in the browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@sentry/nextjs": "^10.62.0",
         "@supabase/supabase-js": "^2.110.0",
         "bcryptjs": "^3.0.3",
+        "ioredis": "^5.11.1",
         "jose": "^6.2.3",
         "lucide-react": "^1.22.0",
         "next": "^16.2.9",
@@ -1035,6 +1036,12 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -4642,6 +4649,15 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4836,6 +4852,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-libc": {
@@ -6235,6 +6260,28 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8152,6 +8199,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8797,6 +8865,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@sentry/nextjs": "^10.62.0",
     "@supabase/supabase-js": "^2.110.0",
     "bcryptjs": "^3.0.3",
+    "ioredis": "^5.11.1",
     "jose": "^6.2.3",
     "lucide-react": "^1.22.0",
     "next": "^16.2.9",

--- a/src/app/api/admin/orgs/[id]/entitlement-override/route.ts
+++ b/src/app/api/admin/orgs/[id]/entitlement-override/route.ts
@@ -1,5 +1,6 @@
 import { sql } from "@/lib/db";
 import { requireSuperadmin, logStaffAction } from "@/lib/admin";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
 import { handler, HttpError } from "@/lib/http";
 import { z } from "zod";
 
@@ -31,6 +32,7 @@ export async function POST(
         int_value  = excluded.int_value,
         reason     = excluded.reason`;
 
+    await invalidateOrgEntitlements(id);
     await logStaffAction(staff.id, "entitlement_override", "entitlement", id, {
       feature_key, bool_value, int_value, reason,
     });
@@ -52,6 +54,7 @@ export async function DELETE(
       delete from org_entitlement_overrides
       where org_id = ${id} and feature_key = ${feature_key}`;
 
+    await invalidateOrgEntitlements(id);
     await logStaffAction(staff.id, "entitlement_override_removed", "entitlement", id, { feature_key });
     return { ok: true };
   });

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -3,6 +3,7 @@ import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
 import { syncSubscription } from "@/lib/billing";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
 
 // ---------------------------------------------------------------------------
 // Event handlers
@@ -26,6 +27,7 @@ async function handleSubscriptionChanged(stripeSub: Stripe.Subscription) {
   const orgId = stripeSub.metadata?.org_id;
   if (!orgId) return;
   await syncSubscription(orgId, stripeSub);
+  await invalidateOrgEntitlements(orgId);
 }
 
 async function handleSubscriptionDeleted(stripeSub: Stripe.Subscription) {
@@ -35,6 +37,7 @@ async function handleSubscriptionDeleted(stripeSub: Stripe.Subscription) {
     update subscriptions
     set plan_key = 'community', status = 'canceled', updated_at = now()
     where org_id = ${orgId}`;
+  await invalidateOrgEntitlements(orgId);
 }
 
 /** In Stripe v22 the subscription ref moved to invoice.parent.subscription_details.subscription */

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,97 @@
+import "server-only";
+import Redis from "ioredis";
+
+/**
+ * Redis (Upstash) client + cache-aside helpers (doc 02 §5.3, doc 05 §8).
+ *
+ * Everything here is **fail-open**: if REDIS_URL is unset or Redis is
+ * unreachable, cache reads miss and writes no-op, so the app falls back to
+ * Postgres. Redis is a latency optimisation, never a correctness dependency.
+ */
+const globalForRedis = globalThis as unknown as { _redis?: Redis | null };
+
+function client(): Redis | null {
+  if (globalForRedis._redis !== undefined) return globalForRedis._redis;
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    globalForRedis._redis = null;
+    return null;
+  }
+  const redis = new Redis(url, {
+    lazyConnect: false,
+    maxRetriesPerRequest: 1,
+    enableOfflineQueue: false,
+    // Don't let a Redis outage crash the process; we fail open per call.
+    retryStrategy: (times) => Math.min(times * 200, 2000),
+  });
+  redis.on("error", () => {
+    /* swallow — callers handle null/misses */
+  });
+  globalForRedis._redis = redis;
+  return redis;
+}
+
+/** True when a Redis URL is configured (cache is active). */
+export function cacheEnabled(): boolean {
+  return Boolean(process.env.REDIS_URL);
+}
+
+/** Get + JSON-parse a cached value, or null on miss/error. */
+export async function cacheGet<T>(key: string): Promise<T | null> {
+  const c = client();
+  if (!c) return null;
+  try {
+    const raw = await c.get(key);
+    return raw ? (JSON.parse(raw) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** JSON-serialise + set with a TTL (seconds). No-op on error. */
+export async function cacheSet(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+  const c = client();
+  if (!c) return;
+  try {
+    await c.set(key, JSON.stringify(value), "EX", ttlSeconds);
+  } catch {
+    /* fail open */
+  }
+}
+
+/** Delete keys matching a glob pattern (e.g. "ent:{org}:*"). No-op on error. */
+export async function cacheDelPattern(pattern: string): Promise<void> {
+  const c = client();
+  if (!c) return;
+  try {
+    const stream = c.scanStream({ match: pattern, count: 100 });
+    const pipeline = c.pipeline();
+    let any = false;
+    for await (const keys of stream as AsyncIterable<string[]>) {
+      for (const k of keys) {
+        pipeline.del(k);
+        any = true;
+      }
+    }
+    if (any) await pipeline.exec();
+  } catch {
+    /* fail open */
+  }
+}
+
+/**
+ * Fixed-window counter. Returns the new count for `key` within the window, or
+ * null if Redis is unavailable (caller should fall back). Sets the TTL on the
+ * first increment of a window.
+ */
+export async function incrWindow(key: string, windowSeconds: number): Promise<number | null> {
+  const c = client();
+  if (!c) return null;
+  try {
+    const n = await c.incr(key);
+    if (n === 1) await c.expire(key, windowSeconds);
+    return n;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,16 +1,40 @@
 import { sql } from "@/lib/db";
 import { PaymentRequiredError } from "@/lib/errors";
+import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
 
 export { PaymentRequiredError } from "@/lib/errors";
 
 type Resolved = { bool_value: boolean | null; int_value: number | null };
 
+// Resolved entitlements change only on subscription / override writes, so they
+// cache well. Short TTL bounds staleness even if an invalidation is missed.
+const ENT_TTL_SECONDS = 300;
+const entKey = (orgId: string, featureKey: string) => `ent:${orgId}:${featureKey}`;
+
 /**
- * Resolve a single entitlement for an org.
+ * Drop all cached entitlements for an org. Call after any subscription or
+ * entitlement-override change (Stripe webhook, admin override).
+ */
+export async function invalidateOrgEntitlements(orgId: string): Promise<void> {
+  await cacheDelPattern(`ent:${orgId}:*`);
+}
+
+/**
+ * Resolve a single entitlement for an org (cache-aside).
  * Priority: org_entitlement_overrides → plan_entitlements → null (deny).
  * Falls back to 'community' plan when no subscription row exists.
  */
 async function resolve(orgId: string, featureKey: string): Promise<Resolved | null> {
+  const cached = await cacheGet<Resolved | null>(entKey(orgId, featureKey));
+  if (cached !== null) return cached;
+
+  const fresh = await resolveFromDb(orgId, featureKey);
+  // Cache the resolved value (including a "deny" null, stored as JSON null).
+  await cacheSet(entKey(orgId, featureKey), fresh, ENT_TTL_SECONDS);
+  return fresh;
+}
+
+async function resolveFromDb(orgId: string, featureKey: string): Promise<Resolved | null> {
   const [ov] = await sql<Resolved[]>`
     select bool_value, int_value
     from org_entitlement_overrides

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { sql } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
+import { incrWindow } from "@/lib/cache";
 
 export interface RateLimitConfig {
   /** Max requests allowed within `windowSeconds`. */
@@ -24,6 +25,16 @@ export async function rateLimit(
   key: string,
   { max, windowSeconds }: RateLimitConfig,
 ): Promise<void> {
+  // Prefer Redis (single INCR + EXPIRE, no DB contention). incrWindow returns
+  // null when Redis is unavailable, so we fall back to the Postgres bucket.
+  const redisCount = await incrWindow(`rl:${key}`, windowSeconds);
+  if (redisCount !== null) {
+    if (redisCount > max) {
+      throw new HttpError(429, "Too many requests — slow down and try again.");
+    }
+    return;
+  }
+
   const now = new Date();
   const windowStart = new Date(
     Math.floor(now.getTime() / (windowSeconds * 1000)) * (windowSeconds * 1000),


### PR DESCRIPTION
Doc 02 §5.3 / doc 05 §8.

- `src/lib/cache.ts` — ioredis client, **fail-open**: no-op when `REDIS_URL` is unset or Redis is unreachable, so the app always falls back to Postgres. Redis is a latency optimisation, never a correctness dependency.
- **Entitlements cache-aside**: `ent:{org}:{feature}` (300s TTL), invalidated on subscription change (Stripe webhook `subscription.updated`/`deleted`) and on admin entitlement overrides.
- **Rate limiting**: Redis fixed-window (`INCR`+`EXPIRE`) when available, else the existing Postgres bucket.

`tsc --noEmit` clean. Requires `REDIS_URL` set as a Fly secret (staged on stg + prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)