### PR TITLE
feat(engine): fixture generation & calendar slotting (PROMPT-09)

### DIFF
--- a/engine/05-formats-progression-tiebreakers.md
+++ b/engine/05-formats-progression-tiebreakers.md
@@ -53,14 +53,19 @@ Bracket size `S = nextPowerOfTwo(entrants)`. Standard fold placement: seed posit
 fixtures auto-decide as `award`). Feeds: fixture (r,i) winner → (r+1, ⌊i/2⌋) slot `i mod 2`.
 Optional 3rd-place playoff from semifinal losers. Cross-pool seeding template for
 group→KO: A1–B2, B1–A2 pattern generalised: winners face runners-up of another pool,
-same-pool rematch deferred to latest possible round.
+same-pool rematch deferred to latest possible round. (PROMPT-09: implemented as a
+rank-interleave of pool finishers fed into the fold — exact for two pools; for k>2 pools
+it defers same-pool rematches only as far as the fold allows, full latest-round deferral
+is a later refinement.)
 
 ### 2.4 Double elimination
 Winners bracket = SE bracket; each WB round's losers drop into the losers bracket at the
 canonical slot (LB alternates "minor" rounds absorbing WB losers and "major" rounds).
 Grand final: WB champion vs LB champion; **bracket reset** optional (LB champ must win
 twice) via config. Feeds encoded the same `winner_to/loser_to` way — the engine's fixture
-wiring is uniform across SE/DE/stepladder.
+wiring is uniform across SE/DE/stepladder. (PROMPT-09: the reset decider is generated as a
+`conditional` grand-final fixture fed by GF1's winner/loser; the persistence adapter voids
+it when the WB champion wins GF1, and void counts as settled for stage completion.)
 
 ### 2.5 Stepladder (v1 compatibility)
 Rank R4 v R3 → winner v R2 → winner v R1 (final). Generalised to size k.

--- a/packages/engine/src/scheduling/bracket.test.ts
+++ b/packages/engine/src/scheduling/bracket.test.ts
@@ -1,0 +1,217 @@
+// Bracket generation — spec 05 §2.3–2.5, invariants §6.
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import {
+  crossPoolSeedOrder,
+  generateDoubleElim,
+  generateSingleElim,
+  generateStepladder,
+  nextPowerOfTwo,
+  seedPositions,
+  type BracketFixtureGen,
+} from "./bracket.ts";
+
+const field = (n: number): string[] => Array.from({ length: n }, (_, i) => `s${i + 1}`);
+
+// mulberry32 — a seeded coin for resolving brackets in the property tests.
+function rng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Play a bracket out to completion, following winner/loser feeds. Byes (`award`)
+// and walkovers (a feed from a bye's non-existent loser) advance without a loss.
+// Skips conditional (bracket-reset) games. Returns per-entrant loss counts and
+// the champion (winner of the last isFinal game resolved).
+function resolveBracket(
+  fixtures: readonly BracketFixtureGen[],
+  coin: () => number,
+): { losses: Map<string, number>; champion: string | undefined } {
+  const winner = new Map<string, string | undefined>();
+  const loser = new Map<string, string | undefined>();
+  const losses = new Map<string, number>();
+  const resolved = new Set<string>();
+  const ready = (ref?: { fixtureId: string }): boolean => ref === undefined || resolved.has(ref.fixtureId);
+  const val = (ref?: { fixtureId: string; side: "winner" | "loser" }): string | undefined =>
+    ref === undefined ? undefined : ref.side === "winner" ? winner.get(ref.fixtureId) : loser.get(ref.fixtureId);
+
+  for (let guard = 0; guard < fixtures.length + 2; guard++) {
+    let progress = false;
+    for (const fx of fixtures) {
+      if (resolved.has(fx.id) || fx.conditional === true) continue;
+      if (!ready(fx.homeFrom) || !ready(fx.awayFrom)) continue;
+      if (fx.award !== undefined) {
+        winner.set(fx.id, fx.award);
+        loser.set(fx.id, undefined);
+        resolved.add(fx.id);
+        progress = true;
+        continue;
+      }
+      const home = fx.home ?? val(fx.homeFrom);
+      const away = fx.away ?? val(fx.awayFrom);
+      if (home === undefined && away === undefined) continue;
+      if (home === undefined || away === undefined) {
+        // Walkover — the present side advances.
+        const solo = (home ?? away) as string;
+        winner.set(fx.id, solo);
+        loser.set(fx.id, undefined);
+        resolved.add(fx.id);
+        progress = true;
+        continue;
+      }
+      const w = coin() < 0.5 ? home : away;
+      const l = w === home ? away : home;
+      winner.set(fx.id, w);
+      loser.set(fx.id, l);
+      losses.set(l, (losses.get(l) ?? 0) + 1);
+      resolved.add(fx.id);
+      progress = true;
+    }
+    if (!progress) break;
+  }
+
+  const finals = fixtures.filter((f) => f.isFinal === true && resolved.has(f.id));
+  const last = finals[finals.length - 1];
+  return { losses, champion: last === undefined ? undefined : winner.get(last.id) };
+}
+
+describe("seedPositions — golden standard fold (spec 05 §2.3)", () => {
+  it("matches the published 8-seed layout", () => {
+    expect(seedPositions(8)).toEqual([1, 8, 5, 4, 3, 6, 7, 2]);
+  });
+
+  it("matches the standard 1–16 fold layout", () => {
+    expect(seedPositions(16)).toEqual([1, 16, 9, 8, 5, 12, 13, 4, 3, 14, 11, 6, 7, 10, 15, 2]);
+  });
+
+  it("seed 1 and seed 2 are in opposite halves (meet only in the final)", () => {
+    for (const size of [2, 4, 8, 16, 32, 64]) {
+      const pos = seedPositions(size);
+      expect(pos[0]).toBe(1);
+      expect(pos[size - 1]).toBe(2);
+    }
+  });
+});
+
+describe("generateSingleElim — structure, byes & feeds (spec 05 §2.3)", () => {
+  it("byes = S − n are awarded to the top seeds", () => {
+    // 6 entrants ⇒ bracket of 8, 2 byes ⇒ seeds s1, s2 auto-advance.
+    const { fixtures } = generateSingleElim({ entrants: field(6) });
+    const awards = fixtures.filter((f) => f.award !== undefined).map((f) => f.award);
+    expect(new Set(awards)).toEqual(new Set(["s1", "s2"]));
+  });
+
+  it("adds a 3rd-place playoff fed by the two semifinal losers", () => {
+    const { fixtures } = generateSingleElim({ entrants: field(4), thirdPlace: true });
+    const tp = fixtures.find((f) => f.thirdPlace === true);
+    expect(tp).toBeDefined();
+    expect(tp?.homeFrom?.side).toBe("loser");
+    expect(tp?.awayFrom?.side).toBe("loser");
+  });
+
+  it("depth is log2(S), one final, and resolves to a single champion (n up to 64)", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 2, max: 64 }), fc.integer(), (n, seed) => {
+        const bracket = generateSingleElim({ entrants: field(n) });
+        const size = nextPowerOfTwo(n);
+        expect(bracket.rounds).toBe(Math.log2(size));
+        expect(bracket.fixtures.filter((f) => f.isFinal === true)).toHaveLength(1);
+        // S − 1 games decide a single-elim of S slots (byes included as awards).
+        expect(bracket.fixtures).toHaveLength(size - 1);
+        const { champion } = resolveBracket(bracket.fixtures, rng(seed));
+        expect(champion).toBeDefined();
+      }),
+    );
+  });
+
+  it("is idempotent — regeneration is byte-identical", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 2, max: 64 }), (n) => {
+        expect(generateSingleElim({ entrants: field(n), thirdPlace: true })).toEqual(
+          generateSingleElim({ entrants: field(n), thirdPlace: true }),
+        );
+      }),
+    );
+  });
+});
+
+describe("crossPoolSeedOrder — group→KO template (spec 05 §2.3)", () => {
+  it("produces the A1–B2 / B1–A2 first round for two pools", () => {
+    const order = crossPoolSeedOrder([
+      ["A1", "A2"],
+      ["B1", "B2"],
+    ]);
+    expect(order).toEqual(["A1", "B1", "A2", "B2"]);
+    const { fixtures } = generateSingleElim({ entrants: order });
+    const r0 = fixtures
+      .filter((f) => f.round === 0)
+      .map((f) => new Set([f.home, f.away]));
+    // A1 vs B2 and A2 vs B1 — winners face the other pool's runner-up.
+    expect(r0).toContainEqual(new Set(["A1", "B2"]));
+    expect(r0).toContainEqual(new Set(["A2", "B1"]));
+  });
+});
+
+describe("generateDoubleElim — invariants (spec 05 §2.4, §6)", () => {
+  it("2n−2 games for a power-of-two field", () => {
+    for (const n of [2, 4, 8, 16]) {
+      const { fixtures } = generateDoubleElim({ entrants: field(n) });
+      expect(fixtures).toHaveLength(2 * n - 2);
+    }
+  });
+
+  it("champion has ≤ 2 losses and every other entrant ≥ 1 (n ∈ {2,4,8,16,32})", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(2, 4, 8, 16, 32), fc.integer(), (n, seed) => {
+        const { fixtures } = generateDoubleElim({ entrants: field(n) });
+        const { losses, champion } = resolveBracket(fixtures, rng(seed));
+        expect(champion).toBeDefined();
+        expect(losses.get(champion as string) ?? 0).toBeLessThanOrEqual(2);
+        for (const id of field(n)) {
+          if (id === champion) continue;
+          expect(losses.get(id) ?? 0).toBeGreaterThanOrEqual(1);
+        }
+      }),
+    );
+  });
+
+  it("emits a conditional bracket-reset final when configured", () => {
+    const { fixtures } = generateDoubleElim({ entrants: field(8), bracketReset: true });
+    const reset = fixtures.find((f) => f.id === "gf-reset");
+    expect(reset?.conditional).toBe(true);
+    expect(reset?.homeFrom).toEqual({ fixtureId: "gf", side: "winner" });
+    expect(reset?.awayFrom).toEqual({ fixtureId: "gf", side: "loser" });
+  });
+});
+
+describe("generateStepladder — rank ladder (spec 05 §2.5)", () => {
+  it("R4 v R3 → winner v R2 → winner v R1", () => {
+    const { fixtures, rounds } = generateStepladder({ entrants: ["R1", "R2", "R3", "R4"] });
+    expect(rounds).toBe(3);
+    expect(fixtures[0]).toMatchObject({ id: "sl-g0", home: "R3", away: "R4" });
+    expect(fixtures[1]).toMatchObject({ id: "sl-g1", home: "R2", awayFrom: { fixtureId: "sl-g0", side: "winner" } });
+    expect(fixtures[2]).toMatchObject({
+      id: "sl-g2",
+      home: "R1",
+      isFinal: true,
+      awayFrom: { fixtureId: "sl-g1", side: "winner" },
+    });
+  });
+
+  it("resolves to a single champion for any size", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 2, max: 20 }), fc.integer(), (k, seed) => {
+        const { fixtures } = generateStepladder({ entrants: field(k) });
+        expect(fixtures).toHaveLength(k - 1);
+        const { champion } = resolveBracket(fixtures, rng(seed));
+        expect(champion).toBeDefined();
+      }),
+    );
+  });
+});

