### PR TITLE
feat(engine): competition engine — stages, standings, tiebreaker cascade (PROMPT-08)

### DIFF
--- a/packages/engine/src/competition/cascade.test.ts
+++ b/packages/engine/src/competition/cascade.test.ts
@@ -1,0 +1,305 @@
+// Tiebreaker cascade — spec 05 §4 (PROMPT-08 §3, §5, §6).
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import type { StandingsDelta } from "../core/types.ts";
+import type { TiebreakerKey } from "../sport/module.ts";
+import { foldResults, type FixtureResult, type StandingsRow } from "./standings.ts";
+import { buildSwissTable, rankStandings, validateCascade } from "./tiebreakers.ts";
+
+// The two football presets under test (spec 04 §1.6): H2H-first vs GD-first.
+const FIFA2026: TiebreakerKey[] = ["points", "h2h_points", "h2h_diff", "h2h_for", "diff", "for", "fair_play", "lots"];
+const CLASSIC: TiebreakerKey[] = ["points", "diff", "for", "h2h_points", "h2h_diff", "h2h_for", "fair_play", "lots"];
+
+// Football-shaped decided fixture (gf/ga/gd ledger, 3/1/0 points).
+function fb(home: string, away: string, hg: number, ag: number): FixtureResult {
+  const draw = hg === ag;
+  const homeWon = hg > ag;
+  const side = (id: string, gf: number, ga: number, w: number, d: number, l: number, pts: number): StandingsDelta => ({
+    entrantId: id,
+    played: 1,
+    won: w,
+    drawn: d,
+    lost: l,
+    points: pts,
+    metrics: { gf, ga, gd: gf - ga },
+  });
+  return [
+    side(home, hg, ag, homeWon ? 1 : 0, draw ? 1 : 0, !draw && !homeWon ? 1 : 0, draw ? 1 : homeWon ? 3 : 0),
+    side(away, ag, hg, !draw && !homeWon ? 1 : 0, draw ? 1 : 0, homeWon ? 1 : 0, draw ? 1 : homeWon ? 0 : 3),
+  ];
+}
+
+function rankOrder(entrants: string[], results: FixtureResult[], cascade: TiebreakerKey[], opts: { h2hRecursive?: boolean } = {}): string[] {
+  const rows = foldResults(entrants, results);
+  return rankStandings(rows, { cascade, results, h2hRecursive: opts.h2hRecursive === true, rngSeed: 1 }).rows.map((r) => r.entrantId);
+}
+
+// ---------------------------------------------------------------------------
+// Golden #6 — same group, H2H-first vs GD-first give DIFFERENT orders.
+// ---------------------------------------------------------------------------
+
+describe("FIFA 2026 H2H-first vs classic GD-first (golden — spec 05 §4, PROMPT-08 §6)", () => {
+  // 4-team single RR. T1,T2,T3 finish level on 6 pts (each beats T4 + a 1-1-1
+  // cycle among themselves); T4 last. Among {T1,T2,T3}: h2h points are level, so
+  // h2h GD decides one way while overall GD (inflated by T2's 5-0 over T4)
+  // decides the other.
+  const entrants = ["T1", "T2", "T3", "T4"];
+  const results: FixtureResult[] = [
+    fb("T1", "T2", 2, 0),
+    fb("T3", "T1", 1, 0),
+    fb("T2", "T3", 1, 0),
+    fb("T1", "T4", 1, 0),
+    fb("T2", "T4", 5, 0),
+    fb("T3", "T4", 2, 0),
+  ];
+
+  it("H2H-first (fifa2026) orders by the head-to-head sub-table", () => {
+    expect(rankOrder(entrants, results, FIFA2026)).toEqual(["T1", "T3", "T2", "T4"]);
+  });
+
+  it("GD-first (classic) orders by overall goal difference", () => {
+    expect(rankOrder(entrants, results, CLASSIC)).toEqual(["T2", "T3", "T1", "T4"]);
+  });
+
+  it("the two presets genuinely disagree on the same fixtures", () => {
+    expect(rankOrder(entrants, results, FIFA2026)).not.toEqual(rankOrder(entrants, results, CLASSIC));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UEFA recursive vs FIFA fall-through (spec 05 §4.2, PROMPT-08 §3).
+// ---------------------------------------------------------------------------
+
+describe("h2hRecursive — UEFA re-application vs FIFA fall-through (spec 05 §4.2)", () => {
+  // A,B,C,D level on 6 pts (jobber games equalise). The 4-way h2h splits into
+  // {A,B} over {C,D} and leaves each pair level on h2h pts/GD/GF. UEFA re-runs
+  // the head-to-head among just the pair (A beat B, C beat D). FIFA falls
+  // through to overall GD, which the jobber results tilt the OTHER way (B>A, C>D
+  // on overall GD ⇒ B,A,...). The pair order flips between the two.
+  const entrants = ["A", "B", "C", "D", "Ja", "Jb", "Jc", "Jd"];
+  const results: FixtureResult[] = [
+    // Among the tie group (only these count for head-to-head).
+    fb("A", "B", 1, 0),
+    fb("A", "C", 1, 0),
+    fb("D", "A", 1, 0),
+    fb("B", "C", 1, 0),
+    fb("B", "D", 1, 0),
+    fb("C", "D", 1, 0),
+    // External equalisers (jobbers, excluded from h2h; tilt overall GD).
+    fb("Ja", "A", 3, 0), // A loses 0-3 → overall GD −2
+    fb("Jb", "B", 1, 0), // B loses 0-1 → overall GD 0
+    fb("C", "Jc", 3, 0), // C wins 3-0 → overall GD +2
+    fb("D", "Jd", 1, 0), // D wins 1-0 → overall GD 0
+  ];
+
+  it("UEFA (recursive) ranks the pair by their direct game", () => {
+    expect(rankOrder(entrants, results, FIFA2026, { h2hRecursive: true }).slice(0, 4)).toEqual(["A", "B", "C", "D"]);
+  });
+
+  it("FIFA (fall-through) ranks the still-level pair by overall criteria", () => {
+    expect(rankOrder(entrants, results, FIFA2026, { h2hRecursive: false }).slice(0, 4)).toEqual(["B", "A", "C", "D"]);
+  });
+
+  it("the flag changes the result on the same fixtures", () => {
+    const uefa = rankOrder(entrants, results, FIFA2026, { h2hRecursive: true });
+    const fifa = rankOrder(entrants, results, FIFA2026, { h2hRecursive: false });
+    expect(uefa).not.toEqual(fifa);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Intransitive three-way tie — partition refinement, not pairwise (spec 05 §4.2).
+// ---------------------------------------------------------------------------
+
+describe("intransitive H2H cycle (spec 05 §4.2 — pairwise is wrong)", () => {
+  // A beat B, B beat C, C beat A (all 1-0); each also beats D. Pairwise H2H is a
+  // rock-paper-scissors cycle. Partition refinement must treat {A,B,C} as ONE
+  // still-tied class (it never invents a transitive order), leaving the drawing
+  // of lots to decide — not a bogus A>B>C.
+  const entrants = ["A", "B", "C", "D"];
+  const results: FixtureResult[] = [
+    fb("A", "B", 1, 0),
+    fb("B", "C", 1, 0),
+    fb("C", "A", 1, 0),
+    fb("A", "D", 1, 0),
+    fb("B", "D", 1, 0),
+    fb("C", "D", 1, 0),
+  ];
+
+  it("keeps the cycle as one class and sends it to lots (rank_lock territory)", () => {
+    const rows = foldResults(entrants, results);
+    const result = rankStandings(rows, { cascade: FIFA2026, results, rngSeed: 7 });
+    expect(result.lotsGroups).toEqual([["A", "B", "C"]]);
+    expect(result.rows.map((r) => r.entrantId).slice(3)).toEqual(["D"]); // D is unambiguously last
+  });
+
+  it("is deterministic for a fixed rngSeed (reproducible draw of lots)", () => {
+    const rows = foldResults(entrants, results);
+    const once = rankStandings(rows, { cascade: FIFA2026, results, rngSeed: 7 }).rows.map((r) => r.entrantId);
+    const twice = rankStandings(rows, { cascade: FIFA2026, results, rngSeed: 7 }).rows.map((r) => r.entrantId);
+    expect(once).toEqual(twice);
+    expect(once.slice(0, 3).sort()).toEqual(["A", "B", "C"]); // the three are some permutation
+    expect(once.every((_, i) => rows[i] !== undefined)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exact-arithmetic ratio comparators (spec 05 §4.3 — no floats).
+// ---------------------------------------------------------------------------
+
+function ratioRow(id: string, metrics: Record<string, number>, points = 0): StandingsRow {
+  return { entrantId: id, played: 1, won: 0, drawn: 0, lost: 0, points, metrics };
+}
+
+describe("ratio comparators cross-multiply integer ledgers (spec 05 §4.3)", () => {
+  it("net run rate compares (rf·bb − ra·bf) exactly", () => {
+    // A: 200/(40 overs=240 balls) for, 180/240 against → NRR = (200−180)/240 > 0.
+    // B: 201/240 for, 200/240 against → NRR = +1/240, smaller than A's +20/240.
+    const rows = [
+      ratioRow("B", { runs_for: 201, balls_faced_eff: 240, runs_against: 200, balls_bowled_eff: 240 }),
+      ratioRow("A", { runs_for: 200, balls_faced_eff: 240, runs_against: 180, balls_bowled_eff: 240 }),
+    ];
+    expect(rankStandings(rows, { cascade: ["points", "nrr"] }).rows.map((r) => r.entrantId)).toEqual(["A", "B"]);
+  });
+
+  it("set ratio treats a clean sweep (0 lost) as the top ratio", () => {
+    const rows = [
+      ratioRow("X", { sets_won: 6, sets_lost: 2 }), // 3.0
+      ratioRow("Y", { sets_won: 4, sets_lost: 0 }), // ∞
+    ];
+    expect(rankStandings(rows, { cascade: ["points", "set_ratio"] }).rows.map((r) => r.entrantId)).toEqual(["Y", "X"]);
+  });
+
+  it("point ratio orders 22/20 above 21/20 without floats", () => {
+    const rows = [
+      ratioRow("P", { points_won: 21, points_lost: 20 }),
+      ratioRow("Q", { points_won: 22, points_lost: 20 }),
+    ];
+    expect(rankStandings(rows, { cascade: ["points", "point_ratio"] }).rows.map((r) => r.entrantId)).toEqual(["Q", "P"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Swiss cascade-time metrics via the assembled ledger (spec 05 §4.1).
+// ---------------------------------------------------------------------------
+
+describe("buchholz / direct comparators from the Swiss ledger", () => {
+  // Boardgame half-points (win 2, draw 1). Two players tie on score; Buchholz
+  // (Σ opponents' scores) breaks it.
+  function bg(home: string, away: string, winner: "home" | "away" | "draw"): FixtureResult {
+    const mk = (id: string, w: number, d: number, l: number, pts: number): StandingsDelta => ({
+      entrantId: id,
+      played: 1,
+      won: w,
+      drawn: d,
+      lost: l,
+      points: pts,
+      metrics: { wins: w },
+    });
+    if (winner === "draw") return [mk(home, 0, 1, 0, 1), mk(away, 0, 1, 0, 1)];
+    if (winner === "home") return [mk(home, 1, 0, 0, 2), mk(away, 0, 0, 1, 0)];
+    return [mk(home, 0, 0, 1, 0), mk(away, 1, 0, 0, 2)];
+  }
+
+  it("orders equal-score players by Buchholz, then direct encounter", () => {
+    // A, B, X all score 2 (one win each); Y scores 0. Buchholz: A's opponent is
+    // X (score 2) and X's opponents are A+Y (2+0) → both 2; B's opponent is only
+    // Y (0) → 0. So {A,X} share Buchholz 2 over B; the A–X direct game (A won)
+    // separates them. Final: A, X, B, Y.
+    const entrants = ["A", "B", "X", "Y"];
+    const results: FixtureResult[] = [
+      bg("A", "X", "home"), // A 2, X 0
+      bg("X", "Y", "home"), // X 2, Y 0
+      bg("B", "Y", "home"), // B 2, Y 0
+    ];
+    const rows = foldResults(entrants, results);
+    const swiss = buildSwissTable(entrants, results);
+    const order = rankStandings(rows, { cascade: ["points", "buchholz", "direct", "wins", "lots"], results, swiss, rngSeed: 1 }).rows.map((r) => r.entrantId);
+    expect(order).toEqual(["A", "X", "B", "Y"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cascade validation (spec 05 §4.1).
+// ---------------------------------------------------------------------------
+
+describe("validateCascade rejects unsupported keys (spec 05 §4.1)", () => {
+  const footballMetrics = [
+    { key: "gf", label: "GF", direction: "desc" as const },
+    { key: "ga", label: "GA", direction: "asc" as const },
+    { key: "gd", label: "GD", direction: "desc" as const },
+    { key: "fair_play", label: "FP", direction: "desc" as const },
+  ];
+
+  it("accepts a cascade whose metrics the sport maintains", () => {
+    expect(() => validateCascade(FIFA2026, { metrics: footballMetrics })).not.toThrow();
+  });
+
+  it("rejects nrr when the NRR ledger is absent", () => {
+    expect(() => validateCascade(["points", "nrr"], { metrics: footballMetrics })).toThrow(/NRR/);
+  });
+
+  it("rejects set_ratio without sets won/lost", () => {
+    expect(() => validateCascade(["points", "set_ratio"], { metrics: footballMetrics })).toThrow(/sets won\/lost/);
+  });
+
+  it("rejects buchholz unless a Swiss ledger is assembled", () => {
+    expect(() => validateCascade(["points", "buchholz"], { metrics: [] })).toThrow(/Swiss ledger/);
+    expect(() => validateCascade(["points", "buchholz"], { metrics: [], swiss: true })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property suite (spec 05 §6).
+// ---------------------------------------------------------------------------
+
+describe("cascade properties (spec 05 §6)", () => {
+  const entrants = ["A", "B", "C", "D"];
+  const allPairs: [string, string][] = [
+    ["A", "B"], ["A", "C"], ["A", "D"], ["B", "C"], ["B", "D"], ["C", "D"],
+  ];
+  // A random single round-robin: each pair plays once with random goals.
+  const rrArb = fc.tuple(...allPairs.map(() => fc.tuple(fc.nat(4), fc.nat(4)))).map((scores) =>
+    allPairs.map(([h, a], i) => {
+      const [hg, ag] = scores[i] as [number, number];
+      return fb(h, a, hg, ag);
+    }),
+  );
+
+  it("ranking is a total order — distinct ranks 1..n, permutation-independent", () => {
+    fc.assert(
+      fc.property(rrArb, fc.shuffledSubarray(entrants, { minLength: 4 }), (results, shuffledEntrants) => {
+        const a = rankStandings(foldResults(entrants, results), { cascade: FIFA2026, results, rngSeed: 3 });
+        const b = rankStandings(foldResults(shuffledEntrants, results), { cascade: FIFA2026, results, rngSeed: 3 });
+        const ranks = a.rows.map((r) => r.rank);
+        expect([...ranks].sort((x, y) => (x ?? 0) - (y ?? 0))).toEqual([1, 2, 3, 4]);
+        // Order is independent of the input row permutation.
+        expect(a.rows.map((r) => r.entrantId)).toEqual(b.rows.map((r) => r.entrantId));
+      }),
+    );
+  });
+
+  it("irrelevant-fixture stability — a game outside the tie-group never reorders it (spec 05 §6)", () => {
+    // C and D tie for the last two places; A and B are clear of them. Perturbing
+    // the A-B fixture (both outside the C/D tie-group) must not reorder C vs D
+    // under head-to-head. A,B always beat C,D so the tie-group is stable.
+    const base = (ab: FixtureResult): FixtureResult[] => [
+      ab,
+      fb("A", "C", 5, 0),
+      fb("A", "D", 5, 0),
+      fb("B", "C", 5, 0),
+      fb("B", "D", 5, 0),
+      fb("C", "D", 2, 1), // C beats D head-to-head
+    ];
+    const tieOrder = (results: FixtureResult[]): string[] =>
+      rankStandings(foldResults(entrants, results), { cascade: FIFA2026, results, rngSeed: 1 })
+        .rows.map((r) => r.entrantId)
+        .filter((id) => id === "C" || id === "D");
+
+    fc.assert(
+      fc.property(fc.nat(6), fc.nat(6), (hg, ag) => {
+        expect(tieOrder(base(fb("A", "B", hg, ag)))).toEqual(["C", "D"]);
+      }),
+    );
+  });
+});

--- a/packages/engine/src/competition/division.test.ts
+++ b/packages/engine/src/competition/division.test.ts
@@ -1,0 +1,168 @@
+// End-to-end simulated division — spec 05 acceptance (PROMPT-08 §Acceptance):
+// a generic-sport group → knockout division walked start-to-finish with STUB
+// generators (real generation is PROMPT-09). Exercises fold → cascade →
+// qualification → bracket → final ranks against the actual generic SportModule.
+import { describe, expect, it } from "vitest";
+import { foldMatch } from "../core/events.ts";
+import type { EventEnvelope } from "../core/events.ts";
+import type { LineupPair, StageCtx } from "../core/types.ts";
+import { generic, type GenericCfg } from "../sports/generic/generic.ts";
+import { makeEnvelope } from "../testkit/helpers.ts";
+import type { FixtureResult } from "./standings.ts";
+import { resolveQualification } from "./qualification.ts";
+import {
+  completeBracketStage,
+  completeTableStage,
+  isBracketStageComplete,
+  isTableStageComplete,
+  openStage,
+  type BracketFixture,
+  type BracketStage,
+  type DivisionEvent,
+  type TableFixture,
+  type TableStage,
+} from "./stage.ts";
+
+const CFG: GenericCfg = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+const CTX: StageCtx = { kind: "group" };
+
+function lineup(entrantId: string): LineupPair["home"] {
+  return { entrantId, slots: [{ personId: `${entrantId}-1`, slot: "starting", orderNo: 1 }] };
+}
+
+// Play one fixture through the real generic module and return its [home, away]
+// standings deltas + who won (the sport module is the source of truth).
+function play(home: string, away: string, hg: number, ag: number): { result: FixtureResult; winner: string | null } {
+  const lineups: LineupPair = { home: lineup(home), away: lineup(away) };
+  const events: EventEnvelope[] = [
+    makeEnvelope(0, { type: "core.start", payload: {} }),
+    makeEnvelope(1, { type: "generic.result", payload: { p1Score: hg, p2Score: ag } }),
+  ];
+  const state = foldMatch(generic, CFG, lineups, events);
+  const outcome = generic.outcome(state);
+  if (outcome === null) throw new Error("fixture did not decide");
+  const result = generic.standingsDelta(outcome, CFG, CTX, state);
+  const winner = outcome.kind === "win" ? outcome.winner : null;
+  return { result, winner };
+}
+
+// Stub round-robin: every pair once, higher-seed (earlier in `order`) wins 1-0.
+function roundRobin(pool: string, order: string[]): TableFixture[] {
+  const fixtures: TableFixture[] = [];
+  let n = 0;
+  for (let i = 0; i < order.length; i++) {
+    for (let j = i + 1; j < order.length; j++) {
+      const home = order[i] as string;
+      const away = order[j] as string;
+      fixtures.push({ id: `${pool}-${n++}`, poolId: pool, status: "decided", result: play(home, away, 1, 0).result });
+    }
+  }
+  return fixtures;
+}
+
+// Standard fold seeding order (spec 05 §2.3): 1 meets 2 only in the final.
+function seedOrder(size: number): number[] {
+  let seeds = [1, 2];
+  while (seeds.length < size) {
+    const sum = seeds.length * 2 + 1;
+    const next: number[] = [];
+    for (const seed of seeds) {
+      next.push(seed, sum - seed);
+    }
+    seeds = next;
+  }
+  return seeds;
+}
+
+// Stub single-elimination bracket over a seed list (seed 1 first); lower seed
+// number wins each tie. Returns the fixtures (with winner/loser + isFinal).
+function bracket(seedList: string[]): BracketFixture[] {
+  const rankOf = new Map(seedList.map((id, i) => [id, i]));
+  let survivors = seedOrder(seedList.length).map((seed) => seedList[seed - 1] as string);
+  const fixtures: BracketFixture[] = [];
+  let round = 0;
+  while (survivors.length > 1) {
+    const isFinal = survivors.length === 2;
+    const winners: string[] = [];
+    for (let i = 0; i < survivors.length; i += 2) {
+      const home = survivors[i] as string;
+      const away = survivors[i + 1] as string;
+      const homeIsHigher = (rankOf.get(home) ?? 0) < (rankOf.get(away) ?? 0);
+      const { winner } = play(home, away, homeIsHigher ? 1 : 0, homeIsHigher ? 0 : 1);
+      const won = winner as string;
+      const lost = won === home ? away : home;
+      fixtures.push({ id: `ko-r${round}-${i / 2}`, round, ...(isFinal ? { isFinal: true } : {}), status: "decided", home, away, winner: won, loser: lost });
+      winners.push(won);
+    }
+    survivors = winners;
+    round++;
+  }
+  return fixtures;
+}
+
+// Walk a whole division and return the champion + the division-event ledger.
+function runDivision(): { champion: string; events: DivisionEvent[]; finalRanks: string[] } {
+  const events: DivisionEvent[] = [];
+
+  // --- Group stage: two pools of three, top two of each advance. ---
+  const groupStage: TableStage = {
+    id: "groups",
+    kind: "group",
+    entrants: ["a1", "a2", "a3", "b1", "b2", "b3"],
+    cascade: ["points", "diff", "for", "lots"],
+    rngSeed: 42,
+  };
+  events.push(...openStage(groupStage.id));
+  const groupFixtures = [...roundRobin("A", ["a1", "a2", "a3"]), ...roundRobin("B", ["b1", "b2", "b3"])];
+  expect(isTableStageComplete(groupStage, groupFixtures)).toBe(true);
+
+  const completedGroups = completeTableStage(groupStage, groupFixtures);
+  events.push(...completedGroups.events);
+
+  // --- Qualification: A1,B1,A2,B2 seed the bracket (cross-pool template). ---
+  const seeds = resolveQualification(
+    { from: "groups", take: [{ pool: "A", rank: 1 }, { pool: "B", rank: 1 }, { pool: "A", rank: 2 }, { pool: "B", rank: 2 }] },
+    completedGroups.tables,
+  );
+
+  // --- Knockout stage: seeded SE bracket to the final. ---
+  const koStage: BracketStage = { id: "ko", kind: "knockout", seeds: new Map(seeds.map((id, i) => [id, i + 1])) };
+  events.push(...openStage(koStage.id));
+  const koFixtures = bracket(seeds);
+  expect(isBracketStageComplete(koStage, koFixtures)).toBe(true);
+
+  const completedKo = completeBracketStage(koStage, koFixtures);
+  events.push(...completedKo.events);
+
+  return { champion: completedKo.finalRanks[0] as string, events, finalRanks: completedKo.finalRanks };
+}
+
+describe("full division: group → knockout, generic sport (spec 05 acceptance)", () => {
+  it("crowns the top seed and produces a complete final ranking", () => {
+    const { champion, finalRanks } = runDivision();
+    // a1 tops pool A, b1 tops pool B; seeds a1,b1,a2,b2 → a1 wins the bracket.
+    expect(champion).toBe("a1");
+    expect(finalRanks).toEqual(["a1", "b1", "a2", "b2"]);
+  });
+
+  it("logs the structural division events for both stages (spec 05 §5)", () => {
+    const { events } = runDivision();
+    expect(events.filter((e) => e.type === "stage_opened").map((e) => e.stageId)).toEqual(["groups", "ko"]);
+    const completed = events.filter((e) => e.type === "stage_completed");
+    expect(completed).toHaveLength(2);
+    expect(completed[1]).toMatchObject({ stageId: "ko", finalRanks: ["a1", "b1", "a2", "b2"] });
+  });
+
+  it("is idempotent — re-running the division reproduces it exactly (spec 05 §3)", () => {
+    const first = runDivision();
+    const second = runDivision();
+    expect(second.finalRanks).toEqual(first.finalRanks);
+    expect(second.events).toEqual(first.events);
+  });
+});

--- a/packages/engine/src/competition/qualification.test.ts
+++ b/packages/engine/src/competition/qualification.test.ts
@@ -1,0 +1,131 @@
+// Qualification resolution — spec 05 §3 (PROMPT-08 §4).
+import { describe, expect, it } from "vitest";
+import type { StandingsDelta } from "../core/types.ts";
+import { foldResults, type FixtureResult, type StandingsRow } from "./standings.ts";
+import { rankStandings } from "./tiebreakers.ts";
+import { qualificationSize, resolveQualification, type PoolTable } from "./qualification.ts";
+
+function fb(home: string, away: string, hg: number, ag: number): FixtureResult {
+  const draw = hg === ag;
+  const homeWon = hg > ag;
+  const side = (id: string, gf: number, ga: number, w: number, d: number, l: number, pts: number): StandingsDelta => ({
+    entrantId: id,
+    played: 1,
+    won: w,
+    drawn: d,
+    lost: l,
+    points: pts,
+    metrics: { gf, ga, gd: gf - ga },
+  });
+  return [
+    side(home, hg, ag, homeWon ? 1 : 0, draw ? 1 : 0, !draw && !homeWon ? 1 : 0, draw ? 1 : homeWon ? 3 : 0),
+    side(away, ag, hg, !draw && !homeWon ? 1 : 0, draw ? 1 : 0, homeWon ? 1 : 0, draw ? 1 : homeWon ? 0 : 3),
+  ];
+}
+
+function rankedPool(pool: string, entrants: string[], results: FixtureResult[]): PoolTable {
+  const rows = rankStandings(foldResults(entrants, results), {
+    cascade: ["points", "diff", "for", "lots"],
+    results,
+    rngSeed: 1,
+  }).rows;
+  return { pool, rows, results };
+}
+
+function row(id: string, rank: number, points: number, metrics: Record<string, number> = {}): StandingsRow {
+  return { entrantId: id, played: 0, won: 0, drawn: 0, lost: 0, points, metrics, rank };
+}
+
+describe("resolveQualification — pool-rank picks (spec 05 §3)", () => {
+  const tables = {
+    pools: [
+      { pool: "A", rows: [row("A1", 1, 9), row("A2", 2, 6), row("A3", 3, 3)] },
+      { pool: "B", rows: [row("B1", 1, 7), row("B2", 2, 5), row("B3", 3, 1)] },
+    ],
+  };
+
+  it("resolves {pool, rank} picks in listed order (A1–B2, B1–A2 template)", () => {
+    const seeds = resolveQualification(
+      { take: [{ pool: "A", rank: 1 }, { pool: "B", rank: 1 }, { pool: "A", rank: 2 }, { pool: "B", rank: 2 }] },
+      tables,
+    );
+    expect(seeds).toEqual(["A1", "B1", "A2", "B2"]);
+  });
+
+  it("throws when a pool has no entrant at the requested rank", () => {
+    expect(() => resolveQualification({ take: [{ pool: "A", rank: 9 }] }, tables)).toThrow(/ranked 9/);
+  });
+});
+
+describe("resolveQualification — topN (spec 05 §3)", () => {
+  const overall = [row("L1", 1, 20), row("L2", 2, 18), row("L3", 3, 15), row("L4", 4, 12)];
+
+  it("takes the top N of an overall (league) table", () => {
+    expect(resolveQualification({ topN: 2 }, { pools: [], overall })).toEqual(["L1", "L2"]);
+  });
+
+  it("throws when topN exceeds the field", () => {
+    expect(() => resolveQualification({ topN: 9 }, { pools: [], overall })).toThrow(/exceeds/);
+  });
+});
+
+describe("resolveQualification — best-of-rank across pools (spec 05 §3)", () => {
+  // Both third-placed teams take 3 pts off their pool's bottom side, with equal
+  // overall GD (−1) but A3 has the flashier goals-for (beat A4 5-0). RAW
+  // comparison → A3. Normalised (drop the bottom side, UEFA) → A3 collapses to
+  // GD −6 while B3 only falls to −2, so B3 wins.
+  const poolA = rankedPool("A", ["A1", "A2", "A3", "A4"], [
+    fb("A1", "A2", 1, 0),
+    fb("A1", "A3", 3, 0),
+    fb("A1", "A4", 1, 0),
+    fb("A2", "A3", 3, 0),
+    fb("A2", "A4", 1, 0),
+    fb("A3", "A4", 5, 0),
+  ]);
+  const poolB = rankedPool("B", ["B1", "B2", "B3", "B4"], [
+    fb("B1", "B2", 1, 0),
+    fb("B1", "B3", 1, 0),
+    fb("B1", "B4", 1, 0),
+    fb("B2", "B3", 1, 0),
+    fb("B2", "B4", 1, 0),
+    fb("B3", "B4", 1, 0),
+  ]);
+  const tables = { pools: [poolA, poolB] };
+
+  it("third-placed rows are what we expect", () => {
+    expect(poolA.rows.find((r) => r.rank === 3)?.entrantId).toBe("A3");
+    expect(poolB.rows.find((r) => r.rank === 3)?.entrantId).toBe("B3");
+  });
+
+  it("plain metric comparison picks the flashier third-placed side", () => {
+    expect(resolveQualification({ bestOfRank: { rank: 3, count: 1 } }, tables)).toEqual(["A3"]);
+  });
+
+  it("UEFA normalisation (drop the bottom side) flips the pick", () => {
+    expect(
+      resolveQualification({ bestOfRank: { rank: 3, count: 1, normaliseUnequalPools: true } }, tables),
+    ).toEqual(["B3"]);
+  });
+});
+
+describe("qualification invariants (spec 05 §6)", () => {
+  const tables = {
+    pools: [
+      { pool: "A", rows: [row("A1", 1, 9), row("A2", 2, 6)] },
+      { pool: "B", rows: [row("B1", 1, 7), row("B2", 2, 5)] },
+    ],
+    overall: [row("A1", 1, 9), row("B1", 2, 7), row("A2", 3, 6), row("B2", 4, 5)],
+  };
+
+  it("output size matches the spec (qualificationSize)", () => {
+    const take = { take: [{ pool: "A", rank: 1 }, { pool: "B", rank: 1 }] };
+    expect(resolveQualification(take, tables)).toHaveLength(qualificationSize(take));
+    expect(qualificationSize({ topN: 3 })).toBe(3);
+    expect(qualificationSize({ bestOfRank: { rank: 3, count: 2 } })).toBe(2);
+  });
+
+  it("is idempotent — identical inputs yield an identical seed list", () => {
+    const spec = { topN: 3 };
+    expect(resolveQualification(spec, tables)).toEqual(resolveQualification(spec, tables));
+  });
+});

--- a/packages/engine/src/competition/qualification.ts
+++ b/packages/engine/src/competition/qualification.ts
@@ -1,4 +1,171 @@
-// Resolve stage→stage feeds (final ranks → next stage's seeded slots) —
-// spec 03 §4, spec 05. Implemented in PROMPT-08.
+// Qualification resolution — spec 05 §3. When a stage completes the engine
+// resolves the next stage's qualification spec into an ORDERED seed list that
+// feeds the next stage's generator. Pure and idempotent: identical inputs yield
+// an identical list (property test), so regeneration is deterministic.
+import { EngineError } from "../core/errors.ts";
+import type { EntrantId } from "../core/types.ts";
+import {
+  foldResults,
+  resultsAmong,
+  type FixtureResult,
+  type StandingsRow,
+} from "./standings.ts";
+import { rankStandings } from "./tiebreakers.ts";
 
-export {};
+// spec 05 §3 — the three qualification shapes.
+export interface PoolRankPick {
+  pool: string;
+  rank: number;
+}
+export interface TakePicks {
+  from?: string;
+  take: readonly PoolRankPick[];
+}
+export interface TopN {
+  from?: string;
+  topN: number;
+}
+export interface BestOfRank {
+  from?: string;
+  bestOfRank: {
+    rank: number;
+    count: number;
+    // UEFA "best third-placed" across unequal pools: normalise by dropping each
+    // candidate's results vs its pool's lowest-ranked member before comparing
+    // (spec 05 §3). Default false ⇒ plain metric comparison.
+    normaliseUnequalPools?: boolean;
+  };
+}
+export type QualificationSpec = TakePicks | TopN | BestOfRank;
+
+// A completed stage's ranked tables. `results` (pool fixtures) is needed only
+// for best-of-rank normalisation.
+export interface PoolTable {
+  pool: string;
+  rows: readonly StandingsRow[]; // ranked: rank = 1..n, distinct
+  results?: readonly FixtureResult[];
+}
+export interface StageTables {
+  pools: readonly PoolTable[];
+  overall?: readonly StandingsRow[]; // league / topN source
+}
+
+function isTake(spec: QualificationSpec): spec is TakePicks {
+  return "take" in spec;
+}
+function isTopN(spec: QualificationSpec): spec is TopN {
+  return "topN" in spec;
+}
+
+// The seed count a spec must produce — the next stage's generator input size
+// (spec 05 §6 invariant: qualification output size matches next stage input).
+export function qualificationSize(spec: QualificationSpec): number {
+  if (isTake(spec)) return spec.take.length;
+  if (isTopN(spec)) return spec.topN;
+  return spec.bestOfRank.count;
+}
+
+function rowAtRank(table: PoolTable, rank: number): StandingsRow {
+  const row = table.rows.find((entry) => entry.rank === rank);
+  if (row === undefined) {
+    throw new EngineError(
+      "STAGE_NOT_READY",
+      `pool "${table.pool}" has no entrant ranked ${rank} (table incomplete?)`,
+      { pool: table.pool, rank },
+    );
+  }
+  return row;
+}
+
+function poolByName(tables: StageTables, name: string): PoolTable {
+  const table = tables.pools.find((pool) => pool.pool === name);
+  if (table === undefined) {
+    throw new EngineError("STAGE_NOT_READY", `no pool named "${name}" in the completed stage`, {
+      pool: name,
+    });
+  }
+  return table;
+}
+
+// Recompute a candidate's row with its results vs the pool's lowest-ranked
+// member dropped (UEFA normalisation, spec 05 §3). If the candidate *is* the
+// bottom member (shouldn't happen for third-placed picks), nothing is dropped.
+function normalisedRow(table: PoolTable, candidateId: EntrantId): StandingsRow {
+  const results = table.results ?? [];
+  const bottom = table.rows[table.rows.length - 1];
+  if (bottom === undefined || bottom.entrantId === candidateId || results.length === 0) {
+    const full = table.rows.find((row) => row.entrantId === candidateId);
+    if (full === undefined) {
+      throw new EngineError("STAGE_NOT_READY", `candidate "${candidateId}" not in its pool table`, {
+        candidateId,
+      });
+    }
+    return full;
+  }
+  const survivors = table.rows
+    .map((row) => row.entrantId)
+    .filter((id) => id !== bottom.entrantId);
+  const kept = resultsAmong(new Set(survivors), results);
+  const refolded = foldResults(survivors, kept);
+  const row = refolded.find((entry) => entry.entrantId === candidateId);
+  if (row === undefined) {
+    throw new EngineError("STAGE_NOT_READY", `candidate "${candidateId}" not in its pool table`, {
+      candidateId,
+    });
+  }
+  return row;
+}
+
+// Order candidates by a simple metric cascade (spec 05 §3 default: points →
+// diff → for → wins), with a deterministic seed→id fallback. No head-to-head:
+// candidates come from different pools and never met.
+function orderCandidates(rows: StandingsRow[]): StandingsRow[] {
+  return rankStandings(rows, {
+    cascade: ["points", "diff", "for", "wins"],
+  }).rows;
+}
+
+// Resolve a qualification spec against a completed stage's tables → ordered
+// seed list (spec 05 §3).
+export function resolveQualification(spec: QualificationSpec, tables: StageTables): EntrantId[] {
+  if (isTake(spec)) {
+    return spec.take.map((pick) => rowAtRank(poolByName(tables, pick.pool), pick.rank).entrantId);
+  }
+
+  if (isTopN(spec)) {
+    const source =
+      tables.overall ??
+      (tables.pools.length === 1 ? (tables.pools[0] as PoolTable).rows : undefined);
+    if (source === undefined) {
+      throw new EngineError("STAGE_NOT_READY", "topN needs an overall table (or a single pool)", {
+        topN: spec.topN,
+      });
+    }
+    if (source.length < spec.topN) {
+      throw new EngineError("STAGE_NOT_READY", `topN=${spec.topN} exceeds ${source.length} entrants`, {
+        topN: spec.topN,
+      });
+    }
+    return [...source]
+      .sort((a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity))
+      .slice(0, spec.topN)
+      .map((row) => row.entrantId);
+  }
+
+  // bestOfRank — "the N best rank-R finishers across pools".
+  const { rank, count, normaliseUnequalPools } = spec.bestOfRank;
+  const candidates = tables.pools.map((pool) => {
+    const picked = rowAtRank(pool, rank);
+    return normaliseUnequalPools === true ? normalisedRow(pool, picked.entrantId) : picked;
+  });
+  if (candidates.length < count) {
+    throw new EngineError(
+      "STAGE_NOT_READY",
+      `bestOfRank needs ${count} pools with a rank-${rank} finisher, found ${candidates.length}`,
+      { rank, count },
+    );
+  }
+  return orderCandidates(candidates)
+    .slice(0, count)
+    .map((row) => row.entrantId);
+}

--- a/packages/engine/src/competition/stage.test.ts
+++ b/packages/engine/src/competition/stage.test.ts
@@ -1,0 +1,190 @@
+// Stage state machines — spec 05 §1 (completion), §3 (rank locks), §5
+// (division events, withdrawal). PROMPT-08 §1.
+import { describe, expect, it } from "vitest";
+import type { StandingsDelta } from "../core/types.ts";
+import type { FixtureResult } from "./standings.ts";
+import {
+  bracketRanks,
+  completeBracketStage,
+  completeTableStage,
+  isBracketStageComplete,
+  isTableStageComplete,
+  openStage,
+  withdrawBracketEntrant,
+  withdrawTableEntrant,
+  type BracketFixture,
+  type BracketStage,
+  type TableFixture,
+  type TableStage,
+} from "./stage.ts";
+
+function fb(home: string, away: string, hg: number, ag: number): FixtureResult {
+  const draw = hg === ag;
+  const homeWon = hg > ag;
+  const side = (id: string, gf: number, ga: number, w: number, d: number, l: number, pts: number): StandingsDelta => ({
+    entrantId: id,
+    played: 1,
+    won: w,
+    drawn: d,
+    lost: l,
+    points: pts,
+    metrics: { gf, ga, gd: gf - ga },
+  });
+  return [
+    side(home, hg, ag, homeWon ? 1 : 0, draw ? 1 : 0, !draw && !homeWon ? 1 : 0, draw ? 1 : homeWon ? 3 : 0),
+    side(away, ag, hg, !draw && !homeWon ? 1 : 0, draw ? 1 : 0, homeWon ? 1 : 0, draw ? 1 : homeWon ? 0 : 3),
+  ];
+}
+
+const leagueStage: TableStage = {
+  id: "s1",
+  kind: "league",
+  entrants: ["X", "Y", "Z"],
+  cascade: ["points", "diff", "for", "lots"],
+  rngSeed: 5,
+};
+
+describe("openStage", () => {
+  it("emits stage_opened", () => {
+    expect(openStage("s1")).toEqual([{ type: "stage_opened", stageId: "s1" }]);
+  });
+});
+
+describe("completion predicates (spec 05 §1)", () => {
+  it("league completes only when every fixture is settled", () => {
+    const decided: TableFixture[] = [
+      { id: "f1", status: "decided", result: fb("X", "Y", 1, 0) },
+      { id: "f2", status: "void" },
+    ];
+    expect(isTableStageComplete(leagueStage, decided)).toBe(true);
+    expect(
+      isTableStageComplete(leagueStage, [...decided, { id: "f3", status: "scheduled" }]),
+    ).toBe(false);
+  });
+
+  it("swiss completes when the configured rounds are all played", () => {
+    const swiss: TableStage = { ...leagueStage, kind: "swiss", rounds: 2 };
+    const fixtures: TableFixture[] = [
+      { id: "r1a", roundNo: 1, status: "decided", result: fb("X", "Y", 1, 0) },
+      { id: "r2a", roundNo: 2, status: "decided", result: fb("X", "Z", 1, 0) },
+    ];
+    expect(isTableStageComplete(swiss, fixtures)).toBe(true);
+    expect(isTableStageComplete({ ...swiss, rounds: 3 }, fixtures)).toBe(false);
+  });
+
+  it("a bracket completes when its final is decided", () => {
+    const stage: BracketStage = { id: "ko", kind: "knockout" };
+    const semis: BracketFixture[] = [
+      { id: "sf1", round: 0, status: "decided", home: "A", away: "B", winner: "A", loser: "B" },
+      { id: "fin", round: 1, isFinal: true, status: "scheduled", home: "A", away: "C" },
+    ];
+    expect(isBracketStageComplete(stage, semis)).toBe(false);
+    semis[1] = { ...(semis[1] as BracketFixture), status: "decided", winner: "A", loser: "C" };
+    expect(isBracketStageComplete(stage, semis)).toBe(true);
+  });
+});
+
+describe("completeTableStage — division events (spec 05 §3/§5)", () => {
+  it("emits stage_completed with cross-pool interleaved final ranks", () => {
+    const stage: TableStage = {
+      id: "grp",
+      kind: "group",
+      entrants: ["A1", "A2", "B1", "B2"],
+      cascade: ["points", "diff", "for", "lots"],
+    };
+    const fixtures: TableFixture[] = [
+      { id: "a", poolId: "A", status: "decided", result: fb("A1", "A2", 2, 0) },
+      { id: "b", poolId: "B", status: "decided", result: fb("B1", "B2", 3, 0) },
+    ];
+    const { events, tables } = completeTableStage(stage, fixtures);
+    expect(tables.pools.map((p) => p.pool)).toEqual(["A", "B"]);
+    // rank-1s first (A1, B1), then rank-2s (A2, B2).
+    const completed = events.find((e) => e.type === "stage_completed");
+    expect(completed).toEqual({ type: "stage_completed", stageId: "grp", finalRanks: ["A1", "B1", "A2", "B2"] });
+  });
+
+  it("emits rank_lock_required + rank_lock when the cascade exhausts to lots", () => {
+    const fixtures: TableFixture[] = [{ id: "f", status: "decided", result: fb("X", "Y", 1, 1) }];
+    const stage: TableStage = { id: "s", kind: "league", entrants: ["X", "Y"], cascade: ["points", "lots"], rngSeed: 2 };
+    const { events } = completeTableStage(stage, fixtures);
+    expect(events).toContainEqual({ type: "rank_lock_required", stageId: "s", group: ["X", "Y"] });
+    expect(events).toContainEqual({ type: "rank_lock", stageId: "s", method: "lots", group: ["X", "Y"] });
+  });
+
+  it("marks lot-decided rows as rankLocked", () => {
+    const fixtures: TableFixture[] = [{ id: "f", status: "decided", result: fb("X", "Y", 2, 2) }];
+    const stage: TableStage = { id: "s", kind: "league", entrants: ["X", "Y"], cascade: ["points", "lots"], rngSeed: 2 };
+    const { tables } = completeTableStage(stage, fixtures);
+    expect(tables.overall?.every((r) => r.rankLocked === true)).toBe(true);
+  });
+});
+
+describe("bracketRanks (spec 05 §1)", () => {
+  const stage: BracketStage = { id: "ko", kind: "knockout", seeds: new Map([["S1", 1], ["S2", 2], ["S3", 3], ["S4", 4]]) };
+  const bracket: BracketFixture[] = [
+    { id: "sf1", round: 0, status: "decided", home: "S1", away: "S4", winner: "S1", loser: "S4" },
+    { id: "sf2", round: 0, status: "decided", home: "S2", away: "S3", winner: "S2", loser: "S3" },
+    { id: "fin", round: 1, isFinal: true, status: "decided", home: "S1", away: "S2", winner: "S1", loser: "S2" },
+  ];
+
+  it("ranks champion, runner-up, then losers by elimination round & seed", () => {
+    expect(bracketRanks(stage, bracket)).toEqual(["S1", "S2", "S3", "S4"]);
+  });
+
+  it("a 3rd-place playoff fixes ranks 3 and 4 from its result", () => {
+    const withThird: BracketFixture[] = [
+      ...bracket,
+      { id: "3p", round: 1, thirdPlace: true, status: "decided", home: "S3", away: "S4", winner: "S4", loser: "S3" },
+    ];
+    expect(bracketRanks(stage, withThird)).toEqual(["S1", "S2", "S4", "S3"]);
+  });
+
+  it("completeBracketStage emits stage_completed with those ranks", () => {
+    const { events, finalRanks } = completeBracketStage(stage, bracket);
+    expect(finalRanks).toEqual(["S1", "S2", "S3", "S4"]);
+    expect(events).toEqual([{ type: "stage_completed", stageId: "ko", finalRanks }]);
+  });
+});
+
+describe("withdrawal policies (spec 05 §5)", () => {
+  const stage: TableStage = { id: "s", kind: "league", entrants: ["W", "A", "B", "C"], cascade: ["points", "lots"] };
+
+  it("void_remaining EXPUNGES when the entrant has played < 50%", () => {
+    const { events, updates } = withdrawTableEntrant(stage, "W", {
+      played: [{ id: "p1", status: "decided", result: fb("W", "A", 1, 0) }],
+      pending: [
+        { id: "p2", opponent: "B" },
+        { id: "p3", opponent: "C" },
+      ],
+    });
+    expect(events[0]).toMatchObject({ type: "entrant_withdrawn", entrantId: "W", policy: "void_remaining", mode: "expunge" });
+    expect(updates).toEqual([
+      { fixtureId: "p1", status: "void" },
+      { fixtureId: "p2", status: "void" },
+      { fixtureId: "p3", status: "void" },
+    ]);
+  });
+
+  it("void_remaining AWARDS remaining games when the entrant has played ≥ 50%", () => {
+    const { events, updates } = withdrawTableEntrant(stage, "W", {
+      played: [
+        { id: "p1", status: "decided", result: fb("W", "A", 1, 0) },
+        { id: "p2", status: "decided", result: fb("W", "B", 0, 1) },
+      ],
+      pending: [{ id: "p3", opponent: "C" }],
+    });
+    expect(events[0]).toMatchObject({ mode: "award" });
+    expect(updates).toEqual([{ fixtureId: "p3", status: "walkover", walkoverTo: "C" }]);
+  });
+
+  it("bracket_walkover advances the opponent in each pending fixture", () => {
+    const koStage: BracketStage = { id: "ko", kind: "knockout" };
+    const fixtures: BracketFixture[] = [
+      { id: "qf", round: 0, status: "decided", home: "W", away: "P", winner: "W", loser: "P" },
+      { id: "sf", round: 1, status: "scheduled", home: "W", away: "Q" },
+    ];
+    const { events, updates } = withdrawBracketEntrant(koStage, "W", fixtures);
+    expect(events[0]).toMatchObject({ type: "entrant_withdrawn", policy: "bracket_walkover" });
+    expect(updates).toEqual([{ fixtureId: "sf", status: "walkover", walkoverTo: "Q" }]);
+  });
+});

--- a/packages/engine/src/competition/stage.ts
+++ b/packages/engine/src/competition/stage.ts
@@ -1,4 +1,401 @@
-// Stage state machines (draft → active → complete) — spec 03 §4, spec 05.
-// Completion predicate per stage kind. Implemented in PROMPT-08.
+// Stage state machines — spec 05 §1 (six kinds), §3 (rank locks), §5 (division
+// events, withdrawal policies). A stage moves draft → open → complete; this
+// module owns the completion predicate per kind, the ranking of a completed
+// stage into `finalRanks`, and the division-event ledger those transitions
+// emit. Fixture GENERATION is PROMPT-09 — a stage here consumes an
+// already-generated fixture set (its status + results) and never builds one.
+import type { EntrantId, StageKind } from "../core/types.ts";
+import { foldResults, type FixtureResult } from "./standings.ts";
+import type { PoolTable, StageTables } from "./qualification.ts";
+import type { TiebreakerKey } from "../sport/module.ts";
+import { buildSwissTable, rankStandings } from "./tiebreakers.ts";
 
-export {};
+// spec 02 §6 fixture statuses that matter to a stage's completion/ranking.
+export type FixtureStatus = "scheduled" | "in_play" | "decided" | "void" | "walkover";
+
+const SETTLED: ReadonlySet<FixtureStatus> = new Set(["decided", "void", "walkover"]);
+const COUNTS_FOR_STANDINGS: ReadonlySet<FixtureStatus> = new Set(["decided", "walkover"]);
+
+// A league/group/swiss fixture as the stage sees it: a status and, once
+// decided, the sport module's [home, away] delta pair (void fixtures carry no
+// result and never reach the standings fold).
+export interface TableFixture {
+  id: string;
+  poolId?: string;
+  roundNo?: number;
+  status: FixtureStatus;
+  result?: FixtureResult;
+}
+
+// A bracket fixture (knockout / double_elim / stepladder). `round` is 0-based
+// and monotonic (higher = later); the deciding game carries `isFinal`.
+export interface BracketFixture {
+  id: string;
+  bracket?: "WB" | "LB" | "GF"; // double-elim lanes; omit for single bracket
+  round: number;
+  isFinal?: boolean; // SE final / DE grand final (or bracket-reset game)
+  thirdPlace?: boolean;
+  status: FixtureStatus;
+  home?: EntrantId;
+  away?: EntrantId;
+  winner?: EntrantId; // set once decided/walkover
+  loser?: EntrantId;
+}
+
+// Everything the ranking pass needs about a table stage that isn't in the
+// fixtures themselves (spec 05 §4 cascade is data).
+export interface TableStage {
+  id: string;
+  kind: Extract<StageKind, "league" | "group" | "swiss">;
+  entrants: readonly EntrantId[];
+  cascade: readonly TiebreakerKey[];
+  h2hRecursive?: boolean;
+  swiss?: boolean; // assemble the Swiss ledger for buchholz/sberger/direct
+  seeds?: ReadonlyMap<EntrantId, number>;
+  rngSeed?: number;
+  rounds?: number; // swiss: N rounds to play
+}
+
+export interface BracketStage {
+  id: string;
+  kind: Extract<StageKind, "knockout" | "double_elim" | "stepladder">;
+  seeds?: ReadonlyMap<EntrantId, number>;
+}
+
+// spec 05 §5 — the structural ledger. (fixtures_generated / fixture_replaced
+// belong to generation, PROMPT-09.)
+export type DivisionEvent =
+  | { type: "stage_opened"; stageId: string }
+  | { type: "stage_completed"; stageId: string; finalRanks: EntrantId[] }
+  | { type: "rank_lock_required"; stageId: string; group: EntrantId[] }
+  | { type: "rank_lock"; stageId: string; method: "lots"; group: EntrantId[] }
+  | {
+      type: "entrant_withdrawn";
+      stageId: string;
+      entrantId: EntrantId;
+      policy: "void_remaining" | "bracket_walkover";
+      mode?: "expunge" | "award";
+    };
+
+// spec 05 §5 — a stage's instruction to re-status fixtures after a withdrawal
+// (the sport-agnostic stage can't mint an award delta; the adapter turns
+// `walkoverTo` into an `award` outcome via the sport module).
+export interface FixtureUpdate {
+  fixtureId: string;
+  status: Extract<FixtureStatus, "void" | "walkover">;
+  walkoverTo?: EntrantId;
+}
+
+// ---------------------------------------------------------------------------
+// Completion predicates — spec 05 §1
+// ---------------------------------------------------------------------------
+
+function poolOf(fixture: TableFixture): string {
+  return fixture.poolId ?? "";
+}
+
+// league / group: every fixture decided or void (group pools all complete is
+// the same condition — pools only partition the fixtures). swiss: the first
+// `rounds` rounds all settled.
+export function isTableStageComplete(stage: TableStage, fixtures: readonly TableFixture[]): boolean {
+  if (fixtures.length === 0) return false;
+  if (stage.kind === "swiss") {
+    const rounds = stage.rounds ?? 0;
+    if (rounds <= 0) return false;
+    for (let round = 1; round <= rounds; round++) {
+      const inRound = fixtures.filter((fixture) => fixture.roundNo === round);
+      if (inRound.length === 0 || !inRound.every((fixture) => SETTLED.has(fixture.status))) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return fixtures.every((fixture) => SETTLED.has(fixture.status));
+}
+
+// knockout / stepladder: the final is decided. double_elim: the grand final
+// (the last `isFinal` game — a bracket reset adds a second) is decided.
+export function isBracketStageComplete(
+  _stage: BracketStage,
+  fixtures: readonly BracketFixture[],
+): boolean {
+  const finals = fixtures.filter((fixture) => fixture.isFinal === true);
+  if (finals.length === 0) return false;
+  return finals.every((fixture) => SETTLED.has(fixture.status));
+}
+
+// ---------------------------------------------------------------------------
+// Opening
+// ---------------------------------------------------------------------------
+
+export function openStage(stageId: string): DivisionEvent[] {
+  return [{ type: "stage_opened", stageId }];
+}
+
+// ---------------------------------------------------------------------------
+// Completing a table stage → per-pool ranked tables + division events
+// ---------------------------------------------------------------------------
+
+function poolNames(fixtures: readonly TableFixture[]): string[] {
+  const names = new Set<string>();
+  for (const fixture of fixtures) names.add(poolOf(fixture));
+  if (names.size === 0) names.add("");
+  return [...names];
+}
+
+// Which entrants belong to a pool: those appearing in the pool's fixtures. For
+// a single-pool (league) stage every entrant is in the one pool.
+function entrantsOfPool(
+  pool: string,
+  fixtures: readonly TableFixture[],
+  allEntrants: readonly EntrantId[],
+  single: boolean,
+): EntrantId[] {
+  if (single) return [...allEntrants];
+  const ids = new Set<EntrantId>();
+  for (const fixture of fixtures) {
+    if (poolOf(fixture) !== pool || fixture.result === undefined) continue;
+    ids.add(fixture.result[0].entrantId);
+    ids.add(fixture.result[1].entrantId);
+  }
+  // Include declared entrants that happen to sit in this pool but have no
+  // counted result yet (e.g. all their games void) via the allEntrants order.
+  return allEntrants.filter((id) => ids.has(id));
+}
+
+export interface CompletedTableStage {
+  events: DivisionEvent[];
+  tables: StageTables;
+}
+
+// Fold + rank each pool of a completed table stage. Emits stage_completed
+// {finalRanks}, plus rank_lock_required + rank_lock for any tie the cascade
+// left to a drawing of lots (spec 05 §3/§4.4). finalRanks interleaves pools by
+// rank (all pool winners, then all runners-up, …) — the cross-pool seeding
+// order (spec 05 §2.3).
+export function completeTableStage(
+  stage: TableStage,
+  fixtures: readonly TableFixture[],
+): CompletedTableStage {
+  const pools = poolNames(fixtures);
+  const single = pools.length === 1;
+  const events: DivisionEvent[] = [];
+  const poolTables: PoolTable[] = [];
+
+  for (const pool of pools) {
+    const poolFixtures = single ? fixtures : fixtures.filter((fixture) => poolOf(fixture) === pool);
+    const entrants = entrantsOfPool(pool, fixtures, stage.entrants, single);
+    const results = poolFixtures
+      .filter((fixture) => COUNTS_FOR_STANDINGS.has(fixture.status) && fixture.result !== undefined)
+      .map((fixture) => fixture.result as FixtureResult);
+
+    const rows = foldResults(entrants, results);
+    const ranked = rankStandings(rows, {
+      cascade: stage.cascade,
+      results,
+      h2hRecursive: stage.h2hRecursive === true,
+      ...(stage.seeds === undefined ? {} : { seeds: stage.seeds }),
+      ...(stage.rngSeed === undefined ? {} : { rngSeed: stage.rngSeed }),
+      ...(stage.swiss === true ? { swiss: buildSwissTable(entrants, results) } : {}),
+    });
+
+    for (const group of ranked.lotsGroups) {
+      events.push({ type: "rank_lock_required", stageId: stage.id, group });
+      events.push({ type: "rank_lock", stageId: stage.id, method: "lots", group });
+    }
+    poolTables.push({ pool, rows: ranked.rows, results });
+  }
+
+  const finalRanks = crossPoolOrder(poolTables);
+  events.push({ type: "stage_completed", stageId: stage.id, finalRanks });
+
+  const overall = single ? (poolTables[0] as PoolTable).rows : undefined;
+  return {
+    events,
+    tables: { pools: poolTables, ...(overall === undefined ? {} : { overall }) },
+  };
+}
+
+// Interleave pools by rank: rank-1 of every pool (in pool order), then rank-2,
+// … — the group→knockout seeding template (spec 05 §2.3).
+function crossPoolOrder(pools: readonly PoolTable[]): EntrantId[] {
+  const maxRank = Math.max(0, ...pools.map((pool) => pool.rows.length));
+  const order: EntrantId[] = [];
+  for (let rank = 1; rank <= maxRank; rank++) {
+    for (const pool of pools) {
+      const row = pool.rows.find((entry) => entry.rank === rank);
+      if (row !== undefined) order.push(row.entrantId);
+    }
+  }
+  return order;
+}
+
+// ---------------------------------------------------------------------------
+// Completing a bracket stage → final ranks from bracket position
+// ---------------------------------------------------------------------------
+
+export interface CompletedBracketStage {
+  events: DivisionEvent[];
+  finalRanks: EntrantId[];
+}
+
+export function completeBracketStage(
+  stage: BracketStage,
+  fixtures: readonly BracketFixture[],
+): CompletedBracketStage {
+  const finalRanks = bracketRanks(stage, fixtures);
+  return {
+    events: [{ type: "stage_completed", stageId: stage.id, finalRanks }],
+    finalRanks,
+  };
+}
+
+// Rank entrants by bracket position (spec 05 §1 "ranking" column). Champion =
+// winner of the last `isFinal` game; runner-up = its loser; everyone else is
+// ordered by how late they were eliminated (later round = better), then by
+// seed. An optional 3rd-place playoff fixes ranks 3 and 4 from its result.
+export function bracketRanks(
+  stage: BracketStage,
+  fixtures: readonly BracketFixture[],
+): EntrantId[] {
+  const entrants = new Set<EntrantId>();
+  for (const fixture of fixtures) {
+    for (const id of [fixture.home, fixture.away, fixture.winner, fixture.loser]) {
+      if (id !== undefined) entrants.add(id);
+    }
+  }
+
+  // The deciding game: the latest-round decided final.
+  const decidedFinals = fixtures
+    .filter((fixture) => fixture.isFinal === true && SETTLED.has(fixture.status))
+    .sort((a, b) => b.round - a.round);
+  const grandFinal = decidedFinals[0];
+
+  const lastLossRound = new Map<EntrantId, number>();
+  for (const fixture of fixtures) {
+    if (!SETTLED.has(fixture.status) || fixture.loser === undefined) continue;
+    const prev = lastLossRound.get(fixture.loser) ?? -1;
+    if (fixture.round > prev) lastLossRound.set(fixture.loser, fixture.round);
+  }
+
+  const seedOf = (id: EntrantId): number => stage.seeds?.get(id) ?? Number.MAX_SAFE_INTEGER;
+  const rankRest = (ids: EntrantId[]): EntrantId[] =>
+    ids.sort((a, b) => {
+      const ra = lastLossRound.get(a) ?? -1;
+      const rb = lastLossRound.get(b) ?? -1;
+      if (ra !== rb) return rb - ra; // eliminated later ⇒ ranked higher
+      const sa = seedOf(a);
+      const sb = seedOf(b);
+      if (sa !== sb) return sa - sb;
+      return a < b ? -1 : a > b ? 1 : 0;
+    });
+
+  const order: EntrantId[] = [];
+  const placed = new Set<EntrantId>();
+  const place = (id: EntrantId | undefined): void => {
+    if (id === undefined || placed.has(id)) return;
+    order.push(id);
+    placed.add(id);
+  };
+
+  if (grandFinal !== undefined) {
+    place(grandFinal.winner);
+    place(grandFinal.loser);
+  }
+
+  // 3rd-place playoff overrides the semifinal-loser ordering for ranks 3–4.
+  const thirdPlace = fixtures.find(
+    (fixture) => fixture.thirdPlace === true && SETTLED.has(fixture.status),
+  );
+  if (thirdPlace !== undefined) {
+    place(thirdPlace.winner);
+    place(thirdPlace.loser);
+  }
+
+  for (const id of rankRest([...entrants].filter((id) => !placed.has(id)))) place(id);
+  return order;
+}
+
+// ---------------------------------------------------------------------------
+// Withdrawal policies — spec 05 §5
+// ---------------------------------------------------------------------------
+
+export interface WithdrawalResult {
+  events: DivisionEvent[];
+  updates: FixtureUpdate[];
+}
+
+function involvesEntrant(fixture: TableFixture, entrantId: EntrantId): boolean {
+  return (
+    fixture.result?.[0].entrantId === entrantId || fixture.result?.[1].entrantId === entrantId
+  );
+}
+
+// spec 05 §5 — league/group `void_remaining`: if the withdrawing entrant has
+// played < 50% of its fixtures, EXPUNGE (void all its games so the standings
+// read as if it never entered); otherwise AWARD its remaining fixtures to the
+// opponents as forfeits and keep the games already played. `played`/`total`
+// are the entrant's decided vs scheduled fixture counts (the caller knows the
+// full schedule, including result-less pending fixtures).
+export function withdrawTableEntrant(
+  stage: TableStage,
+  entrantId: EntrantId,
+  fixtures: {
+    played: readonly TableFixture[]; // decided games this entrant appears in
+    pending: readonly { id: string; opponent: EntrantId }[]; // its unplayed games
+  },
+): WithdrawalResult {
+  const playedCount = fixtures.played.filter((fixture) => involvesEntrant(fixture, entrantId)).length;
+  const total = playedCount + fixtures.pending.length;
+  const fraction = total === 0 ? 0 : playedCount / total;
+  const expunge = fraction < 0.5;
+
+  const updates: FixtureUpdate[] = [];
+  if (expunge) {
+    for (const fixture of fixtures.played) {
+      if (involvesEntrant(fixture, entrantId)) updates.push({ fixtureId: fixture.id, status: "void" });
+    }
+    for (const pending of fixtures.pending) updates.push({ fixtureId: pending.id, status: "void" });
+  } else {
+    for (const pending of fixtures.pending) {
+      updates.push({ fixtureId: pending.id, status: "walkover", walkoverTo: pending.opponent });
+    }
+  }
+
+  return {
+    events: [
+      {
+        type: "entrant_withdrawn",
+        stageId: stage.id,
+        entrantId,
+        policy: "void_remaining",
+        mode: expunge ? "expunge" : "award",
+      },
+    ],
+    updates,
+  };
+}
+
+// spec 05 §5 — knockout `bracket_walkover`: the withdrawing entrant's remaining
+// fixtures are walked over to the opponent, who advances.
+export function withdrawBracketEntrant(
+  stage: BracketStage,
+  entrantId: EntrantId,
+  fixtures: readonly BracketFixture[],
+): WithdrawalResult {
+  const updates: FixtureUpdate[] = [];
+  for (const fixture of fixtures) {
+    if (SETTLED.has(fixture.status)) continue;
+    if (fixture.home !== entrantId && fixture.away !== entrantId) continue;
+    const opponent = fixture.home === entrantId ? fixture.away : fixture.home;
+    updates.push({
+      fixtureId: fixture.id,
+      status: "walkover",
+      ...(opponent === undefined ? {} : { walkoverTo: opponent }),
+    });
+  }
+  return {
+    events: [{ type: "entrant_withdrawn", stageId: stage.id, entrantId, policy: "bracket_walkover" }],
+    updates,
+  };
+}

--- a/packages/engine/src/competition/standings.test.ts
+++ b/packages/engine/src/competition/standings.test.ts
@@ -1,0 +1,82 @@
+// Standings fold — spec 02 §7 / spec 05 §6 (order-independence property).
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import type { StandingsDelta } from "../core/types.ts";
+import {
+  flattenResults,
+  foldResults,
+  foldStandings,
+  resultsAmong,
+  type FixtureResult,
+} from "./standings.ts";
+
+// A football-shaped decided fixture: 3/1/0 points, gf/ga/gd ledger.
+function fb(home: string, away: string, hg: number, ag: number): FixtureResult {
+  const draw = hg === ag;
+  const homeWon = hg > ag;
+  const side = (id: string, gf: number, ga: number, w: number, d: number, l: number, pts: number): StandingsDelta => ({
+    entrantId: id,
+    played: 1,
+    won: w,
+    drawn: d,
+    lost: l,
+    points: pts,
+    metrics: { gf, ga, gd: gf - ga },
+  });
+  const hp = draw ? 1 : homeWon ? 3 : 0;
+  const ap = draw ? 1 : homeWon ? 0 : 3;
+  return [
+    side(home, hg, ag, homeWon ? 1 : 0, draw ? 1 : 0, !draw && !homeWon ? 1 : 0, hp),
+    side(away, ag, hg, !draw && !homeWon ? 1 : 0, draw ? 1 : 0, homeWon ? 1 : 0, ap),
+  ];
+}
+
+const ENTRANTS = ["A", "B", "C", "D"];
+const RESULTS: FixtureResult[] = [
+  fb("A", "B", 2, 1),
+  fb("A", "C", 0, 0),
+  fb("A", "D", 3, 0),
+  fb("B", "C", 1, 2),
+  fb("B", "D", 1, 1),
+  fb("C", "D", 4, 0),
+];
+
+describe("foldStandings", () => {
+  it("sums played/points and the sport ledger per entrant", () => {
+    const rows = foldResults(ENTRANTS, RESULTS);
+    const a = rows.find((r) => r.entrantId === "A");
+    // A: W vs B, D vs C, W vs D → 2W 1D, 7 pts; GF 5 GA 1 GD +4.
+    expect(a).toMatchObject({
+      played: 3,
+      won: 2,
+      drawn: 1,
+      lost: 0,
+      points: 7,
+      metrics: { gf: 5, ga: 1, gd: 4 },
+    });
+  });
+
+  it("returns rows in entrant order regardless of fixture order", () => {
+    const rows = foldResults(ENTRANTS, RESULTS);
+    expect(rows.map((r) => r.entrantId)).toEqual(ENTRANTS);
+  });
+
+  it("is order-independent — shuffling fixtures yields byte-identical rows (spec 05 §6)", () => {
+    fc.assert(
+      fc.property(fc.shuffledSubarray(RESULTS, { minLength: RESULTS.length }), (shuffled) => {
+        expect(foldResults(ENTRANTS, shuffled)).toEqual(foldResults(ENTRANTS, RESULTS));
+      }),
+    );
+  });
+
+  it("rejects a delta for an entrant outside the pool (keeps the fold deterministic)", () => {
+    expect(() => foldStandings(["A"], flattenResults([fb("A", "Z", 1, 0)]))).toThrow(/not in the pool/);
+  });
+
+  it("resultsAmong keeps only fixtures contested within the group", () => {
+    const among = resultsAmong(new Set(["A", "B"]), RESULTS);
+    expect(among).toHaveLength(1);
+    expect(among[0]?.[0].entrantId).toBe("A");
+    expect(among[0]?.[1].entrantId).toBe("B");
+  });
+});

--- a/packages/engine/src/competition/standings.ts
+++ b/packages/engine/src/competition/standings.ts
@@ -1,5 +1,101 @@
-// Standings fold + tiebreaker cascade executor — spec 03 §4, spec 05.
-// Applies standingsDelta in fixture-decided order, emits StandingsSnapshot.
-// Implemented in PROMPT-08.
+// Standings fold — spec 02 §7 + spec 05 §4. A standings table is a derived fold
+// over decided fixtures: the sport module contributes a [home, away] pair of
+// StandingsDeltas per outcome (spec 03 §3), the competition engine sums them
+// into StandingsRows, then ranks via the tiebreaker cascade (tiebreakers.ts).
+//
+// The fold is deterministic and ORDER-INDEPENDENT: addition is commutative, so
+// shuffling the decided-fixture set yields byte-identical rows (property test in
+// standings.test.ts, spec 05 §6). Ranking is a separate pass — this file never
+// sorts.
+import type { EntrantId, StandingsDelta } from "../core/types.ts";
 
-export {};
+// spec 02 §7 — the folded row. `metrics` is the sport's ledger (gf/ga/gd ·
+// runs_for/balls_faced_eff · sets_won/sets_lost · …); ratio tiebreaks read the
+// integer ledger and cross-multiply, never divide (spec 05 §4.3). `rank` /
+// `rankLocked` are filled by the ranking pass, not the fold.
+export interface StandingsRow {
+  entrantId: EntrantId;
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  points: number;
+  metrics: Record<string, number>;
+  rank?: number;
+  rankLocked?: boolean;
+}
+
+// The two deltas a decided fixture contributes, in [home, away] order (the pair
+// a SportModule.standingsDelta returns). The pair also names both entrants of
+// the fixture, which is what head-to-head sub-tables need (spec 05 §4.2).
+export type FixtureResult = readonly [StandingsDelta, StandingsDelta];
+
+function zeroRow(entrantId: EntrantId): StandingsRow {
+  return { entrantId, played: 0, won: 0, drawn: 0, lost: 0, points: 0, metrics: {} };
+}
+
+function addDelta(row: StandingsRow, delta: StandingsDelta): void {
+  row.played += delta.played;
+  row.won += delta.won;
+  row.drawn += delta.drawn;
+  row.lost += delta.lost;
+  row.points += delta.points;
+  for (const [key, value] of Object.entries(delta.metrics)) {
+    row.metrics[key] = (row.metrics[key] ?? 0) + value;
+  }
+}
+
+// Folds every delta over the given entrant set into one row per entrant. Rows
+// come back in `entrants` order (deterministic); a delta for an entrant not in
+// the set is a bug (mismatched pool/fixture wiring) and throws rather than
+// silently inventing a row — that would make the fold order-dependent.
+export function foldStandings(
+  entrants: readonly EntrantId[],
+  deltas: Iterable<StandingsDelta>,
+): StandingsRow[] {
+  const byEntrant = new Map<EntrantId, StandingsRow>();
+  const order: EntrantId[] = [];
+  for (const id of entrants) {
+    if (!byEntrant.has(id)) {
+      byEntrant.set(id, zeroRow(id));
+      order.push(id);
+    }
+  }
+  for (const delta of deltas) {
+    const row = byEntrant.get(delta.entrantId);
+    if (row === undefined) {
+      throw new Error(`standings delta references entrant "${delta.entrantId}" not in the pool`);
+    }
+    addDelta(row, delta);
+  }
+  return order.map((id) => byEntrant.get(id) as StandingsRow);
+}
+
+// Convenience: fold a set of fixture results (delta pairs) rather than a flat
+// delta stream. Equivalent to foldStandings over the flattened deltas.
+export function foldResults(
+  entrants: readonly EntrantId[],
+  results: Iterable<FixtureResult>,
+): StandingsRow[] {
+  return foldStandings(entrants, flattenResults(results));
+}
+
+// Flattens delta pairs into a single delta stream (home, away, home, away, …).
+export function flattenResults(results: Iterable<FixtureResult>): StandingsDelta[] {
+  const out: StandingsDelta[] = [];
+  for (const [home, away] of results) {
+    out.push(home, away);
+  }
+  return out;
+}
+
+// The subset of results contested entirely within `group` — the mini-table
+// source for head-to-head refinement (spec 05 §4.2 step 1).
+export function resultsAmong(
+  group: ReadonlySet<EntrantId>,
+  results: readonly FixtureResult[],
+): FixtureResult[] {
+  return results.filter(
+    ([home, away]) => group.has(home.entrantId) && group.has(away.entrantId),
+  );
+}

--- a/packages/engine/src/competition/tiebreakers.ts
+++ b/packages/engine/src/competition/tiebreakers.ts
@@ -11,10 +11,20 @@
 // value) because ½·(opponent score) is a quarter-point. Use pointsToText for
 // display.
 //
-// NOTE — the comparator *registry* (TiebreakerKey → comparator, antisymmetry/
-// transitivity property tests, h2h partition refinement) lands in PROMPT-08;
-// this file provides the metric functions those comparators call.
-import type { EntrantId } from "../core/types.ts";
+// The comparator *registry* (TiebreakerKey → comparator), h2h partition
+// refinement and the ranking driver are in the second half of this file
+// (PROMPT-08); the functions above are the cascade-time metrics those
+// comparators call.
+import { EngineError } from "../core/errors.ts";
+import { shuffle } from "../core/rng.ts";
+import type { EntrantId, MetricSpec } from "../core/types.ts";
+import type { TiebreakerKey } from "../sport/module.ts";
+import {
+  foldResults,
+  resultsAmong,
+  type FixtureResult,
+  type StandingsRow,
+} from "./standings.ts";
 
 export type Color = "W" | "B";
 export type GameResult = "win" | "draw" | "loss";
@@ -171,4 +181,432 @@ export function pointsToText(halfPoints: number): string {
   const half = halfPoints % 2 === 1 ? "½" : "";
   if (whole === 0) return half === "" ? "0" : "½";
   return `${whole}${half}`;
+}
+
+// ===========================================================================
+// Comparator registry + tiebreaker cascade — spec 05 §4 (PROMPT-08).
+//
+// A standings table is entrants sorted by a *cascade of comparators*. The
+// cascade is data (a TiebreakerKey[]); ranking is iterative PARTITION
+// REFINEMENT, never a pairwise sort — pairwise comparison breaks transitivity
+// for head-to-head keys (spec 05 §4.2). Each key refines the current
+// equivalence classes into finer, ordered sub-classes; a class of size 1 is
+// final. Ratio metrics compare by cross-multiplication of integer ledgers, so
+// ordering never touches a float (spec 05 §4.3).
+// ===========================================================================
+
+// >0 ⇒ a ranks ABOVE b; <0 ⇒ below; 0 ⇒ level on this key.
+export type Comparator = (a: StandingsRow, b: StandingsRow, ctx: RankContext) => number;
+
+export interface RankContext {
+  cascade: readonly TiebreakerKey[];
+  // Decided fixtures of the pool being ranked — the source for head-to-head
+  // and direct-encounter mini-tables (spec 05 §4.2). Empty ⇒ no h2h data.
+  results?: readonly FixtureResult[];
+  // UEFA recursive h2h re-application (true) vs FIFA fall-through (false),
+  // spec 05 §4.2 step 3.
+  h2hRecursive?: boolean;
+  // Assembled Swiss ledger for buchholz/sberger/direct (spec 05 §4.1); the
+  // boardgame cascade needs it, most sports do not.
+  swiss?: SwissTable;
+  // Entrant seeds for the `seed` comparator and deterministic residual-tie
+  // ordering; lower number = higher seed.
+  seeds?: ReadonlyMap<EntrantId, number>;
+  // Division rngSeed for `lots` (spec 05 §4.4); combined with sorted tie-group
+  // ids so the draw is reproducible and audited.
+  rngSeed?: number;
+}
+
+export interface RankingResult {
+  // Ranked rows (clones — the input is never mutated), `rank` = 1..n, distinct.
+  rows: StandingsRow[];
+  // Tie-groups a drawing of lots decided (sorted ids) — each needs a
+  // `rank_lock_required` division event before progression (spec 05 §3).
+  lotsGroups: EntrantId[][];
+}
+
+const sgn = (n: number): number => (n > 0 ? 1 : n < 0 ? -1 : 0);
+
+// Ledger key aliases: the abstract `diff`/`for` tiebreaks map to whatever the
+// sport calls goal/run difference and goals/runs for (spec 04 per-sport).
+const DIFF_KEYS = ["gd", "diff", "run_diff"] as const;
+const FOR_KEYS = ["gf", "for", "runs_for"] as const;
+
+function metricOf(row: StandingsRow, keys: readonly string[]): number {
+  for (const key of keys) {
+    const value = row.metrics[key];
+    if (value !== undefined) return value;
+  }
+  return 0;
+}
+
+// Compare fractions an/ad vs bn/bd by cross-multiplication — no floats (spec 05
+// §4.3). Denominators are ≥ 0; x/0 with x>0 is treated as +∞ (an unbeaten
+// ratio), and 0/0 as 0 (no data). Numerators may be negative (net run rate).
+function compareRatio(an: number, ad: number, bn: number, bd: number): number {
+  const aInf = ad === 0 && an > 0;
+  const bInf = bd === 0 && bn > 0;
+  if (aInf || bInf) return aInf && bInf ? 0 : aInf ? 1 : -1;
+  const an2 = ad === 0 ? 0 : an;
+  const ad2 = ad === 0 ? 1 : ad;
+  const bn2 = bd === 0 ? 0 : bn;
+  const bd2 = bd === 0 ? 1 : bd;
+  const lhs = BigInt(an2) * BigInt(bd2);
+  const rhs = BigInt(bn2) * BigInt(ad2);
+  return lhs > rhs ? 1 : lhs < rhs ? -1 : 0;
+}
+
+// Net run rate as an exact fraction: rf/bf − ra/bb = (rf·bb − ra·bf)/(bf·bb)
+// (spec 04 §5 / cricket.md). Compared, never divided.
+function nrrFraction(row: StandingsRow): { n: number; d: number } {
+  const rf = metricOf(row, ["runs_for"]);
+  const bf = metricOf(row, ["balls_faced_eff"]);
+  const ra = metricOf(row, ["runs_against"]);
+  const bb = metricOf(row, ["balls_bowled_eff"]);
+  return { n: rf * bb - ra * bf, d: bf * bb };
+}
+
+// spec 05 §4.1 — one comparator per non-structural TiebreakerKey. h2h_* /
+// direct / lots are handled by the refinement driver (they need the tie-group
+// context, not a pairwise value).
+const COMPARATORS: Partial<Record<TiebreakerKey, Comparator>> = {
+  points: (a, b) => sgn(a.points - b.points),
+  wins: (a, b) => sgn(a.won - b.won),
+  diff: (a, b) => sgn(metricOf(a, DIFF_KEYS) - metricOf(b, DIFF_KEYS)),
+  for: (a, b) => sgn(metricOf(a, FOR_KEYS) - metricOf(b, FOR_KEYS)),
+  fair_play: (a, b) => sgn(metricOf(a, ["fair_play"]) - metricOf(b, ["fair_play"])),
+  nrr: (a, b) => {
+    const na = nrrFraction(a);
+    const nb = nrrFraction(b);
+    return compareRatio(na.n, na.d, nb.n, nb.d);
+  },
+  set_ratio: (a, b) =>
+    compareRatio(
+      metricOf(a, ["sets_won"]),
+      metricOf(a, ["sets_lost"]),
+      metricOf(b, ["sets_won"]),
+      metricOf(b, ["sets_lost"]),
+    ),
+  point_ratio: (a, b) =>
+    compareRatio(
+      metricOf(a, ["points_won"]),
+      metricOf(a, ["points_lost"]),
+      metricOf(b, ["points_won"]),
+      metricOf(b, ["points_lost"]),
+    ),
+  // Swiss cascade-time metrics — read the assembled ledger (spec 05 §4.1).
+  buchholz: (a, b, ctx) =>
+    ctx.swiss ? sgn(buchholz(ctx.swiss, a.entrantId) - buchholz(ctx.swiss, b.entrantId)) : 0,
+  buchholz_cut1: (a, b, ctx) =>
+    ctx.swiss
+      ? sgn(buchholzCut1(ctx.swiss, a.entrantId) - buchholzCut1(ctx.swiss, b.entrantId))
+      : 0,
+  sberger: (a, b, ctx) =>
+    ctx.swiss
+      ? sgn(sonnebornBerger(ctx.swiss, a.entrantId) - sonnebornBerger(ctx.swiss, b.entrantId))
+      : 0,
+  seed: (a, b, ctx) => {
+    const sa = ctx.seeds?.get(a.entrantId) ?? Number.MAX_SAFE_INTEGER;
+    const sb = ctx.seeds?.get(b.entrantId) ?? Number.MAX_SAFE_INTEGER;
+    return sgn(sb - sa); // lower seed number ranks above
+  },
+};
+
+const H2H_KEYS = new Set<TiebreakerKey>(["h2h_points", "h2h_diff", "h2h_for"]);
+
+function isH2HKey(key: TiebreakerKey): boolean {
+  return H2H_KEYS.has(key);
+}
+
+// Inside an h2h mini-table, "h2h GD" simply means "GD computed among the tied
+// set" — so the block keys map to their plain equivalents applied to mini rows.
+function h2hToPlain(key: TiebreakerKey): TiebreakerKey {
+  return key === "h2h_points" ? "points" : key === "h2h_diff" ? "diff" : "for";
+}
+
+// Sort a tied class by a comparator (best first) and split into equal-neighbour
+// sub-classes. Sound because every comparator here is a total preorder.
+function groupBySort(cls: StandingsRow[], cmp: Comparator, ctx: RankContext): StandingsRow[][] {
+  const sorted = [...cls].sort((a, b) => -sgn(cmp(a, b, ctx)));
+  const groups: StandingsRow[][] = [];
+  let current: StandingsRow[] = [];
+  for (const row of sorted) {
+    const prev = current[current.length - 1];
+    if (prev !== undefined && sgn(cmp(prev, row, ctx)) !== 0) {
+      groups.push(current);
+      current = [];
+    }
+    current.push(row);
+  }
+  if (current.length > 0) groups.push(current);
+  return groups;
+}
+
+// Refine using only scalar/ratio comparator keys (no h2h/direct/lots) — the
+// engine inside an h2h mini-table and the residual driver.
+function refinePlain(
+  rows: StandingsRow[],
+  keys: readonly TiebreakerKey[],
+  ctx: RankContext,
+): StandingsRow[][] {
+  let classes: StandingsRow[][] = [rows];
+  for (const key of keys) {
+    const cmp = COMPARATORS[key];
+    if (cmp === undefined) continue;
+    classes = classes.flatMap((cls) => (cls.length > 1 ? groupBySort(cls, cmp, ctx) : [cls]));
+    if (classes.every((cls) => cls.length === 1)) break;
+  }
+  return classes;
+}
+
+// spec 05 §4.2 — head-to-head partition refinement over a maximal run of h2h_*
+// keys. (1) build a mini-table from fixtures among the tied set; (2) refine it
+// by the block's plain equivalents; (3) UEFA only: re-run the block on any
+// partially-split sub-tie (rebuilding the mini-table among just those
+// entrants). FIFA 2026 (h2hRecursive=false) applies the block once, then the
+// outer cascade falls through to overall criteria.
+function h2hBlock(
+  cls: StandingsRow[],
+  block: readonly TiebreakerKey[],
+  ctx: RankContext,
+): StandingsRow[][] {
+  const ids = new Set(cls.map((row) => row.entrantId));
+  const among = resultsAmong(ids, ctx.results ?? []);
+  const miniRows = foldResults(
+    cls.map((row) => row.entrantId),
+    among,
+  );
+  const plainKeys = block.map(h2hToPlain);
+  const miniClasses = refinePlain(miniRows, plainKeys, ctx);
+
+  const byId = new Map(cls.map((row) => [row.entrantId, row]));
+  const ordered = miniClasses.map((mini) =>
+    mini.map((row) => byId.get(row.entrantId) as StandingsRow),
+  );
+
+  if (ctx.h2hRecursive !== true) return ordered;
+  return ordered.flatMap((sub) =>
+    // Recurse only when the block *partially* split the group; a sub-tie the
+    // same size as the input made no progress (guards against non-termination).
+    sub.length > 1 && sub.length < cls.length ? h2hBlock(sub, block, ctx) : [sub],
+  );
+}
+
+// Direct-encounter refinement among the tied set: half-points each entrant
+// scored against the others (spec 05 §4.1). Uses the Swiss ledger when present
+// (boardgame), else the pool results. Building a mini-league (not pairwise)
+// keeps it transitive for 3+ tied entrants.
+function directRefine(cls: StandingsRow[], ctx: RankContext): StandingsRow[][] {
+  const ids = new Set(cls.map((row) => row.entrantId));
+  const score = (id: EntrantId): number => {
+    if (ctx.swiss) {
+      const row = ctx.swiss.find((entry) => entry.entrant === id);
+      if (row === undefined) return 0;
+      return row.games.reduce(
+        (sum, game) =>
+          game.opponent !== null && !game.unplayed && ids.has(game.opponent)
+            ? sum + game.scored
+            : sum,
+        0,
+      );
+    }
+    const among = resultsAmong(ids, ctx.results ?? []);
+    return among.reduce((sum, [home, away]) => {
+      if (home.entrantId === id) return sum + home.points;
+      if (away.entrantId === id) return sum + away.points;
+      return sum;
+    }, 0);
+  };
+  const cmp: Comparator = (a, b) => sgn(score(a.entrantId) - score(b.entrantId));
+  return groupBySort(cls, cmp, ctx);
+}
+
+// The full cascade driver: refine one equivalence class through the cascade,
+// consuming a maximal run of h2h keys as a single block.
+function refine(
+  classes: StandingsRow[][],
+  cascade: readonly TiebreakerKey[],
+  ctx: RankContext,
+): StandingsRow[][] {
+  let current = classes;
+  let i = 0;
+  while (i < cascade.length) {
+    const key = cascade[i] as TiebreakerKey;
+    if (key === "lots") {
+      i++;
+      continue; // resolved after the cascade (rankStandings)
+    }
+    if (isH2HKey(key)) {
+      const block: TiebreakerKey[] = [];
+      while (i < cascade.length && isH2HKey(cascade[i] as TiebreakerKey)) {
+        block.push(cascade[i] as TiebreakerKey);
+        i++;
+      }
+      current = current.flatMap((cls) => (cls.length > 1 ? h2hBlock(cls, block, ctx) : [cls]));
+    } else if (key === "direct") {
+      current = current.flatMap((cls) => (cls.length > 1 ? directRefine(cls, ctx) : [cls]));
+      i++;
+    } else {
+      const cmp = COMPARATORS[key];
+      if (cmp !== undefined) {
+        current = current.flatMap((cls) => (cls.length > 1 ? groupBySort(cls, cmp, ctx) : [cls]));
+      }
+      i++;
+    }
+    if (current.every((cls) => cls.length === 1)) break;
+  }
+  return current;
+}
+
+// FNV-1a fold of the division rngSeed and sorted tie-group ids → a stable
+// 32-bit lot seed (spec 05 §4.4). Same seed + same ids ⇒ same draw.
+function lotSeed(rngSeed: number, sortedIds: readonly EntrantId[]): number {
+  let hash = rngSeed >>> 0;
+  for (const id of sortedIds) {
+    for (let k = 0; k < id.length; k++) {
+      hash = Math.imul(hash ^ id.charCodeAt(k), 0x01000193) >>> 0;
+    }
+    hash = Math.imul(hash ^ 0x2c, 0x01000193) >>> 0; // separator between ids
+  }
+  return hash >>> 0;
+}
+
+function bySeedThenId(ctx: RankContext): (a: StandingsRow, b: StandingsRow) => number {
+  return (a, b) => {
+    const sa = ctx.seeds?.get(a.entrantId) ?? Number.MAX_SAFE_INTEGER;
+    const sb = ctx.seeds?.get(b.entrantId) ?? Number.MAX_SAFE_INTEGER;
+    if (sa !== sb) return sa - sb;
+    return a.entrantId < b.entrantId ? -1 : a.entrantId > b.entrantId ? 1 : 0;
+  };
+}
+
+// Rank a folded standings table by the cascade (spec 05 §4). Returns cloned
+// rows in a total order with distinct 1..n ranks. A class the cascade cannot
+// separate is broken by `lots` if the cascade lists it (marking the group for a
+// rank_lock_required event), otherwise by seed→id — a deterministic fallback
+// that never silently randomises (spec 05 §3).
+export function rankStandings(rows: readonly StandingsRow[], ctx: RankContext): RankingResult {
+  const clones = rows.map((row) => ({ ...row, metrics: { ...row.metrics } }));
+  const classes = refine([clones], ctx.cascade, ctx);
+  const hasLots = ctx.cascade.includes("lots");
+  const rngSeed = ctx.rngSeed ?? 0;
+
+  const order: StandingsRow[] = [];
+  const lotsGroups: EntrantId[][] = [];
+  for (const cls of classes) {
+    if (cls.length === 1) {
+      order.push(cls[0] as StandingsRow);
+      continue;
+    }
+    if (hasLots) {
+      const ids = cls.map((row) => row.entrantId).sort();
+      const drawn = shuffle(lotSeed(rngSeed, ids), ids);
+      const byId = new Map(cls.map((row) => [row.entrantId, row]));
+      for (const id of drawn) {
+        const row = byId.get(id) as StandingsRow;
+        row.rankLocked = true;
+        order.push(row);
+      }
+      lotsGroups.push(ids);
+    } else {
+      for (const row of [...cls].sort(bySeedThenId(ctx))) order.push(row);
+    }
+  }
+
+  order.forEach((row, index) => {
+    row.rank = index + 1;
+  });
+  return { rows: order, lotsGroups };
+}
+
+// spec 05 §4.1 — reject cascade keys whose metrics the sport doesn't maintain
+// (validated at division-config time). `swiss` marks a stage that assembles the
+// Swiss ledger (buchholz/sberger/direct); the rest map to declared MetricSpecs.
+export function validateCascade(
+  cascade: readonly TiebreakerKey[],
+  opts: { metrics: readonly MetricSpec[]; swiss?: boolean },
+): void {
+  const keys = new Set(opts.metrics.map((metric) => metric.key));
+  const has = (...alts: string[]): boolean => alts.some((key) => keys.has(key));
+  const reject = (key: TiebreakerKey, need: string): never => {
+    throw new EngineError(
+      "CONFIG_INVALID",
+      `tiebreaker "${key}" needs ${need}, which this sport does not maintain`,
+      { key },
+    );
+  };
+  for (const key of cascade) {
+    switch (key) {
+      case "points":
+      case "wins":
+      case "h2h_points":
+      case "seed":
+      case "lots":
+        break; // structural — always available
+      case "diff":
+      case "h2h_diff":
+        if (!has(...DIFF_KEYS)) reject(key, "a goal/run difference metric");
+        break;
+      case "for":
+      case "h2h_for":
+        if (!has(...FOR_KEYS)) reject(key, "a goals/runs-for metric");
+        break;
+      case "fair_play":
+        if (!has("fair_play")) reject(key, "a fair_play metric");
+        break;
+      case "nrr":
+        if (!has("runs_for") || !has("balls_faced_eff") || !has("runs_against") || !has("balls_bowled_eff")) {
+          reject(key, "the NRR ledger (runs/balls for & against)");
+        }
+        break;
+      case "set_ratio":
+        if (!has("sets_won") || !has("sets_lost")) reject(key, "sets won/lost");
+        break;
+      case "point_ratio":
+        if (!has("points_won") || !has("points_lost")) reject(key, "points won/lost");
+        break;
+      case "buchholz":
+      case "buchholz_cut1":
+      case "sberger":
+      case "direct":
+        if (opts.swiss !== true) reject(key, "an assembled Swiss ledger");
+        break;
+    }
+  }
+}
+
+// Assemble a SwissTable from decided fixture results for the buchholz/sberger/
+// direct comparators (spec 05 §4.1, PROMPT-07 note). Each entrant's card is
+// built from the fixtures it played; `scored` is read straight off the
+// module's delta points (half-points for the boardgame module). Colour/byes
+// aren't recoverable from deltas — pass richer cards directly when needed.
+export function buildSwissTable(
+  entrants: readonly EntrantId[],
+  results: readonly FixtureResult[],
+): SwissTable {
+  const cards = new Map<EntrantId, SwissGame[]>();
+  const scoreOf = new Map<EntrantId, number>();
+  for (const id of entrants) {
+    cards.set(id, []);
+    scoreOf.set(id, 0);
+  }
+  const resultOf = (delta: FixtureResult[number]): GameResult =>
+    delta.won > 0 ? "win" : delta.drawn > 0 ? "draw" : "loss";
+  const push = (self: FixtureResult[number], opp: FixtureResult[number]): void => {
+    const card = cards.get(self.entrantId);
+    if (card === undefined) {
+      throw new Error(`Swiss ledger built for entrant "${self.entrantId}" outside the entrant set`);
+    }
+    card.push({ opponent: opp.entrantId, result: resultOf(self), scored: self.points });
+    scoreOf.set(self.entrantId, (scoreOf.get(self.entrantId) ?? 0) + self.points);
+  };
+  for (const [home, away] of results) {
+    push(home, away);
+    push(away, home);
+  }
+  return entrants.map((entrant) => ({
+    entrant,
+    score: scoreOf.get(entrant) ?? 0,
+    games: cards.get(entrant) ?? [],
+  }));
 }


### PR DESCRIPTION
Implements PROMPT-08: the sport-agnostic competition engine (spec `engine/05-formats-progression-tiebreakers.md`). Fills the four `competition/` stubs; `tiebreakers.ts` keeps its PROMPT-07 Swiss metrics and appends the cascade engine.

## What landed
- **`standings.ts`** — order-independent `StandingsDelta → StandingsRow[]` fold with the sport's metric ledger; `resultsAmong` for head-to-head subsets.
- **`tiebreakers.ts`** — comparator registry for every `TiebreakerKey` + `rankStandings` via **partition refinement** (never pairwise):
  - h2h partition-refinement with `h2hRecursive` (UEFA recursive vs FIFA 2026 fall-through, spec §4.2)
  - Swiss `buchholz`/`buchholz_cut1`/`sberger`/`direct` from an assembled ledger (`buildSwissTable`)
  - `nrr`/`set_ratio`/`point_ratio` by **BigInt cross-multiplication — no floats** (spec §4.3)
  - seeded `lots` emitting `rank_lock_required` (spec §4.4); `validateCascade` rejects keys the sport doesn't maintain
- **`qualification.ts`** — pool-rank picks / `topN` / `bestOfRank` with UEFA unequal-pool normalisation; idempotent; `qualificationSize`.
- **`stage.ts`** — six-kind completion predicates, division-event ledger (`stage_opened`/`stage_completed`/`rank_lock*`/`entrant_withdrawn`), `bracketRanks`, withdrawal policies (`void_remaining` expunge<50%/award, `bracket_walkover`).

## Tests (56 new, 354/354 engine green)
FIFA H2H-first vs GD-first golden (genuinely different orders), UEFA-vs-FIFA recursion divergence, intransitive 3-cycle → lots, exact ratio arithmetic, cascade validation, property suite (total order, irrelevant-fixture stability, fold order-independence, qualification size), and a **full group→knockout division run end-to-end** on the generic module with stub generators. Engine boundary gate clean; typecheck clean.

## Deviations (spec 05 — consistent refinements, no doc drift)
- `diff`/`for` keys resolve ledger aliases (`gd`/`gf`) — sports name the metric differently
- residual ties with no `lots` in cascade break deterministically by seed→id (not randomisation, no lock)
- `direct` is a transitive mini-league (not raw pairwise)
- `fixtures_generated`/`fixture_replaced` events + real generators deferred to PROMPT-09 (stubbed in the e2e test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pEsHzfZ8KyB3Bz6sDKfn