### PR TITLE
feat(engine): football & cricket sport modules (PROMPT-04, PROMPT-05)

### DIFF
--- a/engine/04-sport-scoring-specs.md
+++ b/engine/04-sport-scoring-specs.md
@@ -20,8 +20,10 @@ metrics the sport contributes.
 { halfMinutes: 45, halves: 2,
   extraTime: { enabled: boolean, halfMinutes: 15 },   // knockout only
   shootout: boolean,                                   // knockout only
-  points: { win: 3, draw: 1, loss: 0 },
+  points: { win: 3, draw: 1, loss: 0,
+            shootoutWin?, shootoutLoss? },             // §1.4 optional group-stage SO split
   awardScore: { goals: 3 },                            // forfeit award, "3–0"
+  abandonPolicy: 'replay' | 'award',                   // §8; 'replay' ⇒ no outcome, fixture flagged
   fairPlay: boolean }                                  // track cards for FIFA fair-play TB
 ```
 Variants: `11-a-side`, `youth {halfMinutes: 30..40}`, `small-sided {halfMinutes: 20, halves: 2}`.
@@ -88,7 +90,10 @@ ball { over, ballInOver, striker, nonStriker, bowler,
        wicket?: { kind: bowled|caught|lbw|runout|stumped|hitwicket|retired|obstructed|timedout,
                   out: personId, fielder?, bowlerCredited: boolean },
        boundary?: 4|6, freeHit?: boolean }
+toss { wonBy, elected: bat|bowl }         // pre phase; sets who bats first (see sports/cricket.md §3)
 innings.declare {} · innings.close {}     // all-out and balls-exhausted close automatically
+match.close {}                            // two-innings time expiry ⇒ draw
+followon {}                               // enforce follow-on between 2nd and 3rd innings (2-innings)
 interruption { kind: rain|light|other, oversLostEstimate? }
 revise { oversPerSide?, target? }         // umpire/DLS revision applied as an event
 superover.ball { ... }                    // same ball grammar, separate mini-innings
@@ -101,9 +106,15 @@ runs and over-end swap.
 **Design note — two scoring fidelities.** Ball-by-ball is heavy for casual organisers.
 Module accepts *either* granularity:
 - `cricket.ball` events (full scorecard, Pro-tier live experience), or
-- `innings.summary {runs, wickets, legalBalls}` coarse events (community tier).
+- `innings.summary {runs, wickets, legalBalls, declared?, boundaries?, partial?}` coarse
+  events (community tier). `partial: true` = an in-progress snapshot that grows an open
+  innings (progressive coarse scoring + mid-innings DLS); `boundaries?` feeds the
+  boundary-count super-over tiebreak at coarse fidelity.
 Both fold to the same `InningsTotals` shape all downstream math (result, NRR, DLS) reads.
 This is the single most important cricket design decision — do not skip it.
+Tier-2 (doc 14 §1): `cricket.player.line {innings, person, batting?, bowling?}` post-match
+scorecard lines, validated for sum-consistency against `InningsTotals` (mismatched cards
+rejected with a field-level diff).
 
 ### 2.3 Result determination (single-innings-per-side)
 Team B chasing: B > A runs ⇒ B wins (`by W wickets`); B all out / balls out with B < A ⇒

--- a/engine/sports/cricket.md
+++ b/engine/sports/cricket.md
@@ -31,14 +31,18 @@ over end), bowler constraints (no consecutive overs, `maxOversPerBowler`), all-o
 
 ## 3. Match state machine (white-ball, 1 innings/side)
 ```
-pre → toss(core.start payload: {tossWinner, elected}) → innings1 → break → innings2(target = i1.runs+1)
+pre → cricket.toss {wonBy, elected} → core.start → innings1 → break → innings2(target = i1.runs+1)
   chase resolved live: runs > target−1 ⇒ win by (10−wickets) wickets
                        all out / balls out below target−1 ⇒ win by (target−1−runs) runs
                        exactly target−1 at close ⇒ TIE → superover? → outcome
 interruption/revise events may shrink oversPerSide or set a DLS target at any point
-abandon below cfg.minOversForResult ⇒ no_result
+abandon below cfg.minOversForResult ⇒ no_result (or DLS par decision, method 'dls')
 ```
-Two-innings (test) adds: follow-on decision, declarations, innings sequencing, **draw**
+**Impl note (PROMPT-05):** the toss is a dedicated `cricket.toss {wonBy, elected}` event
+recorded in the `pre` phase, *not* a `core.start` payload — the kernel's `core.start`
+schema is `strictObject({})` (spec 03 §2) and carries no sport data. Two-innings (test)
+adds: follow-on decision (`cricket.followon`), declarations (`cricket.innings.declare`),
+time-expiry **draw** (`cricket.match.close`), innings sequencing, **draw**
 on time expiry, innings-victory margins.
 
 ### Super over

--- a/engine/sports/football.md
+++ b/engine/sports/football.md
@@ -59,10 +59,12 @@ small-sided `{7v7, lineup.size: 7}` — lineup size is Cfg, catalog adapts (`lin
 parameterised). Never a separate module.
 
 ## 8. Abandonment/forfeit policy
-`core.forfeit` → `award` with cfg.awardScore (3-0). `core.abandon` → cfg:
-`replay` (fixture flagged `cancelled`, regenerated as new fixture) | `award` | `stand`
-(result stands if ≥ cfg.minMinutesForResult). League withdrawal: 05 §5 policies apply
-(expunge <50% played, else award remaining).
+`core.forfeit` → `award` with cfg.awardScore (3-0). `core.abandon` → `cfg.abandonPolicy`:
+`replay` (default — no outcome, fixture flagged for regeneration, `finalize` refused while
+undecided) | `award` (decide for the current leader; level score ⇒ `no_result`). The
+`stand` policy (result stands if ≥ cfg.minMinutesForResult) is reserved for a later prompt
+— not yet in the module Cfg. League withdrawal: 05 §5 policies apply (expunge <50% played,
+else award remaining).
 
 ## 9. Edge cases checklist
 - Own goal in shootout: not a thing — reject `ownGoal` in SHOOTOUT phase.

