### PR TITLE
feat(engine): set-based & board-game sport modules (PROMPT-06, PROMPT-07)

### DIFF
--- a/packages/engine/src/competition/tiebreakers.test.ts
+++ b/packages/engine/src/competition/tiebreakers.test.ts
@@ -1,0 +1,137 @@
+// Swiss tiebreak goldens — spec 05 §4 / chess.md §4, PROMPT-07 §5.
+//
+// Golden cross-table: a 6-player single round-robin (5 rounds, everyone meets
+// everyone once) with a strict hierarchy A > B > C > D > E > F. A round-robin
+// makes every tiebreak hand-verifiable: each player's opponents are ALL other
+// players, so Buchholz = (Σ all scores) − own score, and Sonneborn-Berger is the
+// sum of beaten opponents' scores. All values are exact integers (half-points;
+// SB in quarter-points) — no floats anywhere (PROMPT-07 acceptance).
+import { describe, expect, it } from "vitest";
+import {
+  buchholz,
+  buchholzCut1,
+  colorHistory,
+  directEncounter,
+  sonnebornBerger,
+  swissTiebreaks,
+  wins,
+  type Color,
+  type SwissGame,
+  type SwissRow,
+  type SwissTable,
+} from "./tiebreakers.ts";
+
+// win = 2 half-points, loss = 0. Colours cycle W,B,… per player's card.
+function card(entrant: string, results: Array<[opp: string, won: boolean]>): SwissRow {
+  const games: SwissGame[] = results.map(([opp, won], i) => ({
+    opponent: opp,
+    result: won ? "win" : "loss",
+    scored: won ? 2 : 0,
+    color: (i % 2 === 0 ? "W" : "B") as Color,
+  }));
+  return { entrant, score: games.reduce((s, g) => s + g.scored, 0), games };
+}
+
+// A beats everyone; B beats all but A; … F loses all.
+const table: SwissTable = [
+  card("A", [["B", true], ["C", true], ["D", true], ["E", true], ["F", true]]),
+  card("B", [["A", false], ["C", true], ["D", true], ["E", true], ["F", true]]),
+  card("C", [["A", false], ["B", false], ["D", true], ["E", true], ["F", true]]),
+  card("D", [["A", false], ["B", false], ["C", false], ["E", true], ["F", true]]),
+  card("E", [["A", false], ["B", false], ["C", false], ["D", false], ["F", true]]),
+  card("F", [["A", false], ["B", false], ["C", false], ["D", false], ["E", false]]),
+];
+
+describe("Swiss cross-table golden (6-player round-robin)", () => {
+  it("reproduces the published score column (half-points)", () => {
+    const scores = Object.fromEntries(table.map((r) => [r.entrant, r.score]));
+    expect(scores).toEqual({ A: 10, B: 8, C: 6, D: 4, E: 2, F: 0 });
+  });
+
+  it("Buchholz = Σ all − own (each plays the whole field)", () => {
+    // Total = 30 half-points; Buchholz(X) = 30 − score(X).
+    expect(buchholz(table, "A")).toBe(20);
+    expect(buchholz(table, "B")).toBe(22);
+    expect(buchholz(table, "C")).toBe(24);
+    expect(buchholz(table, "D")).toBe(26);
+    expect(buchholz(table, "E")).toBe(28);
+    expect(buchholz(table, "F")).toBe(30);
+  });
+
+  it("Buchholz Cut-1 drops each player's lowest opponent", () => {
+    // Everyone's weakest opponent is F (0) — except F, whose weakest is E (2).
+    expect(buchholzCut1(table, "A")).toBe(20);
+    expect(buchholzCut1(table, "B")).toBe(22);
+    expect(buchholzCut1(table, "C")).toBe(24);
+    expect(buchholzCut1(table, "D")).toBe(26);
+    expect(buchholzCut1(table, "E")).toBe(28);
+    expect(buchholzCut1(table, "F")).toBe(28); // 30 − 2
+  });
+
+  it("Sonneborn-Berger = Σ beaten opponents' scores (quarter-points)", () => {
+    // SB_q = Σ scored·oppScore. A beat {8,6,4,2,0}: 2·20 = 40; F beat none: 0.
+    expect(sonnebornBerger(table, "A")).toBe(40);
+    expect(sonnebornBerger(table, "B")).toBe(24);
+    expect(sonnebornBerger(table, "C")).toBe(12);
+    expect(sonnebornBerger(table, "D")).toBe(4);
+    expect(sonnebornBerger(table, "E")).toBe(0);
+    expect(sonnebornBerger(table, "F")).toBe(0);
+  });
+
+  it("counts wins and reads colour history off the card", () => {
+    expect(wins(table, "A")).toBe(5);
+    expect(wins(table, "E")).toBe(1);
+    expect(wins(table, "F")).toBe(0);
+    expect(colorHistory(table[0] as SwissRow)).toBe("WBWBW");
+  });
+
+  it("resolves direct encounters head-to-head", () => {
+    expect(directEncounter(table, "A", "F")).toBe(1);
+    expect(directEncounter(table, "F", "A")).toBe(-1);
+    expect(directEncounter(table, "C", "D")).toBe(1);
+  });
+
+  it("bundles every tiebreak as exact integers (no floats in the ledger)", () => {
+    for (const row of table) {
+      const tb = swissTiebreaks(table, row.entrant);
+      for (const value of [tb.score, tb.buchholz, tb.buchholzCut1, tb.sonnebornBerger, tb.wins]) {
+        expect(Number.isInteger(value)).toBe(true);
+      }
+    }
+    expect(swissTiebreaks(table, "C")).toMatchObject({
+      score: 6,
+      buchholzCut1: 24,
+      buchholz: 24,
+      sonnebornBerger: 12,
+      wins: 3,
+      colorHistory: "WBWBW",
+    });
+  });
+});
+
+describe("FIDE virtual opponent for unplayed games (Handbook C.07)", () => {
+  // X: R1 beat Y, R2 bye (unplayed, full point), R3 beat Z. 3 rounds.
+  // Virtual opponent for the R2 bye = scoreBefore (2) + (rounds 3 − index 1) = 4.
+  const withBye: SwissTable = [
+    {
+      entrant: "X",
+      score: 6,
+      games: [
+        { opponent: "Y", result: "win", scored: 2, color: "W" },
+        { opponent: null, result: "win", scored: 2, unplayed: true }, // bye
+        { opponent: "Z", result: "win", scored: 2, color: "W" },
+      ],
+    },
+    { entrant: "Y", score: 3, games: [] },
+    { entrant: "Z", score: 1, games: [] },
+  ];
+
+  it("uses the virtual-opponent score for the bye round", () => {
+    // Buchholz = score(Y) 3 + virtual 4 + score(Z) 1 = 8.
+    expect(buchholz(withBye, "X")).toBe(8);
+    // Cut-1 drops the lowest opponent (Z = 1) → 3 + 4 = 7.
+    expect(buchholzCut1(withBye, "X")).toBe(7);
+    // SB counts the win vs the virtual opponent too: 2·(3 + 4 + 1) = 16.
+    expect(sonnebornBerger(withBye, "X")).toBe(16);
+  });
+});

--- a/packages/engine/src/competition/tiebreakers.ts
+++ b/packages/engine/src/competition/tiebreakers.ts
@@ -1,4 +1,174 @@
-// Tiebreaker comparator registry — spec 05 §5 (cascade must be antisymmetric &
-// transitive; property-tested). Implemented in PROMPT-08.
+// Swiss / cascade-time tiebreak computations — spec 05 §4 + engine/sports/
+// chess.md §4 (PROMPT-07). Buchholz, Buchholz Cut-1 and Sonneborn-Berger depend
+// on opponents' *final* scores, so they cannot be folded incrementally into a
+// StandingsDelta — they are computed here, at rank time, from a ledger the
+// competition engine assembles (opponent list + per-game score/result/colour
+// the boardgame module exposes via standingsDelta).
+//
+// Everything is integer (spec 04 §9.4, PROMPT-07 acceptance — no floats):
+// scores are HALF-POINTS (1 = 2, ½ = 1, 0 = 0). Buchholz keeps half-points;
+// Sonneborn-Berger is returned in QUARTER-points (÷4 for the conventional
+// value) because ½·(opponent score) is a quarter-point. Use pointsToText for
+// display.
+//
+// NOTE — the comparator *registry* (TiebreakerKey → comparator, antisymmetry/
+// transitivity property tests, h2h partition refinement) lands in PROMPT-08;
+// this file provides the metric functions those comparators call.
+import type { EntrantId } from "../core/types.ts";
 