--- a/packages/engine/src/scheduling/bracket.ts
+++ b/packages/engine/src/scheduling/bracket.ts
@@ -1,3 +1,348 @@
-// Seeded SE/DE brackets, byes, feeds — spec 05. Implemented in PROMPT-09.
+// Seeded brackets — spec 05 §2.3 (single elimination), §2.4 (double
+// elimination), §2.5 (stepladder). Pure and deterministic given
+// (entrants, seeds, config); the fixture wiring is uniform across SE/DE/
+// stepladder — every slot is either a concrete seeded entrant, an auto-decided
+// bye award, or a feed from another fixture's winner/loser.
+import type { EntrantId } from "../core/types.ts";
+import { seedOrder } from "./roundrobin.ts";
 
-export {};
+// A slot filled by the winner or loser of an earlier fixture (spec 05 §2.3
+// feeds; §2.4 uniform winner_to/loser_to wiring).
+export interface BracketSlotRef {
+  fixtureId: string;
+  side: "winner" | "loser";
+}
+
+export interface BracketFixtureGen {
+  id: string;
+  bracket?: "WB" | "LB" | "GF"; // omit for a single-lane SE bracket
+  round: number; // 0-based, monotonic within a lane (higher = later)
+  isFinal?: boolean; // SE final / DE grand final(s)
+  thirdPlace?: boolean;
+  conditional?: boolean; // DE bracket-reset game: played only if the LB champ wins GF1
+  home?: EntrantId; // concrete seeded entrant (round 1)
+  away?: EntrantId;
+  homeFrom?: BracketSlotRef; // feed
+  awayFrom?: BracketSlotRef;
+  award?: EntrantId; // bye: auto-decided at generation, the advancing entrant
+}
+
+export interface GeneratedBracket {
+  fixtures: BracketFixtureGen[];
+  rounds: number; // SE: bracket depth log2(S). DE: WB depth.
+}
+
+// ---------------------------------------------------------------------------
+// Seeding fold — spec 05 §2.3
+// ---------------------------------------------------------------------------
+
+export function nextPowerOfTwo(n: number): number {
+  let p = 1;
+  while (p < n) p *= 2;
+  return p;
+}
+
+// Recursive interleave placing seed numbers into bracket slots so 1 meets 2
+// only in the final, 1v4/2v3 in the semis, etc. (spec 05 §2.3):
+//   [1] → [1,2] → [1,4,3,2] → [1,8,5,4,3,6,7,2] → …
+// Each parent seed s spawns the pair (s, sum−s); the orientation alternates by
+// parent index so the layout matches the standard fold (the 16-seed layout is
+// the golden in the tests).
+export function seedPositions(size: number): number[] {
+  let seeds = [1];
+  while (seeds.length < size) {
+    const sum = seeds.length * 2 + 1;
+    const next: number[] = [];
+    seeds.forEach((s, i) => {
+      if (i % 2 === 0) next.push(s, sum - s);
+      else next.push(sum - s, s);
+    });
+    seeds = next;
+  }
+  return seeds;
+}
+
+const winnerOf = (fixtureId: string): BracketSlotRef => ({ fixtureId, side: "winner" });
+const loserOf = (fixtureId: string): BracketSlotRef => ({ fixtureId, side: "loser" });
+
+// ---------------------------------------------------------------------------
+// Single elimination — spec 05 §2.3
+// ---------------------------------------------------------------------------
+
+export interface SingleElimOptions {
+  entrants: readonly EntrantId[];
+  seeds?: ReadonlyMap<EntrantId, number>;
+  thirdPlace?: boolean; // add a 3rd-place playoff between the semifinal losers
+  idPrefix?: string; // fixture-id namespace (default 'se'); DE uses 'wb'
+  bracketTag?: "WB"; // tag fixtures (DE winners bracket)
+}
+
+interface SEResult {
+  fixtures: BracketFixtureGen[];
+  gameIds: string[][]; // [round][i] — for DE loser wiring
+  rounds: number;
+  finalId: string | undefined;
+  semifinalIds: string[]; // the two SF game ids (round rounds-2), else []
+}
+
+// Build the SE bracket structure. Round-0 slots come from the seed fold; byes
+// (S − n, awarded to the top seeds) auto-decide as `award`; every later slot is
+// a winner feed. Returns the game-id grid so double elimination can wire the
+// losers.
+function buildSingleElim(opts: SingleElimOptions): SEResult {
+  const ordered = seedOrder(opts.entrants, opts.seeds);
+  const n = ordered.length;
+  const prefix = opts.idPrefix ?? "se";
+  const empty: SEResult = { fixtures: [], gameIds: [], rounds: 0, finalId: undefined, semifinalIds: [] };
+  if (n < 2) return empty;
+
+  const size = nextPowerOfTwo(n);
+  const positions = seedPositions(size);
+  const rounds = Math.log2(size);
+  const entrantOfSeed = (k: number): EntrantId | null => (k <= n ? (ordered[k - 1] as EntrantId) : null);
+
+  const fixtures: BracketFixtureGen[] = [];
+  const gameIds: string[][] = [];
+  const tag = opts.bracketTag;
+  // A DE winners bracket has no "final" of its own — only the grand final does.
+  const markFinal = tag === undefined;
+
+  // Round 0 — seeded entrants / byes.
+  gameIds[0] = [];
+  for (let i = 0; i < size / 2; i++) {
+    const id = `${prefix}-r0-i${i}`;
+    const hs = positions[2 * i] as number;
+    const as = positions[2 * i + 1] as number;
+    const hE = entrantOfSeed(hs);
+    const aE = entrantOfSeed(as);
+    const base: BracketFixtureGen = {
+      id,
+      round: 0,
+      ...(tag === undefined ? {} : { bracket: tag }),
+      ...(rounds === 1 && markFinal ? { isFinal: true } : {}), // 2-entrant bracket: round 0 is the final
+    };
+    if (hE !== null && aE !== null) {
+      fixtures.push({ ...base, home: hE, away: aE });
+    } else {
+      // Exactly one side is a bye ⇒ the real entrant is awarded through.
+      const real = (hE ?? aE) as EntrantId;
+      fixtures.push({ ...base, home: real, award: real });
+    }
+    (gameIds[0] as string[]).push(id);
+  }
+
+  // Later rounds — winner feeds.
+  for (let r = 1; r < rounds; r++) {
+    gameIds[r] = [];
+    const games = size / 2 ** (r + 1);
+    const prev = gameIds[r - 1] as string[];
+    for (let i = 0; i < games; i++) {
+      const id = `${prefix}-r${r}-i${i}`;
+      fixtures.push({
+        id,
+        round: r,
+        ...(tag === undefined ? {} : { bracket: tag }),
+        ...(r === rounds - 1 && markFinal ? { isFinal: true } : {}),
+        homeFrom: winnerOf(prev[2 * i] as string),
+        awayFrom: winnerOf(prev[2 * i + 1] as string),
+      });
+      (gameIds[r] as string[]).push(id);
+    }
+  }
+
+  const finalId = (gameIds[rounds - 1] as string[])[0];
+  const semifinalIds = rounds >= 2 ? [...(gameIds[rounds - 2] as string[])] : [];
+  return { fixtures, gameIds, rounds, finalId, semifinalIds };
+}
+
+export function generateSingleElim(opts: SingleElimOptions): GeneratedBracket {
+  const se = buildSingleElim(opts);
+  const fixtures = [...se.fixtures];
+
+  // 3rd-place playoff from the semifinal losers (spec 05 §2.3).
+  if (opts.thirdPlace === true && se.semifinalIds.length === 2) {
+    fixtures.push({
+      id: `${opts.idPrefix ?? "se"}-3p`,
+      round: se.rounds - 1,
+      thirdPlace: true,
+      homeFrom: loserOf(se.semifinalIds[0] as string),
+      awayFrom: loserOf(se.semifinalIds[1] as string),
+    });
+  }
+
+  return { fixtures, rounds: se.rounds };
+}
+
+// ---------------------------------------------------------------------------
+// Cross-pool seeding (group → knockout) — spec 05 §2.3
+// ---------------------------------------------------------------------------
+
+// Interleave pool finishers by rank (all winners, then all runners-up, …) — the
+// A1–B2 / B1–A2 template: fed as the seed order into generateSingleElim it
+// places pool winners against other pools' runners-up, and a same-pool rematch
+// can only occur in the final (for two pools; larger pool counts defer it as far
+// as the fold allows). `pools[p]` is pool p's finishers in rank order.
+export function crossPoolSeedOrder(pools: readonly (readonly EntrantId[])[]): EntrantId[] {
+  const maxRank = Math.max(0, ...pools.map((p) => p.length));
+  const order: EntrantId[] = [];
+  for (let rank = 0; rank < maxRank; rank++) {
+    for (const pool of pools) {
+      const e = pool[rank];
+      if (e !== undefined) order.push(e);
+    }
+  }
+  return order;
+}
+
+// ---------------------------------------------------------------------------
+// Double elimination — spec 05 §2.4
+// ---------------------------------------------------------------------------
+
+export interface DoubleElimOptions {
+  entrants: readonly EntrantId[];
+  seeds?: ReadonlyMap<EntrantId, number>;
+  bracketReset?: boolean; // grand-final bracket reset (LB champ must win twice)
+}
+
+// Winners bracket = an SE bracket. Each WB round's losers drop into the losers
+// bracket at the canonical slot; the LB alternates "minor" rounds (absorbing WB
+// losers) and "major" rounds (pairing LB survivors). Grand final = WB champion
+// vs LB champion, with an optional bracket-reset decider.
+export function generateDoubleElim(opts: DoubleElimOptions): GeneratedBracket {
+  const wb = buildSingleElim({
+    entrants: opts.entrants,
+    ...(opts.seeds === undefined ? {} : { seeds: opts.seeds }),
+    idPrefix: "wb",
+    bracketTag: "WB",
+  });
+  if (wb.finalId === undefined) return { fixtures: [...wb.fixtures], rounds: wb.rounds };
+
+  const fixtures: BracketFixtureGen[] = [...wb.fixtures];
+  const k = wb.rounds; // WB depth = log2(size)
+  const size = 2 ** k;
+
+  // Losers bracket. 2(k−1) rounds; game counts follow the drop pattern.
+  const lbGameIds: string[][] = [];
+  const lbRounds = 2 * (k - 1);
+
+  if (lbRounds >= 1) {
+    // LB round 0 (minor): pairs adjacent WB round-0 losers.
+    lbGameIds[0] = [];
+    for (let i = 0; i < size / 4; i++) {
+      const id = `lb-r0-i${i}`;
+      fixtures.push({
+        id,
+        bracket: "LB",
+        round: k, // LB numbered after WB so later rounds sort later
+        homeFrom: loserOf((wb.gameIds[0] as string[])[2 * i] as string),
+        awayFrom: loserOf((wb.gameIds[0] as string[])[2 * i + 1] as string),
+      });
+      (lbGameIds[0] as string[]).push(id);
+    }
+
+    for (let L = 1; L < lbRounds; L++) {
+      lbGameIds[L] = [];
+      const prev = lbGameIds[L - 1] as string[];
+      if (L % 2 === 1) {
+        // Major: winner(prev[i]) vs loser of WB round m+1, game i.
+        const m = (L - 1) / 2;
+        const wbLosers = wb.gameIds[m + 1] as string[];
+        for (let i = 0; i < prev.length; i++) {
+          const id = `lb-r${L}-i${i}`;
+          fixtures.push({
+            id,
+            bracket: "LB",
+            round: k + L,
+            homeFrom: winnerOf(prev[i] as string),
+            awayFrom: loserOf(wbLosers[i] as string),
+          });
+          (lbGameIds[L] as string[]).push(id);
+        }
+      } else {
+        // Minor: winner(prev[2i]) vs winner(prev[2i+1]).
+        for (let i = 0; i < prev.length / 2; i++) {
+          const id = `lb-r${L}-i${i}`;
+          fixtures.push({
+            id,
+            bracket: "LB",
+            round: k + L,
+            homeFrom: winnerOf(prev[2 * i] as string),
+            awayFrom: winnerOf(prev[2 * i + 1] as string),
+          });
+          (lbGameIds[L] as string[]).push(id);
+        }
+      }
+    }
+  }
+
+  // Grand final — WB champion (home) vs LB champion (away). With no LB (a
+  // 2-entrant field) the LB champion is simply the WB final's loser.
+  const gfRound = k + lbRounds;
+  const lbChampFeed =
+    lbRounds >= 1 ? winnerOf((lbGameIds[lbRounds - 1] as string[])[0] as string) : loserOf(wb.finalId);
+  fixtures.push({
+    id: "gf",
+    bracket: "GF",
+    round: gfRound,
+    isFinal: true,
+    homeFrom: winnerOf(wb.finalId),
+    awayFrom: lbChampFeed,
+  });
+
+  // Optional bracket reset: a second grand final between the same two, played
+  // only if the LB champion wins GF1. The persistence adapter voids it when the
+  // WB champion wins (void counts as settled for stage completion).
+  if (opts.bracketReset === true) {
+    fixtures.push({
+      id: "gf-reset",
+      bracket: "GF",
+      round: gfRound + 1,
+      isFinal: true,
+      conditional: true,
+      homeFrom: winnerOf("gf"),
+      awayFrom: loserOf("gf"),
+    });
+  }
+
+  return { fixtures, rounds: wb.rounds };
+}
+
+// ---------------------------------------------------------------------------
+// Stepladder — spec 05 §2.5
+// ---------------------------------------------------------------------------
+
+export interface StepladderOptions {
+  entrants: readonly EntrantId[];
+  seeds?: ReadonlyMap<EntrantId, number>;
+}
+
+// Rank-ordered ladder: the two lowest seeds play, the winner climbs to meet the
+// next seed up, … up to the top seed in the final (R4 v R3 → winner v R2 →
+// winner v R1). Generalised to any size k ≥ 2.
+export function generateStepladder(opts: StepladderOptions): GeneratedBracket {
+  const ordered = seedOrder(opts.entrants, opts.seeds); // rank 1 … k
+  const k = ordered.length;
+  if (k < 2) return { fixtures: [], rounds: 0 };
+
+  const fixtures: BracketFixtureGen[] = [];
+  // Game 0: the two lowest seeds (rank k−1 home, rank k away).
+  fixtures.push({
+    id: "sl-g0",
+    round: 0,
+    ...(k === 2 ? { isFinal: true } : {}),
+    home: ordered[k - 2] as EntrantId,
+    away: ordered[k - 1] as EntrantId,
+  });
+  // Game j (1…k−2): the waiting seed (rank k−1−j) vs the previous winner.
+  for (let j = 1; j <= k - 2; j++) {
+    fixtures.push({
+      id: `sl-g${j}`,
+      round: j,
+      ...(j === k - 2 ? { isFinal: true } : {}),
+      home: ordered[k - 2 - j] as EntrantId,
+      awayFrom: winnerOf(`sl-g${j - 1}`),
+    });
+  }
+
+  return { fixtures, rounds: k - 1 };
+}

