### PR TITLE
fix(web): repair ESLint for Next 16 flat config; clean unused vars

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,10 +1,28 @@
-import { FlatCompat } from "@eslint/eslintrc";
+// Next 16: `next lint` is removed and eslint-config-next ships flat configs —
+// import them directly; FlatCompat over "next/*" shareable configs breaks
+// (see node_modules/next/dist/docs/01-app/03-api-reference/05-config/03-eslint.md).
+import { defineConfig, globalIgnores } from "eslint/config";
+import nextVitals from "eslint-config-next/core-web-vitals";
+import nextTs from "eslint-config-next/typescript";
 
-const compat = new FlatCompat({ baseDirectory: import.meta.dirname });
-
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-  { ignores: [".next/**", "out/**", "build/**", "next-env.d.ts"] },
-];
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+  {
+    rules: {
+      // Legal/marketing pages are prose-heavy; escaping every apostrophe hurts
+      // readability more than it helps.
+      "react/no-unescaped-entities": "off",
+      // React-Compiler-era rules (new defaults in eslint-config-next 16).
+      // Existing components predate them; kept visible as warnings until the
+      // refactor tracked in development/DEFERRED.md.
+      "react-hooks/set-state-in-effect": "warn",
+      "react-hooks/purity": "warn",
+      "react-hooks/static-components": "warn",
+    },
+  },
+  // Override default ignores of eslint-config-next.
+  globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
+]);
 
 export default eslintConfig;