-export {};
+export type Color = "W" | "B";
+export type GameResult = "win" | "draw" | "loss";
+
+// One game on an entrant's card, in round order.
+export interface SwissGame {
+  // The real opponent, or null for a bye (no opponent). `unplayed` games (byes,
+  // forfeits, absences) use a FIDE virtual opponent for Buchholz/SB.
+  opponent: EntrantId | null;
+  result: GameResult;
+  scored: number; // half-points earned in this game (win 2 / draw 1 / loss 0 / byeScore)
+  color?: Color | null; // colour held; null/absent ⇒ excluded from colour history
+  unplayed?: boolean;
+}
+
+export interface SwissRow {
+  entrant: EntrantId;
+  score: number; // Σ scored (half-points) — the primary standings key
+  games: SwissGame[]; // in round order (index = round − 1)
+}
+
+export type SwissTable = readonly SwissRow[];
+
+function indexTable(table: SwissTable): Map<EntrantId, SwissRow> {
+  const map = new Map<EntrantId, SwissRow>();
+  for (const row of table) map.set(row.entrant, row);
+  return map;
+}
+
+// FIDE virtual opponent (Handbook C.07 — Tie-Break Regulations 2023, "Unplayed
+// games"): a bye/forfeit is scored against a virtual opponent whose score = the
+// player's score *before* that round, plus ½ point for every round from the
+// unplayed one to the end inclusive (i.e. the opponent is assumed to draw the
+// rest). In half-points: scoreBefore + (rounds − index).
+function virtualOpponentScore(row: SwissRow, gameIndex: number): number {
+  const rounds = row.games.length;
+  let scoreBefore = 0;
+  for (let i = 0; i < gameIndex; i++) scoreBefore += (row.games[i] as SwissGame).scored;
+  return scoreBefore + (rounds - gameIndex);
+}
+
+// The score attributed to the opponent of `row`'s game at `index` — the real
+// opponent's final score, or the virtual opponent's for an unplayed game.
+function opponentScore(byEntrant: Map<EntrantId, SwissRow>, row: SwissRow, index: number): number {
+  const game = row.games[index] as SwissGame;
+  if (game.unplayed || game.opponent === null) return virtualOpponentScore(row, index);
+  const opp = byEntrant.get(game.opponent);
+  if (opp === undefined) {
+    throw new Error(`Swiss ledger references unknown opponent "${game.opponent}"`);
+  }
+  return opp.score;
+}
+
+function requireRow(byEntrant: Map<EntrantId, SwissRow>, entrant: EntrantId): SwissRow {
+  const row = byEntrant.get(entrant);
+  if (row === undefined) throw new Error(`entrant "${entrant}" is not in the Swiss table`);
+  return row;
+}
+
+// Buchholz = Σ opponents' final scores (half-points). Cut-`cut` drops the
+// `cut` lowest opponent scores (FIDE recommends Cut-1 first) — spec 04 §6.3.
+export function buchholz(table: SwissTable, entrant: EntrantId, opts: { cut?: number } = {}): number {
+  const byEntrant = indexTable(table);
+  const row = requireRow(byEntrant, entrant);
+  const scores = row.games.map((_, i) => opponentScore(byEntrant, row, i));
+  const cut = opts.cut ?? 0;
+  if (cut <= 0) return scores.reduce((sum, s) => sum + s, 0);
+  const sorted = [...scores].sort((a, b) => a - b);
+  return sorted.slice(cut).reduce((sum, s) => sum + s, 0);
+}
+
+export function buchholzCut1(table: SwissTable, entrant: EntrantId): number {
+  return buchholz(table, entrant, { cut: 1 });
+}
+
+// Sonneborn-Berger = Σ (defeated opponents' scores) + ½ Σ (drawn opponents'
+// scores) — spec 04 §6.3. Returned in QUARTER-points (integer): a win weights
+// the opponent score ×2, a draw ×1, a loss ×0 (½·score → quarter-points).
+export function sonnebornBerger(table: SwissTable, entrant: EntrantId): number {
+  const byEntrant = indexTable(table);
+  const row = requireRow(byEntrant, entrant);
+  let total = 0;
+  row.games.forEach((game, i) => {
+    const oppScore = opponentScore(byEntrant, row, i);
+    const weight = game.result === "win" ? 2 : game.result === "draw" ? 1 : 0;
+    total += weight * oppScore;
+  });
+  return total;
+}
+
+// Number of wins (cascade tail) — spec 04 §6.3.
+export function wins(table: SwissTable, entrant: EntrantId): number {
+  const row = requireRow(indexTable(table), entrant);
+  return row.games.filter((game) => game.result === "win").length;
+}
+
+// Direct-encounter result between two tied entrants (building block for the
+// `direct` comparator, spec 05 §4.2): +1 if `a` scored more head-to-head, −1 if
+// less, 0 if level or they never met. Half-point aware.
+export function directEncounter(table: SwissTable, a: EntrantId, b: EntrantId): number {
+  const byEntrant = indexTable(table);
+  // Each side's head-to-head half-points, read straight off its own card.
+  const scoredAgainst = (row: SwissRow, foe: EntrantId): { met: boolean; scored: number } => {
+    let scored = 0;
+    let met = false;
+    for (const game of row.games) {
+      if (game.opponent !== foe || game.unplayed) continue;
+      met = true;
+      scored += game.scored;
+    }
+    return { met, scored };
+  };
+  const aVsB = scoredAgainst(requireRow(byEntrant, a), b);
+  const bVsA = scoredAgainst(requireRow(byEntrant, b), a);
+  if (!aVsB.met && !bVsA.met) return 0; // never met
+  return aVsB.scored > bVsA.scored ? 1 : aVsB.scored < bVsA.scored ? -1 : 0;
+}
+
+// Colour history string for the pairing algorithm (spec 05 §2.2, chess.md §3):
+// 'W'/'B' in round order, skipping games with no colour (byes/forfeits/colours
+// off). Constraint checks (no 3 in a row, |W−B| ≤ 2) live in the pairing code.
+export function colorHistory(row: SwissRow): string {
+  return row.games
+    .filter((game) => game.color === "W" || game.color === "B")
+    .map((game) => game.color)
+    .join("");
+}
+
+// Convenience bundle for the ranking cascade — all integers.
+export interface SwissTiebreaks {
+  score: number; // half-points
+  buchholzCut1: number; // half-points
+  buchholz: number; // half-points
+  sonnebornBerger: number; // quarter-points
+  wins: number;
+  colorHistory: string;
+}
+
+export function swissTiebreaks(table: SwissTable, entrant: EntrantId): SwissTiebreaks {
+  const row = requireRow(indexTable(table), entrant);
+  return {
+    score: row.score,
+    buchholzCut1: buchholzCut1(table, entrant),
+    buchholz: buchholz(table, entrant),
+    sonnebornBerger: sonnebornBerger(table, entrant),
+    wins: wins(table, entrant),
+    colorHistory: colorHistory(row),
+  };
+}
+
+// Half-points → conventional score string (2 → "1", 1 → "½", 7 → "3½").
+export function pointsToText(halfPoints: number): string {
+  const whole = Math.floor(halfPoints / 2);
+  const half = halfPoints % 2 === 1 ? "½" : "";
+  if (whole === 0) return half === "" ? "0" : "½";
+  return `${whole}${half}`;
+}

--- a/packages/engine/src/sports/boardgame/boardgame.test.ts
+++ b/packages/engine/src/sports/boardgame/boardgame.test.ts
@@ -1,0 +1,117 @@
+// Board-game goldens + conformance — spec 04 §6, PROMPT-07.
+import { describe, expect, it } from "vitest";
+import { foldMatch, type CoreEv, type EventEnvelope } from "../../core/events.ts";
+import type { LineupPair, StageCtx } from "../../core/types.ts";
+import { conformanceSuite, defaultLineupPair, makeEnvelope } from "../../testkit/index.ts";
+import { boardgame, BOARDGAME_TIEBREAKERS, type BoardgameState } from "./boardgame.ts";
+
+const lineups: LineupPair = defaultLineupPair(boardgame.positions); // entrants H / A
+const cfg = boardgame.configSchema.parse({});
+const league: StageCtx = { kind: "league" };
+
+function stream(...specs: Array<[type: string, payload?: unknown]>): EventEnvelope[] {
+  return specs.map(([type, payload], i) => makeEnvelope(i, { type, payload: payload ?? {} }));
+}
+function fold(events: EventEnvelope[], config = cfg): BoardgameState {
+  return foldMatch(boardgame, config, lineups, events) as BoardgameState;
+}
+const asEv = (event: EventEnvelope) => event as EventEnvelope<CoreEv>;
+
+describe("boardgame golden: decisive game (White wins)", () => {
+  const state = fold(stream(["core.start"], ["boardgame.result", { winner: "H", method: "checkmate" }]));
+
+  it("decides for the winner and displays points, not half-points", () => {
+    expect(state.outcome).toEqual({ kind: "win", winner: "H", loser: "A", method: "checkmate" });
+    expect(boardgame.summary(state).headline).toBe("1 — 0");
+    expect(boardgame.summary(state).detail).toMatchObject({ method: "checkmate", colorOfHome: "W" });
+  });
+
+  it("pays win/loss as integer half-points with colour + win metrics", () => {
+    const [home, away] = boardgame.standingsDelta(state.outcome!, cfg, league, state);
+    expect(home).toMatchObject({ won: 1, points: 2, metrics: { wins: 1, white: 1, black: 0 } });
+    expect(away).toMatchObject({ lost: 1, points: 0, metrics: { wins: 0, white: 0, black: 1 } });
+    // Half-point integers only — never a 0.5 float (PROMPT-07 acceptance).
+    expect(Number.isInteger(home.points)).toBe(true);
+    expect(Number.isInteger(away.points)).toBe(true);
+  });
+});
+
+describe("boardgame golden: draw (½-½)", () => {
+  const state = fold(stream(["core.start"], ["boardgame.result", { winner: null, method: "agreement" }]));
+
+  it("splits a half-point (stored as 1) to each side", () => {
+    expect(state.outcome).toEqual({ kind: "draw" });
+    expect(boardgame.summary(state).headline).toBe("½ — ½");
+    const [home, away] = boardgame.standingsDelta(state.outcome!, cfg, league, state);
+    expect([home.points, away.points]).toEqual([1, 1]);
+    expect(home).toMatchObject({ drawn: 1, metrics: { wins: 0, white: 1, black: 0 } });
+    expect(away).toMatchObject({ drawn: 1, metrics: { wins: 0, white: 0, black: 1 } });
+    expect(home.points + away.points).toBe(2);
+  });
+});
+
+describe("boardgame golden: forfeit + double forfeit", () => {
+  it("scores a forfeit like a win but excludes it from colour history", () => {
+    const state = fold(stream(["core.start"], ["core.forfeit", { by: "A", reason: "no-show" }]));
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "H", method: "forfeit" });
+    const [home, away] = boardgame.standingsDelta(state.outcome!, cfg, league, state);
+    expect(home).toMatchObject({ won: 1, points: 2, metrics: { wins: 1, white: 0, black: 0 } });
+    expect(away.metrics).toMatchObject({ white: 0, black: 0 }); // colour excluded
+  });
+
+  it("maps a double forfeit to a 0-0 no-result", () => {
+    const state = fold(
+      stream(["core.start"], ["boardgame.result", { winner: null, method: "double_forfeit" }]),
+    );
+    expect(state.outcome).toEqual({ kind: "no_result" });
+    const [home, away] = boardgame.standingsDelta(state.outcome!, cfg, league, state);
+    expect([home.points, away.points]).toEqual([0, 0]);
+    expect(home.points + away.points).toBe(0); // inside declaredPointsSets
+  });
+});
+
+describe("boardgame contract declarations", () => {
+  it("always allows draws, even in knockout (KO ties resolve via mini-matches)", () => {
+    for (const stage of ["league", "group", "swiss", "knockout", "double_elim"] as const) {
+      expect(boardgame.supportsDraws(cfg, stage)).toBe(true);
+    }
+  });
+
+  it("declares the FIDE cascade and {2, 0} point totals", () => {
+    expect(boardgame.defaultTiebreakers).toEqual(BOARDGAME_TIEBREAKERS);
+    expect(boardgame.defaultTiebreakers.slice(0, 4)).toEqual([
+      "points",
+      "buchholz_cut1",
+      "buchholz",
+      "sberger",
+    ]);
+    expect([...boardgame.declaredPointsSets(cfg)].sort((a, b) => a - b)).toEqual([0, 2]);
+  });
+
+  it("disables colour metadata when colours are off (go / generic 1-v-1)", () => {
+    const noColor = boardgame.configSchema.parse({ colors: false });
+    const state = fold(
+      stream(["core.start"], ["boardgame.result", { winner: "H", method: "resign" }]),
+      noColor,
+    );
+    expect(state.colorOfHome).toBeNull();
+    const [home] = boardgame.standingsDelta(state.outcome!, noColor, league, state);
+    expect(home.metrics).toMatchObject({ white: 0, black: 0 });
+  });
+
+  it("rejects a result before kickoff and finalize while undecided", () => {
+    expect(() =>
+      boardgame.apply(
+        boardgame.init(cfg, lineups),
+        makeEnvelope(0, { type: "boardgame.result", payload: { winner: "H" } }) as EventEnvelope<never>,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "WRONG_PHASE" }));
+    const live = fold(stream(["core.start"]));
+    expect(() =>
+      boardgame.apply(live, asEv(makeEnvelope(9, { type: "core.finalize", payload: {} }))),
+    ).toThrowError(expect.objectContaining({ code: "WRONG_PHASE" }));
+  });
+});
+
+// PROMPT-07 acceptance — conformance green.
+conformanceSuite(boardgame);