--- a/packages/engine/src/scheduling/calendar.test.ts
+++ b/packages/engine/src/scheduling/calendar.test.ts
@@ -1,0 +1,252 @@
+// Calendar slotting — spec 05 §2.6, doc 06 §4.3, doc 12.
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import {
+  slotFixtures,
+  validateAssignments,
+  type Assignment,
+  type SchedulableFixture,
+  type SlotConfig,
+} from "./calendar.ts";
+
+const MIN = 60_000;
+const baseConfig = (over: Partial<SlotConfig> = {}): SlotConfig => ({
+  startAt: 0,
+  matchMinutes: 30,
+  gapMinutes: 5,
+  courts: ["C1"],
+  perEntrantMinRest: 0,
+  ...over,
+});
+
+describe("slotFixtures — greedy placement (spec 05 §2.6)", () => {
+  it("packs one court sequentially with the configured gap", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "f1", roundNo: 1, home: "A", away: "B" },
+      { id: "f2", roundNo: 1, home: "C", away: "D" },
+      { id: "f3", roundNo: 1, home: "E", away: "F" },
+    ];
+    const { assignments, conflicts } = slotFixtures({ fixtures, config: baseConfig() });
+    expect(conflicts).toHaveLength(0);
+    const times = assignments.map((a) => a.startAt).sort((x, y) => x - y);
+    // 30-min matches + 5-min gap ⇒ starts at 0, 35, 70 minutes.
+    expect(times).toEqual([0, 35 * MIN, 70 * MIN]);
+  });
+
+  it("spreads across courts before stacking", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "f1", roundNo: 1, home: "A", away: "B" },
+      { id: "f2", roundNo: 1, home: "C", away: "D" },
+    ];
+    const { assignments } = slotFixtures({ fixtures, config: baseConfig({ courts: ["C1", "C2"] }) });
+    // Both can start at 0 on different courts.
+    expect(new Set(assignments.map((a) => a.court))).toEqual(new Set(["C1", "C2"]));
+    expect(assignments.every((a) => a.startAt === 0)).toBe(true);
+  });
+
+  it("honours per-entrant rest between an entrant's matches", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "f1", roundNo: 1, home: "A", away: "B" },
+      { id: "f2", roundNo: 2, home: "A", away: "C" }, // A plays again
+    ];
+    const { assignments } = slotFixtures({
+      fixtures,
+      config: baseConfig({ courts: ["C1", "C2"], perEntrantMinRest: 60 }),
+    });
+    const f1 = assignments.find((a) => a.fixtureId === "f1") as Assignment;
+    const f2 = assignments.find((a) => a.fixtureId === "f2") as Assignment;
+    expect(f2.startAt - f1.endAt).toBeGreaterThanOrEqual(60 * MIN);
+  });
+
+  it("never schedules inside a blackout window", () => {
+    const fixtures: SchedulableFixture[] = [{ id: "f1", roundNo: 1, home: "A", away: "B" }];
+    const { assignments } = slotFixtures({
+      fixtures,
+      config: baseConfig({ blackouts: [{ from: 0, to: 45 * MIN }] }),
+    });
+    expect((assignments[0] as Assignment).startAt).toBeGreaterThanOrEqual(45 * MIN);
+  });
+
+  it("avoids court+time already taken by a sibling division (doc 06 §4.3)", () => {
+    const existing: Assignment[] = [
+      { fixtureId: "sib", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: ["X"], people: [] },
+    ];
+    const fixtures: SchedulableFixture[] = [{ id: "f1", roundNo: 1, home: "A", away: "B" }];
+    const { assignments } = slotFixtures({ fixtures, config: baseConfig(), existing });
+    // C1 is busy 0–30 (+5 gap) ⇒ our fixture starts at 35.
+    expect((assignments[0] as Assignment).startAt).toBe(35 * MIN);
+  });
+
+  it("warns (does not block) on a per-person overlap across divisions", () => {
+    const existing: Assignment[] = [
+      { fixtureId: "sib", court: "C9", startAt: 0, endAt: 30 * MIN, entrants: ["X"], people: ["kid1"] },
+    ];
+    const fixtures: SchedulableFixture[] = [
+      { id: "f1", roundNo: 1, home: "A", away: "B", people: ["kid1"] },
+    ];
+    const { assignments, conflicts } = slotFixtures({
+      fixtures,
+      config: baseConfig({ courts: ["C1"] }),
+      existing,
+    });
+    // Placed at 0 on a free court, but kid1 also plays sib at 0 → warn.
+    expect(assignments).toHaveLength(1);
+    expect(conflicts.some((c) => c.reason === "person_overlap")).toBe(true);
+  });
+
+  it("honours a locked slot and reports a court clash rather than moving it", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "lockA", roundNo: 1, home: "A", away: "B", locked: { court: "C1", startAt: 100 * MIN } },
+      { id: "lockB", roundNo: 1, home: "C", away: "D", locked: { court: "C1", startAt: 100 * MIN } },
+    ];
+    const { assignments, conflicts } = slotFixtures({ fixtures, config: baseConfig() });
+    expect(assignments.map((a) => a.startAt)).toEqual([100 * MIN, 100 * MIN]); // both kept as pinned
+    expect(conflicts.some((c) => c.reason === "court")).toBe(true);
+  });
+
+  it("reports no_slot instead of silently dropping a constraint", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "f1", roundNo: 1, home: "A", away: "B" },
+      { id: "f2", roundNo: 1, home: "C", away: "D" },
+    ];
+    // One court, horizon shorter than the second match would need.
+    const { assignments, conflicts } = slotFixtures({
+      fixtures,
+      config: baseConfig({ horizonMinutes: 10 }),
+    });
+    expect(assignments).toHaveLength(1);
+    expect(conflicts).toEqual([{ fixtureId: "f2", reason: "no_slot", detail: expect.any(String) }]);
+  });
+});
+
+describe("validateAssignments — board conflict report (doc 12 §2/§4)", () => {
+  it("flags a court double-booking", () => {
+    const a: Assignment[] = [
+      { fixtureId: "x", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: ["A"], people: [] },
+      { fixtureId: "y", court: "C1", startAt: 10 * MIN, endAt: 40 * MIN, entrants: ["B"], people: [] },
+    ];
+    const conflicts = validateAssignments(a, { perEntrantMinRest: 0, gapMinutes: 0 });
+    expect(conflicts.some((c) => c.reason === "court")).toBe(true);
+  });
+
+  it("flags an entrant playing two overlapping matches", () => {
+    const a: Assignment[] = [
+      { fixtureId: "x", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: ["A"], people: [] },
+      { fixtureId: "y", court: "C2", startAt: 10 * MIN, endAt: 40 * MIN, entrants: ["A"], people: [] },
+    ];
+    const conflicts = validateAssignments(a, { perEntrantMinRest: 0, gapMinutes: 0 });
+    expect(conflicts.some((c) => c.reason === "person_overlap")).toBe(true);
+  });
+
+  it("flags a rest violation between an entrant's matches", () => {
+    const a: Assignment[] = [
+      { fixtureId: "x", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: ["A"], people: [] },
+      { fixtureId: "y", court: "C2", startAt: 40 * MIN, endAt: 70 * MIN, entrants: ["A"], people: [] },
+    ];
+    const conflicts = validateAssignments(a, { perEntrantMinRest: 60, gapMinutes: 0 });
+    expect(conflicts.some((c) => c.reason === "rest")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Properties — spec 05 §2.6 / §6
+// ---------------------------------------------------------------------------
+
+const fixtureArb = fc.array(
+  fc.record({
+    id: fc.string({ minLength: 1, maxLength: 4 }),
+    roundNo: fc.integer({ min: 1, max: 5 }),
+    home: fc.constantFrom("A", "B", "C", "D", "E", "F"),
+    away: fc.constantFrom("A", "B", "C", "D", "E", "F"),
+  }),
+  { minLength: 1, maxLength: 20 },
+);
+
+describe("slotFixtures — invariants (spec 05 §6)", () => {
+  it("no two assignments clash on a court (respecting the gap)", () => {
+    fc.assert(
+      fc.property(fixtureArb, fc.integer({ min: 1, max: 3 }), (raw, courtCount) => {
+        const fixtures = dedupeIds(raw);
+        const courts = Array.from({ length: courtCount }, (_, i) => `C${i}`);
+        const { assignments } = slotFixtures({ fixtures, config: baseConfig({ courts, gapMinutes: 5 }) });
+        for (let i = 0; i < assignments.length; i++) {
+          for (let j = i + 1; j < assignments.length; j++) {
+            const a = assignments[i] as Assignment;
+            const b = assignments[j] as Assignment;
+            if (a.court !== b.court) continue;
+            const clash = a.startAt < b.endAt + 5 * MIN && b.startAt < a.endAt + 5 * MIN;
+            expect(clash).toBe(false);
+          }
+        }
+      }),
+    );
+  });
+
+  it("every entrant's consecutive matches respect rest", () => {
+    fc.assert(
+      fc.property(fixtureArb, (raw) => {
+        const fixtures = dedupeIds(raw).filter((f) => f.home !== f.away);
+        const rest = 45;
+        const { assignments } = slotFixtures({
+          fixtures,
+          config: baseConfig({ courts: ["C0", "C1", "C2"], perEntrantMinRest: rest }),
+        });
+        const byEntrant = new Map<string, Assignment[]>();
+        for (const a of assignments) {
+          for (const e of a.entrants) (byEntrant.get(e) ?? byEntrant.set(e, []).get(e)!).push(a);
+        }
+        for (const list of byEntrant.values()) {
+          list.sort((x, y) => x.startAt - y.startAt);
+          for (let i = 1; i < list.length; i++) {
+            expect((list[i] as Assignment).startAt - (list[i - 1] as Assignment).endAt).toBeGreaterThanOrEqual(
+              rest * MIN,
+            );
+          }
+        }
+      }),
+    );
+  });
+
+  it("no assignment lands in a blackout window", () => {
+    fc.assert(
+      fc.property(fixtureArb, (raw) => {
+        const fixtures = dedupeIds(raw);
+        const blackouts = [{ from: 20 * MIN, to: 80 * MIN }];
+        const { assignments } = slotFixtures({
+          fixtures,
+          config: baseConfig({ courts: ["C0", "C1"], blackouts }),
+        });
+        for (const a of assignments) {
+          expect(a.startAt < 80 * MIN && 20 * MIN < a.endAt).toBe(false);
+        }
+      }),
+    );
+  });
+
+  it("never silently drops a fixture — each is assigned or conflicted", () => {
+    fc.assert(
+      fc.property(fixtureArb, (raw) => {
+        const fixtures = dedupeIds(raw);
+        const { assignments, conflicts } = slotFixtures({ fixtures, config: baseConfig({ courts: ["C0", "C1"] }) });
+        const assigned = new Set(assignments.map((a) => a.fixtureId));
+        const noSlot = new Set(conflicts.filter((c) => c.reason === "no_slot").map((c) => c.fixtureId));
+        for (const f of fixtures) expect(assigned.has(f.id) || noSlot.has(f.id)).toBe(true);
+      }),
+    );
+  });
+
+  it("is idempotent — identical inputs yield identical output", () => {
+    fc.assert(
+      fc.property(fixtureArb, (raw) => {
+        const fixtures = dedupeIds(raw);
+        const cfg = baseConfig({ courts: ["C0", "C1"], perEntrantMinRest: 30 });
+        expect(slotFixtures({ fixtures, config: cfg })).toEqual(slotFixtures({ fixtures, config: cfg }));
+      }),
+    );
+  });
+});
+
+// fast-check may repeat ids; the slotter keys on id, so keep them unique per case.
+function dedupeIds(raw: SchedulableFixture[]): SchedulableFixture[] {
+  return raw.map((f, i) => ({ ...f, id: `${f.id}-${i}` }));
+}

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -1,4 +1,262 @@
-// Time/venue slotting — pure constraint pass, spec 12 (scheduling UX). No
-// wall-clock reads; all times injected. Implemented in PROMPT-09/PROMPT-17.
+// Calendar slotting — spec 05 §2.6, doc 12 (scheduling UX). A pure constraint
+// pass mapping generated fixtures → (time, court): greedy round-order assignment
+// honouring court occupancy, per-entrant rest and blackout windows, reporting
+// every conflict rather than silently dropping a constraint. Cross-division
+// aware (doc 06 §4.3): it accepts sibling divisions' assignments as fixed court
+// occupancy and warns on per-person overlaps. No wall-clock reads — all times
+// are injected (the same unit throughout, e.g. epoch ms); durations are minutes.
+import type { EntrantId } from "../core/types.ts";
 
-export {};
+const MS_PER_MIN = 60_000;
+
+export interface Blackout {
+  court?: string; // court-scoped window; omit for a global blackout
+  from: number;
+  to: number; // exclusive
+}
+
+export interface SlotConfig {
+  startAt: number; // earliest slot (injected)
+  matchMinutes: number;
+  gapMinutes: number; // minimum gap between two matches on the same court
+  courts: string[]; // court/venue labels, tried in order
+  perEntrantMinRest: number; // minutes an entrant must rest between its matches
+  blackouts?: readonly Blackout[];
+  horizonMinutes?: number; // how far past startAt to search before reporting no_slot
+}
+
+export interface SchedulableFixture {
+  id: string;
+  roundNo?: number; // scheduled in ascending round order (feed dependencies respected)
+  home?: EntrantId; // may be a TBD feed (undefined) — then no rest/overlap checks apply
+  away?: EntrantId;
+  people?: readonly string[]; // person ids, for cross-division overlap (doc 06 §4.3)
+  locked?: { court: string; startAt: number }; // pinned assignment — honoured as-is
+}
+
+export interface Assignment {
+  fixtureId: string;
+  court: string;
+  startAt: number;
+  endAt: number;
+  entrants: EntrantId[];
+  people: string[];
+}
+
+export type ConflictReason =
+  | "no_slot" // no court/time within the horizon satisfies the hard constraints
+  | "court" // two matches share a court+time (blocks — physically impossible)
+  | "rest" // an entrant is below perEntrantMinRest (warn)
+  | "blackout" // inside a blackout window (warn)
+  | "person_overlap"; // a person plays in two overlapping matches (warn — doc 06 §4.3)
+
+export interface Conflict {
+  fixtureId: string;
+  reason: ConflictReason;
+  detail?: string;
+}
+
+export interface SlotInput {
+  fixtures: readonly SchedulableFixture[];
+  config: SlotConfig;
+  existing?: readonly Assignment[]; // sibling divisions' assignments (cross-division)
+}
+
+export interface SlotResult {
+  assignments: Assignment[];
+  conflicts: Conflict[];
+}
+
+const entrantsOf = (f: SchedulableFixture): EntrantId[] =>
+  [f.home, f.away].filter((e): e is EntrantId => e !== undefined);
+
+const overlaps = (aStart: number, aEnd: number, bStart: number, bEnd: number): boolean =>
+  aStart < bEnd && bStart < aEnd;
+
+// Does [start, start+dur) clash with a court booking (respecting `gap` on both
+// sides) or a blackout window on `court`?
+function courtBlocked(
+  court: string,
+  start: number,
+  durMs: number,
+  gapMs: number,
+  bookings: readonly Assignment[],
+  blackouts: readonly Blackout[],
+): "court" | "blackout" | null {
+  const end = start + durMs;
+  for (const b of bookings) {
+    if (b.court !== court) continue;
+    // Require a full gap between neighbouring matches on the same court.
+    if (overlaps(start, end + gapMs, b.startAt, b.endAt + gapMs)) return "court";
+  }
+  for (const bo of blackouts) {
+    if (bo.court !== undefined && bo.court !== court) continue;
+    if (overlaps(start, end, bo.from, bo.to)) return "blackout";
+  }
+  return null;
+}
+
+// Earliest start ≥ lowerBound on `court` that is neither court-blocked nor in a
+// blackout, or null if none exists before `horizon`. Candidate starts are the
+// lower bound plus the trailing edge of every booking/blackout that could push
+// the fixture later — the standard interval-gap scan.
+function earliestOnCourt(
+  court: string,
+  lowerBound: number,
+  durMs: number,
+  gapMs: number,
+  horizon: number,
+  bookings: readonly Assignment[],
+  blackouts: readonly Blackout[],
+): number | null {
+  const candidates = [lowerBound];
+  for (const b of bookings) if (b.court === court) candidates.push(b.endAt + gapMs);
+  for (const bo of blackouts) if (bo.court === undefined || bo.court === court) candidates.push(bo.to);
+  candidates.sort((a, b) => a - b);
+  for (const start of candidates) {
+    if (start < lowerBound || start > horizon) continue;
+    if (courtBlocked(court, start, durMs, gapMs, bookings, blackouts) === null) return start;
+  }
+  return null;
+}
+
+// Greedy auto-schedule. Fixtures are placed in (roundNo, id) order; locked
+// fixtures keep their pinned slot (and report a `court` clash if they collide);
+// the rest take the earliest feasible (court, time). Nothing is placed in
+// violation of a hard constraint — an unplaceable fixture is reported `no_slot`.
+export function slotFixtures(input: SlotInput): SlotResult {
+  const { config } = input;
+  const durMs = config.matchMinutes * MS_PER_MIN;
+  const gapMs = config.gapMinutes * MS_PER_MIN;
+  const restMs = config.perEntrantMinRest * MS_PER_MIN;
+  const horizon = config.startAt + (config.horizonMinutes ?? 365 * 24 * 60) * MS_PER_MIN;
+  const blackouts = config.blackouts ?? [];
+
+  const bookings: Assignment[] = [...(input.existing ?? [])]; // court occupancy (incl. siblings)
+  const placed: Assignment[] = [];
+  const conflicts: Conflict[] = [];
+  const lastEnd = new Map<EntrantId, number>(); // this division's per-entrant rest tracking
+
+  const ordered = [...input.fixtures].sort((a, b) => {
+    const ra = a.roundNo ?? 0;
+    const rb = b.roundNo ?? 0;
+    if (ra !== rb) return ra - rb;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+  const locked = ordered.filter((f) => f.locked !== undefined);
+  const free = ordered.filter((f) => f.locked === undefined);
+
+  const commit = (f: SchedulableFixture, court: string, start: number): Assignment => {
+    const ent = entrantsOf(f);
+    const assignment: Assignment = {
+      fixtureId: f.id,
+      court,
+      startAt: start,
+      endAt: start + durMs,
+      entrants: ent,
+      people: [...(f.people ?? [])],
+    };
+    bookings.push(assignment);
+    placed.push(assignment);
+    for (const e of ent) lastEnd.set(e, Math.max(lastEnd.get(e) ?? -Infinity, assignment.endAt));
+    // Per-person overlap against everything already on the board (warn only).
+    for (const person of assignment.people) {
+      for (const other of bookings) {
+        if (other === assignment) continue;
+        if (!other.people.includes(person)) continue;
+        if (overlaps(assignment.startAt, assignment.endAt, other.startAt, other.endAt)) {
+          conflicts.push({
+            fixtureId: f.id,
+            reason: "person_overlap",
+            detail: `person ${person} also in ${other.fixtureId}`,
+          });
+        }
+      }
+    }
+    return assignment;
+  };
+
+  // 1) Locked fixtures — honour the pin; report (don't fix) a court collision.
+  for (const f of locked) {
+    const lock = f.locked as { court: string; startAt: number };
+    const clash = courtBlocked(lock.court, lock.startAt, durMs, gapMs, bookings, blackouts);
+    if (clash !== null) {
+      conflicts.push({ fixtureId: f.id, reason: clash, detail: `locked slot clashes on ${lock.court}` });
+    }
+    commit(f, lock.court, lock.startAt);
+  }
+
+  // 2) Greedy placement of the rest.
+  for (const f of free) {
+    const ent = entrantsOf(f);
+    let ready = config.startAt;
+    for (const e of ent) ready = Math.max(ready, (lastEnd.get(e) ?? -Infinity) + restMs);
+
+    let best: { court: string; start: number } | null = null;
+    for (const court of config.courts) {
+      const start = earliestOnCourt(court, ready, durMs, gapMs, horizon, bookings, blackouts);
+      if (start === null) continue;
+      if (best === null || start < best.start) best = { court, start };
+    }
+
+    if (best === null) {
+      conflicts.push({ fixtureId: f.id, reason: "no_slot", detail: "no court/time within horizon" });
+      continue;
+    }
+    commit(f, best.court, best.start);
+  }
+
+  return { assignments: placed, conflicts };
+}
+
+// Full conflict report over a fixed board (the drag-and-drop validate pass, doc
+// 12 §2/§4): court double-bookings (block), rest and blackout violations, and
+// per-person overlaps (warn). Pure — the same inputs always give the same report.
+export function validateAssignments(
+  assignments: readonly Assignment[],
+  config: Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts">,
+  existing: readonly Assignment[] = [],
+): Conflict[] {
+  const restMs = config.perEntrantMinRest * MS_PER_MIN;
+  const gapMs = config.gapMinutes * MS_PER_MIN;
+  const blackouts = config.blackouts ?? [];
+  const conflicts: Conflict[] = [];
+  const board = [...existing, ...assignments];
+
+  for (const a of assignments) {
+    // Court clash / blackout — check against everything else on the board.
+    const others = board.filter((o) => o !== a);
+    if (courtBlocked(a.court, a.startAt, a.endAt - a.startAt, gapMs, others, blackouts) === "court") {
+      conflicts.push({ fixtureId: a.fixtureId, reason: "court", detail: `court ${a.court} double-booked` });
+    }
+    for (const bo of blackouts) {
+      if (bo.court !== undefined && bo.court !== a.court) continue;
+      if (overlaps(a.startAt, a.endAt, bo.from, bo.to)) {
+        conflicts.push({ fixtureId: a.fixtureId, reason: "blackout", detail: "inside a blackout window" });
+        break;
+      }
+    }
+    // Rest & person overlap — against other matches sharing an entrant/person.
+    for (const other of board) {
+      if (other === a) continue;
+      for (const e of a.entrants) {
+        if (!other.entrants.includes(e)) continue;
+        if (overlaps(a.startAt, a.endAt, other.startAt, other.endAt)) {
+          conflicts.push({ fixtureId: a.fixtureId, reason: "person_overlap", detail: `entrant ${e} overlap` });
+        } else {
+          const gap = a.startAt >= other.endAt ? a.startAt - other.endAt : other.startAt - a.endAt;
+          if (gap < restMs) {
+            conflicts.push({ fixtureId: a.fixtureId, reason: "rest", detail: `entrant ${e} below rest` });
+          }
+        }
+      }
+      for (const p of a.people) {
+        if (!other.people.includes(p)) continue;
+        if (overlaps(a.startAt, a.endAt, other.startAt, other.endAt)) {
+          conflicts.push({ fixtureId: a.fixtureId, reason: "person_overlap", detail: `person ${p} overlap` });
+        }
+      }
+    }
+  }
+  return conflicts;
+}

--- a/packages/engine/src/scheduling/roundrobin.test.ts
+++ b/packages/engine/src/scheduling/roundrobin.test.ts
@@ -1,0 +1,158 @@
+// Round-robin generation — spec 05 §2.1, invariants §6.
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import {
+  generateRoundRobin,
+  roundRobinFixtureCount,
+  type RoundRobinSchedule,
+} from "./roundrobin.ts";
+
+const field = (n: number): string[] => Array.from({ length: n }, (_, i) => `e${i}`);
+const pairKey = (a: string, b: string): string => (a < b ? `${a}|${b}` : `${b}|${a}`);
+
+describe("generateRoundRobin — golden 6-team circle method (spec 05 §2.1)", () => {
+  // The textbook circle-method schedule (fix team 1, rotate the rest): the
+  // canonical published 6-team single round robin. Pair sets per round:
+  const PUBLISHED: string[][] = [
+    ["1|6", "2|5", "3|4"],
+    ["1|5", "4|6", "2|3"],
+    ["1|4", "3|5", "2|6"],
+    ["1|3", "2|4", "5|6"],
+    ["1|2", "3|6", "4|5"],
+  ];
+  const schedule = generateRoundRobin({ entrants: ["1", "2", "3", "4", "5", "6"], config: { legs: 2 } });
+
+  const roundPairs = (roundNo: number): Set<string> =>
+    new Set(
+      (schedule.rounds.find((r) => r.roundNo === roundNo)?.fixtures ?? []).map((f) =>
+        pairKey(f.home, f.away),
+      ),
+    );
+
+  it("leg 1 rounds match the published circle-method table", () => {
+    for (let r = 1; r <= 5; r++) {
+      expect(roundPairs(r)).toEqual(new Set(PUBLISHED[r - 1]));
+    }
+  });
+
+  it("leg 2 mirrors leg 1 (same pairings, home/away swapped)", () => {
+    for (let r = 1; r <= 5; r++) {
+      expect(roundPairs(r + 5)).toEqual(new Set(PUBLISHED[r - 1]));
+    }
+    // Each leg-1 fixture has an away/home-swapped twin in leg 2.
+    const leg1 = schedule.fixtures.filter((f) => f.leg === 1).map((f) => `${f.home}>${f.away}`);
+    const leg2Swapped = schedule.fixtures.filter((f) => f.leg === 2).map((f) => `${f.away}>${f.home}`);
+    expect(new Set(leg1)).toEqual(new Set(leg2Swapped));
+  });
+
+  it("double round robin has n(n−1)/2·legs = 30 fixtures", () => {
+    expect(schedule.fixtures).toHaveLength(30);
+    expect(schedule.fixtures).toHaveLength(roundRobinFixtureCount(6, 2));
+  });
+
+  it("board assignment rotates — the pivot's game is not always court 1", () => {
+    const pivotCourts = new Set(
+      schedule.fixtures.filter((f) => f.home === "1" || f.away === "1").map((f) => f.court),
+    );
+    expect(pivotCourts.size).toBeGreaterThan(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Property suites — spec 05 §6 (fast-check, n up to 64)
+// ---------------------------------------------------------------------------
+
+// Every entrant appears exactly once per round (playing or on the bye).
+function eachEntrantOncePerRound(schedule: RoundRobinSchedule, entrants: string[]): void {
+  for (const round of schedule.rounds) {
+    const seen = new Set<string>();
+    for (const f of round.fixtures) {
+      expect(seen.has(f.home)).toBe(false);
+      expect(seen.has(f.away)).toBe(false);
+      seen.add(f.home);
+      seen.add(f.away);
+    }
+    if (round.bye !== undefined) {
+      expect(seen.has(round.bye)).toBe(false);
+      seen.add(round.bye);
+    }
+    expect(seen).toEqual(new Set(entrants));
+  }
+}
+
+describe("generateRoundRobin — invariants (spec 05 §6)", () => {
+  const nArb = fc.integer({ min: 2, max: 64 });
+  const legsArb = fc.constantFrom<1 | 2>(1, 2);
+
+  it("completeness: fixture count is n(n−1)/2·legs", () => {
+    fc.assert(
+      fc.property(nArb, legsArb, (n, legs) => {
+        const schedule = generateRoundRobin({ entrants: field(n), config: { legs } });
+        expect(schedule.fixtures).toHaveLength(roundRobinFixtureCount(n, legs));
+      }),
+    );
+  });
+
+  it("uniqueness: every pair meets exactly once per leg, ≤1 fixture per entrant per round", () => {
+    fc.assert(
+      fc.property(nArb, legsArb, (n, legs) => {
+        const schedule = generateRoundRobin({ entrants: field(n), config: { legs } });
+        eachEntrantOncePerRound(schedule, field(n));
+        for (let leg = 1; leg <= legs; leg++) {
+          const counts = new Map<string, number>();
+          for (const f of schedule.fixtures.filter((x) => x.leg === leg)) {
+            const key = pairKey(f.home, f.away);
+            counts.set(key, (counts.get(key) ?? 0) + 1);
+          }
+          // n(n−1)/2 distinct pairs, each once.
+          expect(counts.size).toBe((n * (n - 1)) / 2);
+          for (const c of counts.values()) expect(c).toBe(1);
+        }
+      }),
+    );
+  });
+
+  it("home/away balance: |home−away| ≤ 1 per entrant per leg", () => {
+    fc.assert(
+      fc.property(nArb, legsArb, (n, legs) => {
+        const schedule = generateRoundRobin({ entrants: field(n), config: { legs } });
+        for (let leg = 1; leg <= legs; leg++) {
+          const home = new Map<string, number>();
+          const away = new Map<string, number>();
+          for (const f of schedule.fixtures.filter((x) => x.leg === leg)) {
+            home.set(f.home, (home.get(f.home) ?? 0) + 1);
+            away.set(f.away, (away.get(f.away) ?? 0) + 1);
+          }
+          for (const id of field(n)) {
+            expect(Math.abs((home.get(id) ?? 0) - (away.get(id) ?? 0))).toBeLessThanOrEqual(1);
+          }
+        }
+      }),
+    );
+  });
+
+  it("idempotence: regeneration is byte-identical (spec 05 §6)", () => {
+    fc.assert(
+      fc.property(nArb, legsArb, fc.integer(), (n, legs, rngSeed) => {
+        const a = generateRoundRobin({ entrants: field(n), config: { legs }, rngSeed });
+        const b = generateRoundRobin({ entrants: field(n), config: { legs }, rngSeed });
+        expect(a).toEqual(b);
+      }),
+    );
+  });
+
+  it("odd fields: exactly one bye per round, each entrant byes (n−1)/… times evenly", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 3, max: 63 }).filter((n) => n % 2 === 1), (n) => {
+        const schedule = generateRoundRobin({ entrants: field(n) });
+        const byeCounts = new Map<string, number>();
+        for (const round of schedule.rounds) {
+          expect(round.bye).toBeDefined();
+          byeCounts.set(round.bye as string, (byeCounts.get(round.bye as string) ?? 0) + 1);
+        }
+        // Over a full single RR each entrant sits out exactly once.
+        for (const id of field(n)) expect(byeCounts.get(id)).toBe(1);
+      }),
+    );
+  });
+});

--- a/packages/engine/src/scheduling/roundrobin.ts
+++ b/packages/engine/src/scheduling/roundrobin.ts
@@ -1,5 +1,162 @@
-// Circle-method round robin — spec 03 §1, spec 05 (formats). Deterministic
-// given (entrants, seeds, config, rng seed); completeness n(n−1)/2·legs is a
-// testkit invariant. Implemented in PROMPT-09.
+// Circle-method round robin — spec 05 §2.1. Deterministic given
+// (entrants, seeds, config, rngSeed); regeneration is byte-identical (spec 05
+// §6 idempotence). Zero effectful deps: no wall clock, no Math.random.
+//
+// Construction (provably balanced "two-row" circle method):
+//   Lay the padded field in two rows of n/2. Column i pairs top-row i with
+//   bottom-row i; the top player is home, bottom away. One player is the pivot
+//   (top-left, column 0) and stays put; every other slot rotates by one each
+//   round, so over n−1 rounds each pair meets exactly once. The pivot's own
+//   game flips home/away by round parity — which keeps |home−away| ≤ 1 for
+//   *every* entrant (proof: each rotating entrant visits all n−1 non-pivot
+//   slots once; n/2−1 are fixed-home, n/2−1 fixed-away, and the single column-0
+//   slot flips, so the count is (n/2−1) ± 1 either way).
+//   Odd field ⇒ the pivot is the BYE, so column 0 is always the bye pairing and
+//   every real game is a fixed-orientation column — real entrants come out with
+//   |home−away| = 0.
+import type { EntrantId } from "../core/types.ts";
 
-export {};
+// legs=2 mirrors leg 1 (same pairings, home/away swapped). Board indices are
+// assigned 1..(games per round) and rotated so the pivot never monopolises
+// board 1; physical court packing is calendar.ts's job (spec 05 §2.6).
+export interface RoundRobinConfig {
+  legs?: 1 | 2;
+}
+
+export interface RoundRobinOptions {
+  entrants: readonly EntrantId[];
+  // Pairing order: entrants sorted by seed ascending (1 = top) when supplied,
+  // else input order. The top of the order is the pivot for even fields.
+  seeds?: ReadonlyMap<EntrantId, number>;
+  config?: RoundRobinConfig;
+  // Accepted for a uniform generator signature (spec 05 §2.6 item 5); the
+  // circle method is fully determined by seed order, so it is not consulted.
+  rngSeed?: number;
+}
+
+export interface RoundRobinFixture {
+  id: string; // `rr-r{roundNo}-c{court}` — stable across regeneration
+  roundNo: number; // 1-based, continuous across legs
+  leg: number; // 1-based
+  court: number; // 1-based board index within the round (rotated)
+  home: EntrantId;
+  away: EntrantId;
+}
+
+export interface RoundRobinRound {
+  roundNo: number;
+  leg: number;
+  fixtures: RoundRobinFixture[];
+  bye?: EntrantId; // the entrant sitting out (odd field only)
+}
+
+export interface RoundRobinSchedule {
+  rounds: RoundRobinRound[];
+  fixtures: RoundRobinFixture[]; // flat, round-then-court order
+}
+
+// Entrants in pairing order: by seed asc when a seed map is present (ties and
+// unseeded entrants fall back to input order, stably), else input order.
+export function seedOrder(
+  entrants: readonly EntrantId[],
+  seeds?: ReadonlyMap<EntrantId, number>,
+): EntrantId[] {
+  const order = [...entrants];
+  if (seeds === undefined) return order;
+  const index = new Map(order.map((id, i) => [id, i]));
+  return order.sort((a, b) => {
+    const sa = seeds.get(a) ?? Number.MAX_SAFE_INTEGER;
+    const sb = seeds.get(b) ?? Number.MAX_SAFE_INTEGER;
+    if (sa !== sb) return sa - sb;
+    return (index.get(a) as number) - (index.get(b) as number);
+  });
+}
+
+// Rotate `arr` forward by `by` (element at i moves to i+by, wrapping).
+function rotate<T>(arr: readonly T[], by: number): T[] {
+  const n = arr.length;
+  if (n === 0) return [];
+  const k = ((by % n) + n) % n;
+  return arr.map((_, i) => arr[(i - k + n) % n] as T);
+}
+
+export function generateRoundRobin(opts: RoundRobinOptions): RoundRobinSchedule {
+  const real = seedOrder(opts.entrants, opts.seeds);
+  const legs = opts.config?.legs ?? 1;
+  const rounds: RoundRobinRound[] = [];
+  const flat: RoundRobinFixture[] = [];
+  if (real.length < 2) return { rounds, fixtures: flat };
+
+  const odd = real.length % 2 === 1;
+  // Pivot = BYE (null) when odd so column 0 is always the bye; else the top seed.
+  const players: (EntrantId | null)[] = odd ? [null, ...real] : [...real];
+  const n = players.length; // even
+  const half = n / 2;
+  const roundsPerLeg = n - 1;
+  const pivot = players[0] as EntrantId | null; // null iff odd
+  const u0 = players.slice(1); // the n−1 rotating slots
+
+  for (let leg = 1; leg <= legs; leg++) {
+    for (let r = 0; r < roundsPerLeg; r++) {
+      const roundNo = (leg - 1) * roundsPerLeg + r + 1;
+      const u = rotate(u0, r);
+      const fixtures: RoundRobinFixture[] = [];
+      let bye: EntrantId | undefined;
+
+      // Assemble this round's columns as (top, bottom) pairs. Column 0 involves
+      // the pivot; columns 1..half-1 are U-vs-U.
+      const columns: { top: EntrantId | null; bottom: EntrantId | null; isPivot: boolean }[] = [];
+      columns.push({ top: pivot, bottom: (u[n - 2] ?? null) as EntrantId | null, isPivot: true });
+      for (let i = 1; i < half; i++) {
+        columns.push({
+          top: (u[i - 1] ?? null) as EntrantId | null,
+          bottom: (u[n - 2 - i] ?? null) as EntrantId | null,
+          isPivot: false,
+        });
+      }
+
+      // Court rotation: number the real games and offset by the round so the
+      // pivot's game does not always land on board 1.
+      const k = columns.filter((c) => c.top !== null && c.bottom !== null).length;
+      let realSeen = 0;
+
+      for (const col of columns) {
+        if (col.top === null || col.bottom === null) {
+          // The bye pairing: the non-null side sits out this round.
+          bye = (col.top ?? col.bottom) ?? undefined;
+          continue;
+        }
+        // top = home, bottom = away — except the pivot column, which flips by
+        // round parity. Leg 2 mirrors: swap every fixture's home/away.
+        let home = col.top;
+        let away = col.bottom;
+        if (col.isPivot && r % 2 === 1) [home, away] = [away, home];
+        if (leg === 2) [home, away] = [away, home];
+        const court = ((realSeen + r) % k) + 1;
+        realSeen++;
+        const fixture: RoundRobinFixture = {
+          id: `rr-r${roundNo}-c${court}`,
+          roundNo,
+          leg,
+          court,
+          home,
+          away,
+        };
+        fixtures.push(fixture);
+        flat.push(fixture);
+      }
+
+      fixtures.sort((a, b) => a.court - b.court);
+      rounds.push({ roundNo, leg, fixtures, ...(bye === undefined ? {} : { bye }) });
+    }
+  }
+
+  return { rounds, fixtures: flat };
+}
+
+// Total fixture count for a field of `n` real entrants over `legs` — the
+// completeness target n(n−1)/2·legs (spec 05 §2.1).
+export function roundRobinFixtureCount(n: number, legs: 1 | 2 = 1): number {
+  if (n < 2) return 0;
+  return ((n * (n - 1)) / 2) * legs;
+}

--- a/packages/engine/src/scheduling/swiss.test.ts
+++ b/packages/engine/src/scheduling/swiss.test.ts
@@ -1,0 +1,238 @@
+// Swiss pairing — spec 05 §2.2, invariants §6.
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import {
+  pairKey,
+  pairRound,
+  type Colour,
+  type SwissHistory,
+  type SwissStanding,
+} from "./swiss.ts";
+
+const field = (n: number): string[] => Array.from({ length: n }, (_, i) => `p${i}`);
+
+// A tiny seeded PRNG so simulated results are reproducible but realistic.
+function prng(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Simulate a Swiss event: `rank[i] = i+1` (p0 strongest). Results favour the
+// stronger side but allow upsets (~30%) — like a real field, this keeps colour
+// history from perfectly stratifying by score. Returns the per-round pairings
+// plus the accumulated history — enough to assert every invariant.
+interface SimRound {
+  pairings: { home: string; away: string }[];
+  bye?: string;
+}
+function simulate(
+  n: number,
+  rounds: number,
+  opts: { chess?: boolean; seed?: number } = {},
+): { rounds: SimRound[]; colours: Map<string, Colour[]>; played: Set<string>; byes: Set<string> } {
+  const ids = field(n);
+  const rank = new Map(ids.map((id, i) => [id, i + 1]));
+  const score = new Map(ids.map((id) => [id, 0]));
+  const colours = new Map<string, Colour[]>();
+  const played = new Set<string>();
+  const byes = new Set<string>();
+  const out: SimRound[] = [];
+  const rng = prng(opts.seed ?? 1);
+  const pushColour = (id: string, c: Colour): void => {
+    const seq = colours.get(id) ?? [];
+    seq.push(c);
+    colours.set(id, seq);
+  };
+
+  for (let r = 0; r < rounds; r++) {
+    const standings: SwissStanding[] = ids.map((id) => ({
+      entrantId: id,
+      score: score.get(id) as number,
+      rank: rank.get(id) as number,
+    }));
+    const history: SwissHistory = { played, colours, byes };
+    const round = pairRound(standings, history, { chess: opts.chess === true, byeScore: 1 });
+
+    for (const p of round.pairings) {
+      played.add(pairKey(p.home, p.away));
+      if (opts.chess === true) {
+        pushColour(p.home, "W");
+        pushColour(p.away, "B");
+      }
+      // Stronger side usually wins; 30% upset keeps colours decorrelated from score.
+      const strong = (rank.get(p.home) as number) < (rank.get(p.away) as number) ? p.home : p.away;
+      const weak = strong === p.home ? p.away : p.home;
+      const winner = rng() < 0.7 ? strong : weak;
+      score.set(winner, (score.get(winner) as number) + 1);
+    }
+    if (round.bye !== undefined) {
+      byes.add(round.bye);
+      score.set(round.bye, (score.get(round.bye) as number) + 1);
+    }
+    out.push({ pairings: round.pairings, ...(round.bye === undefined ? {} : { bye: round.bye }) });
+  }
+  return { rounds: out, colours, played, byes };
+}
+
+describe("pairRound — golden 5-round Swiss on 9 entrants (spec 05 acceptance)", () => {
+  const sim = simulate(9, 5, { seed: 7 });
+
+  it("pairs every round with exactly one bye (odd field)", () => {
+    expect(sim.rounds).toHaveLength(5);
+    for (const round of sim.rounds) {
+      expect(round.pairings).toHaveLength(4);
+      expect(round.bye).toBeDefined();
+    }
+  });
+
+  it("gives a distinct bye each round (lowest-ranked not-yet-byed)", () => {
+    const byes = sim.rounds.map((r) => r.bye);
+    expect(new Set(byes).size).toBe(5);
+  });
+
+  it("has zero rematches across the whole event", () => {
+    const seen = new Set<string>();
+    for (const round of sim.rounds) {
+      for (const p of round.pairings) {
+        const key = pairKey(p.home, p.away);
+        expect(seen.has(key)).toBe(false);
+        seen.add(key);
+      }
+    }
+  });
+});
+
+describe("pairRound — bye selection (spec 05 §2.2)", () => {
+  it("byes the lowest-ranked entrant not yet byed", () => {
+    const standings: SwissStanding[] = field(5).map((id, i) => ({ entrantId: id, score: 0, rank: i + 1 }));
+    // p4 already byed ⇒ next-lowest un-byed is p3.
+    const round = pairRound(standings, { played: new Set(), byes: new Set(["p4"]) });
+    expect(round.bye).toBe("p3");
+    expect(round.pairings).toHaveLength(2);
+  });
+
+  it("round 1 on an even field pairs the upper board as White (chess)", () => {
+    const standings: SwissStanding[] = field(4).map((id, i) => ({ entrantId: id, score: 0, rank: i + 1 }));
+    const round = pairRound(standings, { played: new Set() }, { chess: true });
+    // Fold 1v3, 2v4; the stronger side of each pair takes White (home).
+    expect(round.bye).toBeUndefined();
+    expect(round.pairings).toHaveLength(2);
+    for (const p of round.pairings) {
+      expect(Number(p.home.slice(1))).toBeLessThan(Number(p.away.slice(1)));
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Properties — spec 05 §6
+// ---------------------------------------------------------------------------
+
+// Brute-force: does a rematch-free perfect matching of `pool` exist given the
+// forbidden `played` pairs? (spec 05 §2.2 verify-via-brute-force, n ≤ 10.)
+function perfectMatchingExists(pool: string[], played: ReadonlySet<string>): boolean {
+  if (pool.length === 0) return true;
+  const [a, ...rest] = pool as [string, ...string[]];
+  for (let i = 0; i < rest.length; i++) {
+    const b = rest[i] as string;
+    if (played.has(pairKey(a, b))) continue;
+    const remaining = rest.filter((_, j) => j !== i);
+    if (perfectMatchingExists(remaining, played)) return true;
+  }
+  return false;
+}
+
+describe("pairRound — invariants (spec 05 §6)", () => {
+  it("no rematch ever, across a simulated tournament (n up to 64)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 2, max: 64 }),
+        fc.integer({ min: 1, max: 6 }),
+        fc.integer(),
+        (n, rounds, seed) => {
+          const sim = simulate(n, rounds, { seed });
+          const seen = new Set<string>();
+          for (const round of sim.rounds) {
+            for (const p of round.pairings) {
+              const key = pairKey(p.home, p.away);
+              expect(seen.has(key)).toBe(false);
+              seen.add(key);
+            }
+          }
+        },
+      ),
+    );
+  });
+
+  it("chess colour bounds hold: |W−B| ≤ 2 and never 3 in a row (n up to 64)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 2, max: 64 }),
+        fc.integer({ min: 1, max: 7 }),
+        fc.integer(),
+        (n, rounds, seed) => {
+          const sim = simulate(n, rounds, { chess: true, seed });
+          for (const [, seq] of sim.colours) {
+            const w = seq.filter((c) => c === "W").length;
+            const b = seq.length - w;
+            expect(Math.abs(w - b)).toBeLessThanOrEqual(2);
+            for (let i = 2; i < seq.length; i++) {
+              expect(seq[i] === seq[i - 1] && seq[i - 1] === seq[i - 2]).toBe(false);
+            }
+          }
+        },
+      ),
+    );
+  });
+
+  it("finds a total pairing whenever a rematch-free matching exists (brute force, n ≤ 10)", () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 5 }).map((k) => 2 * k), // even n ∈ {2,4,6,8,10}
+        fc.integer(), // seed for the random `played` history
+        (n, seed) => {
+          const ids = field(n);
+          // Build a random forbidden-pair set deterministically from `seed`.
+          const played = new Set<string>();
+          let x = seed >>> 0;
+          for (let i = 0; i < n; i++) {
+            for (let j = i + 1; j < n; j++) {
+              x = (Math.imul(x, 1664525) + 1013904223) >>> 0;
+              if (x % 3 === 0) played.add(pairKey(ids[i] as string, ids[j] as string));
+            }
+          }
+          const standings: SwissStanding[] = ids.map((id, i) => ({ entrantId: id, score: 0, rank: i + 1 }));
+          const round = pairRound(standings, { played });
+          const exists = perfectMatchingExists(ids, played);
+          if (exists) {
+            expect(round.pairings).toHaveLength(n / 2);
+            // and it must respect the no-rematch constraint
+            for (const p of round.pairings) expect(played.has(pairKey(p.home, p.away))).toBe(false);
+          } else {
+            expect(round.pairings).toHaveLength(0);
+          }
+        },
+      ),
+    );
+  });
+
+  it("is deterministic — identical inputs yield identical pairings", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 2, max: 32 }), (n) => {
+        const standings: SwissStanding[] = field(n).map((id, i) => ({
+          entrantId: id,
+          score: i % 3,
+          rank: i + 1,
+        }));
+        const a = pairRound(standings, { played: new Set() }, { chess: true });
+        const b = pairRound(standings, { played: new Set() }, { chess: true });
+        expect(a).toEqual(b);
+      }),
+    );
+  });
+});

