### PR TITLE
perf(test): faster vitest via threads pool + isolate:false

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -4,6 +4,8 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
+    pool: "threads",
+    isolate: false,
     coverage: {
       provider: "v8",
       include: [

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+    pool: "threads",
+    isolate: false,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Summary
- Both `vitest.config.ts` files (apps/web, packages/engine) now use `pool: "threads"` and `isolate: false`, per the [Vitest performance guide](https://vitest.dev/guide/improving-performance).
- Safe here: neither test suite uses `vi.mock`, DOM globals, or shared mutable module state (verified — no matches for mocks/stubGlobal in either src tree).
- Measured: `packages/engine` suite 5.8s → 3.6s wall time (~38% faster), 354 tests still passing. `apps/web` suite ~17.7s → ~16.2s (587 tests still passing) — that suite's time is dominated by a CPU-bound fast-check property test in `engine.test.ts` (~18s test-body compute), not config overhead, so gains there are smaller.
- No invocation changes — `npm test`, `vitest run`, `vitest` all work exactly as before.

## Note (pre-existing, out of scope)
Coverage run on `apps/web` fails its branches threshold (86.02% vs 90%) on `main` already, unrelated to this change — confirmed by stashing these edits and re-running coverage on the original config with the same result.

## Test plan
- [x] `packages/engine`: `vitest run` — 354/354 passing
- [x] `apps/web`: `vitest run` — 587/587 passing
- [x] `apps/web` coverage threshold gap confirmed pre-existing (not introduced by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)