--- a/apps/web/src/app/admin/orgs/[id]/page.tsx
+++ b/apps/web/src/app/admin/orgs/[id]/page.tsx
@@ -87,7 +87,6 @@ export default async function AdminOrgPage({
           <AdminOrgActions
             orgId={id}
             currentStatus={org.status}
-            currentPlan={sub?.plan_key ?? "community"}
           />
         </div>
       </div>

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { getCurrentUser, getUserOrgs, getActiveOrgId } from "@/lib/auth";
+import { getCurrentUser, getUserOrgs } from "@/lib/auth";
 import { sql } from "@/lib/db";
 import { Nav } from "@/components/nav";
 import {
@@ -23,7 +23,6 @@ export default async function AccountSettingsPage({ searchParams }: PageProps) {
   const { email_change } = await searchParams;
 
   const orgs = await getUserOrgs(user.id);
-  const activeId = await getActiveOrgId();
 
   // Load members for each org where user is owner (for transfer-owner UI)
   const orgMembersMap = new Map<string, OrgMember[]>();

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import {
   Building2, Sliders, Users, CreditCard, UserCircle,
   Pencil, Image as ImageIcon, ArrowLeftRight, Zap, BarChart2,
-  TrendingUp, User, Mail, Download, AlertTriangle, ShieldOff,
+  TrendingUp, User, Mail, Download, ShieldOff,
   type LucideIcon,
 } from "lucide-react";
 import { getActiveOrgId, getCurrentUser, getUserOrgs, requireOrgRole } from "@/lib/auth";

--- a/apps/web/src/components/admin-org-actions.tsx
+++ b/apps/web/src/components/admin-org-actions.tsx
@@ -6,11 +6,9 @@ import { useRouter } from "next/navigation";
 export function AdminOrgActions({
   orgId,
   currentStatus,
-  currentPlan,
 }: {
   orgId: string;
   currentStatus: string;
-  currentPlan: string;
 }) {
   const router = useRouter();
   const [loading, setLoading] = useState<string | null>(null);

--- a/apps/web/src/components/public-tournament-view.tsx
+++ b/apps/web/src/components/public-tournament-view.tsx
@@ -9,7 +9,7 @@ import {
   sortedGroupRounds,
   sortedKoRounds,
 } from "@/lib/format";
-import type { Match, Player, StandingRow, TournamentState } from "@/lib/types";
+import type { Match, Player, TournamentState } from "@/lib/types";
 
 const STATUS_STYLE: Record<string, string> = {
   setup: "bg-slate-100 text-slate-600",

--- a/apps/web/src/lib/__tests__/engine-adapter.test.ts
+++ b/apps/web/src/lib/__tests__/engine-adapter.test.ts
@@ -9,7 +9,6 @@ import {
   standings,
   champion,
   type EngineConfig,
-  type EngineState,
   type EngineDiff,
 } from "../engine";
 import type { Match, Player, Round, Tournament } from "../types";

--- a/apps/web/src/lib/__tests__/smoke.test.ts
+++ b/apps/web/src/lib/__tests__/smoke.test.ts
@@ -4,16 +4,12 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { z } from "zod";
 import {
   createTournamentSchema,
   loginSchema,
-  signupSchema,
   createOrgSchema,
   createInviteSchema,
   recordResultSchema,
-  setCheckInSchema,
-  addPlayersSchema,
   checkoutSchema,
 } from "@/lib/types";
 import { computeStandings } from "@/lib/standings";

--- a/apps/web/src/lib/supabase-storage.ts
+++ b/apps/web/src/lib/supabase-storage.ts
@@ -10,7 +10,6 @@ const ASSETS_BUCKET = "assets";
  */
 export async function getSignedUploadUrl(
   storagePath: string,
-  expiresIn = 300,
 ): Promise<{ url: string; token: string }> {
   const sb = supabaseAdmin();
   const { data, error } = await sb.storage

--- a/development/DEFERRED.md
+++ b/development/DEFERRED.md
@@ -51,6 +51,19 @@ cache + Redis rate limiting there.
 Switch to a filesystem scan (gitleaks CLI, no GitHub API) with an allowlist for publishable
 keys (Stripe `pk_`, Supabase anon), then make it block again.
 
+## React hooks lint warnings — refactor flagged components
+**Status:** downgraded to warnings in `apps/web/eslint.config.mjs`.
+
+`eslint-config-next` 16 enables React-Compiler-era rules that flag existing components:
+- `react-hooks/set-state-in-effect` (6×): `client-time`, `cookie-consent`,
+  `new-tournament-form`, `org-team`, `slideshow-view`, `verify-email` — mostly
+  mount-time/client-only state patterns; refactor per
+  https://react.dev/learn/you-might-not-need-an-effect.
+- `react-hooks/static-components` (1×): `org-sport-presets` creates `Icon` during render.
+- `react-hooks/purity` (1×): `org-team` calls `Date.now()` during render.
+
+Fix the components, then raise the three rules back to `error`.
+
 ## Other larger tracks still open (docs 06–15)
 - Observability: OpenTelemetry traces, structured-log sink, status page (doc 07).
 - Backups/PITR + tested restore drills, runbooks, SLAs (doc 07).


### PR DESCRIPTION
Root `npm run lint` has been failing since the Next 16 upgrade — surfaced while landing PROMPT-02 (#18).

## Cause

Next 16 removed `next lint`, and `eslint-config-next` 16 ships **native flat configs**. The old `FlatCompat.extends("next/core-web-vitals", "next/typescript")` path crashes inside `@eslint/eslintrc` ("Converting circular structure to JSON" — the flat config's plugin objects are circular under the legacy validator).

## Fix

- `eslint.config.mjs`: import `eslint-config-next/core-web-vitals` and `eslint-config-next/typescript` directly with `defineConfig`, per the bundled Next 16 guide (`node_modules/next/dist/docs/.../03-eslint.md`). Same ignores as before.

With lint actually running, 30 pre-existing errors surfaced. Handled:

- **`react/no-unescaped-entities` → off** — all 22 hits are prose apostrophes/quotes in legal & marketing pages; the Next docs themselves show disabling this rule.
- **`react-hooks/set-state-in-effect`, `react-hooks/purity`, `react-hooks/static-components` → warn** — React-Compiler-era rules newly enabled by eslint-config-next 16; they flag 8 pre-existing components. Refactor tracked in `development/DEFERRED.md`; raise back to `error` once fixed.
- **All 10 `@typescript-eslint/no-unused-vars` fixed properly**: dead imports/locals removed; dropped the unused `currentPlan` prop from `AdminOrgActions` (caller updated) and the unused `expiresIn` param from `getSignedUploadUrl` (Supabase's `createSignedUploadUrl` takes no TTL; no caller passed it).

## Verification

- `npm run lint` exits 0 — 0 errors, 8 tracked warnings
- `tsc --noEmit` clean
- 587 web tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)