--- a/packages/engine/src/scheduling/swiss.ts
+++ b/packages/engine/src/scheduling/swiss.ts
@@ -1,4 +1,324 @@
-// Swiss score-group pairing — spec 05. No-rematch + colour balance within FIDE
-// bounds are testkit invariants (spec 03 §6). Implemented in PROMPT-09.
+// Swiss pairing — spec 05 §2.2. Chess-correct, sport-generic, behind the
+// `pairRound(standings, history, constraints)` interface so the algorithm can be
+// swapped without touching callers (full FIDE Dutch via weighted matching is a
+// later refinement — the spec explicitly defers it).
+//
+// Implementation: order by score group then pairing rank, fold top-vs-bottom,
+// and resolve violations by a COMPLETE backtracking matching that prefers the
+// fold but explores every transposition. Completeness is what makes the "a
+// total pairing exists whenever a perfect matching exists" property hold — the
+// search only fails when no rematch-free (and, for chess, colour-legal) perfect
+// matching exists at all. Determinism: candidate order is fixed (fold distance,
+// then global rank order), so the same inputs always yield the same pairing.
+import type { EntrantId } from "../core/types.ts";
 
-export {};
+export type Colour = "W" | "B";
+
+// One entrant's row as the pairer sees it: current Swiss score and pairing rank
+// (rating/seed; lower = stronger). Everything else (metrics, tiebreaks) is
+// irrelevant to pairing and stays out.
+export interface SwissStanding {
+  entrantId: EntrantId;
+  score: number;
+  rank: number;
+}
+
+export interface SwissHistory {
+  played: ReadonlySet<string>; // pairKey(a,b) of every fixture already contested — no rematch (hard)
+  colours?: ReadonlyMap<EntrantId, readonly Colour[]>; // colour sequence per entrant (chess)
+  byes?: ReadonlySet<EntrantId>; // entrants who already had a bye
+  floats?: ReadonlyMap<EntrantId, number>; // downfloat count (avoid repeat floats — soft)
+}
+
+export interface SwissConstraints {
+  chess?: boolean; // enforce colour rules and read home/away as White/Black
+  byeScore?: number; // documented for the caller; pairRound only names the bye entrant
+}
+
+export interface SwissPairing {
+  home: EntrantId; // chess: White
+  away: EntrantId; // chess: Black
+}
+
+export interface SwissRound {
+  pairings: SwissPairing[];
+  bye?: EntrantId; // odd field: the entrant sitting out (caller scores it `byeScore`)
+  floated: EntrantId[]; // entrants that downfloated this round (merge into history.floats)
+}
+
+// Stable, order-independent key for an unordered pair.
+export function pairKey(a: EntrantId, b: EntrantId): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+const opposite = (c: Colour): Colour => (c === "W" ? "B" : "W");
+
+interface ColourState {
+  diff: number; // white − black
+  streakColour: Colour | null;
+  streakLen: number;
+}
+
+function colourState(seq: readonly Colour[] | undefined): ColourState {
+  if (seq === undefined || seq.length === 0) return { diff: 0, streakColour: null, streakLen: 0 };
+  let w = 0;
+  let b = 0;
+  for (const c of seq) c === "W" ? w++ : b++;
+  const streakColour = seq[seq.length - 1] as Colour;
+  let streakLen = 1;
+  for (let i = seq.length - 2; i >= 0; i--) {
+    if (seq[i] === streakColour) streakLen++;
+    else break;
+  }
+  return { diff: w - b, streakColour, streakLen };
+}
+
+// The two hard colour rules (spec 05 §2.2): |W−B| ≤ 2 after the round, and never
+// three consecutive same colours.
+function canTake(state: ColourState, c: Colour): boolean {
+  if (c === "W" ? state.diff + 1 > 2 : state.diff - 1 < -2) return false;
+  if (state.streakColour === c && state.streakLen >= 2) return false;
+  return true;
+}
+
+// Preferred colour to keep the balance level: the minority colour, or the
+// alternation of the last one when balanced. `null` = no preference (round 1).
+function preferredColour(state: ColourState): Colour | null {
+  if (state.diff > 0) return "B";
+  if (state.diff < 0) return "W";
+  if (state.streakColour !== null) return opposite(state.streakColour);
+  return null;
+}
+
+// Order (score desc, rank asc, id asc) — the pairing order all groups derive from.
+function pairingOrder(standings: readonly SwissStanding[]): SwissStanding[] {
+  return [...standings].sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    if (a.rank !== b.rank) return a.rank - b.rank;
+    return a.entrantId < b.entrantId ? -1 : a.entrantId > b.entrantId ? 1 : 0;
+  });
+}
+
+// Split an already-ordered pool into score groups (runs of equal score, desc).
+function groupByScore(pool: readonly SwissStanding[]): SwissStanding[][] {
+  const groups: SwissStanding[][] = [];
+  for (const s of pool) {
+    const last = groups[groups.length - 1];
+    if (last === undefined || (last[0] as SwissStanding).score !== s.score) groups.push([s]);
+    else last.push(s);
+  }
+  return groups;
+}
+
+// Combinations of `k` items from `items`, yielded in `items` order (so the
+// caller's preference ordering carries through).
+function* combinations<T>(items: readonly T[], k: number): Generator<T[]> {
+  if (k === 0) {
+    yield [];
+    return;
+  }
+  for (let i = 0; i <= items.length - k; i++) {
+    const head = items[i] as T;
+    for (const tail of combinations(items.slice(i + 1), k - 1)) yield [head, tail].flat() as T[];
+  }
+}
+
+// Which `fc` entrants of `current` to float down. Prefer the least-floated, then
+// the lowest-ranked (bottom of the group) — "avoid repeat floats" (spec 05
+// §2.2). Only the bottom window is considered, which bounds the combinations.
+function floaterChoices(
+  current: readonly SwissStanding[],
+  fc: number,
+  floatCountOf: (id: EntrantId) => number,
+): SwissStanding[][] {
+  if (fc === 0) return [[]];
+  const windowSize = Math.min(current.length, Math.max(fc + 3, 4));
+  const window = current.slice(current.length - windowSize);
+  const ordered = [...window].sort((a, b) => {
+    const fa = floatCountOf(a.entrantId);
+    const fb = floatCountOf(b.entrantId);
+    if (fa !== fb) return fa - fb; // least-floated first
+    return current.indexOf(b) - current.indexOf(a); // bottom (lowest-ranked) first
+  });
+  return [...combinations(ordered, fc)];
+}
+
+export function pairRound(
+  standings: readonly SwissStanding[],
+  history: SwissHistory,
+  constraints: SwissConstraints = {},
+): SwissRound {
+  const chess = constraints.chess === true;
+  const stateOf = (id: EntrantId): ColourState => colourState(history.colours?.get(id));
+
+  const ordered = pairingOrder(standings);
+
+  // Bye first (odd field): the lowest-ranked entrant not yet byed (bottom up),
+  // else the absolute lowest if everyone has had one.
+  let bye: EntrantId | undefined;
+  let pool = ordered;
+  if (ordered.length % 2 === 1) {
+    const byed = history.byes ?? new Set<EntrantId>();
+    let pick = ordered[ordered.length - 1] as SwissStanding;
+    for (let i = ordered.length - 1; i >= 0; i--) {
+      const cand = ordered[i] as SwissStanding;
+      if (!byed.has(cand.entrantId)) {
+        pick = cand;
+        break;
+      }
+    }
+    bye = pick.entrantId;
+    pool = ordered.filter((s) => s.entrantId !== bye);
+  }
+
+  const played = history.played;
+  const colourLegal = (a: SwissStanding, b: SwissStanding): boolean => {
+    if (!chess) return true;
+    const sa = stateOf(a.entrantId);
+    const sb = stateOf(b.entrantId);
+    return (canTake(sa, "W") && canTake(sb, "B")) || (canTake(sa, "B") && canTake(sb, "W"));
+  };
+  const hardLegal = (a: SwissStanding, b: SwissStanding): boolean =>
+    !played.has(pairKey(a.entrantId, b.entrantId)) && colourLegal(a, b);
+
+  // Fold-preference candidate order for the strongest unpaired player `a`: its
+  // own score group first (fold partner = top of that group's bottom half),
+  // then nearest groups (minimal float), then rank order.
+  const orderCandidates = (a: SwissStanding, others: SwissStanding[]): SwissStanding[] => {
+    const sameScore = others.filter((o) => o.score === a.score);
+    const foldIdx = Math.floor(sameScore.length / 2);
+    const globalIdx = new Map(others.map((o, i) => [o.entrantId, i]));
+    return [...others].sort((x, y) => {
+      const sx = x.score === a.score;
+      const sy = y.score === a.score;
+      if (sx !== sy) return sx ? -1 : 1;
+      if (sx && sy) {
+        const dx = Math.abs(sameScore.indexOf(x) - foldIdx);
+        const dy = Math.abs(sameScore.indexOf(y) - foldIdx);
+        if (dx !== dy) return dx - dy;
+      } else {
+        const gx = Math.abs(a.score - x.score);
+        const gy = Math.abs(a.score - y.score);
+        if (gx !== gy) return gx - gy;
+      }
+      return (globalIdx.get(x.entrantId) as number) - (globalIdx.get(y.entrantId) as number);
+    });
+  };
+
+  // Complete backtracking matching of one (small) list, fold-preferred. Every
+  // candidate is tried before giving up, so within a group it finds a matching
+  // iff one exists — this is what gives the totality property (a single score
+  // group ⇒ this searches the whole field). Backtracking is confined to the
+  // group, keeping it polynomial across many groups (spec 05 §2.2: "backtracking
+  // over transpositions within score groups is sufficient"). `memoFail` prunes
+  // dead subsets within the call.
+  // Shared search budget across the whole round: hard colour limits can make a
+  // pathological field's infeasibility proof exponential, so we cap total work.
+  // The cap is far above any feasible small case (a single group of ≤14 explores
+  // < 2^14 nodes), so it never truncates a case the totality property covers; it
+  // only bails on degenerate large fields, where the group then floats instead.
+  let nodes = 0;
+  const BUDGET = 200_000;
+  const matchWithin = (list: SwissStanding[]): [SwissStanding, SwissStanding][] | null => {
+    const memoFail = new Set<string>();
+    const rec = (remaining: SwissStanding[]): [SwissStanding, SwissStanding][] | null => {
+      if (remaining.length === 0) return [];
+      if (++nodes > BUDGET) return null;
+      const key = remaining.map((s) => s.entrantId).join(",");
+      if (memoFail.has(key)) return null;
+      const a = remaining[0] as SwissStanding;
+      const others = remaining.slice(1);
+      for (const b of orderCandidates(a, others)) {
+        if (!hardLegal(a, b)) continue;
+        const rest = others.filter((o) => o.entrantId !== b.entrantId);
+        const sub = rec(rest);
+        if (sub !== null) return [[a, b], ...sub];
+      }
+      memoFail.add(key);
+      return null;
+    };
+    return rec(list);
+  };
+
+  // Score-group pairing top-down. Each group is paired internally (with the
+  // carried downfloaters from stronger groups sitting on top); whoever can't be
+  // paired here floats to the next group. Fewest floaters first, and among equal
+  // counts the lowest-ranked / least-recently-floated go down (spec 05 §2.2
+  // float tracking). Bounded: at most a few extra floaters per group.
+  const groups = groupByScore(pool);
+  const floatCountOf = (id: EntrantId): number => history.floats?.get(id) ?? 0;
+
+  const pairFrom = (gi: number, carry: SwissStanding[]): [SwissStanding, SwissStanding][] | null => {
+    if (gi >= groups.length) return carry.length === 0 ? [] : null;
+    const current = [...carry, ...(groups[gi] as SwissStanding[])];
+    const isLast = gi === groups.length - 1;
+    const parity = current.length % 2;
+    const maxFloat = isLast ? 0 : parity + 4; // cap extra floats — keeps it polynomial
+
+    for (let fc = parity; fc <= maxFloat; fc += 2) {
+      if (isLast && fc !== 0) break;
+      for (const floaters of floaterChoices(current, fc, floatCountOf)) {
+        const set = new Set(floaters.map((f) => f.entrantId));
+        const rest = current.filter((c) => !set.has(c.entrantId));
+        const here = matchWithin(rest);
+        if (here === null) continue;
+        const sub = pairFrom(gi + 1, floaters);
+        if (sub !== null) return [...here, ...sub];
+      }
+    }
+    return null;
+  };
+
+  const matched = pairFrom(0, []);
+  if (matched === null) {
+    // No rematch-free (colour-legal) perfect matching exists for this field.
+    return { pairings: [], floated: [], ...(bye === undefined ? {} : { bye }) };
+  }
+
+  // Assign colours (chess) / home-away, and record downfloats.
+  const pairings: SwissPairing[] = [];
+  const floated: EntrantId[] = [];
+  for (const [a, b] of matched) {
+    if (a.score !== b.score) floated.push(a.entrantId); // a is the stronger side ⇒ it floated down
+    pairings.push(assignColours(a, b, chess, stateOf));
+  }
+
+  return { pairings, floated, ...(bye === undefined ? {} : { bye }) };
+}
+
+// Decide who is home (White in chess). Non-chess: the stronger side (a, already
+// the upper board) is home. Chess: satisfy the hard rules first, then colour
+// preferences; neutral ⇒ the upper board takes White (round-1 S1 = White).
+function assignColours(
+  a: SwissStanding,
+  b: SwissStanding,
+  chess: boolean,
+  stateOf: (id: EntrantId) => ColourState,
+): SwissPairing {
+  if (!chess) return { home: a.entrantId, away: b.entrantId };
+
+  const sa = stateOf(a.entrantId);
+  const sb = stateOf(b.entrantId);
+  const aW = canTake(sa, "W") && canTake(sb, "B");
+  const aB = canTake(sa, "B") && canTake(sb, "W");
+
+  let aColour: Colour;
+  if (aW && !aB) aColour = "W";
+  else if (aB && !aW) aColour = "B";
+  else {
+    const pa = preferredColour(sa);
+    const pb = preferredColour(sb);
+    if (pa !== null && pb !== null && pa !== pb) aColour = pa; // both satisfied
+    else if (pa !== null && pb !== null) {
+      // Both want the same colour — the stronger claim (larger imbalance, then
+      // the upper board) gets it.
+      aColour = Math.abs(sa.diff) >= Math.abs(sb.diff) ? pa : opposite(pa);
+    } else if (pa !== null) aColour = pa;
+    else if (pb !== null) aColour = opposite(pb);
+    else aColour = "W"; // both neutral ⇒ upper board White
+  }
+
+  return aColour === "W"
+    ? { home: a.entrantId, away: b.entrantId }
+    : { home: b.entrantId, away: a.entrantId };
+}