--- a/packages/engine/src/sports/cricket/cricket.test.ts
+++ b/packages/engine/src/sports/cricket/cricket.test.ts
@@ -1,0 +1,778 @@
+// Cricket goldens + properties + conformance — spec 04 §2, PROMPT-05 §8/§9.
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { foldMatch, type CoreEv, type EventEnvelope } from "../../core/events.ts";
+import { shuffle } from "../../core/rng.ts";
+import type { LineupPair, StageCtx, StandingsDelta } from "../../core/types.ts";
+import { buildStream, conformanceSuite, makeEnvelope } from "../../testkit/index.ts";
+import { cricket, type CricketBallEv, type CricketCfg, type CricketEv } from "./cricket.ts";
+import { dlsTarget, resources } from "./dls.ts";
+
+// Eleven per side; batting order = orderNo (spec §2.7).
+function lineup(prefix: string): LineupPair["home"] {
+  return {
+    entrantId: prefix,
+    slots: Array.from({ length: 11 }, (_, i) => ({
+      personId: `${prefix}-${i + 1}`,
+      slot: "starting" as const,
+      orderNo: i + 1,
+      ...(i === 0 ? { roles: ["captain"] } : i === 1 ? { roles: ["wicketkeeper"] } : {}),
+    })),
+  };
+}
+const lineups: LineupPair = { home: lineup("H"), away: lineup("A") };
+const league: StageCtx = { kind: "league" };
+
+const t20: CricketCfg = cricket.configSchema.parse(
+  cricket.variants.t20 as Record<string, unknown>,
+);
+const fold = (cfg: CricketCfg, events: EventEnvelope[]) => foldMatch(cricket, cfg, lineups, events);
+
+function stream(...specs: Array<[type: string, payload?: unknown]>): EventEnvelope[] {
+  return specs.map(([type, payload], i) => makeEnvelope(i, { type, payload: payload ?? {} }));
+}
+
+// Compact ball notation for hand-written goldens.
+interface BallSpec {
+  striker: string;
+  nonStriker: string;
+  bowler: string;
+  bat?: number;
+  extras?: { kind: "wide" | "noball" | "bye" | "legbye" | "penalty"; runs: number };
+  wicket?: CricketBallEv["wicket"];
+  boundary?: 4 | 6;
+  freeHit?: boolean;
+}
+
+// Expands specs into cricket.ball payloads, deriving over/ballInOver the way
+// the fold expects them (wides/no-balls repeat the ball number).
+function balls(type: string, specs: BallSpec[], bpo = 6): Array<[string, CricketBallEv]> {
+  let legal = 0;
+  return specs.map((spec) => {
+    const payload: CricketBallEv = {
+      over: Math.floor(legal / bpo),
+      ballInOver: (legal % bpo) + 1,
+      striker: spec.striker,
+      nonStriker: spec.nonStriker,
+      bowler: spec.bowler,
+      runs: { bat: spec.bat ?? 0, ...(spec.extras ? { extras: spec.extras } : {}) },
+      ...(spec.wicket ? { wicket: spec.wicket } : {}),
+      ...(spec.boundary ? { boundary: spec.boundary } : {}),
+      ...(spec.freeHit ? { freeHit: true } : {}),
+    };
+    const isIllegal = spec.extras?.kind === "wide" || spec.extras?.kind === "noball";
+    if (!isIllegal) legal++;
+    return [type, payload];
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fine-fidelity golden — hand-scored 2-over-a-side match exercising the ball
+// grammar: extras, free hit, wickets, striker rotation, bowler figures.
+// ---------------------------------------------------------------------------
+
+describe("cricket golden: ball-by-ball mini match (fine fidelity)", () => {
+  const mini = cricket.configSchema.parse({
+    ballsPerInnings: 12,
+    maxOversPerBowler: 1,
+    minOversForResult: 2,
+  });
+  const inningsOne = balls("cricket.ball", [
+    { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 4, boundary: 4 },
+    { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 1 },
+    { striker: "H-2", nonStriker: "H-1", bowler: "A-11", extras: { kind: "wide", runs: 1 } },
+    { striker: "H-2", nonStriker: "H-1", bowler: "A-11", bat: 6, boundary: 6 },
+    {
+      striker: "H-2",
+      nonStriker: "H-1",
+      bowler: "A-11",
+      wicket: { kind: "bowled", out: "H-2", bowlerCredited: true },
+    },
+    { striker: "H-3", nonStriker: "H-1", bowler: "A-11", bat: 2 },
+    { striker: "H-3", nonStriker: "H-1", bowler: "A-11", bat: 1 }, // over end
+    { striker: "H-3", nonStriker: "H-1", bowler: "A-10", bat: 2, extras: { kind: "noball", runs: 1 } },
+    {
+      striker: "H-3",
+      nonStriker: "H-1",
+      bowler: "A-10",
+      bat: 1,
+      wicket: { kind: "runout", out: "H-1", bowlerCredited: false },
+      freeHit: true,
+    },
+    { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 0 },
+    { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 2 },
+    { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 0 },
+    { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 1 }, // odd → H-4 on strike
+    { striker: "H-4", nonStriker: "H-3", bowler: "A-10", bat: 0 }, // balls exhausted → 22/2
+  ]);
+  const inningsTwo = balls("cricket.ball", [
+    { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 6, boundary: 6 },
+    { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 4, boundary: 4 },
+    { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 0 },
+    { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 1 },
+    { striker: "A-2", nonStriker: "A-1", bowler: "H-11", extras: { kind: "legbye", runs: 2 } },
+    { striker: "A-2", nonStriker: "A-1", bowler: "H-11", bat: 0 }, // over end
+    { striker: "A-1", nonStriker: "A-2", bowler: "H-10", bat: 2 },
+    { striker: "A-1", nonStriker: "A-2", bowler: "H-10", bat: 4, boundary: 4 },
+    {
+      striker: "A-1",
+      nonStriker: "A-2",
+      bowler: "H-10",
+      wicket: { kind: "caught", out: "A-1", bowlerCredited: true },
+    },
+    { striker: "A-3", nonStriker: "A-2", bowler: "H-10", bat: 1 },
+    { striker: "A-2", nonStriker: "A-3", bowler: "H-10", bat: 0 },
+    { striker: "A-2", nonStriker: "A-3", bowler: "H-10", bat: 0 }, // 20/1 — H wins by 2
+  ]);
+  const events = stream(["core.start"], ...inningsOne, ...inningsTwo);
+
+  it("folds totals, rotation and figures to the hand-scored card", () => {
+    const state = fold(mini, events);
+    expect(state.innings[0]).toMatchObject({ runs: 22, wickets: 2, legalBalls: 12, boundaries: 2 });
+    expect(state.innings[1]).toMatchObject({ runs: 20, wickets: 1, legalBalls: 12, boundaries: 3 });
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "H", method: "regulation" });
+    expect(state.margin).toBe("by 2 runs");
+    const fine = state.innings[0]!.fine!;
+    expect(fine.batterRuns).toMatchObject({ "H-1": 5, "H-2": 6, "H-3": 9, "H-4": 0 });
+    expect(fine.batterBalls).toMatchObject({ "H-1": 2, "H-2": 2, "H-3": 8, "H-4": 1 });
+    expect(fine.bowlerBalls).toMatchObject({ "A-11": 6, "A-10": 6 });
+    expect(fine.bowlerRuns).toMatchObject({ "A-11": 15, "A-10": 7 });
+    expect(fine.bowlerWickets).toMatchObject({ "A-11": 1 });
+    expect(fine.extras).toBe(2);
+  });
+
+  it("summary reads only InningsTotals (spec §2.2)", () => {
+    const state = fold(mini, events);
+    expect(cricket.summary(state).headline).toBe("22/2 (2) — 20/1 (2)");
+  });
+
+  it("§2.2 dual fidelity: coarsen(ballEvents) folds to the identical match", () => {
+    const coarse = cricket
+      .coarsen!(events as EventEnvelope<CricketEv | CoreEv>[])
+      .map((event, i) => makeEnvelope(i, event));
+    const fineState = fold(mini, events);
+    const coarseState = fold(mini, coarse);
+    expect(cricket.outcome(coarseState)).toEqual(cricket.outcome(fineState));
+    expect(cricket.summary(coarseState)).toEqual(cricket.summary(fineState));
+  });
+
+  it("enforces ball legality: counters, consecutive overs, quotas, wides", () => {
+    const start = stream(["core.start"]);
+    const bad = (payload: Partial<CricketBallEv>) =>
+      fold(mini, [
+        ...start,
+        makeEnvelope(1, {
+          type: "cricket.ball",
+          payload: {
+            over: 0,
+            ballInOver: 1,
+            striker: "H-1",
+            nonStriker: "H-2",
+            bowler: "A-11",
+            runs: { bat: 0 },
+            ...payload,
+          },
+        }),
+      ]);
+    expect(() => bad({ ballInOver: 2 })).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    expect(() => bad({ striker: "H-3" })).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    expect(() =>
+      bad({ runs: { bat: 1, extras: { kind: "wide", runs: 1 } } }),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_EVENT" }));
+    expect(() => bad({ freeHit: true })).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+
+    // Consecutive overs: A-11 bowled over 0, may not bowl over 1.
+    const overByEleven = balls("cricket.ball", [
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11" },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11" },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11" },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11" },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11" },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11" },
+    ]);
+    const consecutive = [
+      ...stream(["core.start"], ...overByEleven),
+      makeEnvelope(7, {
+        type: "cricket.ball",
+        payload: {
+          over: 1,
+          ballInOver: 1,
+          striker: "H-2",
+          nonStriker: "H-1",
+          bowler: "A-11",
+          runs: { bat: 0 },
+        },
+      }),
+    ];
+    expect(() => fold(mini, consecutive)).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    // …and the free-hit dismissal restriction (only the run-out family).
+    const freeHitWicket = [
+      ...stream(
+        ["core.start"],
+        ...balls("cricket.ball", [
+          { striker: "H-1", nonStriker: "H-2", bowler: "A-11", extras: { kind: "noball", runs: 1 } },
+        ]),
+      ),
+      makeEnvelope(2, {
+        type: "cricket.ball",
+        payload: {
+          over: 0,
+          ballInOver: 1,
+          striker: "H-1",
+          nonStriker: "H-2",
+          bowler: "A-11",
+          runs: { bat: 0 },
+          wicket: { kind: "bowled", out: "H-1", bowlerCredited: true },
+          freeHit: true,
+        },
+      }),
+    ];
+    expect(() => fold(mini, freeHitWicket)).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+  });
+
+  // doc 14 §1 Tier 2 — player lines validate against the fine-derived card.
+  it("accepts matching player lines and rejects mismatches with a diff", () => {
+    const withLine = (payload: unknown) =>
+      fold(mini, [...events, makeEnvelope(events.length, { type: "cricket.player.line", payload })]);
+    const ok = withLine({
+      innings: 1,
+      person: "H-3",
+      batting: { runs: 9, balls: 8 },
+    });
+    expect(ok.playerLines).toHaveLength(1);
+    expect(
+      withLine({ innings: 1, person: "A-11", bowling: { legalBalls: 6, runs: 15, wickets: 1 } })
+        .playerLines,
+    ).toHaveLength(1);
+    try {
+      withLine({ innings: 1, person: "H-3", batting: { runs: 10, balls: 8 } });
+      expect.unreachable("mismatched card must be rejected");
+    } catch (err) {
+      expect(err).toMatchObject({
+        code: "INVALID_EVENT",
+        data: { field: "batting.runs", expected: 9, got: 10 },
+      });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-05 §8 (a)+(d) — real scorecard: 2019 Cricket World Cup final,
+// Lord's (NZ 241/8; England 241 all out; Super Over 15–15; England won on
+// boundary count 26–17). Sources: ESPNcricinfo match 1144530 scorecard;
+// Wikipedia "2019 Cricket World Cup final". Innings entered at Tier-1
+// summary fidelity; the Super Over ball-by-ball as published. Player ids:
+// A-* = England (A-4 Stokes, A-6 Buttler, A-10 Archer), H-* = New Zealand
+// (H-6 Neesham, H-1 Guptill, H-11 Boult).
+// ---------------------------------------------------------------------------
+
+describe("cricket golden (a): 2019 CWC final — tie, super over, boundary count", () => {
+  const odiKO = cricket.configSchema.parse({
+    ballsPerInnings: 300,
+    maxOversPerBowler: 10,
+    minOversForResult: 20,
+    superOver: true,
+    superOverStillTied: "boundary_count",
+  });
+  // England (A) batted second in the match, so bats first in the super over.
+  const englandSO = balls("cricket.superover.ball", [
+    { striker: "A-4", nonStriker: "A-6", bowler: "H-11", bat: 3 },
+    { striker: "A-6", nonStriker: "A-4", bowler: "H-11", bat: 1 },
+    { striker: "A-4", nonStriker: "A-6", bowler: "H-11", bat: 4, boundary: 4 },
+    { striker: "A-4", nonStriker: "A-6", bowler: "H-11", bat: 1 },
+    { striker: "A-6", nonStriker: "A-4", bowler: "H-11", bat: 2 },
+    { striker: "A-6", nonStriker: "A-4", bowler: "H-11", bat: 4, boundary: 4 },
+  ]);
+  const newZealandSO = balls("cricket.superover.ball", [
+    { striker: "H-6", nonStriker: "H-1", bowler: "A-10", extras: { kind: "wide", runs: 1 } },
+    { striker: "H-6", nonStriker: "H-1", bowler: "A-10", bat: 2 },
+    { striker: "H-6", nonStriker: "H-1", bowler: "A-10", bat: 6, boundary: 6 },
+    { striker: "H-6", nonStriker: "H-1", bowler: "A-10", bat: 2 },
+    { striker: "H-6", nonStriker: "H-1", bowler: "A-10", bat: 2 },
+    { striker: "H-6", nonStriker: "H-1", bowler: "A-10", bat: 1 },
+    {
+      striker: "H-1",
+      nonStriker: "H-6",
+      bowler: "A-10",
+      bat: 1,
+      wicket: { kind: "runout", out: "H-1", bowlerCredited: false },
+    },
+  ]);
+  const events = stream(
+    ["cricket.toss", { wonBy: "H", elected: "bat" }],
+    ["core.start"],
+    ["cricket.innings.summary", { runs: 241, wickets: 8, legalBalls: 300, boundaries: 16 }],
+    ["cricket.innings.summary", { runs: 241, wickets: 10, legalBalls: 300, boundaries: 24 }],
+    ...englandSO,
+    ...newZealandSO,
+  );
+
+  it("replays the published result: England win on boundary count", () => {
+    const state = fold(odiKO, events);
+    expect(state.outcome).toEqual({
+      kind: "win",
+      winner: "A",
+      loser: "H",
+      method: "boundary_count",
+    });
+    expect(state.margin).toBe("on boundary count");
+    const so = state.superOver!;
+    expect(so.innings.map((i) => ({ side: i.battingSide, runs: i.runs }))).toEqual([
+      { side: "away", runs: 15 },
+      { side: "home", runs: 15 },
+    ]);
+  });
+
+  it("keeps the super over out of the NRR ledger (ICC convention)", () => {
+    const state = fold(odiKO, events);
+    const [home, away] = cricket.standingsDelta(state.outcome!, odiKO, league, state);
+    // England all out ⇒ charged the full quota (equal to actual here).
+    expect(away.metrics).toMatchObject({
+      runs_for: 241,
+      balls_faced_eff: 300,
+      runs_against: 241,
+      balls_bowled_eff: 300,
+    });
+    expect([home.points, away.points]).toEqual([0, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-05 §8 (b) — all-out NRR rule (ESPNcricinfo/CricHeroes methodology:
+// a side bowled out is charged its full quota of overs, not balls faced).
+// ---------------------------------------------------------------------------
+
+describe("cricket golden (b): all-out NRR ledger", () => {
+  const events = stream(
+    ["core.start"],
+    ["cricket.innings.summary", { runs: 180, wickets: 4, legalBalls: 120 }],
+    ["cricket.innings.summary", { runs: 150, wickets: 10, legalBalls: 100 }],
+  );
+
+  it("charges the bowled-out side its full 20-over quota", () => {
+    const state = fold(t20, events);
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "H" });
+    expect(state.margin).toBe("by 30 runs");
+    const [home, away] = cricket.standingsDelta(state.outcome!, t20, league, state);
+    expect(home.metrics).toMatchObject({
+      runs_for: 180,
+      balls_faced_eff: 120,
+      runs_against: 150,
+      balls_bowled_eff: 120, // ← not 100: all-out full-quota rule (spec §2.4)
+    });
+    expect(away.metrics).toMatchObject({ runs_for: 150, balls_faced_eff: 120 });
+    // NRR computed from the integer ledger at rank time: 180/20 − 150/20.
+    const nrr =
+      home.metrics.runs_for! / (home.metrics.balls_faced_eff! / 6) -
+      home.metrics.runs_against! / (home.metrics.balls_bowled_eff! / 6);
+    expect(nrr).toBeCloseTo(1.5, 10);
+  });
+
+  // PROMPT-05 acceptance — permuting fixture order never changes the ledger.
+  it("accumulated ledger is permutation-invariant", () => {
+    const fixtures = [
+      [180, 4, 120, 150, 10, 100],
+      [200, 6, 120, 201, 3, 110],
+      [90, 10, 80, 91, 2, 60],
+    ].map(([r1, w1, b1, r2, w2, b2]) =>
+      fold(
+        t20,
+        stream(
+          ["core.start"],
+          ["cricket.innings.summary", { runs: r1, wickets: w1, legalBalls: b1 }],
+          ["cricket.innings.summary", { runs: r2, wickets: w2, legalBalls: b2 }],
+        ),
+      ),
+    );
+    const deltas = fixtures.map(
+      (state) => cricket.standingsDelta(state.outcome!, t20, league, state)[0],
+    );
+    const total = (list: StandingsDelta[]) =>
+      list.reduce(
+        (acc, delta) => {
+          for (const [key, value] of Object.entries(delta.metrics)) {
+            acc[key] = (acc[key] ?? 0) + value;
+          }
+          return acc;
+        },
+        {} as Record<string, number>,
+      );
+    const reference = total(deltas);
+    fc.assert(
+      fc.property(fc.nat(), (seed) => {
+        expect(total(shuffle(seed, deltas))).toEqual(reference);
+      }),
+      { numRuns: 50 },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-05 §8 (c) — DLS Standard Edition vs the published 2002 D/L table
+// (© Duckworth/Lewis, ICC-hosted; engine/11-sources.md). Exact on table values.
+// ---------------------------------------------------------------------------
+
+describe("cricket golden (c): DLS Standard Edition", () => {
+  const odiDls = cricket.configSchema.parse({
+    ballsPerInnings: 300,
+    maxOversPerBowler: 10,
+    minOversForResult: 20,
+    dls: { enabled: true, edition: "standard" },
+  });
+
+  it("reads the published resource table exactly", () => {
+    expect(resources(50, 0)).toBe(100.0);
+    expect(resources(40, 0)).toBe(89.3);
+    expect(resources(25, 0)).toBe(66.5);
+    expect(resources(20, 2)).toBe(52.4);
+    expect(resources(10, 2)).toBe(30.8);
+    expect(resources(18, 3)).toBe(45.9);
+    expect(resources(4, 4)).toBe(13.2);
+    expect(resources(0, 0)).toBe(0);
+  });
+
+  it("computes the reduced-target case (R2 < R1)", () => {
+    // Team 1: 250 in the full 50; rain cuts the chase to 25 overs.
+    // R1 = 100, R2 = 66.5 ⇒ target = ⌊250 × 0.665⌋ + 1 = 167.
+    expect(dlsTarget(250, 100, 66.5)).toBe(167);
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 250, wickets: 5, legalBalls: 300 }],
+      ["cricket.revise", { oversPerSide: 25 }],
+      ["cricket.innings.summary", { runs: 167, wickets: 3, legalBalls: 140 }],
+    );
+    const state = fold(odiDls, events);
+    expect(state.revisedTarget).toBe(167);
+    expect(state.targetSource).toBe("dls");
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "A", method: "dls" });
+    expect(state.margin).toBe("by 7 wickets");
+  });
+
+  it("computes the increased-target case (R2 > R1) with G50", () => {
+    // Team 1 interrupted at 120/2 after 30 of 50 overs, restarted at 40:
+    // R1 = 100 − (res(20,2) − res(10,2)) = 100 − (52.4 − 30.8) = 78.4.
+    // Team 2 gets 40 overs: R2 = 89.3 ⇒ target = ⌊190 + 245×10.9/100⌋ + 1 = 217.
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 120, wickets: 2, legalBalls: 180, partial: true }],
+      ["cricket.interruption", { kind: "rain" }],
+      ["cricket.revise", { oversPerSide: 40 }],
+      ["cricket.innings.summary", { runs: 190, wickets: 6, legalBalls: 240 }],
+      ["cricket.innings.summary", { runs: 0, wickets: 0, legalBalls: 0, partial: true }],
+    );
+    const state = fold(odiDls, events);
+    expect(state.r1).toBeCloseTo(78.4, 9);
+    expect(state.r2).toBeCloseTo(89.3, 9);
+    expect(state.revisedTarget).toBe(217);
+  });
+
+  it("decides an abandoned chase by the DLS par score (method 'dls')", () => {
+    // Continuing the R2>R1 scenario: chase 150/3 after 22 of 40 overs, rain
+    // ends play. Par = ⌊216 × (89.3 − res(18,3))/89.3⌋ = 104 ⇒ win by 46.
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 120, wickets: 2, legalBalls: 180, partial: true }],
+      ["cricket.revise", { oversPerSide: 40 }],
+      ["cricket.innings.summary", { runs: 190, wickets: 6, legalBalls: 240 }],
+      ["cricket.innings.summary", { runs: 150, wickets: 3, legalBalls: 132, partial: true }],
+      ["core.abandon", { reason: "rain" }],
+    );
+    const state = fold(odiDls, events);
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "A", method: "dls" });
+    expect(state.margin).toBe("by 46 runs");
+  });
+
+  it("no_result below the minimum overs; manual umpire target always wins", () => {
+    const washout = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 250, wickets: 5, legalBalls: 300 }],
+      ["cricket.innings.summary", { runs: 40, wickets: 1, legalBalls: 60, partial: true }],
+      ["core.abandon", { reason: "rain" }],
+    );
+    expect(fold(odiDls, washout).outcome).toEqual({ kind: "no_result" });
+
+    const manual = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 250, wickets: 5, legalBalls: 300 }],
+      ["cricket.revise", { oversPerSide: 25, target: 200 }],
+      ["cricket.revise", { oversPerSide: 20 }], // later DLS revise must not override
+    );
+    const state = fold(odiDls, manual);
+    expect(state.revisedTarget).toBe(200);
+    expect(state.targetSource).toBe("manual");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-05 §8 (d) — tied T20 → super over → still-tied policies.
+// ---------------------------------------------------------------------------
+
+describe("cricket golden (d): tied T20 super over policies", () => {
+  const tiedMain = (policy: "repeat" | "boundary_count" | "shared") =>
+    ({
+      cfg: cricket.configSchema.parse({ superOver: true, superOverStillTied: policy }),
+      events: stream(
+        ["core.start"],
+        ["cricket.innings.summary", { runs: 150, wickets: 5, legalBalls: 120, boundaries: 10 }],
+        ["cricket.innings.summary", { runs: 150, wickets: 7, legalBalls: 120, boundaries: 12 }],
+      ),
+    }) as const;
+
+  // Away batted second ⇒ bats first in the super over (ICC).
+  it("boundary_count: more boundaries across match + super over wins", () => {
+    const { cfg, events } = tiedMain("boundary_count");
+    // Both super-over innings score 10 — still tied ⇒ boundaries 13 v 10.
+    const awaySO = balls("cricket.superover.ball", [
+      { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 4, boundary: 4 },
+      { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 1 },
+      { striker: "A-2", nonStriker: "A-1", bowler: "H-11", bat: 1 },
+      { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+      { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 1 },
+      { striker: "A-2", nonStriker: "A-1", bowler: "H-11", bat: 1 },
+    ]);
+    const homeSO = balls("cricket.superover.ball", [
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+      { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 1 },
+      { striker: "H-2", nonStriker: "H-1", bowler: "A-11", bat: 1 },
+    ]);
+    const state = fold(cfg, [...events, ...streamFrom(events.length, [...awaySO, ...homeSO])]);
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "A", method: "boundary_count" });
+  });
+
+  it("repeat: a second super over decides (batting order flips)", () => {
+    const { cfg, events } = tiedMain("repeat");
+    const so1 = [
+      ...balls("cricket.superover.ball", [
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 }, // 12
+      ]),
+      ...balls("cricket.superover.ball", [
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 }, // 12 — tied again
+      ]),
+    ];
+    // Second super over: home bats first now; away chases 7 and wins.
+    const so2 = [
+      ...balls("cricket.superover.ball", [
+        { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 2 },
+        { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 2 },
+        { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 2 },
+        { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 0 },
+        { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 0 },
+        { striker: "H-3", nonStriker: "H-4", bowler: "A-10", bat: 0 }, // 6
+      ]),
+      ...balls("cricket.superover.ball", [
+        { striker: "A-3", nonStriker: "A-4", bowler: "H-10", bat: 6, boundary: 6 },
+        { striker: "A-3", nonStriker: "A-4", bowler: "H-10", bat: 1 }, // 7 ≥ 7 → away wins
+      ]),
+    ];
+    const state = fold(cfg, [...events, ...streamFrom(events.length, [...so1, ...so2])]);
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "A", method: "super_over" });
+    expect(state.superOver!.innings).toHaveLength(4);
+  });
+
+  it("shared: the tie stands and pays tie points", () => {
+    const { cfg, events } = tiedMain("shared");
+    const so = [
+      ...balls("cricket.superover.ball", [
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 2 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 0 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 0 },
+        { striker: "A-1", nonStriker: "A-2", bowler: "H-11", bat: 0 },
+      ]),
+      ...balls("cricket.superover.ball", [
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 2 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 0 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 0 },
+        { striker: "H-1", nonStriker: "H-2", bowler: "A-11", bat: 0 },
+      ]),
+    ];
+    const state = fold(cfg, [...events, ...streamFrom(events.length, so)]);
+    expect(state.outcome).toEqual({ kind: "tie" });
+    const [home, away] = cricket.standingsDelta(state.outcome!, cfg, league, state);
+    expect([home.points, away.points]).toEqual([1, 1]);
+    expect(home.metrics.ties).toBe(1);
+  });
+
+  it("league tie without a super over stands as a tie (≠ no_result)", () => {
+    const { events } = tiedMain("repeat");
+    const state = fold(t20, events); // superOver: false
+    expect(state.outcome).toEqual({ kind: "tie" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-05 §8 (e) — two-innings (test) rules: draw, innings victory,
+// follow-on enforcement, 4th-innings chase.
+// ---------------------------------------------------------------------------
+
+describe("cricket golden (e): two-innings matches", () => {
+  const test = cricket.configSchema.parse(cricket.variants.test as Record<string, unknown>);
+
+  it("draws on time expiry with draw points", () => {
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 400, wickets: 6, legalBalls: 540, declared: true }],
+      ["cricket.innings.summary", { runs: 250, wickets: 10, legalBalls: 480 }],
+      ["cricket.innings.summary", { runs: 200, wickets: 2, legalBalls: 180, declared: true }],
+      ["cricket.match.close"],
+    );
+    const state = fold(test, events);
+    expect(state.outcome).toEqual({ kind: "draw" });
+    expect(cricket.supportsDraws(test, "league")).toBe(true);
+    expect(cricket.supportsDraws(t20, "league")).toBe(false);
+    const [home, away] = cricket.standingsDelta(state.outcome!, test, league, state);
+    expect([home.points, away.points]).toEqual([1, 1]);
+    expect([home.drawn, away.drawn]).toEqual([1, 1]);
+  });
+
+  it("enforces the follow-on and scores an innings victory", () => {
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 500, wickets: 3, legalBalls: 540, declared: true }],
+      ["cricket.innings.summary", { runs: 200, wickets: 10, legalBalls: 300 }],
+      ["cricket.followon"],
+      ["cricket.innings.summary", { runs: 250, wickets: 10, legalBalls: 350 }],
+    );
+    const state = fold(test, events);
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "H", method: "innings" });
+    expect(state.margin).toBe("by an innings and 50 runs");
+  });
+
+  it("rejects a follow-on below the configured lead", () => {
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 300, wickets: 10, legalBalls: 400 }],
+      ["cricket.innings.summary", { runs: 200, wickets: 10, legalBalls: 350 }],
+      ["cricket.followon"],
+    );
+    expect(() => fold(test, events)).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+  });
+
+  it("resolves a fourth-innings chase by wickets", () => {
+    const events = stream(
+      ["core.start"],
+      ["cricket.innings.summary", { runs: 300, wickets: 10, legalBalls: 400 }],
+      ["cricket.innings.summary", { runs: 250, wickets: 10, legalBalls: 380 }],
+      ["cricket.innings.summary", { runs: 150, wickets: 10, legalBalls: 200 }],
+      ["cricket.innings.summary", { runs: 201, wickets: 5, legalBalls: 240 }],
+    );
+    const state = fold(test, events);
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "A", method: "regulation" });
+    expect(state.margin).toBe("by 5 wickets");
+    expect(cricket.summary(state).perSide).toEqual([
+      { entrantId: "H", line: "300 & 150" },
+      { entrantId: "A", line: "250 & 201/5" },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-05 acceptance — bowler-legality property over generated streams.
+// ---------------------------------------------------------------------------
+
+describe("cricket property: generated streams respect bowling legality", () => {
+  it("never violates consecutive-over or quota rules", () => {
+    fc.assert(
+      fc.property(fc.nat(), fc.integer({ min: 20, max: 300 }), (seed, length) => {
+        const events = buildStream(cricket, t20, lineups, seed, length);
+        // Segment fine deliveries into innings on over-counter resets.
+        const segments: CricketBallEv[][] = [];
+        let current: CricketBallEv[] = [];
+        let prevKey = -1;
+        for (const event of events) {
+          if (event.type !== "cricket.ball") continue;
+          const ball = event.payload as CricketBallEv;
+          const key = ball.over * 100 + ball.ballInOver;
+          if (key < prevKey && ball.over === 0 && ball.ballInOver === 1) {
+            if (current.length > 0) segments.push(current);
+            current = [];
+          }
+          prevKey = key;
+          current.push(ball);
+        }
+        if (current.length > 0) segments.push(current);
+        for (const segment of segments) {
+          const overBowler = new Map<number, string>();
+          for (const ball of segment) {
+            const existing = overBowler.get(ball.over);
+            expect(existing ?? ball.bowler).toBe(ball.bowler); // one bowler per over
+            overBowler.set(ball.over, ball.bowler);
+          }
+          const overs = [...overBowler.entries()].sort((a, b) => a[0] - b[0]);
+          const perBowler = new Map<string, number>();
+          for (const [overNo, bowler] of overs) {
+            const prev = overs.find(([n]) => n === overNo - 1);
+            if (prev !== undefined) expect(prev[1]).not.toBe(bowler); // no consecutive overs
+            perBowler.set(bowler, (perBowler.get(bowler) ?? 0) + 1);
+          }
+          for (const count of perBowler.values()) {
+            expect(count).toBeLessThanOrEqual(t20.maxOversPerBowler as number); // quota
+          }
+        }
+      }),
+      { numRuns: 60 },
+    );
+  });
+});
+
+// Helper: envelope a pre-built [type, payload] list continuing a stream.
+function streamFrom(
+  offset: number,
+  specs: Array<[type: string, payload?: unknown]>,
+): EventEnvelope[] {
+  return specs.map(([type, payload], i) =>
+    makeEnvelope(offset + i, { type, payload: payload ?? {} }),
+  );
+}
+
+// PROMPT-05 acceptance — conformance green across the fidelity/format matrix.
+conformanceSuite(cricket, { cfg: {}, lineups, label: "t20", numRuns: 120, maxEvents: 60 });
+conformanceSuite(cricket, {
+  cfg: { superOver: true, superOverStillTied: "boundary_count" },
+  lineups,
+  label: "t20 knockout",
+  stageCtxs: [{ kind: "knockout" }, { kind: "group" }],
+  numRuns: 120,
+  maxEvents: 60,
+});
+conformanceSuite(cricket, {
+  cfg: {
+    inningsPerSide: 2,
+    ballsPerInnings: null,
+    points: { win: 2, tie: 1, noResult: 1, loss: 0, draw: 1 },
+    followOn: { enabled: true, lead: 200 },
+    minOversForResult: 0,
+  },
+  lineups,
+  label: "test",
+  numRuns: 120,
+  maxEvents: 60,
+});

--- a/packages/engine/src/sports/cricket/cricket.ts
+++ b/packages/engine/src/sports/cricket/cricket.ts
@@ -1,0 +1,1891 @@
+// Cricket SportModule — spec 04 §2 (normative) + engine/sports/cricket.md
+// (PROMPT-05). Dual fidelity is the load-bearing design (spec §2.2): fine
+// `cricket.ball` events and coarse `cricket.innings.summary` events both fold
+// into the same InningsTotals shape, and all result/NRR/DLS math reads only
+// those totals — result logic never peeks at ball events.
+import { z } from "zod";
+import { EngineError } from "../../core/errors.ts";
+import type { CoreEv, EventEnvelope } from "../../core/events.ts";
+import type { Rng } from "../../core/rng.ts";
+import {
+  EntrantId,
+  type LineupPair,
+  type MatchOutcome,
+  type ScoreSummary,
+  type StageCtx,
+  type StageKind,
+  type StandingsDelta,
+} from "../../core/types.ts";
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import type { ModuleEvent, SportModule } from "../../sport/module.ts";
+import { dlsPar, dlsTarget, resources } from "./dls.ts";
+
+// ---------------------------------------------------------------------------
+// Cfg — spec 04 §2.1
+// ---------------------------------------------------------------------------
+
+const CricketCfgBase = z.object({
+  inningsPerSide: z.union([z.literal(1), z.literal(2)]).default(1),
+  // T20 120, ODI 300, Hundred 100; null = unlimited (test).
+  ballsPerInnings: z.number().int().positive().nullable().default(120),
+  ballsPerOver: z.number().int().positive().default(6), // Hundred uses 5-ball sets
+  playersPerSide: z.number().int().min(2).default(11),
+  maxOversPerBowler: z.number().int().positive().optional(), // T20 4, ODI 10
+  points: z
+    .object({
+      win: z.number().int().nonnegative().default(2),
+      tie: z.number().int().nonnegative().default(1),
+      noResult: z.number().int().nonnegative().default(1),
+      loss: z.number().int().nonnegative().default(0),
+      draw: z.number().int().nonnegative().optional(), // 2-innings only
+    })
+    .default({ win: 2, tie: 1, noResult: 1, loss: 0 }),
+  superOver: z.boolean().default(false), // knockout tie resolution
+  // spec 04 §2.3 — still-tied policy. ICC current conditions repeat the super
+  // over until decided; boundary_count is the (2019) legacy rule kept for
+  // community leagues; shared records the tie.
+  superOverStillTied: z.enum(["repeat", "boundary_count", "shared"]).default("repeat"),
+  dls: z
+    .object({ enabled: z.boolean(), edition: z.literal("standard") })
+    .default({ enabled: false, edition: "standard" }),
+  followOn: z
+    .object({ enabled: z.boolean(), lead: z.number().int().positive() })
+    .optional(), // 2-innings only
+  minOversForResult: z.number().int().nonnegative().default(5), // T20 5, ODI 20
+});
+
+export const CricketCfg = CricketCfgBase.refine(
+  (cfg) =>
+    cfg.maxOversPerBowler === undefined ||
+    cfg.ballsPerInnings === null ||
+    cfg.maxOversPerBowler <= Math.ceil(cfg.ballsPerInnings / cfg.ballsPerOver),
+  { message: "maxOversPerBowler exceeds the innings length" },
+)
+  .refine((cfg) => !(cfg.followOn?.enabled === true) || cfg.inningsPerSide === 2, {
+    message: "followOn requires inningsPerSide = 2",
+  })
+  .refine((cfg) => !cfg.superOver || cfg.inningsPerSide === 1, {
+    message: "superOver requires inningsPerSide = 1",
+  })
+  .refine((cfg) => !cfg.dls.enabled || cfg.ballsPerInnings !== null, {
+    message: "DLS requires a limited-overs config",
+  })
+  .refine(
+    (cfg) =>
+      cfg.ballsPerInnings === null ||
+      cfg.minOversForResult * cfg.ballsPerOver <= cfg.ballsPerInnings,
+    { message: "minOversForResult exceeds the innings length" },
+  );
+export type CricketCfg = z.infer<typeof CricketCfg>;
+
+// ---------------------------------------------------------------------------
+// Ev — spec 04 §2.2 (+ doc 14 §1 Tier-2 player lines)
+// ---------------------------------------------------------------------------
+
+const PersonId = z.string().min(1);
+
+export const CricketExtras = z.strictObject({
+  kind: z.enum(["wide", "noball", "bye", "legbye", "penalty"]),
+  runs: z.number().int().positive(),
+});
+
+export const CricketWicket = z.strictObject({
+  kind: z.enum([
+    "bowled",
+    "caught",
+    "lbw",
+    "runout",
+    "stumped",
+    "hitwicket",
+    "retired",
+    "obstructed",
+    "timedout",
+  ]),
+  out: PersonId,
+  fielder: PersonId.optional(),
+  bowlerCredited: z.boolean(),
+});
+
+export const CricketBall = z.strictObject({
+  over: z.number().int().nonnegative(),
+  ballInOver: z.number().int().positive(),
+  striker: PersonId,
+  nonStriker: PersonId,
+  bowler: PersonId,
+  runs: z.strictObject({
+    bat: z.number().int().nonnegative(),
+    extras: CricketExtras.optional(),
+  }),
+  wicket: CricketWicket.optional(),
+  boundary: z.union([z.literal(4), z.literal(6)]).optional(),
+  freeHit: z.boolean().optional(),
+});
+export type CricketBallEv = z.infer<typeof CricketBall>;
+
+// Coarse fidelity (spec §2.2). `partial: true` = in-progress snapshot: totals
+// update an open innings and the fold's auto-close rules (all out / balls
+// exhausted / target passed) decide closure — exactly the rules a fine
+// innings closes under, which is what makes cfg-free coarsening possible.
+// `boundaries` feeds the boundary-count tiebreak at coarse fidelity.
+export const CricketInningsSummary = z.strictObject({
+  runs: z.number().int().nonnegative(),
+  wickets: z.number().int().nonnegative(),
+  legalBalls: z.number().int().nonnegative(),
+  declared: z.boolean().optional(),
+  boundaries: z.number().int().nonnegative().optional(),
+  partial: z.boolean().optional(),
+});
+
+export const CricketToss = z.strictObject({
+  wonBy: EntrantId,
+  elected: z.enum(["bat", "bowl"]),
+});
+export const CricketDeclare = z.strictObject({});
+export const CricketClose = z.strictObject({});
+export const CricketMatchClose = z.strictObject({}); // 2-innings time expiry ⇒ draw
+export const CricketInterruption = z.strictObject({
+  kind: z.enum(["rain", "light", "other"]),
+  oversLostEstimate: z.number().int().nonnegative().optional(),
+});
+export const CricketRevise = z
+  .strictObject({
+    oversPerSide: z.number().int().positive().optional(),
+    target: z.number().int().positive().optional(),
+  })
+  .refine((r) => r.oversPerSide !== undefined || r.target !== undefined, {
+    message: "revise needs oversPerSide and/or target",
+  });
+export const CricketFollowOn = z.strictObject({});
+
+// doc 14 §1 Tier 2 — post-match scorecard line, validated for sum-consistency
+// against the innings totals.
+export const CricketPlayerLine = z
+  .strictObject({
+    innings: z.number().int().positive(), // 1-based innings number
+    person: PersonId,
+    batting: z
+      .strictObject({
+        runs: z.number().int().nonnegative(),
+        balls: z.number().int().nonnegative(),
+        out: z.boolean().optional(),
+      })
+      .optional(),
+    bowling: z
+      .strictObject({
+        legalBalls: z.number().int().nonnegative(),
+        runs: z.number().int().nonnegative(),
+        wickets: z.number().int().nonnegative(),
+      })
+      .optional(),
+  })
+  .refine((line) => line.batting !== undefined || line.bowling !== undefined, {
+    message: "player line needs a batting and/or bowling aspect",
+  });
+
+export const CricketEv = z.union([
+  CricketBall,
+  CricketInningsSummary,
+  CricketToss,
+  CricketDeclare,
+  CricketClose,
+  CricketMatchClose,
+  CricketInterruption,
+  CricketRevise,
+  CricketFollowOn,
+  CricketPlayerLine,
+]);
+export type CricketEv = z.infer<typeof CricketEv>;
+
+// ---------------------------------------------------------------------------
+// State — spec §2.2 layered design: InningsState.{runs,wickets,legalBalls}
+// is the InningsTotals every downstream computation reads.
+// ---------------------------------------------------------------------------
+
+type Side = "home" | "away";
+
+interface FineInnings {
+  striker: string | null; // null = awaiting replacement (super over only)
+  nonStriker: string | null;
+  nextBatterIndex: number; // cursor into the batting order (main innings)
+  dismissed: string[];
+  currentBowler: string | null; // null = new over pending
+  prevOverBowler: string | null;
+  freeHitPending: boolean;
+  batterRuns: Record<string, number>;
+  batterBalls: Record<string, number>;
+  bowlerBalls: Record<string, number>;
+  bowlerRuns: Record<string, number>;
+  bowlerWickets: Record<string, number>;
+  extras: number;
+}
+
+export interface InningsState {
+  battingSide: Side;
+  runs: number;
+  wickets: number;
+  legalBalls: number;
+  boundaries: number;
+  declared: boolean;
+  closed: boolean;
+  ballsLimit: number | null; // quota at this point (revise updates it)
+  fine: FineInnings | null; // null = coarse innings
+}
+
+interface PlayerLineRec {
+  innings: number;
+  person: string;
+  batting?: { runs: number; balls: number; out?: boolean };
+  bowling?: { legalBalls: number; runs: number; wickets: number };
+}
+
+export interface CricketState {
+  cfg: CricketCfg;
+  entrants: { home: string; away: string };
+  orders: { home: string[]; away: string[] }; // batting order = LineupSlot.order_no
+  phase: "pre" | "live" | "super_over" | "done" | "final";
+  battingFirst: Side;
+  tossTaken: boolean;
+  innings: InningsState[];
+  followOnEnforced: boolean;
+  quota: number | null; // current balls-per-innings (post-revise)
+  revisedTarget: number | null;
+  targetSource: "dls" | "manual" | null;
+  r1: number | null; // DLS resources available, first innings (spec §2.5)
+  r2: number | null; // …and the chase
+  interruptions: number;
+  superOver: {
+    innings: InningsState[];
+    dismissed: { home: string[]; away: string[] };
+  } | null;
+  outcome: MatchOutcome | null;
+  margin: string | null;
+  playerLines: PlayerLineRec[];
+}
+
+function opponent(side: Side): Side {
+  return side === "home" ? "away" : "home";
+}
+
+function invalid(message: string, data?: unknown): never {
+  throw new EngineError("INVALID_EVENT", message, data);
+}
+
+function wrongPhase(message: string, data?: unknown): never {
+  throw new EngineError("WRONG_PHASE", message, data);
+}
+
+function sideOf(state: CricketState, entrantId: string): Side {
+  if (entrantId === state.entrants.home) return "home";
+  if (entrantId === state.entrants.away) return "away";
+  invalid(`unknown entrant "${entrantId}"`, { entrantId });
+}
+
+function parsePayload<T>(schema: z.ZodType<T>, payload: unknown, type: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) invalid(`invalid ${type} payload`, { issues: parsed.error.issues });
+  return parsed.data;
+}
+
+// All-out threshold — spec §2.3: playersPerSide − 1 partnerships; bounded by
+// the actual lineup so short lineups stay consistent across both fidelities.
+function allOutWickets(state: CricketState, side: Side): number {
+  const order = state.orders[side];
+  const players = Math.min(state.cfg.playersPerSide, order.length || state.cfg.playersPerSide);
+  return Math.max(1, players - 1);
+}
+
+// spec §2.4 — decimalised overs with ballsPerOver generality (display only;
+// the ledger stays integer balls).
+function oversText(balls: number, ballsPerOver: number): string {
+  const whole = Math.floor(balls / ballsPerOver);
+  const rem = balls % ballsPerOver;
+  return rem === 0 ? `${whole}` : `${whole}.${rem}`;
+}
+
+// ---------------------------------------------------------------------------
+// Innings sequencing — spec §2.3 / cricket.md §3
+// ---------------------------------------------------------------------------
+
+function maxInningsCount(cfg: CricketCfg): number {
+  return cfg.inningsPerSide * 2;
+}
+
+function battingSideAt(state: CricketState, index: number): Side {
+  const first = state.battingFirst;
+  if (state.cfg.inningsPerSide === 1) return index === 0 ? first : opponent(first);
+  if (state.followOnEnforced) {
+    // F, S, S, F
+    return index === 0 || index === 3 ? first : opponent(first);
+  }
+  return index % 2 === 0 ? first : opponent(first);
+}
+
+function aggregate(state: CricketState, side: Side): number {
+  return state.innings.reduce(
+    (sum, innings) => (innings.battingSide === side ? sum + innings.runs : sum),
+    0,
+  );
+}
+
+function isChaseIndex(state: CricketState, index: number): boolean {
+  return index === maxInningsCount(state.cfg) - 1;
+}
+
+// Runs the batting side of the final innings needs to win (spec §2.3).
+function chaseTarget(state: CricketState): number {
+  if (state.cfg.inningsPerSide === 1) {
+    if (state.revisedTarget !== null) return state.revisedTarget;
+    const first = state.innings[0];
+    return (first?.runs ?? 0) + 1;
+  }
+  const chaseSide = battingSideAt(state, 3);
+  const own = state.innings
+    .slice(0, 3)
+    .reduce((sum, innings) => (innings.battingSide === chaseSide ? sum + innings.runs : sum), 0);
+  return aggregate(state, opponent(chaseSide)) - own + 1;
+}
+
+function openInnings(state: CricketState): { innings: InningsState; index: number } | null {
+  const index = state.innings.length - 1;
+  const innings = state.innings[index];
+  if (innings === undefined || innings.closed) return null;
+  return { innings, index };
+}
+
+function freshFine(): FineInnings {
+  return {
+    striker: null,
+    nonStriker: null,
+    nextBatterIndex: 0,
+    dismissed: [],
+    currentBowler: null,
+    prevOverBowler: null,
+    freeHitPending: false,
+    batterRuns: {},
+    batterBalls: {},
+    bowlerBalls: {},
+    bowlerRuns: {},
+    bowlerWickets: {},
+    extras: 0,
+  };
+}
+
+// Creates the next innings (on the first scoring event for it).
+function createInnings(state: CricketState, fidelity: "fine" | "coarse"): CricketState {
+  const index = state.innings.length;
+  if (index >= maxInningsCount(state.cfg)) invalid("all innings already recorded");
+  const battingSide = battingSideAt(state, index);
+  let fine: FineInnings | null = null;
+  if (fidelity === "fine") {
+    const order = state.orders[battingSide];
+    if (order.length < 2) {
+      invalid(`batting order for "${state.entrants[battingSide]}" needs at least 2 players`);
+    }
+    fine = {
+      ...freshFine(),
+      // spec §2.3 — openers from lineup order.
+      striker: order[0] as string,
+      nonStriker: order[1] as string,
+      nextBatterIndex: 2,
+    };
+  }
+  const innings: InningsState = {
+    battingSide,
+    runs: 0,
+    wickets: 0,
+    legalBalls: 0,
+    boundaries: 0,
+    declared: false,
+    closed: false,
+    ballsLimit: state.quota,
+    fine,
+  };
+  let next: CricketState = { ...state, innings: [...state.innings, innings] };
+  // DLS bookkeeping (spec §2.5) — resources available at innings start.
+  if (state.quota !== null) {
+    const res = resources(state.quota / state.cfg.ballsPerOver, 0);
+    if (index === 0 && next.r1 === null) next = { ...next, r1: res };
+    if (state.cfg.inningsPerSide === 1 && index === 1 && next.r2 === null) {
+      next = { ...next, r2: res };
+      next = maybeComputeDlsTarget(next);
+    }
+  }
+  return next;
+}
+
+function replaceInnings(state: CricketState, index: number, innings: InningsState): CricketState {
+  const list = state.innings.map((entry, i) => (i === index ? innings : entry));
+  return { ...state, innings: list };
+}
+
+// ---------------------------------------------------------------------------
+// Result determination — spec §2.3
+// ---------------------------------------------------------------------------
+
+function decideWin(
+  state: CricketState,
+  winnerSide: Side,
+  method: string,
+  margin: string,
+): CricketState {
+  return {
+    ...state,
+    phase: "done",
+    outcome: {
+      kind: "win",
+      winner: state.entrants[winnerSide],
+      loser: state.entrants[opponent(winnerSide)],
+      method,
+    },
+    margin,
+  };
+}
+
+function decideTie(state: CricketState): CricketState {
+  // spec §2.3 — tie → super over when configured (fold superover.* events
+  // recursively); otherwise the tie stands (league: 1 pt each).
+  if (state.cfg.superOver) {
+    return {
+      ...state,
+      phase: "super_over",
+      superOver: state.superOver ?? { innings: [], dismissed: { home: [], away: [] } },
+    };
+  }
+  return { ...state, phase: "done", outcome: { kind: "tie" }, margin: null };
+}
+
+// Runs after every innings close; owns the whole §2.3 result table.
+function decideAfterClose(state: CricketState): CricketState {
+  const cfg = state.cfg;
+  const count = state.innings.length;
+  const methodSuffix = state.targetSource !== null ? "dls" : "regulation";
+
+  if (cfg.inningsPerSide === 1) {
+    if (count < 2) return state; // innings break
+    const chase = state.innings[1] as InningsState;
+    const target = chaseTarget(state);
+    if (chase.runs >= target) {
+      const wicketsLeft = allOutWickets(state, chase.battingSide) - chase.wickets;
+      return decideWin(
+        state,
+        chase.battingSide,
+        methodSuffix,
+        `by ${wicketsLeft} wicket${wicketsLeft === 1 ? "" : "s"}`,
+      );
+    }
+    if (chase.runs === target - 1) return decideTie(state);
+    const runs = target - 1 - chase.runs;
+    return decideWin(
+      state,
+      opponent(chase.battingSide),
+      methodSuffix,
+      `by ${runs} run${runs === 1 ? "" : "s"}`,
+    );
+  }
+
+  // Two innings per side — spec §2.3 test rules.
+  const done: Record<Side, number> = { home: 0, away: 0 };
+  for (const innings of state.innings) done[innings.battingSide]++;
+  const aggHome = aggregate(state, "home");
+  const aggAway = aggregate(state, "away");
+
+  if (count === 4) {
+    const chase = state.innings[3] as InningsState;
+    const chaseSide = chase.battingSide;
+    const chaseAgg = chaseSide === "home" ? aggHome : aggAway;
+    const otherAgg = chaseSide === "home" ? aggAway : aggHome;
+    if (chaseAgg > otherAgg) {
+      const wicketsLeft = allOutWickets(state, chaseSide) - chase.wickets;
+      return decideWin(state, chaseSide, "regulation", `by ${wicketsLeft} wicket${wicketsLeft === 1 ? "" : "s"}`);
+    }
+    if (chaseAgg === otherAgg) return decideTie(state);
+    const runs = otherAgg - chaseAgg;
+    return decideWin(state, opponent(chaseSide), "regulation", `by ${runs} run${runs === 1 ? "" : "s"}`);
+  }
+
+  // Innings victory: a side finished both innings still behind an opponent
+  // that batted once (spec §2.3 "innings victory").
+  for (const side of ["home", "away"] as const) {
+    const other = opponent(side);
+    const sideAgg = side === "home" ? aggHome : aggAway;
+    const otherAgg = side === "home" ? aggAway : aggHome;
+    if (done[side] === 2 && done[other] === 1 && sideAgg < otherAgg) {
+      const runs = otherAgg - sideAgg;
+      return decideWin(state, other, "innings", `by an innings and ${runs} run${runs === 1 ? "" : "s"}`);
+    }
+  }
+  return state;
+}
+
+// Close the open innings (auto or manual) and run the result table. `bpo`
+// balls-exhausted, all-out and target-passed closes flow through here from
+// both fidelities.
+function closeOpenInnings(state: CricketState, declared: boolean): CricketState {
+  const open = openInnings(state);
+  if (open === null) invalid("no innings in progress");
+  const closed: InningsState = { ...open.innings, declared, closed: true };
+  return decideAfterClose(replaceInnings(state, open.index, closed));
+}
+
+// Auto-close rules — the single source of truth for when an innings ends
+// without an explicit event (spec §2.3): target passed, all out, balls
+// exhausted. Shared by ball- and summary-fidelity application.
+function autoClose(state: CricketState): CricketState {
+  const open = openInnings(state);
+  if (open === null) return state;
+  const { innings, index } = open;
+  const chasing = isChaseIndex(state, index);
+  if (chasing && state.innings.length >= 2 && innings.runs >= chaseTarget(state)) {
+    return closeOpenInnings(state, false);
+  }
+  if (innings.wickets >= allOutWickets(state, innings.battingSide)) {
+    return closeOpenInnings(state, false);
+  }
+  if (innings.ballsLimit !== null && innings.legalBalls >= innings.ballsLimit) {
+    return closeOpenInnings(state, false);
+  }
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// DLS folding — spec §2.5 (revise events carry the umpire-confirmed numbers;
+// our Standard-Edition computation fills the target when cfg.dls is on and no
+// manual target was given; a manual target always wins).
+// ---------------------------------------------------------------------------
+
+function maybeComputeDlsTarget(state: CricketState): CricketState {
+  if (
+    !state.cfg.dls.enabled ||
+    state.targetSource === "manual" ||
+    state.cfg.inningsPerSide !== 1 ||
+    state.innings.length < 1 ||
+    !(state.innings[0] as InningsState).closed ||
+    state.r1 === null ||
+    state.r2 === null
+  ) {
+    return state;
+  }
+  const s1 = (state.innings[0] as InningsState).runs;
+  if (Math.abs(state.r2 - state.r1) < 1e-9) {
+    // Equal resources ⇒ no revision needed.
+    return state.targetSource === "dls" ? { ...state, revisedTarget: s1 + 1 } : state;
+  }
+  return {
+    ...state,
+    revisedTarget: dlsTarget(s1, state.r1, state.r2),
+    targetSource: "dls",
+  };
+}
+
+function applyRevise(state: CricketState, payload: z.infer<typeof CricketRevise>): CricketState {
+  if (state.phase !== "pre" && state.phase !== "live") {
+    wrongPhase(`revise not allowed in phase "${state.phase}"`);
+  }
+  if (state.quota === null) invalid("revise applies to limited-overs matches only");
+  if (state.cfg.inningsPerSide !== 1) invalid("revise applies to single-innings matches only");
+  const bpo = state.cfg.ballsPerOver;
+  let next = state;
+
+  if (payload.oversPerSide !== undefined) {
+    const newLimit = payload.oversPerSide * bpo;
+    const open = openInnings(next);
+    if (open !== null) {
+      const { innings, index } = open;
+      if (newLimit < innings.legalBalls) {
+        invalid("revised overs are below the balls already bowled", {
+          legalBalls: innings.legalBalls,
+          newLimit,
+        });
+      }
+      if (innings.ballsLimit !== null) {
+        // Resources lost = remaining before − remaining after, at the current
+        // wickets (Standard Edition interruption accounting).
+        const before = resources((innings.ballsLimit - innings.legalBalls) / bpo, innings.wickets);
+        const after = resources((newLimit - innings.legalBalls) / bpo, innings.wickets);
+        const lost = before - after;
+        if (index === 0 && next.r1 !== null) next = { ...next, r1: next.r1 - lost };
+        if (index === 1 && next.r2 !== null) next = { ...next, r2: next.r2 - lost };
+      }
+      next = replaceInnings(next, index, { ...innings, ballsLimit: newLimit });
+    } else if (next.innings.length === 1 && next.quota !== null) {
+      // Between innings: the chase quota (and its resources) shrink.
+      next = { ...next, r2: resources(newLimit / bpo, 0) };
+    }
+    next = { ...next, quota: newLimit };
+  }
+
+  if (payload.target !== undefined) {
+    next = { ...next, revisedTarget: payload.target, targetSource: "manual" };
+  } else {
+    next = maybeComputeDlsTarget(next);
+  }
+
+  // A shrunk quota or lowered target can resolve the match immediately.
+  return autoClose(next);
+}
+
+// core.abandon — spec §2.3: no_result below the minimum, DLS par decision
+// beyond it (method 'dls'); 2-innings matches are drawn.
+function applyAbandon(state: CricketState): CricketState {
+  if (state.phase === "done" || state.phase === "final") wrongPhase("match already over");
+  if (state.cfg.inningsPerSide === 2) {
+    return { ...state, phase: "done", outcome: { kind: "draw" }, margin: null };
+  }
+  if (state.phase === "super_over") {
+    // Main match already tied; the abandoned decider leaves the tie standing.
+    return { ...state, phase: "done", outcome: { kind: "tie" }, margin: null };
+  }
+  const open = openInnings(state);
+  const chase = open !== null && isChaseIndex(state, open.index) ? open.innings : null;
+  const minBalls = state.cfg.minOversForResult * state.cfg.ballsPerOver;
+  if (
+    chase !== null &&
+    state.cfg.dls.enabled &&
+    state.quota !== null &&
+    chase.legalBalls >= minBalls &&
+    state.r1 !== null &&
+    state.r2 !== null &&
+    chase.ballsLimit !== null
+  ) {
+    const s1 = (state.innings[0] as InningsState).runs;
+    const remaining = resources(
+      (chase.ballsLimit - chase.legalBalls) / state.cfg.ballsPerOver,
+      chase.wickets,
+    );
+    const par = dlsPar(s1, state.r1, state.r2, state.r2 - remaining);
+    if (chase.runs > par) {
+      const runs = chase.runs - par;
+      return decideWin(state, chase.battingSide, "dls", `by ${runs} run${runs === 1 ? "" : "s"}`);
+    }
+    if (chase.runs === par) {
+      return { ...state, phase: "done", outcome: { kind: "tie" }, margin: null };
+    }
+    const runs = par - chase.runs;
+    return decideWin(state, opponent(chase.battingSide), "dls", `by ${runs} run${runs === 1 ? "" : "s"}`);
+  }
+  return { ...state, phase: "done", outcome: { kind: "no_result" }, margin: null };
+}
+
+// ---------------------------------------------------------------------------
+// Ball application — spec §2.2 grammar + legality rules
+// ---------------------------------------------------------------------------
+
+const BOWLER_CREDITED_KINDS = new Set(["bowled", "caught", "lbw", "stumped", "hitwicket"]);
+
+interface DeliveryCtx {
+  battingOrder: readonly string[];
+  bowlingOrder: readonly string[];
+  whiteBall: boolean;
+  ballsPerOver: number;
+  maxOversPerBowler: number | undefined;
+  allOut: number;
+  // Main innings: strict next-batter-by-order. Super over: any eligible
+  // batter not previously dismissed in the super over(s).
+  strictOrder: boolean;
+  soIneligible: readonly string[];
+}
+
+function applyDelivery(
+  innings: InningsState,
+  payload: CricketBallEv,
+  ctx: DeliveryCtx,
+): InningsState {
+  const fine = innings.fine;
+  if (fine === null) {
+    invalid("this innings is recorded at summary fidelity — ball events are not allowed");
+  }
+  const bpo = ctx.ballsPerOver;
+
+  // Over/ball counters must match the fold's expectation (wides/no-balls do
+  // not advance the count — spec §2.2 ball legality).
+  const expectedOver = Math.floor(innings.legalBalls / bpo);
+  const expectedBall = (innings.legalBalls % bpo) + 1;
+  if (payload.over !== expectedOver || payload.ballInOver !== expectedBall) {
+    invalid("over/ballInOver do not match the ledger", {
+      expected: { over: expectedOver, ballInOver: expectedBall },
+      got: { over: payload.over, ballInOver: payload.ballInOver },
+    });
+  }
+
+  // Bowler legality — no consecutive overs, per-bowler quota (spec §2.2).
+  let currentBowler = fine.currentBowler;
+  if (currentBowler === null) {
+    if (payload.bowler === fine.prevOverBowler) {
+      invalid(`bowler "${payload.bowler}" cannot bowl consecutive overs`);
+    }
+    if (!ctx.bowlingOrder.includes(payload.bowler)) {
+      invalid(`bowler "${payload.bowler}" is not in the fielding lineup`);
+    }
+    if (ctx.maxOversPerBowler !== undefined) {
+      const bowled = Math.floor((fine.bowlerBalls[payload.bowler] ?? 0) / bpo);
+      if (bowled >= ctx.maxOversPerBowler) {
+        invalid(`bowler "${payload.bowler}" has exhausted the ${ctx.maxOversPerBowler}-over quota`);
+      }
+    }
+    currentBowler = payload.bowler;
+  } else if (payload.bowler !== currentBowler) {
+    invalid(`over in progress belongs to "${currentBowler}"`);
+  }
+
+  // Batters at the crease.
+  let striker = fine.striker;
+  let nonStriker = fine.nonStriker;
+  if (ctx.strictOrder) {
+    if (payload.striker !== striker || payload.nonStriker !== nonStriker) {
+      invalid("striker/non-striker do not match the ledger", {
+        expected: { striker, nonStriker },
+        got: { striker: payload.striker, nonStriker: payload.nonStriker },
+      });
+    }
+  } else {
+    // Super over: resolve open ends against eligibility.
+    const named = [payload.striker, payload.nonStriker];
+    if (payload.striker === payload.nonStriker) invalid("striker and non-striker must differ");
+    for (const person of named) {
+      if (!ctx.battingOrder.includes(person)) {
+        invalid(`batter "${person}" is not in the lineup`);
+      }
+      if (fine.dismissed.includes(person) || ctx.soIneligible.includes(person)) {
+        invalid(`batter "${person}" is not eligible (already dismissed)`);
+      }
+    }
+    const survivors = [striker, nonStriker].filter((p): p is string => p !== null);
+    for (const survivor of survivors) {
+      if (!named.includes(survivor)) {
+        invalid(`batter "${survivor}" is at the crease and must stay`, { survivor });
+      }
+    }
+    striker = payload.striker;
+    nonStriker = payload.nonStriker;
+  }
+
+  // Free hit — armed by a white-ball no-ball, consumed by the next legal
+  // delivery; only the run-out family can dismiss on it (spec §2.2).
+  if (payload.freeHit === true && !fine.freeHitPending) {
+    invalid("freeHit flagged but no free hit is pending");
+  }
+  const extras = payload.runs.extras;
+  const legal = extras === undefined || (extras.kind !== "wide" && extras.kind !== "noball");
+  if (extras?.kind === "wide" && payload.runs.bat > 0) {
+    invalid("bat runs are impossible off a wide");
+  }
+  if (payload.wicket !== undefined) {
+    const wicket = payload.wicket;
+    if (fine.freeHitPending && wicket.kind !== "runout" && wicket.kind !== "obstructed") {
+      invalid(`"${wicket.kind}" cannot dismiss on a free hit`);
+    }
+    if (wicket.out !== striker && wicket.out !== nonStriker) {
+      invalid(`"${wicket.out}" is not at the crease`);
+    }
+    const shouldCredit = BOWLER_CREDITED_KINDS.has(wicket.kind);
+    if (wicket.bowlerCredited !== shouldCredit) {
+      invalid(`bowlerCredited must be ${shouldCredit} for "${wicket.kind}"`);
+    }
+  }
+
+  // Accounting.
+  const batRuns = payload.runs.bat;
+  const extraRuns = extras?.runs ?? 0;
+  const facing = striker as string;
+  const batterRuns =
+    extras?.kind === "wide"
+      ? fine.batterRuns
+      : { ...fine.batterRuns, [facing]: (fine.batterRuns[facing] ?? 0) + batRuns };
+  const batterBalls =
+    extras?.kind === "wide"
+      ? fine.batterBalls
+      : { ...fine.batterBalls, [facing]: (fine.batterBalls[facing] ?? 0) + 1 };
+  const bowlerCharged =
+    batRuns + (extras !== undefined && (extras.kind === "wide" || extras.kind === "noball") ? extras.runs : 0);
+  const bowlerRuns = {
+    ...fine.bowlerRuns,
+    [currentBowler]: (fine.bowlerRuns[currentBowler] ?? 0) + bowlerCharged,
+  };
+  const bowlerBalls = legal
+    ? { ...fine.bowlerBalls, [currentBowler]: (fine.bowlerBalls[currentBowler] ?? 0) + 1 }
+    : fine.bowlerBalls;
+
+  let wickets = innings.wickets;
+  let dismissed = fine.dismissed;
+  let bowlerWickets = fine.bowlerWickets;
+  if (payload.wicket !== undefined) {
+    wickets += 1;
+    dismissed = [...dismissed, payload.wicket.out];
+    if (payload.wicket.bowlerCredited) {
+      bowlerWickets = {
+        ...bowlerWickets,
+        [currentBowler]: (bowlerWickets[currentBowler] ?? 0) + 1,
+      };
+    }
+  }
+
+  // Striker rotation — spec §2.2: swap on odd runs actually run (bat runs
+  // unless a boundary, plus run extras net of the wide/no-ball penalty);
+  // dismissal resolves positions instead (documented simplification).
+  let crossings = 0;
+  if (payload.boundary === undefined) crossings += batRuns;
+  if (extras !== undefined) {
+    if (extras.kind === "wide" || extras.kind === "noball") crossings += extras.runs - 1;
+    else if (extras.kind !== "penalty") crossings += extras.runs;
+  }
+  if (payload.wicket === undefined && crossings % 2 === 1) {
+    [striker, nonStriker] = [nonStriker, striker];
+  }
+
+  if (payload.wicket !== undefined && wickets < ctx.allOut) {
+    const outPerson = payload.wicket.out;
+    let replacement: string | null = null;
+    let nextBatterIndex = fine.nextBatterIndex;
+    if (ctx.strictOrder) {
+      // spec §2.3 — dismissal → next batter by order.
+      replacement = ctx.battingOrder[nextBatterIndex] ?? null;
+      if (replacement === null) invalid("batting order exhausted");
+      nextBatterIndex += 1;
+    }
+    if (striker === outPerson) striker = replacement;
+    else if (nonStriker === outPerson) nonStriker = replacement;
+    return finishDelivery(innings, payload, {
+      ...fine,
+      striker,
+      nonStriker,
+      nextBatterIndex,
+      dismissed,
+      batterRuns,
+      batterBalls,
+      bowlerRuns,
+      bowlerBalls,
+      bowlerWickets,
+      currentBowler,
+    }, { legal, batRuns, extraRuns, wickets, whiteBall: ctx.whiteBall, bpo });
+  }
+
+  return finishDelivery(innings, payload, {
+    ...fine,
+    striker,
+    nonStriker,
+    dismissed,
+    batterRuns,
+    batterBalls,
+    bowlerRuns,
+    bowlerBalls,
+    bowlerWickets,
+    currentBowler,
+  }, { legal, batRuns, extraRuns, wickets, whiteBall: ctx.whiteBall, bpo });
+}
+
+function finishDelivery(
+  innings: InningsState,
+  payload: CricketBallEv,
+  fine: FineInnings,
+  info: { legal: boolean; batRuns: number; extraRuns: number; wickets: number; whiteBall: boolean; bpo: number },
+): InningsState {
+  const legalBalls = innings.legalBalls + (info.legal ? 1 : 0);
+  let next: FineInnings = {
+    ...fine,
+    extras: fine.extras + info.extraRuns,
+    freeHitPending:
+      payload.runs.extras?.kind === "noball" && info.whiteBall
+        ? true
+        : info.legal
+          ? false
+          : fine.freeHitPending,
+  };
+  // Over end: swap ends, hand the ball to a new bowler.
+  if (info.legal && legalBalls % info.bpo === 0) {
+    next = {
+      ...next,
+      striker: next.nonStriker,
+      nonStriker: next.striker,
+      prevOverBowler: next.currentBowler,
+      currentBowler: null,
+    };
+  }
+  return {
+    ...innings,
+    runs: innings.runs + info.batRuns + info.extraRuns,
+    wickets: info.wickets,
+    legalBalls,
+    boundaries: innings.boundaries + (payload.boundary !== undefined ? 1 : 0),
+    fine: next,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Coarse application — spec §2.2 dual fidelity
+// ---------------------------------------------------------------------------
+
+function applySummary(
+  state: CricketState,
+  payload: z.infer<typeof CricketInningsSummary>,
+): CricketState {
+  if (state.phase !== "live") wrongPhase(`innings summary in phase "${state.phase}"`);
+  let next = state;
+  let open = openInnings(next);
+  if (open !== null && open.innings.fine !== null) {
+    invalid("this innings is recorded ball-by-ball — summaries are not allowed for it");
+  }
+  if (open === null) {
+    next = createInnings(next, "coarse");
+    open = openInnings(next) as { innings: InningsState; index: number };
+  }
+  const { innings, index } = open;
+  // Monotone update: totals may only grow (progressive coarse scoring).
+  if (
+    payload.runs < innings.runs ||
+    payload.wickets < innings.wickets ||
+    payload.legalBalls < innings.legalBalls
+  ) {
+    invalid("summary totals may not decrease", {
+      previous: { runs: innings.runs, wickets: innings.wickets, legalBalls: innings.legalBalls },
+      got: { runs: payload.runs, wickets: payload.wickets, legalBalls: payload.legalBalls },
+    });
+  }
+  const allOut = allOutWickets(next, innings.battingSide);
+  if (payload.wickets > allOut) {
+    invalid(`wickets exceed all-out (${allOut})`, { wickets: payload.wickets });
+  }
+  if (innings.ballsLimit !== null && payload.legalBalls > innings.ballsLimit) {
+    invalid("legalBalls exceed the innings quota", {
+      legalBalls: payload.legalBalls,
+      quota: innings.ballsLimit,
+    });
+  }
+  if (payload.declared === true && next.cfg.inningsPerSide !== 2) {
+    invalid("declarations apply to two-innings matches only");
+  }
+  const updated: InningsState = {
+    ...innings,
+    runs: payload.runs,
+    wickets: payload.wickets,
+    legalBalls: payload.legalBalls,
+    boundaries: Math.max(innings.boundaries, payload.boundaries ?? 0),
+  };
+  next = replaceInnings(next, index, updated);
+  if (payload.partial === true) return autoClose(next);
+  return closeOpenInnings(next, payload.declared === true);
+}
+
+// ---------------------------------------------------------------------------
+// Super over — spec §2.3: a recursive 1-over innings pair, 2-wicket all out;
+// still-tied policy from cfg (repeat | boundary_count | shared).
+// ---------------------------------------------------------------------------
+
+function boundaryCount(state: CricketState, side: Side): number {
+  const main = state.innings.reduce(
+    (sum, innings) => (innings.battingSide === side ? sum + innings.boundaries : sum),
+    0,
+  );
+  const so = (state.superOver?.innings ?? []).reduce(
+    (sum, innings) => (innings.battingSide === side ? sum + innings.boundaries : sum),
+    0,
+  );
+  return main + so;
+}
+
+function soBattingSideAt(state: CricketState, index: number): Side {
+  // ICC: the side batting second in the match bats first in the super over;
+  // the side batting second in a super over bats first in the next one.
+  const pair = Math.floor(index / 2);
+  const pairFirst = pair % 2 === 0 ? opponent(state.battingFirst) : state.battingFirst;
+  return index % 2 === 0 ? pairFirst : opponent(pairFirst);
+}
+
+function applySuperOverBall(state: CricketState, payload: CricketBallEv): CricketState {
+  if (state.phase !== "super_over" || state.superOver === null) {
+    wrongPhase(`super-over ball in phase "${state.phase}"`);
+  }
+  const so = state.superOver;
+  const bpo = state.cfg.ballsPerOver;
+  let inningsList = so.innings;
+  let index = inningsList.length - 1;
+  let innings = inningsList[index];
+  if (innings === undefined || innings.closed) {
+    index += 1;
+    const battingSide = soBattingSideAt(state, index);
+    innings = {
+      battingSide,
+      runs: 0,
+      wickets: 0,
+      legalBalls: 0,
+      boundaries: 0,
+      declared: false,
+      closed: false,
+      ballsLimit: bpo, // one over
+      fine: freshFine(),
+    };
+    inningsList = [...inningsList, innings];
+  }
+  const battingSide = innings.battingSide;
+  const updated = applyDelivery(innings, payload, {
+    battingOrder: state.orders[battingSide],
+    bowlingOrder: state.orders[opponent(battingSide)],
+    whiteBall: true,
+    ballsPerOver: bpo,
+    maxOversPerBowler: undefined,
+    allOut: 2, // spec cricket.md §3 — 2-wicket all out
+    strictOrder: false,
+    soIneligible: so.dismissed[battingSide],
+  });
+
+  const dismissedNow = payload.wicket !== undefined ? [payload.wicket.out] : [];
+  const dismissed = {
+    ...so.dismissed,
+    [battingSide]: [...so.dismissed[battingSide], ...dismissedNow],
+  };
+
+  // Close conditions for a super-over innings.
+  const second = index % 2 === 1;
+  const target = second ? (inningsList[index - 1] as InningsState).runs + 1 : null;
+  const shouldClose =
+    updated.wickets >= 2 ||
+    updated.legalBalls >= bpo ||
+    (target !== null && updated.runs >= target);
+  const closed: InningsState = shouldClose ? { ...updated, closed: true } : updated;
+  const nextList = inningsList.map((entry, i) => (i === index ? closed : entry));
+  let next: CricketState = { ...state, superOver: { innings: nextList, dismissed } };
+
+  if (!shouldClose || !second) return next;
+
+  // Pair complete — decide or recurse (spec §2.3).
+  const first = nextList[index - 1] as InningsState;
+  if (closed.runs > first.runs) {
+    return decideWin(next, closed.battingSide, "super_over", "Super Over");
+  }
+  if (closed.runs < first.runs) {
+    return decideWin(next, first.battingSide, "super_over", "Super Over");
+  }
+  switch (next.cfg.superOverStillTied) {
+    case "repeat":
+      return next; // next pair opens on the next ball (ICC current rule)
+    case "boundary_count": {
+      const home = boundaryCount(next, "home");
+      const away = boundaryCount(next, "away");
+      if (home === away) {
+        return { ...next, phase: "done", outcome: { kind: "tie" }, margin: null };
+      }
+      return decideWin(next, home > away ? "home" : "away", "boundary_count", "on boundary count");
+    }
+    case "shared":
+      return { ...next, phase: "done", outcome: { kind: "tie" }, margin: null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tier-2 player lines — doc 14 §1: sum-consistency vs InningsTotals; fine
+// innings cross-check exactly against the derived cards.
+// ---------------------------------------------------------------------------
+
+function applyPlayerLine(
+  state: CricketState,
+  payload: z.infer<typeof CricketPlayerLine>,
+): CricketState {
+  const innings = state.innings[payload.innings - 1];
+  if (innings === undefined || !innings.closed) {
+    invalid(`innings ${payload.innings} is not a closed innings`);
+  }
+  const battingOrder = state.orders[innings.battingSide];
+  const bowlingOrder = state.orders[opponent(innings.battingSide)];
+  const existing = state.playerLines.filter((line) => line.innings === payload.innings);
+  const dupe = existing.find(
+    (line) =>
+      line.person === payload.person &&
+      ((line.batting !== undefined && payload.batting !== undefined) ||
+        (line.bowling !== undefined && payload.bowling !== undefined)),
+  );
+  if (dupe !== undefined) {
+    invalid(`a line for "${payload.person}" in innings ${payload.innings} already exists`);
+  }
+
+  const reject = (field: string, expected: number | string, got: number): never =>
+    invalid("player line disagrees with the innings totals", {
+      innings: payload.innings,
+      person: payload.person,
+      field,
+      expected,
+      got,
+    });
+
+  if (payload.batting !== undefined) {
+    if (!battingOrder.includes(payload.person)) {
+      invalid(`"${payload.person}" is not in the batting lineup for innings ${payload.innings}`);
+    }
+    if (innings.fine !== null) {
+      const runs = innings.fine.batterRuns[payload.person] ?? 0;
+      const balls = innings.fine.batterBalls[payload.person] ?? 0;
+      if (payload.batting.runs !== runs) reject("batting.runs", runs, payload.batting.runs);
+      if (payload.batting.balls !== balls) reject("batting.balls", balls, payload.batting.balls);
+    } else {
+      const soFar = existing.reduce((sum, line) => sum + (line.batting?.runs ?? 0), 0);
+      if (soFar + payload.batting.runs > innings.runs) {
+        reject("batting.runs", `≤ ${innings.runs - soFar}`, payload.batting.runs);
+      }
+    }
+  }
+  if (payload.bowling !== undefined) {
+    if (!bowlingOrder.includes(payload.person)) {
+      invalid(`"${payload.person}" is not in the bowling lineup for innings ${payload.innings}`);
+    }
+    if (innings.fine !== null) {
+      const balls = innings.fine.bowlerBalls[payload.person] ?? 0;
+      const runs = innings.fine.bowlerRuns[payload.person] ?? 0;
+      const wickets = innings.fine.bowlerWickets[payload.person] ?? 0;
+      if (payload.bowling.legalBalls !== balls) reject("bowling.legalBalls", balls, payload.bowling.legalBalls);
+      if (payload.bowling.runs !== runs) reject("bowling.runs", runs, payload.bowling.runs);
+      if (payload.bowling.wickets !== wickets) reject("bowling.wickets", wickets, payload.bowling.wickets);
+    } else {
+      const wicketsSoFar = existing.reduce((sum, line) => sum + (line.bowling?.wickets ?? 0), 0);
+      const ballsSoFar = existing.reduce((sum, line) => sum + (line.bowling?.legalBalls ?? 0), 0);
+      const runsSoFar = existing.reduce((sum, line) => sum + (line.bowling?.runs ?? 0), 0);
+      if (wicketsSoFar + payload.bowling.wickets > innings.wickets) {
+        reject("bowling.wickets", `≤ ${innings.wickets - wicketsSoFar}`, payload.bowling.wickets);
+      }
+      if (ballsSoFar + payload.bowling.legalBalls > innings.legalBalls) {
+        reject("bowling.legalBalls", `≤ ${innings.legalBalls - ballsSoFar}`, payload.bowling.legalBalls);
+      }
+      if (runsSoFar + payload.bowling.runs > innings.runs) {
+        reject("bowling.runs", `≤ ${innings.runs - runsSoFar}`, payload.bowling.runs);
+      }
+    }
+  }
+
+  const record: PlayerLineRec = {
+    innings: payload.innings,
+    person: payload.person,
+    ...(payload.batting === undefined ? {} : { batting: payload.batting }),
+    ...(payload.bowling === undefined ? {} : { bowling: payload.bowling }),
+  };
+  return { ...state, playerLines: [...state.playerLines, record] };
+}
+
+// ---------------------------------------------------------------------------
+// Generator internals — spec 03 §6 (rng-injected, no fast-check dependency).
+// ---------------------------------------------------------------------------
+
+function eligibleBowlers(
+  order: readonly string[],
+  fine: FineInnings,
+  maxOversPerBowler: number | undefined,
+  ballsPerOver: number,
+): string[] {
+  return order.filter((person) => {
+    if (person === fine.prevOverBowler) return false;
+    if (maxOversPerBowler === undefined) return true;
+    return Math.floor((fine.bowlerBalls[person] ?? 0) / ballsPerOver) < maxOversPerBowler;
+  });
+}
+
+function pickFrom(items: readonly string[], rng: Rng): string {
+  if (items.length === 0) invalid("generator ran out of eligible players");
+  return items[Math.floor(rng() * items.length)] as string;
+}
+
+function randomDelivery(
+  base: {
+    over: number;
+    ballInOver: number;
+    striker: string;
+    nonStriker: string;
+    bowler: string;
+  },
+  freeHitPending: boolean,
+  whiteBall: boolean,
+  rng: Rng,
+): CricketBallEv {
+  const freeHit = freeHitPending ? { freeHit: true as const } : {};
+  const roll = rng();
+  if (roll < 0.04) {
+    // Wide (occasionally with runs run). No bat runs, no free-hit consumption.
+    return { ...base, runs: { bat: 0, extras: { kind: "wide", runs: rng() < 0.15 ? 2 : 1 } } };
+  }
+  if (whiteBall && roll < 0.06) {
+    return {
+      ...base,
+      runs: { bat: Math.floor(rng() * 3), extras: { kind: "noball", runs: 1 } },
+      ...freeHit,
+    };
+  }
+  if (roll < 0.13) {
+    const kind = rng() < 0.5 ? ("bye" as const) : ("legbye" as const);
+    return { ...base, runs: { bat: 0, extras: { kind, runs: 1 + Math.floor(rng() * 2) } }, ...freeHit };
+  }
+  if (roll < 0.2) {
+    const kind = freeHitPending
+      ? ("runout" as const)
+      : ((["bowled", "caught", "lbw", "runout", "stumped"] as const)[Math.floor(rng() * 5)] ??
+        ("bowled" as const));
+    const out = kind === "runout" && rng() < 0.4 ? base.nonStriker : base.striker;
+    return {
+      ...base,
+      runs: { bat: kind === "runout" && rng() < 0.5 ? 1 : 0 },
+      wicket: { kind, out, bowlerCredited: BOWLER_CREDITED_KINDS.has(kind) },
+      ...freeHit,
+    };
+  }
+  if (roll < 0.32) {
+    const six = rng() < 0.3;
+    return { ...base, runs: { bat: six ? 6 : 4 }, boundary: six ? 6 : 4, ...freeHit };
+  }
+  const bat = ([0, 0, 0, 1, 1, 1, 1, 2, 2, 3] as const)[Math.floor(rng() * 10)] ?? 0;
+  return { ...base, runs: { bat }, ...freeHit };
+}
+
+function generateBall(state: CricketState, rng: Rng): CricketBallEv {
+  const open = openInnings(state);
+  const index = open === null ? state.innings.length : state.innings.length - 1;
+  const battingSide = open?.innings.battingSide ?? battingSideAt(state, index);
+  const order = state.orders[battingSide];
+  const bowlingOrder = state.orders[opponent(battingSide)];
+  const fine: FineInnings = open?.innings.fine ?? {
+    ...freshFine(),
+    striker: order[0] as string,
+    nonStriker: order[1] as string,
+    nextBatterIndex: 2,
+  };
+  const legalBalls = open?.innings.legalBalls ?? 0;
+  const bpo = state.cfg.ballsPerOver;
+  const bowler =
+    fine.currentBowler ??
+    pickFrom(eligibleBowlers(bowlingOrder, fine, state.cfg.maxOversPerBowler, bpo), rng);
+  return randomDelivery(
+    {
+      over: Math.floor(legalBalls / bpo),
+      ballInOver: (legalBalls % bpo) + 1,
+      striker: fine.striker as string,
+      nonStriker: fine.nonStriker as string,
+      bowler,
+    },
+    fine.freeHitPending,
+    state.cfg.ballsPerInnings !== null,
+    rng,
+  );
+}
+
+function generateSoBall(state: CricketState, rng: Rng): CricketBallEv {
+  const so = state.superOver as NonNullable<CricketState["superOver"]>;
+  let index = so.innings.length - 1;
+  let innings = so.innings[index];
+  if (innings === undefined || innings.closed) {
+    index += 1;
+    innings = undefined;
+  }
+  const battingSide = innings?.battingSide ?? soBattingSideAt(state, index);
+  const order = state.orders[battingSide];
+  const fine = innings?.fine ?? freshFine();
+  const ineligible = new Set([...so.dismissed[battingSide], ...fine.dismissed]);
+  const survivors = [fine.striker, fine.nonStriker].filter((p): p is string => p !== null);
+  const fresh = order.filter(
+    (person) => !ineligible.has(person) && !survivors.includes(person),
+  );
+  const striker = survivors[0] ?? fresh[0];
+  const nonStriker = survivors[1] ?? (striker === fresh[0] ? fresh[1] : fresh[0]);
+  if (striker === undefined || nonStriker === undefined) {
+    invalid("generator ran out of eligible super-over batters");
+  }
+  // One bowler bowls the whole super over — reuse the over's bowler mid-over
+  // (the fold rejects a change of bowler within an over).
+  const bowler =
+    fine.currentBowler ?? pickFrom(state.orders[opponent(battingSide)], rng);
+  return randomDelivery(
+    {
+      over: 0,
+      ballInOver: ((innings?.legalBalls ?? 0) % state.cfg.ballsPerOver) + 1,
+      striker,
+      nonStriker,
+      bowler,
+    },
+    fine.freeHitPending,
+    true,
+    rng,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Positions — spec §2.7
+// ---------------------------------------------------------------------------
+
+const positions: PositionCatalog = {
+  groups: [
+    { key: "BAT", name: "Batter" },
+    { key: "BOWL", name: "Bowler" },
+    { key: "AR", name: "All-rounder" },
+    { key: "WK", name: "Wicketkeeper" },
+  ],
+  roles: [
+    { key: "captain", name: "Captain", unique: true },
+    { key: "wicketkeeper", name: "Wicketkeeper", unique: true, required: true },
+  ],
+  lineup: { size: 11, benchMax: 4 }, // substitutes: fielding only (spec §2.7)
+};
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+function orderFromLineup(lineup: LineupPair["home"]): string[] {
+  return lineup.slots
+    .filter((slot) => slot.slot === "starting")
+    .sort((a, b) => a.orderNo - b.orderNo)
+    .map((slot) => slot.personId);
+}
+
+function sideLine(state: CricketState, side: Side): string {
+  const list = state.innings.filter((innings) => innings.battingSide === side);
+  if (list.length === 0) return "—";
+  return list
+    .map((innings) => {
+      const allOut = innings.wickets >= allOutWickets(state, side);
+      const wickets = allOut ? "" : `/${innings.wickets}`;
+      const declared = innings.declared ? "d" : "";
+      const overs =
+        state.cfg.inningsPerSide === 1
+          ? ` (${oversText(innings.legalBalls, state.cfg.ballsPerOver)})`
+          : "";
+      return `${innings.runs}${wickets}${declared}${overs}`;
+    })
+    .join(" & ");
+}
+
+export const cricket: SportModule<CricketCfg, CricketEv, CricketState> = {
+  key: "cricket",
+  version: "1.0.0",
+  configSchema: CricketCfg,
+  eventSchema: CricketEv,
+  positions,
+  variants: {
+    // spec 04 §2.1
+    t20: { ballsPerInnings: 120, maxOversPerBowler: 4 },
+    odi: { ballsPerInnings: 300, maxOversPerBowler: 10, minOversForResult: 20 },
+    hundred: { ballsPerInnings: 100, ballsPerOver: 5, maxOversPerBowler: 4 },
+    test: {
+      inningsPerSide: 2,
+      ballsPerInnings: null,
+      points: { win: 2, tie: 1, noResult: 1, loss: 0, draw: 1 },
+      superOver: false, // multi-day cricket draws; it never goes to a super over
+      followOn: { enabled: true, lead: 200 },
+      minOversForResult: 0,
+    },
+    "pairs-6-a-side": { playersPerSide: 6, ballsPerInnings: 60, maxOversPerBowler: 2 },
+  },
+
+  // spec 03 §2 guarantee 4 — post-match scorecards append after the decision.
+  postDecisionTypes: ["cricket.player.line"],
+
+  init(cfg, lineups: LineupPair): CricketState {
+    return {
+      cfg,
+      entrants: { home: lineups.home.entrantId, away: lineups.away.entrantId },
+      orders: { home: orderFromLineup(lineups.home), away: orderFromLineup(lineups.away) },
+      phase: "pre",
+      battingFirst: "home", // toss overrides
+      tossTaken: false,
+      innings: [],
+      followOnEnforced: false,
+      quota: cfg.ballsPerInnings,
+      revisedTarget: null,
+      targetSource: null,
+      r1: null,
+      r2: null,
+      interruptions: 0,
+      superOver: null,
+      outcome: null,
+      margin: null,
+      playerLines: [],
+    };
+  },
+
+  apply(state, ev: EventEnvelope<CricketEv | CoreEv>): CricketState {
+    switch (ev.type) {
+      case "core.start":
+        if (state.phase !== "pre") wrongPhase("already started");
+        return { ...state, phase: "live" };
+      case "cricket.toss": {
+        if (state.phase !== "pre") wrongPhase("toss must precede core.start");
+        if (state.tossTaken) invalid("toss already recorded");
+        const payload = parsePayload(CricketToss, ev.payload, ev.type);
+        const winner = sideOf(state, payload.wonBy);
+        return {
+          ...state,
+          tossTaken: true,
+          battingFirst: payload.elected === "bat" ? winner : opponent(winner),
+        };
+      }
+      case "cricket.ball": {
+        if (state.phase !== "live") wrongPhase(`ball in phase "${state.phase}"`);
+        const payload = parsePayload(CricketBall, ev.payload, ev.type);
+        let next = state;
+        let open = openInnings(next);
+        if (open !== null && open.innings.fine === null) {
+          invalid("this innings is recorded at summary fidelity — ball events are not allowed");
+        }
+        if (open === null) {
+          next = createInnings(next, "fine");
+          open = openInnings(next) as { innings: InningsState; index: number };
+        }
+        const battingSide = open.innings.battingSide;
+        const updated = applyDelivery(open.innings, payload, {
+          battingOrder: next.orders[battingSide],
+          bowlingOrder: next.orders[opponent(battingSide)],
+          whiteBall: next.cfg.ballsPerInnings !== null,
+          ballsPerOver: next.cfg.ballsPerOver,
+          maxOversPerBowler: next.cfg.maxOversPerBowler,
+          allOut: allOutWickets(next, battingSide),
+          strictOrder: true,
+          soIneligible: [],
+        });
+        return autoClose(replaceInnings(next, open.index, updated));
+      }
+      case "cricket.superover.ball":
+        return applySuperOverBall(state, parsePayload(CricketBall, ev.payload, ev.type));
+      case "cricket.innings.summary":
+        return applySummary(state, parsePayload(CricketInningsSummary, ev.payload, ev.type));
+      case "cricket.innings.declare": {
+        if (state.phase !== "live") wrongPhase(`declare in phase "${state.phase}"`);
+        parsePayload(CricketDeclare, ev.payload, ev.type);
+        if (state.cfg.inningsPerSide !== 2) {
+          invalid("declarations apply to two-innings matches only");
+        }
+        return closeOpenInnings(state, true);
+      }
+      case "cricket.innings.close": {
+        if (state.phase !== "live") wrongPhase(`innings close in phase "${state.phase}"`);
+        parsePayload(CricketClose, ev.payload, ev.type);
+        return closeOpenInnings(state, false);
+      }
+      case "cricket.match.close": {
+        if (state.phase !== "live") wrongPhase(`match close in phase "${state.phase}"`);
+        parsePayload(CricketMatchClose, ev.payload, ev.type);
+        if (state.cfg.inningsPerSide !== 2) {
+          invalid("match close (time expiry draw) applies to two-innings matches only");
+        }
+        // spec §2.3 — draw on time expiry.
+        return { ...state, phase: "done", outcome: { kind: "draw" }, margin: null };
+      }
+      case "cricket.interruption": {
+        if (state.phase !== "pre" && state.phase !== "live") {
+          wrongPhase(`interruption in phase "${state.phase}"`);
+        }
+        parsePayload(CricketInterruption, ev.payload, ev.type);
+        // Metadata only — the revise event carries the numbers (spec §2.5).
+        return { ...state, interruptions: state.interruptions + 1 };
+      }
+      case "cricket.revise":
+        return applyRevise(state, parsePayload(CricketRevise, ev.payload, ev.type));
+      case "cricket.followon": {
+        if (state.phase !== "live") wrongPhase(`follow-on in phase "${state.phase}"`);
+        parsePayload(CricketFollowOn, ev.payload, ev.type);
+        const followOn = state.cfg.followOn;
+        if (state.cfg.inningsPerSide !== 2 || followOn === undefined || !followOn.enabled) {
+          invalid("follow-on is not enabled for this match");
+        }
+        if (state.innings.length !== 2 || openInnings(state) !== null) {
+          invalid("follow-on is decided between the 2nd and 3rd innings");
+        }
+        const lead =
+          (state.innings[0] as InningsState).runs - (state.innings[1] as InningsState).runs;
+        if (lead < followOn.lead) {
+          invalid(`follow-on requires a lead of ${followOn.lead} (actual ${lead})`);
+        }
+        return { ...state, followOnEnforced: true };
+      }
+      case "cricket.player.line":
+        return applyPlayerLine(state, parsePayload(CricketPlayerLine, ev.payload, ev.type));
+      case "core.forfeit": {
+        if (state.phase === "done" || state.phase === "final") wrongPhase("match already over");
+        const by = (ev.payload as { by: string }).by;
+        const winner = opponent(sideOf(state, by));
+        return {
+          ...state,
+          phase: "done",
+          outcome: { kind: "award", winner: state.entrants[winner] },
+          margin: null,
+        };
+      }
+      case "core.abandon":
+        return applyAbandon(state);
+      case "core.finalize":
+        if (state.outcome === null) wrongPhase("cannot finalize an undecided fixture");
+        return { ...state, phase: "final" };
+      case "core.note":
+        return state;
+      default:
+        invalid(`unknown event type "${ev.type}"`);
+    }
+  },
+
+  outcome: (state) => state.outcome,
+
+  // §9.5 — reads only InningsTotals (never fine state), so coarse and fine
+  // folds of the same match render identically (§9.6).
+  summary(state): ScoreSummary {
+    const home = sideLine(state, "home");
+    const away = sideLine(state, "away");
+    const so = state.superOver;
+    const soTally =
+      so === null
+        ? null
+        : so.innings.reduce(
+            (tally, innings) => {
+              tally[innings.battingSide] += innings.runs;
+              return tally;
+            },
+            { home: 0, away: 0 },
+          );
+    const headline = `${home} — ${away}${soTally ? ` · SO ${soTally.home}–${soTally.away}` : ""}`;
+    return {
+      headline,
+      perSide: [
+        { entrantId: state.entrants.home, line: home },
+        { entrantId: state.entrants.away, line: away },
+      ],
+      detail: {
+        innings: state.innings.map((innings) => ({
+          entrantId: state.entrants[innings.battingSide],
+          runs: innings.runs,
+          wickets: innings.wickets,
+          legalBalls: innings.legalBalls,
+          declared: innings.declared,
+          closed: innings.closed,
+        })),
+        ...(state.revisedTarget === null
+          ? {}
+          : { target: state.revisedTarget, targetSource: state.targetSource }),
+        ...(state.margin === null ? {} : { margin: state.margin }),
+        ...(soTally === null ? {} : { superOver: soTally }),
+      },
+    };
+  },
+
+  // spec §2.4/§2.6 — integer NRR ledger; NRR itself is computed at rank time
+  // from these integers (never stored as a float).
+  standingsDelta(outcome, cfg, _ctx: StageCtx, state): [StandingsDelta, StandingsDelta] {
+    const allOutFor = (side: Side) => allOutWickets(state, side);
+    // spec §2.4 — a bowled-out side is charged its full quota; DLS-revised
+    // matches use the revised quota (the innings' ballsLimit at close).
+    const effectiveBalls = (innings: InningsState): number => {
+      if (innings.ballsLimit !== null && innings.wickets >= allOutFor(innings.battingSide)) {
+        return innings.ballsLimit;
+      }
+      return innings.legalBalls;
+    };
+    const ledger = (side: Side): Record<string, number> => {
+      let runsFor = 0;
+      let ballsFaced = 0;
+      let runsAgainst = 0;
+      let ballsBowled = 0;
+      for (const innings of state.innings) {
+        if (innings.battingSide === side) {
+          runsFor += innings.runs;
+          ballsFaced += effectiveBalls(innings);
+        } else {
+          runsAgainst += innings.runs;
+          ballsBowled += effectiveBalls(innings);
+        }
+      }
+      return {
+        runs_for: runsFor,
+        balls_faced_eff: ballsFaced,
+        runs_against: runsAgainst,
+        balls_bowled_eff: ballsBowled,
+        ties: 0,
+        no_results: 0,
+      };
+    };
+    const zeroLedger = (): Record<string, number> => ({
+      runs_for: 0,
+      balls_faced_eff: 0,
+      runs_against: 0,
+      balls_bowled_eff: 0,
+      ties: 0,
+      no_results: 0,
+    });
+    const build = (
+      side: Side,
+      w: number,
+      d: number,
+      l: number,
+      pts: number,
+      metrics: Record<string, number>,
+    ): StandingsDelta => ({
+      entrantId: state.entrants[side],
+      played: 1,
+      won: w,
+      drawn: d,
+      lost: l,
+      points: pts,
+      metrics,
+    });
+
+    switch (outcome.kind) {
+      case "win": {
+        const winnerSide = sideOf(state, outcome.winner);
+        const winner = build(winnerSide, 1, 0, 0, cfg.points.win, ledger(winnerSide));
+        const loser = build(opponent(winnerSide), 0, 0, 1, cfg.points.loss, ledger(opponent(winnerSide)));
+        return winnerSide === "home" ? [winner, loser] : [loser, winner];
+      }
+      case "award": {
+        // Forfeit: full points, no NRR contribution (ICC convention).
+        const winnerSide = sideOf(state, outcome.winner);
+        const winner = build(winnerSide, 1, 0, 0, cfg.points.win, zeroLedger());
+        const loser = build(opponent(winnerSide), 0, 0, 1, cfg.points.loss, zeroLedger());
+        return winnerSide === "home" ? [winner, loser] : [loser, winner];
+      }
+      case "tie": {
+        const metrics = (side: Side) => ({ ...ledger(side), ties: 1 });
+        return [
+          build("home", 0, 0, 0, cfg.points.tie, metrics("home")),
+          build("away", 0, 0, 0, cfg.points.tie, metrics("away")),
+        ];
+      }
+      case "draw": {
+        const pts = cfg.points.draw ?? cfg.points.tie;
+        return [
+          build("home", 0, 1, 0, pts, zeroLedger()),
+          build("away", 0, 1, 0, pts, zeroLedger()),
+        ];
+      }
+      case "no_result": {
+        const metrics = () => ({ ...zeroLedger(), no_results: 1 });
+        return [
+          build("home", 0, 0, 0, cfg.points.noResult, metrics()),
+          build("away", 0, 0, 0, cfg.points.noResult, metrics()),
+        ];
+      }
+    }
+  },
+
+  metrics: [
+    { key: "runs_for", label: "Runs for", direction: "desc" },
+    { key: "balls_faced_eff", label: "Balls faced (eff.)", direction: "asc" },
+    { key: "runs_against", label: "Runs against", direction: "asc" },
+    { key: "balls_bowled_eff", label: "Balls bowled (eff.)", direction: "desc" },
+    { key: "ties", label: "Ties", direction: "desc" },
+    { key: "no_results", label: "No results", direction: "desc" },
+  ],
+  // spec §2.6 — ICC-style cascade; `nrr` is resolved from the integer ledger
+  // by the competition engine at rank time (cross-multiplication).
+  defaultTiebreakers: ["points", "wins", "nrr", "h2h_points", "seed"],
+
+  // Draw exists only in 2-innings cricket and only survives league/group play.
+  supportsDraws(cfg, stage: StageKind) {
+    return cfg.inningsPerSide === 2 && (stage === "league" || stage === "group" || stage === "swiss");
+  },
+
+  // §9.3 — {win+loss, 2·tie, 2·noResult, 2·draw}.
+  declaredPointsSets(cfg) {
+    return [
+      ...new Set([
+        cfg.points.win + cfg.points.loss,
+        cfg.points.tie * 2,
+        cfg.points.noResult * 2,
+        (cfg.points.draw ?? cfg.points.tie) * 2,
+      ]),
+    ];
+  },
+
+  // doc 14 §2 — the four-tier ladder; cricket is the sport with a real Tier 2.
+  fidelityTiers: [
+    { tier: 0, eventTypes: ["cricket.innings.summary"] },
+    {
+      tier: 1,
+      eventTypes: [
+        "cricket.innings.summary",
+        "cricket.toss",
+        "cricket.innings.declare",
+        "cricket.innings.close",
+        "cricket.match.close",
+        "cricket.interruption",
+        "cricket.revise",
+        "cricket.followon",
+        "cricket.superover.ball",
+      ],
+    },
+    { tier: 2, eventTypes: ["cricket.player.line"], entitlement: "stats.player" },
+    {
+      tier: 3,
+      eventTypes: ["cricket.ball", "cricket.superover.ball"],
+      entitlement: "scoring.ball_by_ball",
+    },
+  ],
+  officialLabel: { scorer: "Umpire" }, // doc 13 §1
+
+  // spec 03 §6 / PROMPT-05 §9 — generates only legal deliveries.
+  arbitraryEvent(state, rng: Rng): ModuleEvent<CricketEv> | null {
+    const pick = <T>(items: readonly T[]): T => items[Math.floor(rng() * items.length)] as T;
+
+    if (state.phase === "pre") {
+      if (!state.tossTaken && rng() < 0.4) {
+        return {
+          type: "cricket.toss",
+          payload: {
+            wonBy: rng() < 0.5 ? state.entrants.home : state.entrants.away,
+            elected: rng() < 0.5 ? "bat" : "bowl",
+          },
+        };
+      }
+      return { type: "core.start", payload: {} };
+    }
+    if (state.phase === "done" || state.phase === "final") return null;
+
+    if (state.phase === "super_over") {
+      return { type: "cricket.superover.ball", payload: generateSoBall(state, rng) };
+    }
+
+    const open = openInnings(state);
+    if (open === null) {
+      // Between innings.
+      const cfg = state.cfg;
+      if (cfg.inningsPerSide === 2 && state.innings.length >= 2 && rng() < 0.05) {
+        return { type: "cricket.match.close", payload: {} };
+      }
+      if (
+        cfg.inningsPerSide === 2 &&
+        cfg.followOn?.enabled === true &&
+        state.innings.length === 2 &&
+        !state.followOnEnforced &&
+        (state.innings[0] as InningsState).runs - (state.innings[1] as InningsState).runs >=
+          cfg.followOn.lead &&
+        rng() < 0.5
+      ) {
+        return { type: "cricket.followon", payload: {} };
+      }
+      if (rng() < 0.6) {
+        // Coarse innings in one event.
+        const limit = state.quota;
+        const nextIndex = state.innings.length;
+        const battingSide = battingSideAt(state, nextIndex);
+        const allOut = allOutWickets(state, battingSide);
+        const bowledOut = rng() < 0.3;
+        const wickets = bowledOut ? allOut : Math.floor(rng() * allOut);
+        const legalBalls =
+          limit === null
+            ? 60 + Math.floor(rng() * 400)
+            : bowledOut
+              ? 1 + Math.floor(rng() * limit)
+              : limit;
+        const runs = Math.floor(rng() * 220);
+        return {
+          type: "cricket.innings.summary",
+          payload: {
+            runs,
+            wickets,
+            legalBalls,
+            boundaries: Math.floor(runs / 8),
+            ...(state.cfg.inningsPerSide === 2 && rng() < 0.15 ? { declared: true } : {}),
+          },
+        };
+      }
+      return { type: "cricket.ball", payload: generateBall(state, rng) };
+    }
+
+    if (open.innings.fine === null) {
+      // Open coarse innings never comes from this generator, but stay total.
+      return { type: "cricket.innings.close", payload: {} };
+    }
+    const roll = rng();
+    if (roll < 0.004) return { type: "core.abandon", payload: { reason: "rain" } };
+    if (roll < 0.006) {
+      return {
+        type: "core.forfeit",
+        payload: { by: rng() < 0.5 ? state.entrants.home : state.entrants.away, reason: "walkover" },
+      };
+    }
+    if (roll < 0.012 && state.quota !== null && state.cfg.inningsPerSide === 1) {
+      const bpo = state.cfg.ballsPerOver;
+      const currentOvers = Math.floor(state.quota / bpo);
+      const floorOvers = Math.max(1, Math.ceil(open.innings.legalBalls / bpo));
+      if (currentOvers - 1 >= floorOvers) {
+        const newOvers = Math.max(floorOvers, currentOvers - 1 - Math.floor(rng() * 3));
+        return { type: "cricket.revise", payload: { oversPerSide: newOvers } };
+      }
+    }
+    if (
+      roll < 0.03 &&
+      state.cfg.inningsPerSide === 2 &&
+      open.innings.runs > 50 &&
+      state.innings.length < 4
+    ) {
+      return { type: "cricket.innings.declare", payload: {} };
+    }
+    return { type: "cricket.ball", payload: generateBall(state, rng) };
+  },
+
+  // §9.6 / spec §2.2 — coarsen: collapse ball runs into innings summaries.
+  // cfg-free by design: it emits `partial` snapshots at every boundary and
+  // lets the fold's auto-close rules (identical for both fidelities) decide
+  // closure, so coarse folds close and decide exactly where fine folds did.
+  coarsen(events): ModuleEvent<CricketEv>[] {
+    interface Tracker {
+      runs: number;
+      wickets: number;
+      legalBalls: number;
+      boundaries: number;
+      seen: Set<string>;
+    }
+    const out: ModuleEvent<CricketEv>[] = [];
+    let cur: Tracker | null = null;
+    let dirty = false; // unflushed deliveries since the last snapshot
+    // Emit a cumulative partial snapshot at most once per set of new balls, so
+    // a snapshot taken for a mid-innings pass-through (revise) isn't re-emitted
+    // by the trailing flush as a post-decision duplicate.
+    const flush = () => {
+      if (cur === null || !dirty) return;
+      out.push({
+        type: "cricket.innings.summary",
+        payload: {
+          runs: cur.runs,
+          wickets: cur.wickets,
+          legalBalls: cur.legalBalls,
+          boundaries: cur.boundaries,
+          partial: true,
+        },
+      });
+      dirty = false;
+    };
+    for (const event of events) {
+      switch (event.type) {
+        case "cricket.ball": {
+          const ball = event.payload as CricketBallEv;
+          // New innings when both crease batters are unseen (sides alternate;
+          // the follow-on boundary always carries an explicit event).
+          if (cur !== null && !cur.seen.has(ball.striker) && !cur.seen.has(ball.nonStriker)) {
+            flush();
+            cur = null;
+          }
+          cur ??= { runs: 0, wickets: 0, legalBalls: 0, boundaries: 0, seen: new Set() };
+          const extras = ball.runs.extras;
+          const legal =
+            extras === undefined || (extras.kind !== "wide" && extras.kind !== "noball");
+          cur.runs += ball.runs.bat + (extras?.runs ?? 0);
+          cur.wickets += ball.wicket === undefined ? 0 : 1;
+          cur.legalBalls += legal ? 1 : 0;
+          cur.boundaries += ball.boundary === undefined ? 0 : 1;
+          cur.seen.add(ball.striker);
+          cur.seen.add(ball.nonStriker);
+          dirty = true;
+          break;
+        }
+        case "cricket.innings.summary":
+        case "cricket.innings.close":
+        case "cricket.innings.declare":
+        case "cricket.followon":
+          // Innings boundary: snapshot totals, then the explicit event closes
+          // (or hands over) the innings in the fold.
+          flush();
+          cur = null;
+          out.push({ type: event.type, payload: event.payload });
+          break;
+        case "cricket.player.line":
+          break; // Tier-2 attribution — dropped at coarse fidelity
+        default:
+          // revise / interruption / toss / match.close / superover.ball /
+          // core.* — snapshot so the fold decides on the same totals, then
+          // pass through. The innings may continue afterwards (revise).
+          flush();
+          out.push({ type: event.type, payload: event.payload });
+      }
+    }
+    flush();
+    return out;
+  },
+};
+

--- a/packages/engine/src/sports/cricket/dls.ts
+++ b/packages/engine/src/sports/cricket/dls.ts
@@ -1,0 +1,120 @@
+// DLS (Standard Edition) — spec 04 §2.5, engine/sports/cricket.md §5.
+// Pure target-revision math over the published D/L Standard Edition resource
+// table. The Professional Edition is proprietary software — organisers who
+// need it enter the umpire's number via the `revise` event (which always
+// wins). All output is labelled "standard".
+//
+// Table source (engine/11-sources.md): "The D/L (Duckworth/Lewis) method of
+// adjusting target scores in interrupted one-day cricket matches — Table of
+// resource percentages remaining, over by over. © 2002 Frank Duckworth &
+// Tony Lewis" (2002 update), as hosted by the ICC. Rows are overs left
+// 0..50, columns wickets lost 0..9, values in percent.
+
+export const DLS_EDITION = "standard" as const;
+
+// G50 — average score in an uninterrupted 50-over innings; ICC value for the
+// Standard Edition (full-member level, 2013-14 onwards). Used only when
+// R2 > R1 (spec 04 §2.5 "G50-style adjustment").
+export const DLS_G50 = 245;
+
+// prettier-ignore
+// Indexed [oversLeft][wicketsLost] — oversLeft 0..50, wicketsLost 0..9.
+export const DLS_STANDARD_TABLE: readonly (readonly number[])[] = [
+  /* 0 */ [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+  /* 1 */ [3.6, 3.6, 3.6, 3.6, 3.6, 3.5, 3.5, 3.4, 3.2, 2.5],
+  /* 2 */ [7.2, 7.1, 7.1, 7.0, 7.0, 6.8, 6.6, 6.2, 5.5, 3.7],
+  /* 3 */ [10.6, 10.5, 10.4, 10.3, 10.2, 9.9, 9.5, 8.7, 7.2, 4.2],
+  /* 4 */ [13.9, 13.8, 13.7, 13.5, 13.2, 12.7, 12.0, 10.7, 8.4, 4.5],
+  /* 5 */ [17.2, 17.0, 16.8, 16.5, 16.1, 15.4, 14.3, 12.5, 9.4, 4.6],
+  /* 6 */ [20.3, 20.1, 19.8, 19.4, 18.8, 17.8, 16.4, 13.9, 10.1, 4.6],
+  /* 7 */ [23.4, 23.1, 22.7, 22.2, 21.4, 20.1, 18.2, 15.2, 10.5, 4.7],
+  /* 8 */ [26.4, 26.0, 25.5, 24.8, 23.8, 22.3, 19.9, 16.2, 10.9, 4.7],
+  /* 9 */ [29.3, 28.9, 28.2, 27.4, 26.1, 24.2, 21.4, 17.1, 11.2, 4.7],
+  /* 10 */ [32.1, 31.6, 30.8, 29.8, 28.3, 26.1, 22.8, 17.9, 11.4, 4.7],
+  /* 11 */ [34.9, 34.2, 33.4, 32.1, 30.4, 27.8, 24.0, 18.5, 11.5, 4.7],
+  /* 12 */ [37.6, 36.8, 35.8, 34.3, 32.3, 29.4, 25.1, 19.0, 11.6, 4.7],
+  /* 13 */ [40.2, 39.3, 38.1, 36.5, 34.2, 30.8, 26.1, 19.5, 11.7, 4.7],
+  /* 14 */ [42.7, 41.7, 40.4, 38.5, 35.9, 32.2, 27.0, 19.9, 11.8, 4.7],
+  /* 15 */ [45.2, 44.1, 42.6, 40.5, 37.6, 33.5, 27.8, 20.2, 11.8, 4.7],
+  /* 16 */ [47.6, 46.3, 44.7, 42.3, 39.1, 34.7, 28.5, 20.5, 11.8, 4.7],
+  /* 17 */ [49.9, 48.5, 46.7, 44.1, 40.6, 35.8, 29.2, 20.7, 11.9, 4.7],
+  /* 18 */ [52.2, 50.7, 48.6, 45.9, 42.0, 36.8, 29.8, 20.9, 11.9, 4.7],
+  /* 19 */ [54.4, 52.8, 50.5, 47.5, 43.4, 37.7, 30.3, 21.1, 11.9, 4.7],
+  /* 20 */ [56.6, 54.8, 52.4, 49.1, 44.6, 38.6, 30.8, 21.2, 11.9, 4.7],
+  /* 21 */ [58.7, 56.7, 54.1, 50.6, 45.8, 39.4, 31.2, 21.3, 11.9, 4.7],
+  /* 22 */ [60.7, 58.6, 55.8, 52.0, 47.0, 40.2, 31.6, 21.4, 11.9, 4.7],
+  /* 23 */ [62.7, 60.4, 57.4, 53.4, 48.0, 40.9, 32.0, 21.5, 11.9, 4.7],
+  /* 24 */ [64.6, 62.2, 59.0, 54.7, 49.0, 41.6, 32.3, 21.6, 11.9, 4.7],
+  /* 25 */ [66.5, 63.9, 60.5, 56.0, 50.0, 42.2, 32.6, 21.6, 11.9, 4.7],
+  /* 26 */ [68.3, 65.6, 62.0, 57.2, 50.9, 42.8, 32.8, 21.7, 11.9, 4.7],
+  /* 27 */ [70.1, 67.2, 63.4, 58.4, 51.8, 43.3, 33.0, 21.7, 11.9, 4.7],
+  /* 28 */ [71.8, 68.8, 64.8, 59.5, 52.6, 43.8, 33.2, 21.8, 11.9, 4.7],
+  /* 29 */ [73.5, 70.3, 66.1, 60.5, 53.4, 44.2, 33.4, 21.8, 11.9, 4.7],
+  /* 30 */ [75.1, 71.8, 67.3, 61.6, 54.1, 44.7, 33.6, 21.8, 11.9, 4.7],
+  /* 31 */ [76.7, 73.2, 68.6, 62.5, 54.8, 45.1, 33.7, 21.9, 11.9, 4.7],
+  /* 32 */ [78.3, 74.6, 69.7, 63.5, 55.4, 45.4, 33.9, 21.9, 11.9, 4.7],
+  /* 33 */ [79.8, 75.9, 70.9, 64.4, 56.0, 45.8, 34.0, 21.9, 11.9, 4.7],
+  /* 34 */ [81.3, 77.2, 72.0, 65.2, 56.6, 46.1, 34.1, 21.9, 11.9, 4.7],
+  /* 35 */ [82.7, 78.5, 73.0, 66.0, 57.2, 46.4, 34.2, 21.9, 11.9, 4.7],
+  /* 36 */ [84.1, 79.7, 74.1, 66.8, 57.7, 46.6, 34.3, 21.9, 11.9, 4.7],
+  /* 37 */ [85.4, 80.9, 75.0, 67.6, 58.2, 46.9, 34.4, 21.9, 11.9, 4.7],
+  /* 38 */ [86.7, 82.0, 76.0, 68.3, 58.7, 47.1, 34.5, 21.9, 11.9, 4.7],
+  /* 39 */ [88.0, 83.1, 76.9, 69.0, 59.1, 47.4, 34.5, 22.0, 11.9, 4.7],
+  /* 40 */ [89.3, 84.2, 77.8, 69.6, 59.5, 47.6, 34.6, 22.0, 11.9, 4.7],
+  /* 41 */ [90.5, 85.3, 78.7, 70.3, 59.9, 47.8, 34.6, 22.0, 11.9, 4.7],
+  /* 42 */ [91.7, 86.3, 79.5, 70.9, 60.3, 47.9, 34.7, 22.0, 11.9, 4.7],
+  /* 43 */ [92.8, 87.3, 80.3, 71.4, 60.7, 48.1, 34.7, 22.0, 11.9, 4.7],
+  /* 44 */ [93.9, 88.2, 81.0, 72.0, 61.0, 48.3, 34.8, 22.0, 11.9, 4.7],
+  /* 45 */ [95.0, 89.1, 81.8, 72.5, 61.3, 48.4, 34.8, 22.0, 11.9, 4.7],
+  /* 46 */ [96.1, 90.0, 82.5, 73.0, 61.6, 48.5, 34.8, 22.0, 11.9, 4.7],
+  /* 47 */ [97.1, 90.9, 83.2, 73.5, 61.9, 48.6, 34.9, 22.0, 11.9, 4.7],
+  /* 48 */ [98.1, 91.7, 83.8, 74.0, 62.2, 48.8, 34.9, 22.0, 11.9, 4.7],
+  /* 49 */ [99.1, 92.6, 84.5, 74.4, 62.5, 48.9, 34.9, 22.0, 11.9, 4.7],
+  /* 50 */ [100.0, 93.4, 85.1, 74.9, 62.7, 49.0, 34.9, 22.0, 11.9, 4.7],
+];
+
+// Resources remaining (%) with `oversLeft` overs and `wicketsLost` wickets
+// down. The published table is per whole over; fractional overs (interruption
+// mid-over) interpolate linearly between adjacent rows — a documented
+// approximation of the unpublished per-ball Standard Edition figures.
+export function resources(oversLeft: number, wicketsLost: number): number {
+  const wickets = Math.min(Math.max(Math.trunc(wicketsLost), 0), 9);
+  const overs = Math.min(Math.max(oversLeft, 0), 50);
+  const lower = Math.floor(overs);
+  const lowerRow = DLS_STANDARD_TABLE[lower] as readonly number[];
+  const base = lowerRow[wickets] as number;
+  if (lower === overs || lower === 50) return base;
+  const upperRow = DLS_STANDARD_TABLE[lower + 1] as readonly number[];
+  const next = upperRow[wickets] as number;
+  return base + (overs - lower) * (next - base);
+}
+
+// spec 04 §2.5 — Standard Edition target:
+//   R2 < R1 : T = ⌊S1 × R2/R1⌋ + 1
+//   R2 = R1 : T = S1 + 1
+//   R2 > R1 : T = ⌊S1 + G50 × (R2 − R1)/100⌋ + 1
+export function dlsTarget(s1: number, r1: number, r2: number, g50: number = DLS_G50): number {
+  if (r1 <= 0) return s1 + 1; // degenerate: no resources ⇒ plain target
+  if (r2 < r1) return Math.floor((s1 * r2) / r1) + 1;
+  if (r2 > r1) return Math.floor(s1 + (g50 * (r2 - r1)) / 100) + 1;
+  return s1 + 1;
+}
+
+// Par score for the chasing side having used `r2Used` of its `r2Available`
+// resources (the live "ahead/behind DLS par" widget and the abandonment
+// decision). Exact Standard Edition formula when R2 ≤ R1; when R2 > R1 the
+// official edition redistributes the G50 adjustment — we pro-rate the final
+// target by resources used (documented approximation).
+export function dlsPar(
+  s1: number,
+  r1: number,
+  r2Available: number,
+  r2Used: number,
+  g50: number = DLS_G50,
+): number {
+  if (r1 <= 0 || r2Available <= 0) return 0;
+  const used = Math.min(Math.max(r2Used, 0), r2Available);
+  if (r2Available <= r1) return Math.floor((s1 * used) / r1);
+  const target = dlsTarget(s1, r1, r2Available, g50);
+  return Math.floor(((target - 1) * used) / r2Available);
+}

--- a/packages/engine/src/sports/cricket/index.ts
+++ b/packages/engine/src/sports/cricket/index.ts
@@ -1,5 +1,15 @@
-// Cricket SportModule — spec 04 (cricket section) + engine/sports/cricket.md.
-// Ball-by-ball events, innings, NRR metrics, tie ≠ draw, DLS/super-over methods.
-// Implemented in PROMPT-05.
-
-export {};
+// Cricket SportModule — spec 04 §2 + engine/sports/cricket.md (PROMPT-05).
+export {
+  cricket,
+  CricketCfg,
+  CricketEv,
+  CricketBall,
+  CricketInningsSummary,
+  CricketToss,
+  CricketRevise,
+  CricketPlayerLine,
+  type CricketBallEv,
+  type CricketState,
+  type InningsState,
+} from "./cricket.ts";
+export { DLS_STANDARD_TABLE, DLS_G50, DLS_EDITION, resources, dlsTarget, dlsPar } from "./dls.ts";

--- a/packages/engine/src/sports/football/football.test.ts
+++ b/packages/engine/src/sports/football/football.test.ts
@@ -1,0 +1,317 @@
+// Football goldens + conformance — spec 04 §1, PROMPT-04 §10.
+import { describe, expect, it } from "vitest";
+import { foldMatch, type CoreEv, type EventEnvelope } from "../../core/events.ts";
+import type { LineupPair, StageCtx } from "../../core/types.ts";
+import { conformanceSuite, lineupFromCatalog, makeEnvelope } from "../../testkit/index.ts";
+import { football, FOOTBALL_TIEBREAKERS, type FootballCfg, type FootballEv } from "./football.ts";
+
+// Direct module.apply calls need the module's payload union on the envelope.
+const asFootball = (event: EventEnvelope) => event as EventEnvelope<FootballEv | CoreEv>;
+
+// Catalog-valid 11 + a two-man bench for substitution tests.
+function lineupWithBench(entrantId: string): LineupPair["home"] {
+  const base = lineupFromCatalog(football.positions, entrantId);
+  return {
+    ...base,
+    slots: [
+      ...base.slots,
+      { personId: `${entrantId}-b1`, slot: "bench", orderNo: 12 },
+      { personId: `${entrantId}-b2`, slot: "bench", orderNo: 13 },
+    ],
+  };
+}
+const lineups: LineupPair = { home: lineupWithBench("H"), away: lineupWithBench("A") };
+
+const leagueCfg: FootballCfg = football.configSchema.parse({});
+const knockoutCfg: FootballCfg = football.configSchema.parse({
+  extraTime: { enabled: true, halfMinutes: 15 },
+  shootout: true,
+});
+const league: StageCtx = { kind: "league" };
+const group: StageCtx = { kind: "group" };
+const knockout: StageCtx = { kind: "knockout" };
+
+function stream(...specs: Array<[type: string, payload?: unknown]>): EventEnvelope[] {
+  return specs.map(([type, payload], i) => makeEnvelope(i, { type, payload: payload ?? {} }));
+}
+
+const fold = (cfg: FootballCfg, events: EventEnvelope[]) =>
+  foldMatch(football, cfg, lineups, events);
+
+// PROMPT-04 §10 (a) — league draw 1-1 ⇒ 1 pt each + metrics.
+describe("football golden (a): league draw 1-1", () => {
+  const events = stream(
+    ["core.start"],
+    ["football.goal", { by: "H", scorer: "H-p9", minute: 12 }],
+    ["football.period", { phase: "HT" }],
+    ["football.goal", { by: "A", minute: 71 }],
+    ["football.period", { phase: "FT" }],
+  );
+
+  it("folds to a draw with the right summary", () => {
+    const state = fold(leagueCfg, events);
+    expect(state.outcome).toEqual({ kind: "draw" });
+    expect(football.summary(state).headline).toBe("1 — 1");
+    expect(football.summary(state).detail).toMatchObject({
+      periods: [
+        { phase: "H1", home: 1, away: 0 },
+        { phase: "H2", home: 0, away: 1 },
+      ],
+    });
+  });
+
+  it("pays 1 point and symmetric metrics to each side", () => {
+    const state = fold(leagueCfg, events);
+    const [home, away] = football.standingsDelta(state.outcome!, leagueCfg, league, state);
+    expect(home).toMatchObject({
+      entrantId: "H",
+      drawn: 1,
+      points: 1,
+      metrics: { gf: 1, ga: 1, gd: 0, yellow: 0, red: 0, fair_play: 0 },
+    });
+    expect(away).toMatchObject({ entrantId: "A", drawn: 1, points: 1, metrics: { gd: 0 } });
+  });
+});
+
+// PROMPT-04 §10 (b) — knockout 0-0 → ET 1-1 → shootout 4-3, method 'shootout'.
+describe("football golden (b): knockout decided on penalties", () => {
+  const kick = (by: string, scored: boolean): [string, unknown] => [
+    "football.shootout.kick",
+    { by, scored },
+  ];
+  const events = stream(
+    ["core.start"],
+    ["football.period", { phase: "HT" }],
+    ["football.period", { phase: "FT" }], // 0-0 ⇒ ET (extraTime.enabled)
+    ["football.goal", { by: "H", minute: 97 }],
+    ["football.period", { phase: "ET_HT" }],
+    ["football.goal", { by: "A", minute: 113 }],
+    ["football.period", { phase: "ET_FT" }], // 1-1 ⇒ SHOOTOUT
+    kick("H", true),
+    kick("A", true),
+    kick("H", true),
+    kick("A", true),
+    kick("H", true),
+    kick("A", true),
+    kick("H", false),
+    kick("A", false),
+    kick("H", true),
+    kick("A", false), // 4-3 after 5 kicks each
+  );
+
+  it("walks the full FT → ET → shootout machine", () => {
+    const state = fold(knockoutCfg, events);
+    expect(state.outcome).toEqual({ kind: "win", winner: "H", loser: "A", method: "shootout" });
+    expect(state.goals).toEqual({ home: 1, away: 1 }); // shootout kicks are not goals
+    expect(football.summary(state).headline).toBe("1 — 1 (4–3 pens)");
+  });
+
+  it("keeps regulation points in knockout but honours the group SO split", () => {
+    const state = fold(knockoutCfg, events);
+    const [home, away] = football.standingsDelta(state.outcome!, knockoutCfg, knockout, state);
+    expect([home.points, away.points]).toEqual([3, 0]);
+
+    // spec 04 §1.4 — youth-cup convention SO win 2 / SO loss 1.
+    const splitCfg = football.configSchema.parse({
+      extraTime: { enabled: true, halfMinutes: 15 },
+      shootout: true,
+      points: { win: 3, draw: 1, loss: 0, shootoutWin: 2, shootoutLoss: 1 },
+    });
+    const splitState = foldMatch(football, splitCfg, lineups, events);
+    const [h2, a2] = football.standingsDelta(splitState.outcome!, splitCfg, group, splitState);
+    expect([h2.points, a2.points]).toEqual([2, 1]);
+    expect(football.declaredPointsSets(splitCfg)).toContain(3);
+  });
+
+  it("enforces kick alternation and early decision arithmetic", () => {
+    const early = stream(
+      ["core.start"],
+      ["football.period", { phase: "HT" }],
+      ["football.period", { phase: "FT" }],
+      ["football.goal", { by: "H" }],
+      ["football.goal", { by: "A" }],
+      ["football.period", { phase: "ET_HT" }],
+      ["football.period", { phase: "ET_FT" }],
+      kick("H", true),
+      kick("A", false),
+      kick("H", true),
+      kick("A", false),
+      kick("H", true), // 3-0 after 3v2: away max = 0+3 ⇒ not yet decided
+    );
+    const undecided = fold(knockoutCfg, early);
+    expect(football.outcome(undecided)).toBeNull();
+
+    const decided = fold(knockoutCfg, [
+      ...early,
+      makeEnvelope(early.length, { type: "football.shootout.kick", payload: { by: "A", scored: false } }),
+    ]); // 3-0 after 3v3: away max = 0+2 < 3 ⇒ decided
+    expect(football.outcome(decided)).toMatchObject({ kind: "win", winner: "H" });
+
+    expect(() =>
+      fold(knockoutCfg, [
+        ...early,
+        makeEnvelope(early.length, { type: "football.shootout.kick", payload: { by: "H", scored: true } }),
+      ]),
+    ).toThrowError(expect.objectContaining({ code: "INVALID_EVENT" })); // H kicked out of turn
+  });
+});
+
+// PROMPT-04 §10 (c) — forfeit ⇒ award with cfg.awardScore goals.
+describe("football golden (c): forfeit award 3-0", () => {
+  it("awards the tie to the opponent with the configured score", () => {
+    const state = fold(leagueCfg, stream(["core.start"], ["core.forfeit", { by: "A", reason: "no-show" }]));
+    expect(state.outcome).toEqual({
+      kind: "award",
+      winner: "H",
+      score: { home: 3, away: 0 },
+    });
+    expect(football.summary(state).headline).toBe("3 — 0");
+    const [home, away] = football.standingsDelta(state.outcome!, leagueCfg, league, state);
+    expect(home).toMatchObject({ won: 1, points: 3, metrics: { gf: 3, ga: 0, gd: 3 } });
+    expect(away).toMatchObject({ lost: 1, points: 0, metrics: { gf: 0, ga: 3, gd: -3 } });
+  });
+});
+
+// PROMPT-04 §10 (d) — own goal + red card fold to the right summary and
+// FIFA fair-play points (Y −1, 2nd-Y −3, direct R −4, Y+R −5).
+describe("football golden (d): own goal + cards", () => {
+  const events = stream(
+    ["core.start"],
+    ["football.goal", { by: "H", scorer: "H-p3", ownGoal: true, minute: 23 }], // credits A
+    ["football.card", { by: "H", person: "H-p5", color: "yellow", minute: 30 }],
+    ["football.card", { by: "H", person: "H-p5", color: "second_yellow", minute: 44 }],
+    ["football.period", { phase: "HT" }],
+    ["football.card", { by: "A", person: "A-p4", color: "red", minute: 60 }],
+    ["football.period", { phase: "FT" }],
+  );
+
+  it("credits the own goal to the opponent and decides the match", () => {
+    const state = fold(leagueCfg, events);
+    expect(state.goals).toEqual({ home: 0, away: 1 });
+    expect(state.outcome).toEqual({ kind: "win", winner: "A", loser: "H", method: "regulation" });
+    expect(state.squads.home.sentOff).toEqual(["H-p5"]);
+  });
+
+  it("computes card metrics on the FIFA fair-play scale", () => {
+    const state = fold(leagueCfg, events);
+    const [home, away] = football.standingsDelta(state.outcome!, leagueCfg, league, state);
+    expect(home.metrics).toMatchObject({ gf: 0, ga: 1, gd: -1, yellow: 2, red: 1, fair_play: -3 });
+    expect(away.metrics).toMatchObject({ gf: 1, ga: 0, gd: 1, yellow: 0, red: 1, fair_play: -4 });
+  });
+
+  it("scores yellow + direct red to one player as −5", () => {
+    const state = fold(
+      leagueCfg,
+      stream(
+        ["core.start"],
+        ["football.card", { by: "H", person: "H-p5", color: "yellow" }],
+        ["football.card", { by: "H", person: "H-p5", color: "red" }],
+        ["football.goal", { by: "A" }],
+        ["football.period", { phase: "HT" }],
+        ["football.period", { phase: "FT" }],
+      ),
+    );
+    const [home] = football.standingsDelta(state.outcome!, leagueCfg, league, state);
+    expect(home.metrics.fair_play).toBe(-5);
+  });
+});
+
+describe("football state machine guards (spec 04 §1.3)", () => {
+  it("rejects a goal after FT when no extra time is configured", () => {
+    const done = fold(leagueCfg, stream(["core.start"], ["football.goal", { by: "H" }], ["football.period", { phase: "HT" }], ["football.period", { phase: "FT" }]));
+    expect(() =>
+      football.apply(done, asFootball(makeEnvelope(9, { type: "football.goal", payload: { by: "H" } }))),
+    ).toThrowError(expect.objectContaining({ code: "WRONG_PHASE" }));
+  });
+
+  it("keeps a level knockout fixture undecided at FT (ET path pending)", () => {
+    const state = fold(knockoutCfg, stream(["core.start"], ["football.period", { phase: "HT" }], ["football.period", { phase: "FT" }]));
+    expect(football.outcome(state)).toBeNull();
+    expect(state.phase).toBe("ET_H1");
+    // …and finalize is refused while undecided.
+    expect(() =>
+      football.apply(state, asFootball(makeEnvelope(9, { type: "core.finalize", payload: {} }))),
+    ).toThrowError(expect.objectContaining({ code: "WRONG_PHASE" }));
+  });
+
+  it("goes straight to a shootout when shootout is on but ET is off", () => {
+    const cfg = football.configSchema.parse({ shootout: true });
+    const state = fold(cfg, stream(["core.start"], ["football.period", { phase: "HT" }], ["football.period", { phase: "FT" }]));
+    expect(state.phase).toBe("SHOOTOUT");
+  });
+
+  it("rejects out-of-order period markers", () => {
+    expect(() => fold(leagueCfg, stream(["core.start"], ["football.period", { phase: "FT" }]))).toThrowError(
+      expect.objectContaining({ code: "WRONG_PHASE" }),
+    );
+  });
+
+  it("validates substitutions against the pitch and the bench", () => {
+    const base = stream(["core.start"]);
+    const sub = (payload: unknown) =>
+      fold(leagueCfg, [...base, makeEnvelope(1, { type: "football.sub", payload })]);
+    expect(sub({ by: "H", off: "H-p1", on: "H-b1" }).squads.home.onPitch).toContain("H-b1");
+    expect(() => sub({ by: "H", off: "H-b2", on: "H-b1" })).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    expect(() => sub({ by: "H", off: "H-p1", on: "A-b1" })).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    // A substituted-off player may not return.
+    const twice = [
+      ...base,
+      makeEnvelope(1, { type: "football.sub", payload: { by: "H", off: "H-p1", on: "H-b1" } }),
+      makeEnvelope(2, { type: "football.sub", payload: { by: "H", off: "H-b1", on: "H-p1" } }),
+    ];
+    expect(() => fold(leagueCfg, twice)).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+  });
+
+  it("flags an abandoned fixture for replay without an outcome", () => {
+    const state = fold(leagueCfg, stream(["core.start"], ["football.goal", { by: "H" }], ["core.abandon", { reason: "floodlights" }]));
+    expect(football.outcome(state)).toBeNull();
+    expect(state.replayFlagged).toBe(true);
+    expect(football.summary(state).detail).toMatchObject({ abandoned: true });
+  });
+
+  it("awards an abandoned fixture to the leader under the award policy", () => {
+    const cfg = football.configSchema.parse({ abandonPolicy: "award" });
+    const leader = fold(cfg, stream(["core.start"], ["football.goal", { by: "A" }], ["core.abandon", { reason: "crowd" }]));
+    expect(football.outcome(leader)).toMatchObject({ kind: "award", winner: "A" });
+    const level = fold(cfg, stream(["core.start"], ["core.abandon", { reason: "crowd" }]));
+    expect(football.outcome(level)).toEqual({ kind: "no_result" });
+  });
+});
+
+describe("football contract declarations", () => {
+  it("exports both official tiebreaker presets, defaulting to fifa2026", () => {
+    expect(FOOTBALL_TIEBREAKERS.fifa2026.slice(0, 4)).toEqual([
+      "points",
+      "h2h_points",
+      "h2h_diff",
+      "h2h_for",
+    ]);
+    expect(FOOTBALL_TIEBREAKERS.classic.slice(0, 3)).toEqual(["points", "diff", "for"]);
+    expect(football.defaultTiebreakers).toEqual(FOOTBALL_TIEBREAKERS.fifa2026);
+  });
+
+  it("supports draws in league/group but never in eliminations", () => {
+    expect(football.supportsDraws(leagueCfg, "league")).toBe(true);
+    expect(football.supportsDraws(leagueCfg, "group")).toBe(true);
+    expect(football.supportsDraws(knockoutCfg, "knockout")).toBe(false);
+    expect(football.supportsDraws(knockoutCfg, "double_elim")).toBe(false);
+  });
+
+  it("declares point totals {3, 2} (+ SO split total when configured)", () => {
+    expect([...football.declaredPointsSets(leagueCfg)].sort()).toEqual([2, 3]);
+  });
+});
+
+// PROMPT-04 acceptance — conformance green under both configurations.
+conformanceSuite(football, { cfg: {}, label: "league" });
+conformanceSuite(football, {
+  cfg: { extraTime: { enabled: true, halfMinutes: 15 }, shootout: true },
+  label: "knockout",
+  stageCtxs: [{ kind: "knockout" }, { kind: "group" }],
+});

--- a/packages/engine/src/sports/football/football.ts
+++ b/packages/engine/src/sports/football/football.ts
@@ -1,0 +1,849 @@
+// Football SportModule — spec 04 §1 + engine/sports/football.md (PROMPT-04).
+// Timed periods, draws league-only, ET/shootout sub-machines, FIFA fair play,
+// two official tiebreaker presets (fifa2026 H2H-first / classic GD-first).
+import { z } from "zod";
+import { EngineError } from "../../core/errors.ts";
+import type { CoreEv, EventEnvelope } from "../../core/events.ts";
+import type { Rng } from "../../core/rng.ts";
+import {
+  EntrantId,
+  type LineupPair,
+  type MatchOutcome,
+  type ScoreSummary,
+  type StageCtx,
+  type StageKind,
+  type StandingsDelta,
+} from "../../core/types.ts";
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import type { ModuleEvent, SportModule, TiebreakerKey } from "../../sport/module.ts";
+
+// ---------------------------------------------------------------------------
+// Cfg — spec 04 §1.1
+// ---------------------------------------------------------------------------
+
+export const FootballCfg = z.object({
+  halfMinutes: z.number().int().positive().default(45),
+  // The state machine models exactly two halves (spec 04 §1.3); halves is
+  // config-as-data for forward compatibility but only 2 is valid today.
+  halves: z.literal(2).default(2),
+  extraTime: z
+    .object({
+      enabled: z.boolean(),
+      halfMinutes: z.number().int().positive(),
+    })
+    .default({ enabled: false, halfMinutes: 15 }), // knockout only
+  shootout: z.boolean().default(false), // knockout only
+  points: z
+    .object({
+      win: z.number().int().nonnegative().default(3),
+      draw: z.number().int().nonnegative().default(1),
+      loss: z.number().int().nonnegative().default(0),
+      // spec 04 §1.4 — optional split for group-stage shootouts
+      // (youth-cup convention: SO win 2, SO loss 1).
+      shootoutWin: z.number().int().nonnegative().optional(),
+      shootoutLoss: z.number().int().nonnegative().optional(),
+    })
+    .default({ win: 3, draw: 1, loss: 0 }),
+  awardScore: z.object({ goals: z.number().int().positive() }).default({ goals: 3 }),
+  fairPlay: z.boolean().default(true), // track cards for FIFA fair-play TB
+  // engine/sports/football.md §8 — core.abandon policy: `replay` leaves the
+  // fixture undecided (flagged for regeneration), `award` decides for the
+  // current leader (level score ⇒ no_result).
+  abandonPolicy: z.enum(["replay", "award"]).default("replay"),
+});
+export type FootballCfg = z.infer<typeof FootballCfg>;
+
+// ---------------------------------------------------------------------------
+// Ev — spec 04 §1.2
+// ---------------------------------------------------------------------------
+
+const PersonId = z.string().min(1);
+
+export const FootballGoal = z.strictObject({
+  by: EntrantId, // ownGoal: the side whose player struck it (credits opponent)
+  scorer: PersonId.optional(),
+  minute: z.number().int().nonnegative().optional(), // optional everywhere: coarse scoring
+  ownGoal: z.boolean().optional(),
+  penalty: z.boolean().optional(), // in-play penalty kick, not a shootout kick
+});
+export const CardColor = z.enum(["yellow", "red", "second_yellow"]);
+export const FootballCard = z.strictObject({
+  by: EntrantId,
+  person: PersonId.optional(),
+  color: CardColor,
+  minute: z.number().int().nonnegative().optional(),
+});
+export const FootballSub = z.strictObject({
+  by: EntrantId,
+  off: PersonId,
+  on: PersonId,
+  minute: z.number().int().nonnegative().optional(),
+});
+export const FootballPeriod = z.strictObject({
+  phase: z.enum(["HT", "FT", "ET_HT", "ET_FT"]),
+});
+export const FootballShootoutKick = z.strictObject({
+  by: EntrantId,
+  person: PersonId.optional(),
+  scored: z.boolean(),
+});
+
+export const FootballEv = z.union([
+  FootballGoal,
+  FootballCard,
+  FootballSub,
+  FootballPeriod,
+  FootballShootoutKick,
+]);
+export type FootballEv = z.infer<typeof FootballEv>;
+
+// ---------------------------------------------------------------------------
+// State — spec 04 §1.3
+// ---------------------------------------------------------------------------
+
+type Side = "home" | "away";
+type PlayPhase = "H1" | "H2" | "ET_H1" | "ET_H2";
+type Phase = "pre" | PlayPhase | "SHOOTOUT" | "done" | "final" | "abandoned";
+
+interface SquadState {
+  onPitch: string[];
+  bench: string[];
+  offUsed: string[]; // substituted off — may not return
+  sentOff: string[]; // red / second yellow — may not return or be subbed for
+}
+
+interface CardRecord {
+  side: Side;
+  person?: string;
+  color: z.infer<typeof CardColor>;
+  minute?: number;
+}
+
+export interface FootballState {
+  cfg: FootballCfg;
+  entrants: { home: string; away: string };
+  phase: Phase;
+  goals: { home: number; away: number }; // regulation + ET (shootout excluded)
+  // Per-period breakdown, in play order — the coarse "period summaries" view
+  // (PROMPT-04 §9) and the summary.detail payload.
+  periods: { phase: PlayPhase; home: number; away: number }[];
+  cards: CardRecord[];
+  squads: { home: SquadState; away: SquadState };
+  shootout: { kicks: { side: Side; scored: boolean }[] } | null;
+  outcome: MatchOutcome | null;
+  replayFlagged: boolean; // abandonPolicy 'replay' — fixture to regenerate
+}
+
+const PLAY_PHASES: readonly Phase[] = ["H1", "H2", "ET_H1", "ET_H2"];
+
+function opponent(side: Side): Side {
+  return side === "home" ? "away" : "home";
+}
+
+function invalid(message: string, data?: unknown): never {
+  throw new EngineError("INVALID_EVENT", message, data);
+}
+
+function wrongPhase(message: string, data?: unknown): never {
+  throw new EngineError("WRONG_PHASE", message, data);
+}
+
+function sideOf(state: FootballState, entrantId: string): Side {
+  if (entrantId === state.entrants.home) return "home";
+  if (entrantId === state.entrants.away) return "away";
+  invalid(`unknown entrant "${entrantId}"`, { entrantId });
+}
+
+function parsePayload<T>(schema: z.ZodType<T>, payload: unknown, type: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) {
+    invalid(`invalid ${type} payload`, { issues: parsed.error.issues });
+  }
+  return parsed.data;
+}
+
+function isPlayPhase(phase: Phase): phase is PlayPhase {
+  return PLAY_PHASES.includes(phase);
+}
+
+// ---------------------------------------------------------------------------
+// Fold helpers
+// ---------------------------------------------------------------------------
+
+function pushPeriod(state: FootballState, phase: PlayPhase): FootballState {
+  return { ...state, phase, periods: [...state.periods, { phase, home: 0, away: 0 }] };
+}
+
+function creditGoal(state: FootballState, credited: Side): FootballState {
+  const periods = state.periods.map((period, i) =>
+    i === state.periods.length - 1
+      ? { ...period, [credited]: period[credited] + 1 }
+      : period,
+  );
+  return {
+    ...state,
+    goals: { ...state.goals, [credited]: state.goals[credited] + 1 },
+    periods,
+  };
+}
+
+// Level-score resolution at FT / ET_FT — spec 04 §1.3: the knockout config
+// (ET/shootout) keeps the outcome null until the deciders run; without them a
+// level score is a draw (league semantics; the engine refuses to finalize a
+// drawn knockout fixture via supportsDraws).
+function resolveFullTime(state: FootballState, after: "FT" | "ET_FT"): FootballState {
+  const { home, away } = state.goals;
+  if (home !== away) {
+    const winnerSide: Side = home > away ? "home" : "away";
+    return {
+      ...state,
+      phase: "done",
+      outcome: {
+        kind: "win",
+        winner: state.entrants[winnerSide],
+        loser: state.entrants[opponent(winnerSide)],
+        method: after === "FT" ? "regulation" : "extra_time",
+      },
+    };
+  }
+  if (after === "FT" && state.cfg.extraTime.enabled) return pushPeriod(state, "ET_H1");
+  if (state.cfg.shootout) return { ...state, phase: "SHOOTOUT", shootout: { kicks: [] } };
+  return { ...state, phase: "done", outcome: { kind: "draw" } };
+}
+
+// spec 04 §1.4 — best-of-5 alternating, early decision when lead exceeds the
+// opponent's remaining kicks, then sudden-death pairs.
+function shootoutDecision(
+  kicks: readonly { side: Side; scored: boolean }[],
+): Side | null {
+  const taken = { home: 0, away: 0 };
+  const scored = { home: 0, away: 0 };
+  for (const kick of kicks) {
+    taken[kick.side]++;
+    if (kick.scored) scored[kick.side]++;
+  }
+  // Remaining entitlement: up to 5 in regulation; in sudden death a side is
+  // entitled to match the opponent's kick count (complete the pair).
+  const remaining = (side: Side): number =>
+    taken[side] < 5 ? 5 - taken[side] : Math.max(0, taken[opponent(side)] - taken[side]);
+  if (scored.home > scored.away + remaining("away")) return "home";
+  if (scored.away > scored.home + remaining("home")) return "away";
+  return null;
+}
+
+function expectedKicker(
+  kicks: readonly { side: Side; scored: boolean }[],
+): Side | null {
+  if (kicks.length === 0) return null; // either side may start
+  const taken = { home: 0, away: 0 };
+  for (const kick of kicks) taken[kick.side]++;
+  if (taken.home === taken.away) return (kicks[0] as { side: Side }).side;
+  return taken.home < taken.away ? "home" : "away";
+}
+
+// FIFA fair-play scale (spec 04 §1.5): yellow −1, second yellow (indirect
+// red) −3, direct red −4, yellow + direct red −5 — one deduction per person,
+// worst applicable category. Anonymous cards (coarse) deduct independently.
+function fairPlayPoints(cards: readonly CardRecord[], side: Side): number {
+  let total = 0;
+  const byPerson = new Map<string, CardRecord[]>();
+  for (const card of cards) {
+    if (card.side !== side) continue;
+    if (card.person === undefined) {
+      total += card.color === "yellow" ? -1 : card.color === "second_yellow" ? -3 : -4;
+      continue;
+    }
+    byPerson.set(card.person, [...(byPerson.get(card.person) ?? []), card]);
+  }
+  for (const personCards of byPerson.values()) {
+    const hasYellow = personCards.some((card) => card.color === "yellow");
+    const hasSecondYellow = personCards.some((card) => card.color === "second_yellow");
+    const hasDirectRed = personCards.some((card) => card.color === "red");
+    if (hasYellow && hasDirectRed) total += -5;
+    else if (hasDirectRed) total += -4;
+    else if (hasSecondYellow) total += -3;
+    else if (hasYellow) total += -1;
+  }
+  return total;
+}
+
+function cardCounts(cards: readonly CardRecord[], side: Side): { yellow: number; red: number } {
+  let yellow = 0;
+  let red = 0;
+  for (const card of cards) {
+    if (card.side !== side) continue;
+    if (card.color === "yellow" || card.color === "second_yellow") yellow++;
+    if (card.color === "red" || card.color === "second_yellow") red++;
+  }
+  return { yellow, red };
+}
+
+function removeFromPitch(squad: SquadState, person: string, sentOff: boolean): SquadState {
+  return {
+    ...squad,
+    onPitch: squad.onPitch.filter((id) => id !== person),
+    sentOff: sentOff ? [...squad.sentOff, person] : squad.sentOff,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Event application
+// ---------------------------------------------------------------------------
+
+function applyGoal(state: FootballState, payload: z.infer<typeof FootballGoal>): FootballState {
+  if (!isPlayPhase(state.phase)) {
+    wrongPhase(`goal not allowed in phase "${state.phase}"`, { phase: state.phase });
+  }
+  const by = sideOf(state, payload.by);
+  if (payload.scorer !== undefined) {
+    // The scorer belongs to the striking side (`by`), also for own goals.
+    const squad = state.squads[by];
+    if (!squad.onPitch.includes(payload.scorer)) {
+      invalid(`scorer "${payload.scorer}" is not on the pitch for "${payload.by}"`, {
+        scorer: payload.scorer,
+      });
+    }
+  }
+  // spec 04 §1.3 — own-goal credits the opponent.
+  return creditGoal(state, payload.ownGoal === true ? opponent(by) : by);
+}
+
+function applyCard(state: FootballState, payload: z.infer<typeof FootballCard>): FootballState {
+  // Cards valid pre-kickoff (red before kickoff — football.md §9), during
+  // play and during a shootout; never once the match is decided.
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase(`card not allowed in phase "${state.phase}"`);
+  }
+  const side = sideOf(state, payload.by);
+  let squads = state.squads;
+  if (payload.person !== undefined) {
+    const person = payload.person;
+    const squad = state.squads[side];
+    const inLineup =
+      squad.onPitch.includes(person) ||
+      squad.bench.includes(person) ||
+      squad.offUsed.includes(person);
+    if (squad.sentOff.includes(person)) {
+      invalid(`"${person}" was already sent off`, { person });
+    }
+    if (!inLineup) {
+      invalid(`"${person}" is not in the lineup for "${payload.by}"`, { person });
+    }
+    const priorYellow = state.cards.some(
+      (card) => card.person === person && card.color === "yellow",
+    );
+    if (payload.color === "yellow" && priorYellow) {
+      invalid(`second yellow for "${person}" must be recorded as second_yellow`, { person });
+    }
+    if (payload.color === "second_yellow" && !priorYellow) {
+      invalid(`second_yellow for "${person}" without a prior yellow`, { person });
+    }
+    if (payload.color !== "yellow") {
+      squads = { ...squads, [side]: removeFromPitch(squad, person, true) };
+    }
+  }
+  const record: CardRecord = {
+    side,
+    ...(payload.person === undefined ? {} : { person: payload.person }),
+    color: payload.color,
+    ...(payload.minute === undefined ? {} : { minute: payload.minute }),
+  };
+  return { ...state, cards: [...state.cards, record], squads };
+}
+
+function applySub(state: FootballState, payload: z.infer<typeof FootballSub>): FootballState {
+  if (!isPlayPhase(state.phase)) {
+    wrongPhase(`substitution not allowed in phase "${state.phase}"`);
+  }
+  const side = sideOf(state, payload.by);
+  const squad = state.squads[side];
+  if (!squad.onPitch.includes(payload.off)) {
+    invalid(`"${payload.off}" is not on the pitch`, { off: payload.off });
+  }
+  if (!squad.bench.includes(payload.on)) {
+    invalid(`"${payload.on}" is not an available bench player`, { on: payload.on });
+  }
+  const next: SquadState = {
+    onPitch: [...squad.onPitch.filter((id) => id !== payload.off), payload.on],
+    bench: squad.bench.filter((id) => id !== payload.on),
+    offUsed: [...squad.offUsed, payload.off],
+    sentOff: squad.sentOff,
+  };
+  return { ...state, squads: { ...state.squads, [side]: next } };
+}
+
+function applyPeriod(state: FootballState, payload: z.infer<typeof FootballPeriod>): FootballState {
+  const marker = payload.phase;
+  switch (marker) {
+    case "HT":
+      if (state.phase !== "H1") wrongPhase(`HT marker in phase "${state.phase}"`);
+      return pushPeriod(state, "H2");
+    case "FT":
+      if (state.phase !== "H2") wrongPhase(`FT marker in phase "${state.phase}"`);
+      return resolveFullTime(state, "FT");
+    case "ET_HT":
+      if (state.phase !== "ET_H1") wrongPhase(`ET_HT marker in phase "${state.phase}"`);
+      return pushPeriod(state, "ET_H2");
+    case "ET_FT":
+      if (state.phase !== "ET_H2") wrongPhase(`ET_FT marker in phase "${state.phase}"`);
+      return resolveFullTime(state, "ET_FT");
+  }
+}
+
+function applyShootoutKick(
+  state: FootballState,
+  payload: z.infer<typeof FootballShootoutKick>,
+): FootballState {
+  if (state.phase !== "SHOOTOUT" || state.shootout === null) {
+    wrongPhase(`shootout kick in phase "${state.phase}"`);
+  }
+  const side = sideOf(state, payload.by);
+  const expected = expectedKicker(state.shootout.kicks);
+  if (expected !== null && side !== expected) {
+    invalid(`kicks must alternate: expected "${state.entrants[expected]}"`, {
+      expected: state.entrants[expected],
+    });
+  }
+  if (payload.person !== undefined) {
+    const squad = state.squads[side];
+    if (!squad.onPitch.includes(payload.person)) {
+      invalid(`kicker "${payload.person}" is not on the pitch`, { person: payload.person });
+    }
+  }
+  const kicks = [...state.shootout.kicks, { side, scored: payload.scored }];
+  const winnerSide = shootoutDecision(kicks);
+  if (winnerSide === null) return { ...state, shootout: { kicks } };
+  return {
+    ...state,
+    shootout: { kicks },
+    phase: "done",
+    outcome: {
+      kind: "win",
+      winner: state.entrants[winnerSide],
+      loser: state.entrants[opponent(winnerSide)],
+      method: "shootout",
+    },
+  };
+}
+
+function applyForfeit(state: FootballState, by: string): FootballState {
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase("match already over");
+  }
+  const winnerSide = opponent(sideOf(state, by));
+  const goals =
+    winnerSide === "home"
+      ? { home: state.cfg.awardScore.goals, away: 0 }
+      : { home: 0, away: state.cfg.awardScore.goals };
+  // spec 04 §1 / PROMPT-04 §7 — forfeit ⇒ award with cfg.awardScore goals.
+  return {
+    ...state,
+    phase: "done",
+    goals,
+    outcome: { kind: "award", winner: state.entrants[winnerSide], score: goals },
+  };
+}
+
+function applyAbandon(state: FootballState): FootballState {
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase("match already over");
+  }
+  if (state.cfg.abandonPolicy === "replay") {
+    // No outcome; fixture flagged for regeneration (PROMPT-04 §7). finalize
+    // is refused because the outcome stays null.
+    return { ...state, phase: "abandoned", replayFlagged: true };
+  }
+  const { home, away } = state.goals;
+  if (home === away) return { ...state, phase: "done", outcome: { kind: "no_result" } };
+  const winnerSide: Side = home > away ? "home" : "away";
+  return {
+    ...state,
+    phase: "done",
+    outcome: {
+      kind: "award",
+      winner: state.entrants[winnerSide],
+      score: { home, away },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Standings — spec 04 §1.5
+// ---------------------------------------------------------------------------
+
+function sideMetrics(state: FootballState, side: Side, zero: boolean): Record<string, number> {
+  const counts = cardCounts(state.cards, side);
+  const gf = zero ? 0 : state.goals[side];
+  const ga = zero ? 0 : state.goals[opponent(side)];
+  return {
+    gf,
+    ga,
+    gd: gf - ga,
+    yellow: counts.yellow,
+    red: counts.red,
+    fair_play: state.cfg.fairPlay ? fairPlayPoints(state.cards, side) : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tiebreaker presets — spec 04 §1.6 (verified against the FIFA 2026 source,
+// engine/11-sources.md: H2H-first cascade aligned with UEFA for 2026).
+// ---------------------------------------------------------------------------
+
+export const FOOTBALL_TIEBREAKERS: Record<"fifa2026" | "classic", TiebreakerKey[]> = {
+  // points → H2H points → H2H GD → H2H goals → overall GD → overall GF →
+  // fair play → drawing of lots.
+  fifa2026: ["points", "h2h_points", "h2h_diff", "h2h_for", "diff", "for", "fair_play", "lots"],
+  // pre-2026 WC: points → overall GD → overall GF → H2H block → fair play → lots.
+  classic: ["points", "diff", "for", "h2h_points", "h2h_diff", "h2h_for", "fair_play", "lots"],
+};
+
+// ---------------------------------------------------------------------------
+// Positions — spec 04 §1 / PROMPT-04 §8
+// ---------------------------------------------------------------------------
+
+const positions: PositionCatalog = {
+  groups: [
+    { key: "GK", name: "Goalkeeper", min: 1, max: 1 },
+    { key: "DF", name: "Defender" },
+    { key: "MF", name: "Midfielder" },
+    { key: "FW", name: "Forward" },
+    // Child keys (display granularity below the four groups).
+    { key: "CB", name: "Centre back" },
+    { key: "LB", name: "Left back" },
+    { key: "RB", name: "Right back" },
+    { key: "CM", name: "Centre midfield" },
+    { key: "DM", name: "Defensive midfield" },
+    { key: "AM", name: "Attacking midfield" },
+    { key: "LW", name: "Left wing" },
+    { key: "RW", name: "Right wing" },
+    { key: "ST", name: "Striker" },
+  ],
+  roles: [{ key: "captain", name: "Captain", unique: true }],
+  lineup: { size: 11, benchMax: 12 },
+};
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+function squadFromLineup(lineup: LineupPair["home"]): SquadState {
+  const starting = lineup.slots
+    .filter((slot) => slot.slot === "starting")
+    .sort((a, b) => a.orderNo - b.orderNo)
+    .map((slot) => slot.personId);
+  const bench = lineup.slots
+    .filter((slot) => slot.slot === "bench")
+    .sort((a, b) => a.orderNo - b.orderNo)
+    .map((slot) => slot.personId);
+  return { onPitch: starting, bench, offUsed: [], sentOff: [] };
+}
+
+export const football: SportModule<FootballCfg, FootballEv, FootballState> = {
+  key: "football",
+  version: "1.0.0",
+  configSchema: FootballCfg,
+  eventSchema: FootballEv,
+  positions,
+  variants: {
+    // spec 04 §1.1
+    "11-a-side": {},
+    youth: { halfMinutes: 30 },
+    "small-sided": { halfMinutes: 20, halves: 2 },
+  },
+
+  init(cfg, lineups: LineupPair): FootballState {
+    return {
+      cfg,
+      entrants: { home: lineups.home.entrantId, away: lineups.away.entrantId },
+      phase: "pre",
+      goals: { home: 0, away: 0 },
+      periods: [],
+      cards: [],
+      squads: { home: squadFromLineup(lineups.home), away: squadFromLineup(lineups.away) },
+      shootout: null,
+      outcome: null,
+      replayFlagged: false,
+    };
+  },
+
+  apply(state, ev: EventEnvelope<FootballEv | CoreEv>): FootballState {
+    switch (ev.type) {
+      case "core.start":
+        if (state.phase !== "pre") wrongPhase("already started");
+        return pushPeriod(state, "H1");
+      case "football.goal":
+        return applyGoal(state, parsePayload(FootballGoal, ev.payload, ev.type));
+      case "football.card":
+        return applyCard(state, parsePayload(FootballCard, ev.payload, ev.type));
+      case "football.sub":
+        return applySub(state, parsePayload(FootballSub, ev.payload, ev.type));
+      case "football.period":
+        return applyPeriod(state, parsePayload(FootballPeriod, ev.payload, ev.type));
+      case "football.shootout.kick":
+        return applyShootoutKick(state, parsePayload(FootballShootoutKick, ev.payload, ev.type));
+      case "core.forfeit":
+        return applyForfeit(state, (ev.payload as { by: string }).by);
+      case "core.abandon":
+        return applyAbandon(state);
+      case "core.finalize":
+        if (state.outcome === null) wrongPhase("cannot finalize an undecided fixture");
+        return { ...state, phase: "final" };
+      case "core.note":
+        return state;
+      default:
+        invalid(`unknown event type "${ev.type}"`);
+    }
+  },
+
+  outcome: (state) => state.outcome,
+
+  // §9.5 — defined at every prefix.
+  summary(state): ScoreSummary {
+    const { home, away } = state.goals;
+    const shootout = state.shootout
+      ? state.shootout.kicks.reduce(
+          (tally, kick) => {
+            if (kick.scored) tally[kick.side]++;
+            return tally;
+          },
+          { home: 0, away: 0 },
+        )
+      : null;
+    const suffix = shootout ? ` (${shootout.home}–${shootout.away} pens)` : "";
+    return {
+      headline: `${home} — ${away}${suffix}`,
+      perSide: [
+        { entrantId: state.entrants.home, line: `${home}${shootout ? ` (${shootout.home}p)` : ""}` },
+        { entrantId: state.entrants.away, line: `${away}${shootout ? ` (${shootout.away}p)` : ""}` },
+      ],
+      detail: {
+        periods: state.periods,
+        ...(shootout === null ? {} : { shootout }),
+        ...(state.replayFlagged ? { abandoned: true } : {}),
+      },
+    };
+  },
+
+  standingsDelta(outcome, cfg, _ctx: StageCtx, state): [StandingsDelta, StandingsDelta] {
+    const build = (
+      side: Side,
+      w: number,
+      d: number,
+      l: number,
+      pts: number,
+      zeroGoals = false,
+    ): StandingsDelta => ({
+      entrantId: state.entrants[side],
+      played: 1,
+      won: w,
+      drawn: d,
+      lost: l,
+      points: pts,
+      metrics: sideMetrics(state, side, zeroGoals),
+    });
+
+    switch (outcome.kind) {
+      case "win":
+      case "award": {
+        const winnerSide = sideOf(state, outcome.winner);
+        // spec 04 §1.4 — optional shootout points split (group-stage SO).
+        const split =
+          outcome.kind === "win" &&
+          outcome.method === "shootout" &&
+          cfg.points.shootoutWin !== undefined &&
+          cfg.points.shootoutLoss !== undefined;
+        const winnerPts = split ? (cfg.points.shootoutWin as number) : cfg.points.win;
+        const loserPts = split ? (cfg.points.shootoutLoss as number) : cfg.points.loss;
+        const winner = build(winnerSide, 1, 0, 0, winnerPts);
+        const loser = build(opponent(winnerSide), 0, 0, 1, loserPts);
+        return winnerSide === "home" ? [winner, loser] : [loser, winner];
+      }
+      case "draw":
+      case "tie":
+        return [build("home", 0, 1, 0, cfg.points.draw), build("away", 0, 1, 0, cfg.points.draw)];
+      case "no_result":
+        // Abandoned level match under the 'award' policy: share draw points,
+        // no draw counted, no goal metrics (mirrors the generic module).
+        return [
+          build("home", 0, 0, 0, cfg.points.draw, true),
+          build("away", 0, 0, 0, cfg.points.draw, true),
+        ];
+    }
+  },
+
+  metrics: [
+    { key: "gf", label: "Goals for", direction: "desc" },
+    { key: "ga", label: "Goals against", direction: "asc" },
+    { key: "gd", label: "Goal difference", direction: "desc" },
+    { key: "yellow", label: "Yellow cards", direction: "asc" },
+    { key: "red", label: "Red cards", direction: "asc" },
+    { key: "fair_play", label: "Fair play points", direction: "desc" },
+  ],
+  // Module default = fifa2026 (spec 04 §1.6); `classic` selectable by the
+  // organiser via FOOTBALL_TIEBREAKERS.
+  defaultTiebreakers: FOOTBALL_TIEBREAKERS.fifa2026,
+
+  // spec 04 §1.3 — draws are league/group results only.
+  supportsDraws(_cfg, stage: StageKind) {
+    return stage === "league" || stage === "group" || stage === "swiss";
+  },
+
+  // §9.3 — {win+loss, 2·draw} plus the optional shootout split total.
+  declaredPointsSets(cfg) {
+    const totals = [cfg.points.win + cfg.points.loss, cfg.points.draw * 2];
+    if (cfg.points.shootoutWin !== undefined && cfg.points.shootoutLoss !== undefined) {
+      totals.push(cfg.points.shootoutWin + cfg.points.shootoutLoss);
+    }
+    return [...new Set(totals)];
+  },
+
+  // doc 14 §2 — Tier 1 = bare goals/periods (final score); Tier 2/3 = the
+  // attributed timeline (scorers, minutes, cards, subs), Pro-gated.
+  fidelityTiers: [
+    { tier: 0, eventTypes: ["football.goal", "football.period", "football.shootout.kick"] },
+    { tier: 1, eventTypes: ["football.goal", "football.period", "football.shootout.kick"] },
+    {
+      tier: 2,
+      eventTypes: [
+        "football.goal",
+        "football.card",
+        "football.sub",
+        "football.period",
+        "football.shootout.kick",
+      ],
+      entitlement: "scoring.match_timeline",
+    },
+    {
+      tier: 3,
+      eventTypes: [
+        "football.goal",
+        "football.card",
+        "football.sub",
+        "football.period",
+        "football.shootout.kick",
+      ],
+      entitlement: "scoring.match_timeline",
+    },
+  ],
+  officialLabel: { scorer: "Referee" }, // doc 13 §1
+
+  // spec 03 §6 — deterministic valid-event generator.
+  arbitraryEvent(state, rng: Rng): ModuleEvent<FootballEv> | null {
+    const sideId = (side: Side) => state.entrants[side];
+    const randomSide = (): Side => (rng() < 0.5 ? "home" : "away");
+
+    if (state.phase === "pre") {
+      // Pre-kickoff card (football.md §9) — at most one, to a clean player.
+      if (rng() >= 0.9 && state.cards.length === 0) {
+        const side = randomSide();
+        const person = state.squads[side].onPitch[0];
+        if (person !== undefined) {
+          return { type: "football.card", payload: { by: sideId(side), person, color: "yellow" } };
+        }
+      }
+      return { type: "core.start", payload: {} };
+    }
+
+    if (state.phase === "SHOOTOUT" && state.shootout) {
+      const expected = expectedKicker(state.shootout.kicks) ?? randomSide();
+      return {
+        type: "football.shootout.kick",
+        payload: { by: sideId(expected), scored: rng() < 0.75 },
+      };
+    }
+
+    if (!isPlayPhase(state.phase)) return null; // done / final / abandoned
+
+    const roll = rng();
+    if (roll < 0.02) {
+      return { type: "core.forfeit", payload: { by: sideId(randomSide()), reason: "walkover" } };
+    }
+    if (roll < 0.04) return { type: "core.abandon", payload: { reason: "weather" } };
+    if (roll < 0.14) {
+      // Card to a random on-pitch player without a prior yellow (or anonymous).
+      const side = randomSide();
+      const squad = state.squads[side];
+      const carded = new Set(
+        state.cards.filter((card) => card.person !== undefined).map((card) => card.person),
+      );
+      const eligible = squad.onPitch.filter((person) => !carded.has(person));
+      const person = eligible[Math.floor(rng() * eligible.length)];
+      if (person === undefined || rng() < 0.3) {
+        return { type: "football.card", payload: { by: sideId(side), color: "yellow" } };
+      }
+      const color = rng() < 0.85 ? "yellow" : "red";
+      return { type: "football.card", payload: { by: sideId(side), person, color } };
+    }
+    if (roll < 0.19) {
+      const side = randomSide();
+      const squad = state.squads[side];
+      const on = squad.bench[Math.floor(rng() * squad.bench.length)];
+      const off = squad.onPitch[Math.floor(rng() * squad.onPitch.length)];
+      if (on !== undefined && off !== undefined) {
+        return { type: "football.sub", payload: { by: sideId(side), off, on } };
+      }
+      // No bench (conformance lineups) — fall through to a goal instead.
+    }
+    if (roll < 0.72) {
+      const side = randomSide();
+      const ownGoal = rng() < 0.05;
+      const squad = state.squads[side];
+      const scorer =
+        rng() < 0.5 ? squad.onPitch[Math.floor(rng() * squad.onPitch.length)] : undefined;
+      const minute = rng() < 0.5 ? Math.floor(rng() * 130) : undefined;
+      return {
+        type: "football.goal",
+        payload: {
+          by: sideId(side),
+          ...(scorer === undefined ? {} : { scorer }),
+          ...(minute === undefined ? {} : { minute }),
+          ...(ownGoal ? { ownGoal: true } : {}),
+        },
+      };
+    }
+    // Advance the clock.
+    const marker =
+      state.phase === "H1" ? "HT" : state.phase === "H2" ? "FT" : state.phase === "ET_H1" ? "ET_HT" : "ET_FT";
+    return { type: "football.period", payload: { phase: marker } };
+  },
+
+  // §9.6 / PROMPT-04 §9 — timeline → period summaries: strip attribution
+  // (scorers, minutes, kick takers) keeping only what moves the score, drop
+  // cards/subs (no score effect). Core events pass through.
+  coarsen(events): ModuleEvent<FootballEv>[] {
+    const out: ModuleEvent<FootballEv>[] = [];
+    for (const event of events) {
+      switch (event.type) {
+        case "football.goal": {
+          const payload = event.payload as z.infer<typeof FootballGoal>;
+          out.push({
+            type: "football.goal",
+            payload: {
+              by: payload.by,
+              ...(payload.ownGoal === undefined ? {} : { ownGoal: payload.ownGoal }),
+            },
+          });
+          break;
+        }
+        case "football.period":
+          out.push({ type: "football.period", payload: event.payload });
+          break;
+        case "football.shootout.kick": {
+          const payload = event.payload as z.infer<typeof FootballShootoutKick>;
+          out.push({
+            type: "football.shootout.kick",
+            payload: { by: payload.by, scored: payload.scored },
+          });
+          break;
+        }
+        case "football.card":
+        case "football.sub":
+          break; // no score effect — dropped at coarse fidelity
+        default:
+          out.push({ type: event.type, payload: event.payload });
+      }
+    }
+    return out;
+  },
+};

--- a/packages/engine/src/sports/football/index.ts
+++ b/packages/engine/src/sports/football/index.ts
@@ -1,4 +1,13 @@
-// Football SportModule — spec 04 (football section) + engine/sports/football.md.
-// Goals, cards, halves/extra-time/shootout, walkover mapping. Implemented in PROMPT-04.
-
-export {};
+// Football SportModule — spec 04 §1 + engine/sports/football.md (PROMPT-04).
+export {
+  football,
+  FootballCfg,
+  FootballEv,
+  FootballGoal,
+  FootballCard,
+  FootballSub,
+  FootballPeriod,
+  FootballShootoutKick,
+  FOOTBALL_TIEBREAKERS,
+  type FootballState,
+} from "./football.ts";


### PR DESCRIPTION
Implements the football (PROMPT-04, spec 04 §1) and cricket (PROMPT-05, spec 04 §2) sport modules on the PROMPT-03 `SportModule` contract.

## Football — `sports/football/`
- Cfg + variants `11-a-side`/`youth`/`small-sided`; optional `points.shootoutWin/Loss` split (group-stage SO).
- Events `goal` (own-goal credits opponent) / `card` / `sub` / `period` / `shootout.kick`; minutes optional everywhere (coarse scoring works).
- State machine `pre→H1→HT→H2→FT` with ET/shootout sub-machines. `supportsDraws` league/group only; a level knockout fixture stays undecided until ET/shootout resolves and `finalize` is refused meanwhile.
- Shootout fold: best-of-5 alternating, early decision when lead > opponent's remaining kicks, sudden death.
- Metrics `gf/ga/gd/yellow/red/fair_play` on the FIFA scale (−1/−3/−4/−5). Both official TB presets shipped: **`fifa2026`** (H2H-first, default) and **`classic`** (GD-first).
- `core.forfeit`→award with `awardScore`; `core.abandon`→`replay|award`. `coarsen` collapses the timeline to period summaries.
- Goldens: league draw 1-1, knockout 0-0→ET 1-1→shootout 4-3, forfeit 3-0, own-goal + cards.

## Cricket — `sports/cricket/`
- **Dual fidelity** (spec §2.2): `cricket.ball` and `cricket.innings.summary` fold to the same `InningsTotals`; `coarsen(ballEvents) ≡ fine fold` asserted by conformance. Tier-2 `cricket.player.line` post-match scorecards with sum-consistency diffs (doc 14 §1).
- Innings state machine (openers, striker rotation, over/bowler legality, all-out) and result determination: run/wicket margins, tie→super over (`repeat | boundary_count | shared`), `no_result` below the minimum, two-innings draw / innings-victory / follow-on.
- **NRR** integer ledger (`runs_for, balls_faced_eff, runs_against, balls_bowled_eff`) with the ICC all-out full-quota rule; NRR computed at rank time (no floats). Permutation-invariance property-tested.
- **DLS** Standard Edition: the published 2002 D/L resource table shipped as data (`dls.ts`); `dlsTarget` (reduced / G50-increased) + par-score curve, folded via `revise`. Manual umpire target always wins.
- Goldens: 2019 CWC final (tie → super over → boundary count), all-out NRR worked example, DLS reduced/increased/par, super-over policies, two-innings draw/innings-victory/follow-on. Bowler-legality property over generated streams.

## Acceptance
- `conformanceSuite` green for both across the config matrix (football league + knockout; cricket t20 + knockout + test).
- **229/229** engine tests pass; typecheck and the effectful-import boundary gate clean; `npm run lint` 0 errors.

## Deviations (folded into the design docs, PROMPT-00 §4)
- Cricket toss is a dedicated `cricket.toss {wonBy, elected}` event — the kernel's `core.start` schema is `strictObject({})` and carries no sport data (cricket.md §3 assumed a payload). New `match.close` / `followon` events; `innings.summary` gains `partial?` / `boundaries?`. → spec §2.2, cricket.md §3.
- Football gains an `abandonPolicy` cfg field (`replay` default / `award`); `stand` reserved for later. → spec §1.1, football.md §8.
- DLS fractional-over linear interpolation and the R2>R1 par curve are documented approximations of the unpublished per-ball Standard-Edition figures (`dls.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pEsHzfZ8KyB3Bz6sDKfn