### PR TITLE
fix(audit): core sha256 + baseline (011 works on Supabase)

### DIFF
--- a/supabase/migrations/011_audit_hash_chain.sql
+++ b/supabase/migrations/011_audit_hash_chain.sql
@@ -13,8 +13,6 @@
 -- table for the tip regardless of the caller's RLS. Idempotent.
 -- =============================================================================
 
-create extension if not exists pgcrypto;
-
 alter table audit_log        add column if not exists prev_hash text;
 alter table audit_log        add column if not exists row_hash  text;
 alter table audit_log        add column if not exists chain_seq bigint;
@@ -28,10 +26,11 @@ create sequence if not exists staff_audit_log_chain_seq;
 create index if not exists audit_log_chain_idx       on audit_log(chain_seq);
 create index if not exists staff_audit_log_chain_idx on staff_audit_log(chain_seq);
 
--- Canonical hash input for a row.
+-- Canonical hash input for a row. Uses the core sha256(bytea) function (no
+-- pgcrypto extension — avoids Supabase's extensions-schema search_path issue).
 create or replace function audit_row_hash(prev text, canonical text) returns text
   language sql immutable as $$
-    select encode(digest(coalesce(prev, '') || '|' || canonical, 'sha256'), 'hex')
+    select encode(sha256(convert_to(coalesce(prev, '') || '|' || canonical, 'utf8')), 'hex')
   $$;
 
 -- audit_log chain
@@ -78,6 +77,38 @@ create trigger trg_zhash before insert on audit_log
 drop trigger if exists trg_zhash on staff_audit_log;
 create trigger trg_zhash before insert on staff_audit_log
   for each row execute function staff_audit_log_hash_chain();
+
+-- Baseline: deterministically (re)build the chain over ALL existing rows in
+-- created_at order. This gives rows that predate the migration a valid hash so
+-- verification passes going forward. No-op on a fresh DB (no rows), and
+-- deterministic so re-running the migration reproduces the same chain.
+do $$
+declare r record; prev text; cs bigint; canonical text;
+begin
+  prev := null; cs := 0;
+  for r in select * from audit_log order by created_at, id loop
+    cs := cs + 1;
+    canonical := concat_ws('|',
+      r.id::text, coalesce(r.tournament_id::text, ''), coalesce(r.actor, ''),
+      r.action, r.summary, coalesce(r.detail::text, ''), r.created_at::text);
+    update audit_log set chain_seq = cs, prev_hash = prev,
+      row_hash = audit_row_hash(prev, canonical) where id = r.id;
+    prev := audit_row_hash(prev, canonical);
+  end loop;
+  if cs > 0 then perform setval('audit_log_chain_seq', cs); end if;
+
+  prev := null; cs := 0;
+  for r in select * from staff_audit_log order by created_at, id loop
+    cs := cs + 1;
+    canonical := concat_ws('|',
+      r.id::text, r.actor_id::text, r.action, r.target_type, r.target_id,
+      coalesce(r.detail::text, ''), r.created_at::text);
+    update staff_audit_log set chain_seq = cs, prev_hash = prev,
+      row_hash = audit_row_hash(prev, canonical) where id = r.id;
+    prev := audit_row_hash(prev, canonical);
+  end loop;
+  if cs > 0 then perform setval('staff_audit_log_chain_seq', cs); end if;
+end $$;
 
 -- Verifiers: return the id of the first row (in chain order) whose recomputed
 -- hash or prev-link doesn't match; null = chain intact.


### PR DESCRIPTION
The merged migration 011 hashed via pgcrypto `digest()` — works in CI's Postgres but fails on Supabase (pgcrypto in the `extensions` schema, outside the function search_path), so audit triggers/verifiers errored at runtime and would break staff-audit inserts.

- Switch to core `sha256(bytea)` (no extension).
- Deterministically baseline the chain over pre-existing rows so verification passes from the migration point.

Applied + verified on the staging DB: both `verify_*_chain()` return null (intact), players fully backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)