### PR DESCRIPTION
## PROMPT-09 — Fixture Generation & Calendar Slotting

Implements the pure, deterministic `scheduling/` layer (spec `05` §2, §6). Zero effectful deps.

### Modules
- **`roundrobin.ts`** — circle method (two-row construction): bye padding, legs (mirrored home/away), court rotation. `|home−away| ≤ 1` per leg holds by construction; odd fields put the BYE at the pivot so real entrants balance exactly.
- **`swiss.ts`** — `pairRound(standings, history, constraints)` behind an interface. Score groups → top-vs-bottom fold → **complete backtracking within each group** + downfloat across groups. No-rematch (hard); chess colour rules `|W−B| ≤ 2` and no 3-in-a-row (hard); float tracking; bye to the lowest un-byed. A search budget bounds worst-case work while the single-group case stays complete (→ totality).
- **`bracket.ts`** — SE fold seeding (recursive interleave, matches the standard 1–16 layout), byes → top seeds as `award`, winner/loser feed wiring, 3rd-place option, cross-pool template, double elimination (WB+LB minor/major drop wiring, grand final, optional conditional bracket reset), stepladder.
- **`calendar.ts`** — greedy slotting with rest/blackout/court constraints → `{assignments, conflicts[]}`, never silently dropping a constraint (unplaceable → `no_slot`). Cross-division aware (sibling assignments as occupancy, per-person overlap warnings; doc `06` §4.3). `validateAssignments()` backs the drag-board validate pass (doc `12` §4).