--- a/packages/engine/src/sports/boardgame/boardgame.ts
+++ b/packages/engine/src/sports/boardgame/boardgame.ts
@@ -1,0 +1,391 @@
+// Board-game SportModule — spec 04 §6 + engine/sports/chess.md (PROMPT-07).
+// Chess, draughts, go, carrom and every generic 1-v-1 win/draw/loss sport. The
+// match itself is trivial (one terminal `result` event); the module exists to
+// carry the metrics and pairing metadata the Swiss competition engine needs.
+//
+// Half-point integers, never floats: 1 / ½ / 0 are stored as 2 / 1 / 0
+// throughout (points, byeScore, the Swiss ledger) and divided by two only for
+// display — spec 04 §6.1, chess.md §2. This keeps the ledger exact (spec 04
+// §9.4) and Buchholz/Sonneborn-Berger integer arithmetic (competition/
+// tiebreakers.ts).
+import { z } from "zod";
+import { EngineError } from "../../core/errors.ts";
+import type { CoreEv, EventEnvelope } from "../../core/events.ts";
+import type { Rng } from "../../core/rng.ts";
+import {
+  EntrantId,
+  type LineupPair,
+  type MatchOutcome,
+  type ScoreSummary,
+  type StageKind,
+  type StandingsDelta,
+} from "../../core/types.ts";
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import type { ModuleEvent, SportModule, TiebreakerKey } from "../../sport/module.ts";
+
+// ---------------------------------------------------------------------------
+// Cfg — spec 04 §6.1
+// ---------------------------------------------------------------------------
+
+// Points are HALF-POINTS (×2): a win is 2 (= 1.0), a draw 1 (= 0.5), a loss 0.
+export const BoardgameScoring = z.object({
+  win: z.number().int().nonnegative().default(2),
+  draw: z.number().int().nonnegative().default(1),
+  loss: z.number().int().nonnegative().default(0),
+});
+
+export const BoardgameCfg = z.object({
+  scoring: BoardgameScoring.default({ win: 2, draw: 1, loss: 0 }),
+  colors: z.boolean().default(true), // home = White (chess.md §2)
+  // Half-points a bye is worth (FIDE full-point bye = 2, half-point bye = 1).
+  // Byes are a competition-level concept; this value is read by the Swiss
+  // engine, not folded here.
+  byeScore: z.number().int().nonnegative().default(2),
+  // Clock family — metadata only, no scoring effect (chess.md §2).
+  variant: z.enum(["classical", "rapid", "blitz"]).default("classical"),
+  clock: z
+    .object({ base: z.number().int().nonnegative(), increment: z.number().int().nonnegative() })
+    .optional(),
+});
+export type BoardgameCfg = z.infer<typeof BoardgameCfg>;
+
+// ---------------------------------------------------------------------------
+// Ev — spec 04 §6.2 (a single terminal event; undo = void it)
+// ---------------------------------------------------------------------------
+
+export const BoardgameMethod = z.enum([
+  "checkmate",
+  "resign",
+  "time",
+  "agreement",
+  "stalemate",
+  "insufficient",
+  "forfeit",
+  "adjudication",
+  "double_forfeit",
+]);
+export type BoardgameMethod = z.infer<typeof BoardgameMethod>;
+
+// winner: entrantId to decide; null = draw (or, with method double_forfeit, a
+// no-result double default — chess.md §7).
+export const BoardgameResult = z.strictObject({
+  winner: EntrantId.nullable(),
+  method: BoardgameMethod.optional(),
+});
+export type BoardgameResult = z.infer<typeof BoardgameResult>;
+
+export const BoardgameEv = BoardgameResult;
+export type BoardgameEv = z.infer<typeof BoardgameEv>;
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+type Side = "home" | "away";
+type Color = "W" | "B";
+
+export interface BoardgameState {
+  cfg: BoardgameCfg;
+  entrants: { home: string; away: string };
+  phase: "pre" | "live" | "done" | "final" | "abandoned";
+  colorOfHome: Color | null; // null = colours disabled (go/generic)
+  method: BoardgameMethod | null;
+  // Forfeits score like a win but are excluded from colour history (chess.md §7).
+  forfeited: boolean;
+  outcome: MatchOutcome | null;
+  replayFlagged: boolean;
+}
+
+function opponent(side: Side): Side {
+  return side === "home" ? "away" : "home";
+}
+
+function invalid(message: string, data?: unknown): never {
+  throw new EngineError("INVALID_EVENT", message, data);
+}
+
+function wrongPhase(message: string, data?: unknown): never {
+  throw new EngineError("WRONG_PHASE", message, data);
+}
+
+function sideOf(state: BoardgameState, entrantId: string): Side {
+  if (entrantId === state.entrants.home) return "home";
+  if (entrantId === state.entrants.away) return "away";
+  invalid(`unknown entrant "${entrantId}"`, { entrantId });
+}
+
+function parsePayload<T>(schema: z.ZodType<T>, payload: unknown, type: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) invalid(`invalid ${type} payload`, { issues: parsed.error.issues });
+  return parsed.data;
+}
+
+// ---------------------------------------------------------------------------
+// Result application
+// ---------------------------------------------------------------------------
+
+function decideResult(
+  state: BoardgameState,
+  winner: string | null,
+  method: BoardgameMethod | undefined,
+): BoardgameState {
+  if (state.phase !== "live") wrongPhase(`result not allowed in phase "${state.phase}"`);
+  const forfeited = method === "forfeit" || method === "double_forfeit";
+  const base = {
+    ...state,
+    phase: "done" as const,
+    method: method ?? null,
+    forfeited,
+  };
+  if (winner === null) {
+    // Double forfeit ⇒ no result (both default); otherwise an ordinary draw.
+    if (method === "double_forfeit") return { ...base, outcome: { kind: "no_result" } };
+    return { ...base, outcome: { kind: "draw" } };
+  }
+  const winnerSide = sideOf(state, winner);
+  return {
+    ...base,
+    outcome: {
+      kind: "win",
+      winner: state.entrants[winnerSide],
+      loser: state.entrants[opponent(winnerSide)],
+      method: method ?? "regulation",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Colour / ledger helpers — the Swiss inputs (spec 04 §6.3, chess.md §3–4)
+// ---------------------------------------------------------------------------
+
+function colorOf(state: BoardgameState, side: Side): Color | null {
+  if (state.colorOfHome === null || state.forfeited) return null; // excluded
+  return side === "home" ? state.colorOfHome : state.colorOfHome === "W" ? "B" : "W";
+}
+
+// Per-side ledger row: `wins` for the cascade tail, `white`/`black` = the colour
+// this entrant held (both 0 when colours are off or the game was forfeited — a
+// forfeit is excluded from colour history). Integers only (spec 04 §9.4).
+function sideMetrics(state: BoardgameState, side: Side, won: boolean): Record<string, number> {
+  const color = colorOf(state, side);
+  return {
+    wins: won ? 1 : 0,
+    white: color === "W" ? 1 : 0,
+    black: color === "B" ? 1 : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Positions — spec 04 §6 / chess.md §5 (team chess uses board order later)
+// ---------------------------------------------------------------------------
+
+const positions: PositionCatalog = {
+  groups: [], // 1-v-1: no positions
+  lineup: { size: 1, benchMax: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// Tiebreakers — spec 04 §6.3 / chess.md §4 (score = the standings points key).
+// ---------------------------------------------------------------------------
+
+export const BOARDGAME_TIEBREAKERS: TiebreakerKey[] = [
+  "points",
+  "buchholz_cut1",
+  "buchholz",
+  "sberger",
+  "direct",
+  "wins",
+  "lots",
+];
+
+// ---------------------------------------------------------------------------
+// Display — half-points → points string (2 → "1", 1 → "½", 3 → "1½").
+// ---------------------------------------------------------------------------
+
+function pointsText(halfPoints: number): string {
+  const whole = Math.floor(halfPoints / 2);
+  const half = halfPoints % 2 === 1 ? "½" : "";
+  if (whole === 0) return half === "" ? "0" : "½";
+  return `${whole}${half}`;
+}
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+export const boardgame: SportModule<BoardgameCfg, BoardgameEv, BoardgameState> = {
+  key: "boardgame",
+  version: "1.0.0",
+  configSchema: BoardgameCfg,
+  eventSchema: BoardgameEv,
+  positions,
+  variants: {
+    // Clock family only — the scoring is identical (chess.md §2).
+    classical: { variant: "classical" },
+    rapid: { variant: "rapid" },
+    blitz: { variant: "blitz" },
+  },
+
+  init(cfg, lineups: LineupPair): BoardgameState {
+    return {
+      cfg,
+      entrants: { home: lineups.home.entrantId, away: lineups.away.entrantId },
+      phase: "pre",
+      colorOfHome: cfg.colors ? "W" : null,
+      method: null,
+      forfeited: false,
+      outcome: null,
+      replayFlagged: false,
+    };
+  },
+
+  apply(state, ev: EventEnvelope<BoardgameEv | CoreEv>): BoardgameState {
+    switch (ev.type) {
+      case "core.start":
+        if (state.phase !== "pre") wrongPhase("already started");
+        return { ...state, phase: "live" };
+      case "boardgame.result": {
+        const payload = parsePayload(BoardgameResult, ev.payload, ev.type);
+        return decideResult(state, payload.winner, payload.method);
+      }
+      case "core.forfeit": {
+        if (state.phase !== "live") wrongPhase(`forfeit not allowed in phase "${state.phase}"`);
+        const by = (ev.payload as { by: string }).by;
+        return decideResult(state, state.entrants[opponent(sideOf(state, by))], "forfeit");
+      }
+      case "core.abandon":
+        if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+          wrongPhase("match already over");
+        }
+        // Rare for a board game; leave undecided and flag for regeneration.
+        return { ...state, phase: "abandoned", replayFlagged: true };
+      case "core.finalize":
+        if (state.outcome === null) wrongPhase("cannot finalize an undecided fixture");
+        return { ...state, phase: "final" };
+      case "core.note":
+        return state; // PGN/move upload rides here (chess.md §6) — no state effect
+      default:
+        invalid(`unknown event type "${ev.type}"`);
+    }
+  },
+
+  outcome: (state) => state.outcome,
+
+  // §9.5 — defined at every prefix; displays points, not half-points.
+  summary(state): ScoreSummary {
+    const { win, draw, loss } = state.cfg.scoring;
+    let home = 0;
+    let away = 0;
+    const outcome = state.outcome;
+    if (outcome?.kind === "win") {
+      const winnerHome = outcome.winner === state.entrants.home;
+      home = winnerHome ? win : loss;
+      away = winnerHome ? loss : win;
+    } else if (outcome?.kind === "draw") {
+      home = draw;
+      away = draw;
+    }
+    const decided = outcome !== null;
+    return {
+      headline: decided ? `${pointsText(home)} — ${pointsText(away)}` : "vs",
+      perSide: [
+        { entrantId: state.entrants.home, line: decided ? pointsText(home) : "" },
+        { entrantId: state.entrants.away, line: decided ? pointsText(away) : "" },
+      ],
+      detail: {
+        ...(state.method === null ? {} : { method: state.method }),
+        ...(state.colorOfHome === null ? {} : { colorOfHome: state.colorOfHome }),
+        ...(state.replayFlagged ? { abandoned: true } : {}),
+      },
+    };
+  },
+
+  standingsDelta(outcome, cfg, _ctx, state): [StandingsDelta, StandingsDelta] {
+    const build = (
+      side: Side,
+      w: number,
+      d: number,
+      l: number,
+      pts: number,
+      won: boolean,
+    ): StandingsDelta => ({
+      entrantId: state.entrants[side],
+      played: 1,
+      won: w,
+      drawn: d,
+      lost: l,
+      points: pts, // half-points — integer (spec 04 §9.4)
+      metrics: sideMetrics(state, side, won),
+    });
+
+    switch (outcome.kind) {
+      case "win": {
+        const winnerSide = sideOf(state, outcome.winner);
+        const winner = build(winnerSide, 1, 0, 0, cfg.scoring.win, true);
+        const loser = build(opponent(winnerSide), 0, 0, 1, cfg.scoring.loss, false);
+        return winnerSide === "home" ? [winner, loser] : [loser, winner];
+      }
+      case "draw":
+        return [
+          build("home", 0, 1, 0, cfg.scoring.draw, false),
+          build("away", 0, 1, 0, cfg.scoring.draw, false),
+        ];
+      case "no_result":
+        // Double forfeit — both default to a zero score (chess.md §7).
+        return [
+          build("home", 0, 0, 0, 0, false),
+          build("away", 0, 0, 0, 0, false),
+        ];
+      default:
+        invalid(`board-game module cannot rank outcome "${outcome.kind}"`);
+    }
+  },
+
+  metrics: [
+    { key: "wins", label: "Wins", direction: "desc" },
+    { key: "white", label: "Games as White", direction: "desc" },
+    { key: "black", label: "Games as Black", direction: "desc" },
+  ],
+  defaultTiebreakers: BOARDGAME_TIEBREAKERS,
+
+  // spec 04 §6 / chess.md §2 — draws always allowed, even in knockout (KO chess
+  // resolves ties via multi-game mini-matches, modelled at the fixture layer).
+  supportsDraws(_cfg, _stage: StageKind) {
+    return true;
+  },
+
+  // §9.3 — {win+loss, 2·draw, 0 (double forfeit)}.
+  declaredPointsSets(cfg) {
+    return [
+      ...new Set([cfg.scoring.win + cfg.scoring.loss, cfg.scoring.draw * 2, 0]),
+    ];
+  },
+
+  // chess.md §6 — single-event sport: no coarse/fine split (Pro depth is PGN
+  // upload + exports, not extra event granularity).
+  fidelityTiers: [
+    { tier: 0, eventTypes: ["boardgame.result"] },
+    { tier: 1, eventTypes: ["boardgame.result"] },
+  ],
+  officialLabel: { scorer: "Arbiter" }, // doc 13 §1
+
+  // spec 03 §6 — deterministic generator: start, then a single result
+  // (win/draw/forfeit) that decides the fixture.
+  arbitraryEvent(state, rng: Rng): ModuleEvent<BoardgameEv> | null {
+    if (state.phase === "pre") return { type: "core.start", payload: {} };
+    if (state.phase !== "live") return null;
+    const roll = rng();
+    if (roll < 0.05) {
+      return { type: "core.forfeit", payload: { by: state.entrants[rng() < 0.5 ? "home" : "away"], reason: "no-show" } };
+    }
+    if (roll < 0.1) {
+      return { type: "boardgame.result", payload: { winner: null, method: "double_forfeit" } };
+    }
+    if (roll < 0.4) {
+      return { type: "boardgame.result", payload: { winner: null, method: "agreement" } };
+    }
+    const winner = state.entrants[rng() < 0.5 ? "home" : "away"];
+    const method = rng() < 0.5 ? "checkmate" : "resign";
+    return { type: "boardgame.result", payload: { winner, method } };
+  },
+};

--- a/packages/engine/src/sports/boardgame/index.ts
+++ b/packages/engine/src/sports/boardgame/index.ts
@@ -1,4 +1,12 @@
-// Chess + generic 1-v-1 win/draw/loss module — spec 04 + engine/sports/chess.md.
-// Colour balance, progress score, FIDE tiebreak inputs. Implemented in PROMPT-07.
-
-export {};
+// Board-game SportModule — spec 04 §6 + engine/sports/chess.md (PROMPT-07).
+// Chess / draughts / go / carrom / generic 1-v-1. Half-point integer scoring.
+export {
+  boardgame,
+  BoardgameCfg,
+  BoardgameEv,
+  BoardgameResult,
+  BoardgameMethod,
+  BoardgameScoring,
+  BOARDGAME_TIEBREAKERS,
+  type BoardgameState,
+} from "./boardgame.ts";

--- a/packages/engine/src/sports/setbased/badminton.ts
+++ b/packages/engine/src/sports/setbased/badminton.ts
@@ -1,0 +1,43 @@
+// Badminton — set-based preset (spec 04 §4 + engine/sports/badminton.md).
+// {3,21,21,2,30}: rally to 21, win by 2, hard cap 30 (29-29 → golden point,
+// 30-29 wins) — the cap is the differentiator vs volleyball's uncapped endgame.
+// Disciplines (MS/WS/MD/WD/XD) are entrant-kind + eligibility combinations, NOT
+// module variants — one module serves all five, so there are no positions.
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import { makeSetBasedModule } from "./kernel.ts";
+
+// badminton.md §7 — no positions; singles vs doubles is the entrant kind
+// (doc 02 §2), which the module never inspects (scoring reads only wonBy). One
+// nominated unit per side.
+const positions: PositionCatalog = {
+  groups: [],
+  lineup: { size: 1, benchMax: 1 },
+};
+
+export const badminton = makeSetBasedModule({
+  key: "badminton",
+  version: "1.0.0",
+  // spec 04 §4 — game to 21, deciding game also to 21, hard cap 30.
+  defaults: {
+    bestOf: 3,
+    setTo: 21,
+    finalSetTo: 21,
+    winBy: 2,
+    cap: 30,
+    // Typical league: flat win points (2/0); configurable per competition.
+    pointsMap: { "*": [2, 0] },
+  },
+  variants: {
+    bwf: {},
+    // Junior/social short format: to 11, cap 15 (badminton.md §2).
+    short: { setTo: 11, finalSetTo: 11, cap: 15 },
+  },
+  positions,
+  unitLabel: { one: "Game", many: "Games" },
+  // spec 04 §4 — points → matches → game ratio → point ratio → h2h. game_ratio
+  // is the set_ratio key (games are the kernel's sets).
+  defaultTiebreakers: ["points", "wins", "set_ratio", "point_ratio", "h2h_points"],
+  officialLabel: { scorer: "Umpire" }, // doc 13 §1
+  coarseEventType: "game.summary",
+  rallyEntitlement: "scoring.rally_by_rally", // doc 10 / badminton.md §3
+});

--- a/packages/engine/src/sports/setbased/index.ts
+++ b/packages/engine/src/sports/setbased/index.ts
@@ -1,5 +1,20 @@
 // Set-based kernel + presets (volleyball / badminton / table-tennis) — spec 04
-// + engine/sports/{volleyball,badminton,table-tennis}.md. Rally scoring, set
-// ratios, deciding-set rules. Implemented in PROMPT-06.
-
-export {};
+// §3–5 + engine/sports/{volleyball,badminton,table-tennis}.md. One parametric
+// rally/set engine, three thin presets (PROMPT-06).
+export {
+  makeSetBasedModule,
+  SetBasedRally,
+  SetBasedSummary,
+  SetSummaryPositional,
+  SetSummaryByEntrant,
+  SetBasedEv,
+  PointsPair,
+  type SetBasedCfg,
+  type SetBasedParams,
+  type SetBasedPreset,
+  type SetBasedState,
+  type SetState,
+} from "./kernel.ts";
+export { volleyball } from "./volleyball.ts";
+export { badminton } from "./badminton.ts";
+export { tabletennis } from "./tabletennis.ts";

--- a/packages/engine/src/sports/setbased/kernel.ts
+++ b/packages/engine/src/sports/setbased/kernel.ts
@@ -1,0 +1,660 @@
+// Set-based scoring kernel — spec 04 §3–5 + engine/sports/{volleyball,badminton,
+// table-tennis}.md (PROMPT-06). ONE parametric engine parameterised by
+// {bestOf, setTo, finalSetTo, winBy, cap, pointsMap}; volleyball, badminton and
+// table tennis are three thin presets — this file owns every line of set logic,
+// the presets add only catalog/metrics/labels. Dual fidelity (spec 04 §9.6):
+// fine `rally {wonBy}` and coarse `*.summary` fold to identical set totals and
+// outcomes, and all result math reads only the folded set ledger.
+import { z } from "zod";
+import { EngineError } from "../../core/errors.ts";
+import type { CoreEv, EventEnvelope } from "../../core/events.ts";
+import type { Rng } from "../../core/rng.ts";
+import {
+  EntrantId,
+  type LineupPair,
+  type MatchOutcome,
+  type MetricSpec,
+  type ScoreSummary,
+  type StageKind,
+  type StandingsDelta,
+} from "../../core/types.ts";
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import type {
+  FidelityTier,
+  ModuleEvent,
+  SportModule,
+  TiebreakerKey,
+} from "../../sport/module.ts";
+
+// ---------------------------------------------------------------------------
+// Kernel parameters & config — spec 04 §3.1 / §4 / §5
+// ---------------------------------------------------------------------------
+
+// A completed-set score maps to [winnerPoints, loserPoints] keyed by the
+// winner's set tally "W-L" (FIVB 3-2 → [2,1]); "*" is the fall-through for
+// every other (clean-win) score. Integers only — spec 04 §9.3.
+export const PointsPair = z.tuple([
+  z.number().int().nonnegative(),
+  z.number().int().nonnegative(),
+]);
+export type PointsPair = z.infer<typeof PointsPair>;
+
+export interface SetBasedParams {
+  bestOf: number;
+  setTo: number;
+  finalSetTo: number;
+  winBy: number;
+  cap: number | null;
+  pointsMap: Record<string, PointsPair>;
+}
+
+// Builds a preset's config schema (defaults = its shipped/first variant).
+// Refinements are the kernel's hard invariants: odd bestOf (so ⌈bestOf/2⌉ has a
+// unique decider) and cap ≥ target.
+function makeConfigSchema(defaults: SetBasedParams) {
+  return z
+    .object({
+      bestOf: z.number().int().positive().default(defaults.bestOf),
+      setTo: z.number().int().positive().default(defaults.setTo),
+      finalSetTo: z.number().int().positive().default(defaults.finalSetTo),
+      winBy: z.number().int().positive().default(defaults.winBy),
+      cap: z.number().int().positive().nullable().default(defaults.cap),
+      pointsMap: z.record(z.string().min(1), PointsPair).default(defaults.pointsMap),
+    })
+    .refine((cfg) => cfg.bestOf % 2 === 1, { message: "bestOf must be odd (a decider must exist)" })
+    .refine((cfg) => cfg.cap === null || cfg.cap >= Math.max(cfg.setTo, cfg.finalSetTo), {
+      message: "cap must be ≥ the set target",
+    })
+    .refine((cfg) => Object.keys(cfg.pointsMap).length > 0, {
+      message: "pointsMap needs at least one entry",
+    });
+}
+
+export type SetBasedCfg = SetBasedParams;
+
+// ---------------------------------------------------------------------------
+// Events — spec 04 §3.2 / §4 / §5
+// ---------------------------------------------------------------------------
+
+export const SetBasedRally = z.strictObject({ wonBy: EntrantId });
+export type SetBasedRally = z.infer<typeof SetBasedRally>;
+
+// Coarse fidelity. Two accepted shapes fold identically:
+//  • positional `{home, away}` — the scorer form (spec 04 §3.2 `set.summary`);
+//  • entrant-keyed `{by, forBy, forOpp}` — the fidelity bridge coarsen emits,
+//    position-independent so coarsen needs no lineup context (`by` scored
+//    `forBy`, the opponent `forOpp`).
+// `partial: true` = an in-progress (non-terminal) snapshot — the coarse analogue
+// of an unfinished rally set, so a stream stopped mid-set renders the same live
+// score after coarsening (spec 04 §9.6).
+export const SetSummaryPositional = z.strictObject({
+  home: z.number().int().nonnegative(),
+  away: z.number().int().nonnegative(),
+  partial: z.boolean().optional(),
+});
+export const SetSummaryByEntrant = z.strictObject({
+  by: EntrantId,
+  forBy: z.number().int().nonnegative(),
+  forOpp: z.number().int().nonnegative(),
+  partial: z.boolean().optional(),
+});
+export const SetBasedSummary = z.union([SetSummaryPositional, SetSummaryByEntrant]);
+export type SetBasedSummary = z.infer<typeof SetBasedSummary>;
+
+export const SetBasedEv = z.union([SetBasedRally, SetBasedSummary]);
+export type SetBasedEv = z.infer<typeof SetBasedEv>;
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+type Side = "home" | "away";
+
+export interface SetState {
+  home: number;
+  away: number;
+  closed: boolean;
+}
+
+export interface SetBasedState {
+  cfg: SetBasedCfg;
+  entrants: { home: string; away: string };
+  phase: "pre" | "live" | "done" | "final" | "abandoned";
+  sets: SetState[]; // closed sets in order + at most one trailing open set
+  setsWon: { home: number; away: number };
+  outcome: MatchOutcome | null;
+  replayFlagged: boolean;
+}
+
+function opponent(side: Side): Side {
+  return side === "home" ? "away" : "home";
+}
+
+function invalid(message: string, data?: unknown): never {
+  throw new EngineError("INVALID_EVENT", message, data);
+}
+
+function wrongPhase(message: string, data?: unknown): never {
+  throw new EngineError("WRONG_PHASE", message, data);
+}
+
+function sideOf(state: SetBasedState, entrantId: string): Side {
+  if (entrantId === state.entrants.home) return "home";
+  if (entrantId === state.entrants.away) return "away";
+  invalid(`unknown entrant "${entrantId}"`, { entrantId });
+}
+
+function parsePayload<T>(schema: z.ZodType<T>, payload: unknown, type: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) invalid(`invalid ${type} payload`, { issues: parsed.error.issues });
+  return parsed.data;
+}
+
+// ---------------------------------------------------------------------------
+// Set-win predicate & reachability — spec 04 §3.3 (single source of truth for
+// both fidelities and coarsen)
+// ---------------------------------------------------------------------------
+
+const majority = (bestOf: number): number => Math.ceil(bestOf / 2);
+
+// The deciding set is the last possible one (index bestOf−1, reached only at
+// ⌈bestOf/2⌉−1 sets each) and uses finalSetTo (spec 04 §3.3).
+function setTarget(params: SetBasedParams, setIndex: number): number {
+  return setIndex === params.bestOf - 1 ? params.finalSetTo : params.setTo;
+}
+
+// Winner of a set at score (h,a), or null while it is still live. `cap` is the
+// hard golden-point ceiling (badminton 30-29); cap=null = uncapped win-by-two
+// endgame (volleyball 32-30). spec 04 §3.3.
+function setWinner(
+  h: number,
+  a: number,
+  target: number,
+  winBy: number,
+  cap: number | null,
+): Side | null {
+  const winner: Side | null = h > a ? "home" : a > h ? "away" : null;
+  if (winner === null) return null;
+  const hi = Math.max(h, a);
+  const lo = Math.min(h, a);
+  if (cap !== null && hi >= cap) return winner;
+  if (hi >= target && hi - lo >= winBy) return winner;
+  return null;
+}
+
+// A summary score is *reachable* iff it is terminal and the score one point
+// earlier (winner one lower) was still live — rejecting 25-24 (winBy 2, no cap)
+// and 22-19 / 31-30 (already decided earlier), accepting 26-24, 30-29 (cap),
+// 32-30 (spec 04 §3.3; badminton/TT §3 corners).
+function reachableSetScore(
+  h: number,
+  a: number,
+  target: number,
+  winBy: number,
+  cap: number | null,
+): boolean {
+  // The set ends *at* the cap, so no score can exceed it (rejects 31-30).
+  if (cap !== null && Math.max(h, a) > cap) return false;
+  const winner = setWinner(h, a, target, winBy, cap);
+  if (winner === null) return false;
+  const prevH = winner === "home" ? h - 1 : h;
+  const prevA = winner === "away" ? a - 1 : a;
+  if (prevH < 0 || prevA < 0) return false;
+  return setWinner(prevH, prevA, target, winBy, cap) === null;
+}
+
+// ---------------------------------------------------------------------------
+// Fold helpers
+// ---------------------------------------------------------------------------
+
+function openSet(state: SetBasedState): { set: SetState; index: number } | null {
+  const index = state.sets.length - 1;
+  const set = state.sets[index];
+  if (set === undefined || set.closed) return null;
+  return { set, index };
+}
+
+function replaceSet(state: SetBasedState, index: number, set: SetState): SetBasedState {
+  return { ...state, sets: state.sets.map((entry, i) => (i === index ? set : entry)) };
+}
+
+function totalPoints(state: SetBasedState, side: Side): number {
+  return state.sets.reduce((sum, set) => sum + set[side], 0);
+}
+
+// Closes the set at `index` for `winnerSide`, banks the set win and decides the
+// match when a side reaches ⌈bestOf/2⌉ sets (spec 04 §3.3). No draws, ever.
+function bankSet(state: SetBasedState, index: number, winnerSide: Side): SetBasedState {
+  const closed: SetState = { ...(state.sets[index] as SetState), closed: true };
+  const setsWon = { ...state.setsWon, [winnerSide]: state.setsWon[winnerSide] + 1 };
+  let next: SetBasedState = { ...replaceSet(state, index, closed), setsWon };
+  if (setsWon[winnerSide] >= majority(state.cfg.bestOf)) {
+    next = {
+      ...next,
+      phase: "done",
+      outcome: {
+        kind: "win",
+        winner: next.entrants[winnerSide],
+        loser: next.entrants[opponent(winnerSide)],
+        method: "regulation",
+      },
+    };
+  }
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Event application
+// ---------------------------------------------------------------------------
+
+function applyRally(state: SetBasedState, payload: SetBasedRally): SetBasedState {
+  if (state.phase !== "live") wrongPhase(`rally not allowed in phase "${state.phase}"`);
+  const side = sideOf(state, payload.wonBy);
+
+  let next = state;
+  let open = openSet(next);
+  if (open === null) {
+    next = { ...next, sets: [...next.sets, { home: 0, away: 0, closed: false }] };
+    open = openSet(next) as { set: SetState; index: number };
+  }
+  const scored: SetState = { ...open.set, [side]: open.set[side] + 1 };
+  const target = setTarget(next.cfg, open.index);
+  const winner = setWinner(scored.home, scored.away, target, next.cfg.winBy, next.cfg.cap);
+  next = replaceSet(next, open.index, scored);
+  return winner === null ? next : bankSet(next, open.index, winner);
+}
+
+// Resolves either summary shape to positional home/away.
+function normalizeSummary(
+  state: SetBasedState,
+  payload: SetBasedSummary,
+): { home: number; away: number; partial: boolean } {
+  if ("by" in payload) {
+    const side = sideOf(state, payload.by);
+    const home = side === "home" ? payload.forBy : payload.forOpp;
+    const away = side === "home" ? payload.forOpp : payload.forBy;
+    return { home, away, partial: payload.partial === true };
+  }
+  return { home: payload.home, away: payload.away, partial: payload.partial === true };
+}
+
+function applySummary(state: SetBasedState, payload: SetBasedSummary): SetBasedState {
+  if (state.phase !== "live") wrongPhase(`set summary not allowed in phase "${state.phase}"`);
+  const params = state.cfg;
+  const { home, away, partial } = normalizeSummary(state, payload);
+
+  if (partial) {
+    // In-progress snapshot: create/refresh an open set; must not already be
+    // terminal (a finished set arrives as a non-partial summary).
+    const open = openSet(state);
+    const index = open?.index ?? state.sets.length;
+    const target = setTarget(params, index);
+    if (setWinner(home, away, target, params.winBy, params.cap) !== null) {
+      invalid("a partial set summary must not be a completed set score", { home, away });
+    }
+    if (open === null) {
+      return { ...state, sets: [...state.sets, { home, away, closed: false }] };
+    }
+    if (home < open.set.home || away < open.set.away) {
+      invalid("a partial set summary may not decrease the score");
+    }
+    return replaceSet(state, index, { ...open.set, home, away });
+  }
+
+  // Completed-set summary: no rally set may be mid-flight (dual fidelity is
+  // per-set, not per-point).
+  const open = openSet(state);
+  if (open !== null && (open.set.home > 0 || open.set.away > 0)) {
+    invalid("this set is being scored rally-by-rally — a set summary is not allowed for it");
+  }
+  const index = open === null ? state.sets.length : open.index;
+  const target = setTarget(params, index);
+  const winner = setWinner(home, away, target, params.winBy, params.cap);
+  if (winner === null || !reachableSetScore(home, away, target, params.winBy, params.cap)) {
+    invalid("set summary is not a reachable final score under the set predicate", {
+      home,
+      away,
+      target,
+      winBy: params.winBy,
+      cap: params.cap,
+    });
+  }
+  const set: SetState = { home, away, closed: false };
+  const withSet =
+    open === null ? { ...state, sets: [...state.sets, set] } : replaceSet(state, index, set);
+  return bankSet(withSet, index, winner);
+}
+
+// Forfeit — spec 04 §3 / volleyball.md §7: award the match to the opponent;
+// completed sets already stand in the ledger.
+function applyForfeit(state: SetBasedState, by: string): SetBasedState {
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase("match already over");
+  }
+  const winnerSide = opponent(sideOf(state, by));
+  return {
+    ...state,
+    phase: "done",
+    outcome: { kind: "award", winner: state.entrants[winnerSide] },
+  };
+}
+
+// Abandon — leave the fixture undecided and flagged for regeneration (mirrors
+// football's replay policy; a gym closure is re-scheduled, not awarded).
+function applyAbandon(state: SetBasedState): SetBasedState {
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase("match already over");
+  }
+  return { ...state, phase: "abandoned", replayFlagged: true };
+}
+
+// ---------------------------------------------------------------------------
+// Generator helper — a reachable completed-set score for the given target.
+// ---------------------------------------------------------------------------
+
+function generateSetScore(
+  target: number,
+  winBy: number,
+  cap: number | null,
+  rng: Rng,
+): [hi: number, lo: number] {
+  // ~25% deuce/cap endings, else a clean win to the target.
+  if (rng() < 0.25) {
+    const ceiling = cap ?? target + winBy + 4;
+    // Winner lands on hi with the loser winBy behind, or exactly at the cap.
+    let hi = target + 1 + Math.floor(rng() * Math.max(1, ceiling - target - 1));
+    if (cap !== null && rng() < 0.4) hi = cap;
+    hi = Math.min(hi, cap ?? hi);
+    const lo = cap !== null && hi === cap ? hi - 1 : hi - winBy;
+    if (reachableSetScore(hi, lo, target, winBy, cap)) return [hi, Math.max(0, lo)];
+  }
+  const lo = Math.floor(rng() * Math.max(1, target - winBy + 1));
+  return [target, lo];
+}
+
+// ---------------------------------------------------------------------------
+// Preset wiring — the parts that differ between the three sports
+// ---------------------------------------------------------------------------
+
+export interface SetBasedPreset {
+  key: string; // 'volleyball' | 'badminton' | 'tabletennis'
+  version: string;
+  defaults: SetBasedParams; // shipped variant (also what coarsen segments under)
+  variants: Record<string, Partial<SetBasedParams>>;
+  positions: PositionCatalog;
+  // Metric labels differ (Sets vs Games); keys stay set_ratio/point_ratio so the
+  // shared comparator registry (PROMPT-08) resolves them uniformly.
+  unitLabel: { one: string; many: string };
+  defaultTiebreakers: TiebreakerKey[];
+  officialLabel: { scorer: string };
+  coarseEventType: "set.summary" | "game.summary";
+  rallyEntitlement: string; // doc 10 FeatureKey for Tier-2/3 rally scoring
+}
+
+function makeMetrics(unit: { one: string; many: string }): MetricSpec[] {
+  return [
+    { key: "sets_won", label: `${unit.many} won`, direction: "desc" },
+    { key: "sets_lost", label: `${unit.many} lost`, direction: "asc" },
+    { key: "points_won", label: "Points won", direction: "desc" },
+    { key: "points_lost", label: "Points lost", direction: "asc" },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Module factory
+// ---------------------------------------------------------------------------
+
+export function makeSetBasedModule(
+  preset: SetBasedPreset,
+): SportModule<SetBasedCfg, SetBasedEv, SetBasedState> {
+  const configSchema = makeConfigSchema(preset.defaults);
+  const rallyType = `${preset.key}.rally`;
+  const summaryType = `${preset.key}.${preset.coarseEventType}`;
+  const coarsenParams = preset.defaults; // spec 04 §9.6 conformance runs at default cfg
+
+  const fidelityTiers: FidelityTier[] = [
+    { tier: 0, eventTypes: [summaryType] },
+    { tier: 1, eventTypes: [summaryType] },
+    { tier: 2, eventTypes: [rallyType], entitlement: preset.rallyEntitlement },
+    { tier: 3, eventTypes: [rallyType], entitlement: preset.rallyEntitlement },
+  ];
+
+  // Award/forfeit points = a clean-sweep win pair: "*" (or the first entry).
+  const cleanSweepPair = (cfg: SetBasedCfg): PointsPair =>
+    cfg.pointsMap["*"] ?? (Object.values(cfg.pointsMap)[0] as PointsPair | undefined) ?? [1, 0];
+
+  // pointsMap lookup for a decided match: exact "W-L", else "*".
+  const matchPoints = (cfg: SetBasedCfg, winnerSets: number, loserSets: number): PointsPair => {
+    const exact = cfg.pointsMap[`${winnerSets}-${loserSets}`];
+    if (exact !== undefined) return exact;
+    const wildcard = cfg.pointsMap["*"];
+    if (wildcard !== undefined) return wildcard;
+    invalid(`no pointsMap entry for set score ${winnerSets}-${loserSets}`);
+  };
+
+  const sideMetrics = (state: SetBasedState, side: Side): Record<string, number> => ({
+    sets_won: state.setsWon[side],
+    sets_lost: state.setsWon[opponent(side)],
+    points_won: totalPoints(state, side),
+    points_lost: totalPoints(state, opponent(side)),
+  });
+
+  return {
+    key: preset.key,
+    version: preset.version,
+    configSchema,
+    eventSchema: SetBasedEv,
+    positions: preset.positions,
+    variants: preset.variants,
+
+    init(cfg, lineups: LineupPair): SetBasedState {
+      return {
+        cfg,
+        entrants: { home: lineups.home.entrantId, away: lineups.away.entrantId },
+        phase: "pre",
+        sets: [],
+        setsWon: { home: 0, away: 0 },
+        outcome: null,
+        replayFlagged: false,
+      };
+    },
+
+    apply(state, ev: EventEnvelope<SetBasedEv | CoreEv>): SetBasedState {
+      switch (ev.type) {
+        case "core.start":
+          if (state.phase !== "pre") wrongPhase("already started");
+          return { ...state, phase: "live" };
+        case rallyType:
+          return applyRally(state, parsePayload(SetBasedRally, ev.payload, ev.type));
+        case summaryType:
+          return applySummary(state, parsePayload(SetBasedSummary, ev.payload, ev.type));
+        case "core.forfeit":
+          return applyForfeit(state, (ev.payload as { by: string }).by);
+        case "core.abandon":
+          return applyAbandon(state);
+        case "core.finalize":
+          if (state.outcome === null) wrongPhase("cannot finalize an undecided fixture");
+          return { ...state, phase: "final" };
+        case "core.note":
+          return state;
+        default:
+          invalid(`unknown event type "${ev.type}"`);
+      }
+    },
+
+    outcome: (state) => state.outcome,
+
+    // §9.5 — defined at every prefix; reads only the folded set ledger so
+    // coarse and fine folds render identically (§9.6).
+    summary(state): ScoreSummary {
+      const points = { home: totalPoints(state, "home"), away: totalPoints(state, "away") };
+      return {
+        headline: `${state.setsWon.home} — ${state.setsWon.away}`,
+        perSide: [
+          { entrantId: state.entrants.home, line: `${state.setsWon.home}` },
+          { entrantId: state.entrants.away, line: `${state.setsWon.away}` },
+        ],
+        detail: {
+          sets: state.sets.map((set) => ({ home: set.home, away: set.away, closed: set.closed })),
+          points,
+          ...(state.replayFlagged ? { abandoned: true } : {}),
+        },
+      };
+    },
+
+    standingsDelta(outcome, cfg, _ctx, state): [StandingsDelta, StandingsDelta] {
+      const build = (side: Side, w: number, l: number, pts: number): StandingsDelta => ({
+        entrantId: state.entrants[side],
+        played: 1,
+        won: w,
+        drawn: 0,
+        lost: l,
+        points: pts,
+        metrics: sideMetrics(state, side),
+      });
+
+      switch (outcome.kind) {
+        case "win": {
+          const winnerSide = sideOf(state, outcome.winner);
+          const [wp, lp] = matchPoints(
+            cfg,
+            state.setsWon[winnerSide],
+            state.setsWon[opponent(winnerSide)],
+          );
+          const winner = build(winnerSide, 1, 0, wp);
+          const loser = build(opponent(winnerSide), 0, 1, lp);
+          return winnerSide === "home" ? [winner, loser] : [loser, winner];
+        }
+        case "award": {
+          // Forfeit: clean-sweep pair to keep the total inside declaredPointsSets.
+          const winnerSide = sideOf(state, outcome.winner);
+          const [wp, lp] = cleanSweepPair(cfg);
+          const winner = build(winnerSide, 1, 0, wp);
+          const loser = build(opponent(winnerSide), 0, 1, lp);
+          return winnerSide === "home" ? [winner, loser] : [loser, winner];
+        }
+        // Set-based sports always produce a winner (§3.3 supportsDraws = false);
+        // abandon leaves the outcome null, so no draw/tie/no_result reaches here.
+        default:
+          invalid(`set-based module cannot rank outcome "${outcome.kind}"`);
+      }
+    },
+
+    metrics: makeMetrics(preset.unitLabel),
+    defaultTiebreakers: preset.defaultTiebreakers,
+
+    supportsDraws(_cfg, _stage: StageKind) {
+      return false;
+    },
+
+    // §9.3 — every decided fixture pays a pointsMap value-sum (award reuses the
+    // clean-sweep pair, whose sum is already present).
+    declaredPointsSets(cfg) {
+      return [...new Set(Object.values(cfg.pointsMap).map(([w, l]) => w + l))];
+    },
+
+    fidelityTiers,
+    officialLabel: preset.officialLabel,
+
+    // spec 03 §6 — deterministic generator. Summary-dominant so best-of-N
+    // matches decide within the conformance event budget; rally bursts exercise
+    // the point-by-point path and coarsen (§9.6).
+    arbitraryEvent(state, rng: Rng): ModuleEvent<SetBasedEv> | null {
+      if (state.phase === "pre") return { type: "core.start", payload: {} };
+      if (state.phase !== "live") return null;
+
+      const randomEntrant = () => (rng() < 0.5 ? state.entrants.home : state.entrants.away);
+      const open = openSet(state);
+      if (open !== null) {
+        // A rally set is mid-flight — keep rallying it to a finish.
+        return { type: rallyType, payload: { wonBy: randomEntrant() } };
+      }
+      const roll = rng();
+      if (roll < 0.02) {
+        return { type: "core.forfeit", payload: { by: randomEntrant(), reason: "walkover" } };
+      }
+      if (roll < 0.04) return { type: "core.abandon", payload: { reason: "venue closed" } };
+      if (roll < 0.14) return { type: rallyType, payload: { wonBy: randomEntrant() } };
+      const target = setTarget(state.cfg, state.sets.length);
+      const [hi, lo] = generateSetScore(target, state.cfg.winBy, state.cfg.cap, rng);
+      const homeWins = rng() < 0.5;
+      return {
+        type: summaryType,
+        payload: { home: homeWins ? hi : lo, away: homeWins ? lo : hi },
+      };
+    },
+
+    // §9.6 — collapse a rally stream into per-set summaries. Completed sets emit
+    // a non-partial entrant-keyed summary; a trailing open set emits a `partial`
+    // snapshot. Segmentation is position-independent: it tracks the two entrant
+    // ids in local slots and asks setWinner which slot won, so no lineup context
+    // is needed. core/positional-summary events flush the open set, then pass
+    // through. Uses the preset default params (coarsenParams; §9.6 runs at the
+    // default cfg — the shipped variant).
+    coarsen(events): ModuleEvent<SetBasedEv>[] {
+      const out: ModuleEvent<SetBasedEv>[] = [];
+      let setsPlayed = 0;
+      // Local slot A = first id seen this set, B = the other.
+      let idA: string | null = null;
+      let idB: string | null = null;
+      let a = 0;
+      let b = 0;
+
+      const resetSet = () => {
+        idA = null;
+        idB = null;
+        a = 0;
+        b = 0;
+      };
+      const flushPartial = () => {
+        if (a === 0 && b === 0) return;
+        // Slot A always fills first, so idA is set whenever any point exists.
+        out.push({
+          type: summaryType,
+          payload: { by: idA as string, forBy: a, forOpp: b, partial: true },
+        });
+        resetSet();
+      };
+
+      for (const event of events) {
+        if (event.type === rallyType) {
+          const { wonBy } = event.payload as SetBasedRally;
+          if (idA === null || wonBy === idA) {
+            idA = wonBy;
+            a += 1;
+          } else {
+            idB = wonBy;
+            b += 1;
+          }
+          const target = setTarget(coarsenParams, setsPlayed);
+          const winner = setWinner(a, b, target, coarsenParams.winBy, coarsenParams.cap);
+          if (winner !== null) {
+            const winnerId = (winner === "home" ? idA : idB) as string;
+            out.push({
+              type: summaryType,
+              payload: {
+                by: winnerId,
+                forBy: winner === "home" ? a : b,
+                forOpp: winner === "home" ? b : a,
+              },
+            });
+            setsPlayed += 1;
+            resetSet();
+          }
+          continue;
+        }
+        // Non-rally: flush the open set, then pass through. A completed
+        // (non-partial) summary already occupies a set slot, so advance the set
+        // index — otherwise a later rally set (e.g. the decider) would segment
+        // under the wrong target (spec 04 §3.3).
+        flushPartial();
+        out.push({ type: event.type, payload: event.payload });
+        if (event.type === summaryType && (event.payload as { partial?: boolean }).partial !== true) {
+          setsPlayed += 1;
+        }
+      }
+      flushPartial();
+      return out;
+    },
+  };
+}

--- a/packages/engine/src/sports/setbased/setbased.test.ts
+++ b/packages/engine/src/sports/setbased/setbased.test.ts
@@ -1,0 +1,408 @@
+// Set-based goldens + property + conformance — spec 04 §3–5, PROMPT-06 §4–5.
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { foldMatch, type CoreEv, type EventEnvelope } from "../../core/events.ts";
+import { mulberry32 } from "../../core/rng.ts";
+import type { LineupPair } from "../../core/types.ts";
+import { conformanceSuite, defaultLineupPair, makeEnvelope } from "../../testkit/index.ts";
+import { badminton } from "./badminton.ts";
+import type { SetBasedCfg, SetBasedEv, SetBasedState } from "./kernel.ts";
+import { makeSetBasedModule } from "./kernel.ts";
+import { tabletennis } from "./tabletennis.ts";
+import { volleyball } from "./volleyball.ts";
+
+type Side = "home" | "away";
+type Mod = ReturnType<typeof makeSetBasedModule>;
+
+const asEv = (event: EventEnvelope) => event as EventEnvelope<SetBasedEv | CoreEv>;
+
+function lineups(mod: Mod): LineupPair {
+  return defaultLineupPair(mod.positions);
+}
+
+// Build an event stream from bare [type, payload] specs.
+function stream(...specs: Array<[type: string, payload?: unknown]>): EventEnvelope[] {
+  return specs.map(([type, payload], i) => makeEnvelope(i, { type, payload: payload ?? {} }));
+}
+
+// core.start + one summary per (home,away) set score.
+function summaryMatch(mod: Mod, scores: Array<[number, number]>): EventEnvelope[] {
+  const type = `${mod.key}.${mod.key === "volleyball" ? "set.summary" : "game.summary"}`;
+  return stream(
+    ["core.start"],
+    ...scores.map(([home, away]) => [type, { home, away }] as [string, unknown]),
+  );
+}
+
+// core.start + a rally per winner side.
+function rallyMatch(mod: Mod, winners: Side[]): EventEnvelope[] {
+  const ls = lineups(mod);
+  const id = (s: Side) => (s === "home" ? ls.home.entrantId : ls.away.entrantId);
+  return stream(
+    ["core.start"],
+    ...winners.map((s) => [`${mod.key}.rally`, { wonBy: id(s) }] as [string, unknown]),
+  );
+}
+
+function fold(mod: Mod, cfg: SetBasedCfg, events: EventEnvelope[]): SetBasedState {
+  return foldMatch(mod, cfg, lineups(mod), events) as SetBasedState;
+}
+
+// ---------------------------------------------------------------------------
+// PROMPT-06 §4 (a) — volleyball 3-2 (25-20, 23-25, 25-18, 24-26, 15-13) → 2:1.
+// ---------------------------------------------------------------------------
+describe("volleyball golden: 3-2 → 2:1 points split", () => {
+  const cfg = volleyball.configSchema.parse({});
+  const events = summaryMatch(volleyball, [
+    [25, 20],
+    [23, 25],
+    [25, 18],
+    [24, 26],
+    [15, 13], // deciding set to finalSetTo 15
+  ]);
+
+  it("decides for home and banks a 3-2 set score", () => {
+    const state = fold(volleyball, cfg, events);
+    expect(state.outcome).toEqual({ kind: "win", winner: "H", loser: "A", method: "regulation" });
+    expect(state.setsWon).toEqual({ home: 3, away: 2 });
+    expect(volleyball.summary(state).headline).toBe("3 — 2");
+  });
+
+  it("pays the FIVB 3-2 split 2:1 with integer point ledgers", () => {
+    const state = fold(volleyball, cfg, events);
+    const [home, away] = volleyball.standingsDelta(state.outcome!, cfg, { kind: "league" }, state);
+    expect(home).toMatchObject({
+      entrantId: "H",
+      won: 1,
+      points: 2,
+      metrics: { sets_won: 3, sets_lost: 2, points_won: 112, points_lost: 102 },
+    });
+    expect(away).toMatchObject({
+      entrantId: "A",
+      lost: 1,
+      points: 1,
+      metrics: { sets_won: 2, sets_lost: 3, points_won: 102, points_lost: 112 },
+    });
+    // §9.3 — a volleyball fixture always totals 3 points.
+    expect(home.points + away.points).toBe(3);
+    expect([...volleyball.declaredPointsSets(cfg)]).toEqual([3]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-06 §4 — a 32-30 extended (uncapped) volleyball set.
+// ---------------------------------------------------------------------------
+describe("volleyball golden: 32-30 extended set (uncapped win-by-two)", () => {
+  const cfg = volleyball.configSchema.parse({});
+
+  it("accepts 32-30 as a reachable set and rejects 33-30 / 25-24", () => {
+    const decided = fold(volleyball, cfg, summaryMatch(volleyball, [[32, 30], [25, 12], [25, 20]]));
+    expect(decided.sets[0]).toEqual({ home: 32, away: 30, closed: true });
+    expect(decided.outcome).toMatchObject({ kind: "win", winner: "H" });
+
+    // 33-30 could never occur (the set ended at 32-30) — reachability rejects it.
+    expect(() => fold(volleyball, cfg, summaryMatch(volleyball, [[33, 30]]))).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    // 25-24 is not a win (margin 1, no cap).
+    expect(() => fold(volleyball, cfg, summaryMatch(volleyball, [[25, 24]]))).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    // 26-24 is the minimal deuce win — accepted.
+    expect(fold(volleyball, cfg, summaryMatch(volleyball, [[26, 24]])).sets[0]).toMatchObject({
+      home: 26,
+      away: 24,
+      closed: true,
+    });
+  });
+
+  it("closes an uncapped rally set only at a two-point margin", () => {
+    // 30-30 then home takes two straight → 32-30.
+    const winners: Side[] = [];
+    for (let i = 0; i < 30; i++) winners.push("home", "away"); // 30-30
+    winners.push("home", "home"); // 32-30
+    const state = fold(volleyball, cfg, rallyMatch(volleyball, winners));
+    expect(state.sets[0]).toEqual({ home: 32, away: 30, closed: true });
+    expect(state.setsWon).toEqual({ home: 1, away: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-06 §4 — badminton golden point 30-29 (hard cap 30).
+// ---------------------------------------------------------------------------
+describe("badminton golden: 30-29 golden point", () => {
+  const cfg = badminton.configSchema.parse({});
+
+  it("closes a rally game at the cap 30-29 and wins the match 2-0", () => {
+    const winners: Side[] = [];
+    for (let i = 0; i < 29; i++) winners.push("home", "away"); // 29-29
+    winners.push("home"); // 30-29 golden point → game 1 to home
+    for (let i = 0; i < 21; i++) winners.push("home"); // 21-0 → game 2, match over
+    const state = fold(badminton, cfg, rallyMatch(badminton, winners));
+    expect(state.sets[0]).toEqual({ home: 30, away: 29, closed: true });
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "H", method: "regulation" });
+    expect(state.setsWon).toEqual({ home: 2, away: 0 });
+    const [home, away] = badminton.standingsDelta(state.outcome!, cfg, { kind: "league" }, state);
+    expect([home.points, away.points]).toEqual([2, 0]);
+  });
+
+  it("validates cap corners via summaries (30-29 ok · 31-30 / 22-19 / 29-29 rejected · 22-20 ok)", () => {
+    const ok = (h: number, a: number) =>
+      fold(badminton, cfg, summaryMatch(badminton, [[h, a]])).sets[0];
+    const bad = (h: number, a: number) =>
+      expect(() => fold(badminton, cfg, summaryMatch(badminton, [[h, a]]))).toThrowError(
+        expect.objectContaining({ code: "INVALID_EVENT" }),
+      );
+    expect(ok(30, 29)).toMatchObject({ home: 30, away: 29, closed: true });
+    expect(ok(22, 20)).toMatchObject({ home: 22, away: 20, closed: true });
+    bad(31, 30); // beyond the cap — unreachable
+    bad(22, 19); // already won at 21-19
+    bad(29, 29); // not terminal
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-06 §4 — table tennis 4-3 in a best-of-7.
+// ---------------------------------------------------------------------------
+describe("tabletennis golden: 4-3 in best-of-7", () => {
+  const cfg = tabletennis.configSchema.parse({ bestOf: 7 });
+
+  it("goes the distance to a 7th deciding game", () => {
+    const state = fold(
+      tabletennis,
+      cfg,
+      summaryMatch(tabletennis, [
+        [11, 7], // H
+        [9, 11], // A
+        [11, 8], // H
+        [7, 11], // A
+        [11, 9], // H
+        [8, 11], // A
+        [11, 9], // H — decider (game 7)
+      ]),
+    );
+    expect(state.setsWon).toEqual({ home: 4, away: 3 });
+    expect(state.outcome).toMatchObject({ kind: "win", winner: "H", method: "regulation" });
+    const [home, away] = tabletennis.standingsDelta(state.outcome!, cfg, { kind: "league" }, state);
+    expect([home.points, away.points]).toEqual([2, 0]);
+  });
+
+  it("rejects 11-10 (margin 1) and accepts 12-10 (deuce)", () => {
+    expect(() => fold(tabletennis, cfg, summaryMatch(tabletennis, [[11, 10]]))).toThrowError(
+      expect.objectContaining({ code: "INVALID_EVENT" }),
+    );
+    expect(fold(tabletennis, cfg, summaryMatch(tabletennis, [[12, 10]])).sets[0]).toMatchObject({
+      home: 12,
+      away: 10,
+      closed: true,
+    });
+  });
+
+  it("does not decide before a side reaches 4 sets", () => {
+    const cfg7 = tabletennis.configSchema.parse({ bestOf: 7 });
+    const state = fold(
+      tabletennis,
+      cfg7,
+      summaryMatch(tabletennis, [[11, 0], [11, 0], [11, 0]]), // 3-0, still live
+    );
+    expect(tabletennis.outcome(state)).toBeNull();
+    expect(state.setsWon).toEqual({ home: 3, away: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Forfeit / abandon / finalize.
+// ---------------------------------------------------------------------------
+describe("set-based match lifecycle", () => {
+  const cfg = volleyball.configSchema.parse({});
+
+  it("awards a forfeited match to the opponent with clean-sweep points", () => {
+    const state = fold(
+      volleyball,
+      cfg,
+      stream(["core.start"], [`volleyball.set.summary`, { home: 25, away: 20 }], [
+        "core.forfeit",
+        { by: "A", reason: "injury, no subs" },
+      ]),
+    );
+    expect(state.outcome).toEqual({ kind: "award", winner: "H" });
+    const [home, away] = volleyball.standingsDelta(state.outcome!, cfg, { kind: "league" }, state);
+    expect([home.points, away.points]).toEqual([3, 0]);
+    expect(home.points + away.points).toBe(3); // still inside declaredPointsSets
+  });
+
+  it("leaves an abandoned match undecided and flagged, and refuses finalize", () => {
+    const state = fold(
+      volleyball,
+      cfg,
+      stream(["core.start"], ["volleyball.rally", { wonBy: "H" }], ["core.abandon", { reason: "power cut" }]),
+    );
+    expect(volleyball.outcome(state)).toBeNull();
+    expect(state.replayFlagged).toBe(true);
+    expect(volleyball.summary(state).detail).toMatchObject({ abandoned: true });
+    expect(() =>
+      volleyball.apply(state, asEv(makeEnvelope(9, { type: "core.finalize", payload: {} }))),
+    ).toThrowError(expect.objectContaining({ code: "WRONG_PHASE" }));
+  });
+
+  it("never supports draws in any stage", () => {
+    for (const stage of ["league", "group", "swiss", "knockout"] as const) {
+      expect(volleyball.supportsDraws(cfg, stage)).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dual fidelity (spec 04 §9.6) — coarsen(rally stream) ≡ summaries.
+// ---------------------------------------------------------------------------
+
+// Seeded rally match: alternate-ish random rallies until the match decides.
+function simulateRallies(mod: Mod, cfg: SetBasedCfg, seed: number, maxRallies: number): EventEnvelope[] {
+  const ls = lineups(mod);
+  const rng = mulberry32(seed);
+  const events: EventEnvelope[] = [makeEnvelope(0, { type: "core.start", payload: {} })];
+  let state = mod.init(cfg, ls);
+  state = mod.apply(state, asEv(events[0] as EventEnvelope));
+  for (let seq = 1; seq <= maxRallies; seq++) {
+    if (mod.outcome(state) !== null) break;
+    const wonBy = rng() < 0.5 ? ls.home.entrantId : ls.away.entrantId;
+    const ev = makeEnvelope(seq, { type: `${mod.key}.rally`, payload: { wonBy } });
+    state = mod.apply(state, asEv(ev));
+    events.push(ev);
+  }
+  return events;
+}
+
+describe("dual fidelity: coarsen(rally stream) folds identically", () => {
+  const cases: Array<[string, Mod]> = [
+    ["volleyball", volleyball],
+    ["badminton", badminton],
+    ["tabletennis", tabletennis],
+  ];
+
+  for (const [name, mod] of cases) {
+    const cfg = mod.configSchema.parse({});
+
+    it(`${name}: a decided rally match coarsens to summaries`, () => {
+      const fine = simulateRallies(mod, cfg, 12345, 4000);
+      const fineState = fold(mod, cfg, fine);
+      expect(mod.outcome(fineState)).not.toBeNull(); // sanity: it terminated
+
+      const coarse = mod
+        .coarsen!(fine.map(asEv))
+        .map((ev, i) => makeEnvelope(i, ev));
+      const coarseState = fold(mod, cfg, coarse);
+      expect(mod.outcome(coarseState)).toEqual(mod.outcome(fineState));
+      expect(mod.summary(coarseState)).toEqual(mod.summary(fineState));
+    });
+
+    it(`${name}: a mid-set (undecided) prefix coarsens to a matching partial`, () => {
+      const full = simulateRallies(mod, cfg, 99, 4000);
+      // A prefix that stops part-way into some set (undecided, open set present).
+      const prefix = full.slice(0, Math.min(full.length - 1, 7));
+      const fineState = fold(mod, cfg, prefix);
+      const coarse = mod.coarsen!(prefix.map(asEv)).map((ev, i) => makeEnvelope(i, ev));
+      const coarseState = fold(mod, cfg, coarse);
+      expect(mod.summary(coarseState)).toEqual(mod.summary(fineState));
+      expect(mod.outcome(coarseState)).toEqual(mod.outcome(fineState));
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PROMPT-06 §5 — properties.
+// ---------------------------------------------------------------------------
+
+// Independent re-derivation of the set predicate (kept separate from the kernel
+// so the property test is a genuine cross-check, not a tautology).
+function targetFor(cfg: SetBasedCfg, setIndex: number): number {
+  return setIndex === cfg.bestOf - 1 ? cfg.finalSetTo : cfg.setTo;
+}
+function isTerminal(h: number, a: number, target: number, winBy: number, cap: number | null): boolean {
+  const hi = Math.max(h, a);
+  const lo = Math.min(h, a);
+  if (h === a) return false;
+  if (cap !== null && hi >= cap) return true;
+  return hi >= target && hi - lo >= winBy;
+}
+function isReachable(h: number, a: number, target: number, winBy: number, cap: number | null): boolean {
+  if (!isTerminal(h, a, target, winBy, cap)) return false;
+  const [ph, pa] = h > a ? [h - 1, a] : [h, a - 1];
+  return !isTerminal(ph, pa, target, winBy, cap);
+}
+
+describe("set-based properties (PROMPT-06 §5)", () => {
+  const mods: Array<[string, Mod]> = [
+    ["volleyball", volleyball],
+    ["badminton", badminton],
+    ["tabletennis", tabletennis],
+  ];
+
+  for (const [name, mod] of mods) {
+    const cfg = mod.configSchema.parse({});
+
+    it(`${name}: every closed set is a reachable terminal score; the decision satisfies the predicate`, () => {
+      fc.assert(
+        fc.property(fc.nat(), fc.integer({ min: 1, max: 60 }), (seed, length) => {
+          const events = buildFromGenerator(mod, cfg, seed, length);
+          const state = fold(mod, cfg, events);
+          state.sets.forEach((set, i) => {
+            if (!set.closed) return;
+            const target = targetFor(cfg, i);
+            expect(isReachable(set.home, set.away, target, cfg.winBy, cfg.cap)).toBe(true);
+          });
+          const outcome = mod.outcome(state);
+          if (outcome !== null && outcome.kind === "win") {
+            const majority = Math.ceil(cfg.bestOf / 2);
+            expect(Math.max(state.setsWon.home, state.setsWon.away)).toBe(majority);
+          }
+        }),
+        { numRuns: 200 },
+      );
+    });
+
+    it(`${name}: a random rally stream always terminates a set (bounded)`, () => {
+      for (let seed = 0; seed < 20; seed++) {
+        const events = simulateRallies(mod, cfg, seed + 1, 2000);
+        const state = fold(mod, cfg, events);
+        // Either the match decided, or at least one set closed within the budget.
+        const closedSets = state.sets.filter((s) => s.closed).length;
+        expect(closedSets).toBeGreaterThan(0);
+      }
+    });
+  }
+
+  it("volleyball (cap = null): a closed set never ends below the win-by margin", () => {
+    const cfg = volleyball.configSchema.parse({});
+    for (let seed = 0; seed < 25; seed++) {
+      const state = fold(volleyball, cfg, simulateRallies(volleyball, cfg, seed * 7 + 3, 4000));
+      for (const set of state.sets) {
+        if (set.closed) expect(Math.abs(set.home - set.away)).toBeGreaterThanOrEqual(cfg.winBy);
+      }
+    }
+  });
+});
+
+// Grow a valid stream by walking the module's own generator (mirrors the
+// testkit's buildStream but local to keep the property self-contained).
+function buildFromGenerator(mod: Mod, cfg: SetBasedCfg, seed: number, maxEvents: number): EventEnvelope[] {
+  const ls = lineups(mod);
+  const rng = mulberry32(seed);
+  let state = mod.init(cfg, ls);
+  const events: EventEnvelope[] = [];
+  for (let i = 0; i < maxEvents; i++) {
+    const next = mod.arbitraryEvent!(state, rng);
+    if (!next) break;
+    const ev = makeEnvelope(events.length, next);
+    state = mod.apply(state, asEv(ev));
+    events.push(ev);
+  }
+  return events;
+}
+
+// ---------------------------------------------------------------------------
+// Conformance — spec 04 §9, green for all three presets at their default cfg.
+// ---------------------------------------------------------------------------
+conformanceSuite(volleyball);
+conformanceSuite(badminton);
+conformanceSuite(tabletennis);

--- a/packages/engine/src/sports/setbased/tabletennis.ts
+++ b/packages/engine/src/sports/setbased/tabletennis.ts
@@ -1,0 +1,44 @@
+// Table tennis — set-based preset (spec 04 §5 + engine/sports/table-tennis.md).
+// {5|7,11,11,2,null}: games to 11, win by 2, no cap (deuce runs 12-10, 15-13…),
+// matches best of 5 (groups) or 7 (KO/finals).
+//
+// NOTE — team ties (Swaythling / modern ITTF club format: a "match" = 4–5
+// individual matches, first to 3) are a *stage-level* feature: the competition
+// engine aggregates child fixtures via Fixture.parent_fixture_id (schema
+// reserves the column). That is NOT this module's concern — this module scores a
+// single singles/doubles fixture only (table-tennis.md §4).
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import { makeSetBasedModule } from "./kernel.ts";
+
+// table-tennis.md §6 — no positions; singles/doubles/mixed = entrant kind (same
+// as badminton). One nominated unit per side.
+const positions: PositionCatalog = {
+  groups: [],
+  lineup: { size: 1, benchMax: 1 },
+};
+
+export const tabletennis = makeSetBasedModule({
+  key: "tabletennis",
+  version: "1.0.0",
+  // spec 04 §5 — ITTF: games to 11, win by 2, no cap; best of 5 by default.
+  defaults: {
+    bestOf: 5,
+    setTo: 11,
+    finalSetTo: 11,
+    winBy: 2,
+    cap: null,
+    pointsMap: { "*": [2, 0] }, // league convention 2/0; configurable
+  },
+  variants: {
+    bo5: {},
+    bo7: { bestOf: 7 }, // KO / finals
+    "hardbat-21": { setTo: 21, finalSetTo: 21 }, // legacy/social — kernel unchanged
+  },
+  positions,
+  unitLabel: { one: "Game", many: "Games" },
+  // spec 04 §5 / table-tennis.md §5 — matches → h2h → game ratio → point ratio.
+  defaultTiebreakers: ["points", "wins", "set_ratio", "point_ratio", "h2h_points"],
+  officialLabel: { scorer: "Umpire" }, // doc 13 §1
+  coarseEventType: "game.summary",
+  rallyEntitlement: "scoring.rally_by_rally", // doc 10 / table-tennis.md §3
+});

--- a/packages/engine/src/sports/setbased/volleyball.ts
+++ b/packages/engine/src/sports/setbased/volleyball.ts
@@ -1,0 +1,52 @@
+// Volleyball — set-based preset (spec 04 §3 + engine/sports/volleyball.md).
+// Indoor {5,25,15,2,null} + beach {3,21,15,2,null}; FIVB match-points convention
+// (3-0/3-1 → 3:0, 3-2 → 2:1) via pointsMap; S/OH/MB/OPP/L catalog with a libero
+// role (validation only — positions never touch scoring). The kernel owns all
+// set logic; this file is configuration.
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import { makeSetBasedModule, type SetBasedParams } from "./kernel.ts";
+
+// spec 04 §3.4 — FIVB league convention. "*" (clean 3-0/3-1) → 3:0; the 3-2
+// split is the only exception → 2:1. Total is 3 either way (declaredPointsSets).
+const FIVB_POINTS: SetBasedParams["pointsMap"] = { "3-2": [2, 1], "*": [3, 0] };
+
+// engine/sports/volleyball.md §5 — S (setter) / OH (outside) / MB (middle) /
+// OPP (opposite) / L (libero); 6 on court, libero as a role tracked for lineups
+// only (rotation is Pro-stat metadata, referees enforce it, not us).
+const positions: PositionCatalog = {
+  groups: [
+    { key: "S", name: "Setter" },
+    { key: "OH", name: "Outside hitter" },
+    { key: "MB", name: "Middle blocker" },
+    { key: "OPP", name: "Opposite" },
+    { key: "L", name: "Libero" },
+  ],
+  roles: [{ key: "libero", name: "Libero" }], // up to 2 per team → not unique
+  lineup: { size: 6, benchMax: 8 },
+};
+
+export const volleyball = makeSetBasedModule({
+  key: "volleyball",
+  version: "1.0.0",
+  // Default = indoor (spec 04 §3.1).
+  defaults: {
+    bestOf: 5,
+    setTo: 25,
+    finalSetTo: 15,
+    winBy: 2,
+    cap: null,
+    pointsMap: FIVB_POINTS,
+  },
+  variants: {
+    indoor: {},
+    // Beach: pairs, best-of-3 to 21, deciding set to 15; simple 2-0 win points.
+    beach: { bestOf: 3, setTo: 21, finalSetTo: 15, pointsMap: { "*": [2, 0] } },
+  },
+  positions,
+  unitLabel: { one: "Set", many: "Sets" },
+  // spec 04 §3.4 — points → matches won → set ratio → point ratio → h2h.
+  defaultTiebreakers: ["points", "wins", "set_ratio", "point_ratio", "h2h_points"],
+  officialLabel: { scorer: "Referee" }, // doc 13 §1
+  coarseEventType: "set.summary",
+  rallyEntitlement: "scoring.rally_by_rally", // doc 10 / volleyball.md §3
+});


### PR DESCRIPTION
Implements **PROMPT-06** (set-based sports kernel) and **PROMPT-07** (board-game module + Swiss metrics).

## PROMPT-06 — set-based kernel + 3 presets
One parametric engine `{bestOf, setTo, finalSetTo, winBy, cap, pointsMap}` in `sports/setbased/kernel.ts`; the three presets are pure configuration (zero duplicated set logic):

| preset | cfg | notes |
|---|---|---|
| `volleyball` | indoor `{5,25,15,2,null}` + beach `{3,21,15,2,null}` | FIVB pointsMap (3-0/3-1→3:0, 3-2→2:1); S/OH/MB/OPP/L + libero catalog |
| `badminton` | `{3,21,21,2,30}` | hard cap 30 golden point; disciplines = entrant kind, no positions |
| `tabletennis` | `{5\|7,11,11,2,null}` | no cap; team ties noted as a future `parent_fixture_id` feature |

- **Set-win predicate**: `≥ target && margin ≥ winBy`, or hard `cap` golden point; deciding set (index `bestOf−1`) uses `finalSetTo`; match at `⌈bestOf/2⌉`. `supportsDraws` always false.
- **Reachability validation** on coarse summaries: rejects 25-24 (no cap), 31-30 / 22-19 (already decided); accepts 26-24, 30-29 (cap), 32-30.
- **Dual fidelity** (§9.6): `rally {wonBy}` and `*.summary {home, away}` fold identically. `coarsen` is position-independent — it emits an entrant-keyed bridge summary (`{by, forBy, forOpp}`) so it needs no lineup context.
- Ratio metrics stored as integer pairs (`sets_won/sets_lost`, `points_won/points_lost`); the cross-multiplication comparator resolves `set_ratio`/`point_ratio` at rank time (PROMPT-08 registry, same pattern as cricket NRR).

## PROMPT-07 — board-game module + Swiss tiebreakers
- `sports/boardgame/` — chess/draughts/go/carrom/generic 1-v-1. **Half-point integers** throughout (win 2 / draw 1 / loss 0 — never `0.5`), single `result` event, colour metadata (home = White), variants classical/rapid/blitz (clock only), `byeScore`. Draws always allowed (KO ties resolve via mini-matches later).
- `competition/tiebreakers.ts` — **Buchholz, Cut-1, Sonneborn-Berger** computed at rank time from the Swiss ledger (they depend on opponents' *final* scores, so cannot fold incrementally). FIDE **virtual-opponent** adjustment for byes/forfeits (Handbook C.07 cited). SB returned in quarter-points to stay integer. Colour-history string exposed for the pairing algorithm.

## Goldens & tests
volleyball 3-2 (25-20, 23-25, 25-18, 24-26, 15-13) → 2:1 · 32-30 extended set · badminton 30-29 golden point · TT 4-3 in best-of-7 · 6-player Swiss cross-table (Buchholz = Σall−own, hand-verified) · properties (rally streams terminate sets, decisions satisfy the predicate, cap=null never ends below the win-by margin).

**Conformance green ×4 modules; half-point/integer ledgers verified. +77 tests → 306 total.** Engine typecheck / `engine:check` / `engine:boundary` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pEsHzfZ8KyB3Bz6sDKfn