Generation is a pure function of `(entrants, seeds, config, rngSeed)` — regeneration is byte-identical (idempotence, feeds included).

### Acceptance
- **Goldens**: 6-team double-RR = published circle-method table; 16-bracket = standard 1–16 fold; 5-round Swiss on 9 entrants, a bye each round, zero rematches.
- **Property suites** (fast-check, n up to 64): completeness `n(n−1)/2·legs`, uniqueness, home/away balance, no-rematch, colour bounds, brute-force totality (n ≤ 10), DE loss invariants, court/rest/blackout, idempotence.

### Verification
- 47 scheduling tests; full engine suite **401 green**.
- `tsc --noEmit` clean · `engine-boundary` clean · `engine-check` pass · `apps/web` lint 0 errors.

### Deviations (doc `05` updated in this PR)
- §2.3 cross-pool: rank-interleave — exact for two pools; k>2 defers same-pool rematches only as far as the fold allows (full latest-round deferral = later refinement).
- §2.4 DE reset: generated as a `conditional` grand-final fixture; the persistence adapter voids it when the WB champion wins GF1 (void = settled).
- Swiss uses score-group-local backtracking + budget rather than full FIDE Dutch weighted matching — which §2.2 already names a later refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pEsHzfZ8KyB3Bz6sDKfn