### PR TITLE
docs(engine): Jul3 feature backlog — clubs/import + 8 design+prompt clusters

### DIFF
--- a/engine/Jul3/00-idea-backlog.md
+++ b/engine/Jul3/00-idea-backlog.md
@@ -1,0 +1,64 @@
+# Jul3/00 — Idea Backlog (organiser feature requests, 3 Jul 2026 intake)
+
+Capture of the full organiser feature-request list so nothing is lost, mapped to where each
+cluster is designed. Style mirrors [16-future-features.md](../16-future-features.md): the
+**Grabbed** clusters have a Jul3 design doc + PROMPT; **Deferred-to-corpus** clusters already
+have a home elsewhere; **Not-yet-designed** are noted for later. Vote counts (×N) and dates
+are from the intake.
+
+## Grabbed — designed in this folder (Jul3)
+
+| # | Cluster | Design | Prompt | Headline asks (date, votes) |
+|---|---------|--------|--------|------------------------------|
+| 1 | Clubs & bulk import | [01](01-clubs-and-bulk-import.md) | PROMPT-21 | single full import teams+players+parent-club+logos (3 Jul); import all players (10 Jan); bulk/reuse logos (25 Nov, 29 May); club→category hierarchy (4 Jun) |
+| 2 | Referee/officials assignment | [02](02-referee-officials-assignment.md) | PROMPT-22 | block-stay before break (29 Jun); assign to pool (20 Jun); phased auto-assign (17 Jun ×2); by rank/result (3 Jun ×3); judges+refs (25 Dec ×2); caps (29 May); hide names (25 Jun) |
+| 3 | Schedule undo & locking | [03](03-schedule-undo-and-locking.md) | PROMPT-23 | UNDO (16 Jun); lock fixtures 2-site (22 Jun ×2); confirm-clear (18 May); filtered clear (4 Jul ×2); remove teams in pool (2 Jul) |
+| 4 | Scheduling constraints v2 + AI | [04](04-scheduling-constraints-v2.md) | PROMPT-24 | cross-category player clash (22 May, 8 Jun, 29 Jun); min break/no back-to-back (4 Jun); start windows (14 Apr, 10 May); bulk shift (10 Jun, 5 Sep ×3, 26 Jun); no-fixed-time (26 Sep ×3, 8 Dec); wait report (16 Sep ×3); AI plan (29 Jun) |
+| 5 | Custom points & standings | [05](05-custom-points-and-standings.md) | PROMPT-25 | netball/rugby/one-goal points (26 Jan, 7 Jan, 22 Oct); carry-over (14 Apr, 25 Nov, 16 Sep); manual override (24 Oct, 3 Jun); tie alert (10 Jun); forfeit/no-result (20 Jan, 8 Dec); penalty entry (28 Jun, 12 Jun); circular H2H (3 Sep); fair-play (3 Sep) |
+| 6 | Exports & print | [06](06-exports-and-print.md) | PROMPT-26 | pretty timetable (2 Jul ×2); volleyball scoresheet (12 Jun ×3); club colours (10 Jun); roster (13 May); landscape standings (29 May); match report by-pitch (18 Mar ×3, 30 Sep ×5, 20 Oct ×2); results export (7 Jul ×3) |
+| 7 | Player stats | [07](07-player-stats.md) | PROMPT-27 | goals+assists auto (16 Apr, 29 Dec ×2, 10 Feb ×2); top scorers (9 Jun); MVP/MOTM (7 Jul ×2, 7 Jan); per-division (7 Jan); scorer-picker numbers (9 Sep ×4, 11 Jun, 10 Jul, 19 May); sortable (27 Nov ×2) |
+| 8 | Format extensions | [08](08-format-extensions.md) | PROMPT-28 | Americano/Mexicano (21 May); custom/non-2^n brackets (7 Jan); CL→EL drop (4 Jul, 8 Apr); independent pools (16 Jun ×3, 10 May); auto-advance + early fill (16 Sep ×2/×4, 12 Aug); >2 encounters (7 Aug ×2); Hammes (20 Jan); ladder (7 Nov, 8 Dec) |
+| 9 | New sports & generic scoring | [09](09-new-sports-and-generic-scoring.md) | PROMPT-29 | Tchoukball/golf/race/Raketlon/Ludosport/darts/baseball/netball; floats+minus (1 Oct, 15 Mar); rename PLD/W/D/L (11 Oct ×3, 29 Jul); multi-event ranking (17 Mar, 16 Mar); corner count (4 Apr) |
+
+## Deferred-to-corpus — already have a home
+
+| Cluster | Where | Asks |
+|---------|-------|------|
+| Registration, fees, waitlist, capacity, moderation, self-roster | doc 16 §1.1 / PROMPT-20a | pay online (18 Aug), waitlist (11 Mar ×2, 2 Jun), moderate registrations (14 Jan ×3), self-fill roster (27 May ×6, 6 Jan), max players/squad (28 Jan, 11 Oct, 15 Feb), registration open date (28 May) |
+| Offline scoring PWA + match timer + live/per-field results | doc 16 §1.2 / PROMPT-20b, doc 13 | offline venue wifi; match timer (13 May, 16 Feb); per-field live results admin (15 Mar ×2, 4 Jun, 13 May); manual mark-live (29 May) |
+| Player accounts, QR check-in, favourites, availability | doc 16 §1.3 / PROMPT-20c | claim/QR (10 Mar); favourites across divisions (8 Jun); check-in/attendance (2 Jun); availability |
+| Comms hub, announcements, push, email-all | doc 16 Tier 2–3 (Inngest-blocked) | broadcast banner/alert (29 Jun ×3); push emergency (8 Jun ×3); pop-up news (29 May); email participants (1 Jul ×3); notification templates + reply-to (29 May) |
+| Public dashboard, presentation, active-game slide, live-ticker | doc 09, doc 12 | active-game slide w/ timer+logos (9 Jun ×1/×2); hide completed (29 May); match duration (29 May); field-count layout (29 May); QR to app (10 Mar); live-ticker (17 Jul); field filter (2 Jun ×4) |
+| Branding, sponsors, custom pages, contact button, white-label | doc 09 branding / doc 16 Tier 3 | bg colour/gradient/overlay (22 May); sponsor logos all pages (23 May); sponsor area (2 Jul); extra pages/regulations (1 Jul); contact button (22 May ×2); white-label fonts (5 Feb); confirmation-email branding (2 Aug) |
+| Discovery / embeds / widgets | doc 15, doc 16 Tier 2 | embed standings/brackets (16 Sep ×3); embeddable widgets |
+| API / third-party / ChatGPT-Claude integration | doc 08 §2 (API keys) | own-webapp via API (9 Jun, 20 May); connect ChatGPT/Claude (7 Apr); Google Sheets |
+| Score granularity (set 3–1 only, tennis 6–4 6–4, tiebreak) | doc 14 | enter overall set score (23 Apr); tennis real scores (2 Jun, 25 Jun); 0.5/minus scores (15 Mar) — engine side in Jul3/09 |
+| Disciplinary (cards→suspension) | doc 16 Tier 3 | card accumulation rules |
+
+## Not-yet-designed — noted, low urgency or app-layer
+
+- **i18n & custom labels** — Portuguese/Brazilian (many, high freq), Czech/Slovak/Italian/
+  Catalan/Swedish/Arabic/Croatian/Slovenian; fully-editable/custom language (16 Dec ×2);
+  gender-neutral German (8 Jul ×2); rename buttons/own text (5 May). App-layer i18n +
+  per-org label overrides; high volume, low complexity. **Candidate: its own app-side prompt.**
+- **Org ops** — copy/duplicate tournament (21 May, 16 Jun ×4, 13 Apr), archive (20 May),
+  group yearly editions (4 Jun), org-level defaults for sign-up/sponsors (23 May), duplicate
+  presentation/dia (17 May, 30 Sep, 8 Jan), copy format across age groups (3 Jun, 7 Jan).
+  Mostly CRUD/duplication utilities over the greenfield model. **Candidate: an "org ops" prompt.**
+- **Scoped permissions** — separate manage-referees vs manage-participants (18 June); admin
+  invite of non-account users (29 May, 10 Mar). Extends doc 13 roles. **Candidate: doc 13 delta.**
+- **Flags/countries** — Basque Country (15 Apr), Jersey (27 Mar), Switzerland (17 Sep),
+  Europe (27 Jan). Trivial data additions.
+- **Kinball 3-team fixture** (2 Feb) & **golf per-hole/handicap** (7 Aug) — break core
+  assumptions (2-sided fixture / per-hole ledger); flagged in Jul3/09 §3, §5 as their own
+  future design+prompt.
+- **Barcodes/QR on match tickets** (27 May), **corner/fairplay deciders** (4 Apr, 3 Sep —
+  partly Jul3/05), **meal/volunteer/shift management** (13 May, 29 May Idea 1), **certificates
+  & awards sheet** (7 Apr ×1, doc 16 Tier 3), **live video draw** (13 Aug ×2), **AI match
+  reports** (doc 16 Tier 4).
+
+## Notes
+- Vote/date data is indicative (from the 3 Jul intake dump), useful for prioritisation not
+  as a contract.
+- Ordering of the Grabbed set for build: 2 (referees), 3 (undo), 5 (points) are the highest
+  pure-engine leverage; 1 (clubs/import) is the headline intake ask; 4/6/7 follow.

--- a/engine/Jul3/01-clubs-and-bulk-import.md
+++ b/engine/Jul3/01-clubs-and-bulk-import.md
@@ -1,0 +1,281 @@
+# Jul3/01 — Clubs & Bulk Import
+
+Promotes the one-line "Imports" backlog item ([16-future-features.md](../16-future-features.md)
+§Tier 3) to a designed feature, and adds the **Club** parent entity that docs 06 §4.4
+(`stats.club_championship`) and 10 (`stats.club_championship`) already assume but 07 never
+tabled. Sits on top of the greenfield model — extends [07-greenfield-schema.md](../07-greenfield-schema.md),
+[08-api-design.md](../08-api-design.md), [10-pro-entitlements.md](../10-pro-entitlements.md).
+Nothing here is implemented (design only, same status as the rest of `engine/`).
+
+## 1. Motivation & scope
+
+Organiser demand, direct from the idea list:
+
+- **Single full import** (3 Jul 2026) — "teams + players together, an extra column for
+  parent club, select clubs and add logos in bulk." The headline ask.
+- **Import all players for all teams in one go** (10 Jan) — "setting up a 100-team
+  tournament shouldn't take an age."
+- **Bulk logo upload** (25 Nov) — "96 logos one-by-one; multi drag-and-drop, even if just
+  randomized, saves a lot of time."
+- **Reuse club logos** (29 May) — same badge across all a club's age-group teams without
+  re-uploading.
+- **Club → subcategories hierarchy** (4 Jun) — "17 clubs × 8 categories = 136 teams; group
+  by club, filter/toggle by club just like by division."
+
+One coherent feature: a persistent **Club** (parent of `teams`), a **spreadsheet import
+pipeline** that materialises clubs + teams + players (+ optional entrant/roster placement)
+in one pass, and **bulk logo** assignment that every child team inherits.
+
+**Non-goals** (each is a different, already-tracked line):
+- Federation / CRM sync over a live API — that's the "own webapp via Tournify API" idea
+  (doc 08 §2 API keys already covers third-party access; not this doc).
+- Public self-registration & entry fees — that's PROMPT-20a (doc 16 §1.1). Import is the
+  **organiser-side** bulk path, not participant self-serve.
+- Importing *formats/fixtures/results* from Challonge/chess-results — a later importer
+  variant; this pass is participants only (clubs/teams/players/entrants).
+
+## 2. Club entity (schema delta on doc 07)
+
+New tenant table, following doc 07 conventions exactly (uuid pk, denormalized `org_id`
+trigger-filled per the 010 pattern, direct RLS `org_id = current_org_id()`, CHECK-enum
+text, `timestamptz`):
+
+```sql
+create table clubs (
+  id           uuid primary key default gen_random_uuid(),
+  org_id       uuid not null references organizations(id) on delete cascade,
+  name         text not null,
+  short_name   text,
+  logo_path    text,                 -- Supabase Storage path; inherited by child teams
+  colors       jsonb,                -- default kit colours; teams inherit unless overridden
+  external_ref text,                 -- FA / affiliation number (idea 29 Jun) — upsert key
+  created_at   timestamptz not null default now(),
+  -- idempotent upsert key: prefer external_ref, else fold(name)
+  unique (org_id, coalesce(external_ref, lower(btrim(name))))
+);
+create index clubs_org_idx on clubs(org_id);
+```
+
+Extend the existing `teams` table:
+
+```sql
+alter table teams add column club_id uuid references clubs(id) on delete set null;
+create index teams_club_idx on teams(club_id);
+```
+
+**Logo/colour resolver (one place):** effective team badge = `teams.logo_path` when set,
+else `clubs.logo_path`; effective colours likewise. Ship as a SQL view `team_display_v`
+(joined into the public read views of doc 07 note 4) so app + dashboard + export read
+identical resolution and the fallback lives in exactly one query. This is what makes
+"upload once per club, all teams show it" true without copying bytes.
+
+**Club is org-scoped and persistent across competitions** — same lifecycle as `teams` and
+`persons` (doc 02 §1). It is *not* a division; the hierarchy is `Club → Team → Entrant(per
+division)`, orthogonal to `Competition → Division`. "Group/toggle by club" (idea 4 Jun) is
+a read-side grouping over `entrants ⋈ teams.club_id`, not a structural stage.
+
+## 3. Import domain model — the pure planner
+
+The engine imports nothing effectful (README ground rule 1; PROMPT-00 §3). So the pipeline
+splits:
+
+```
+apps/web/src/server/       parse file → ImportRow[] (server-only), Storage writes,
+                           DB upserts under withTenant       ← the ONLY I/O
+packages/engine/import/    planImport(rows, snapshot, config) → ImportPlan   ← pure
+```
+
+The engine half is a **deterministic diff**: given the parsed rows, a read-only snapshot of
+what already exists, and a config, it returns the exact list of create/update/link
+operations plus typed issues — and *writes nothing*. The app half parses the upload into
+rows, calls the planner for a dry-run preview, then (on commit) executes the plan's ops
+transactionally.
+
+Types-first (Zod schema → inferred type, per PROMPT-00 §3):
+
+```ts
+// One spreadsheet row, already header-mapped by the app. A row may carry a club, a team,
+// a player, or all three — sparse fields are how "clubs + teams + players together" works.
+ImportRow = z.object({
+  rowNo:             z.number().int(),          // 1-based source line, for issue anchoring
+  clubName:          z.string().optional(),
+  clubShortName:     z.string().optional(),
+  clubExternalRef:   z.string().optional(),
+  teamName:          z.string().optional(),
+  teamShortName:     z.string().optional(),
+  playerFullName:    z.string().optional(),
+  dob:               z.string().date().optional(),
+  gender:            z.enum(['m','f','x']).optional(),
+  squadNumber:       z.number().int().optional(),
+  position:          z.string().optional(),     // validated vs division sport position_catalog
+  isCaptain:         z.boolean().optional(),
+  divisionSlug:      z.string().optional(),      // where to place the team as an entrant
+  entrantDisplayName:z.string().optional(),
+});
+
+// Read-only view of current org state the planner matches against (app fetches, passes in).
+ImportSnapshot = z.object({
+  clubs:    z.array(z.object({ id, name, externalRef: z.string().nullable() })),
+  teams:    z.array(z.object({ id, name, clubId: z.string().nullable() })),
+  persons:  z.array(z.object({ id, fullName, dob: z.string().nullable(), externalRef: z.string().nullable() })),
+  divisions:z.array(z.object({ id, slug, sportKey, positionKeys: z.array(z.string()) })),
+  entrants: z.array(z.object({ id, divisionId, teamId: z.string().nullable() })),
+});
+
+ImportConfig = z.object({
+  personMatch:   z.enum(['strict','lenient']).default('lenient'),
+  createDivisions: z.literal(false).default(false),   // import never creates divisions (§4)
+  minorConsentDefault: z.boolean().default(false),     // doc 06 §4.7
+});
+
+ImportOp = z.discriminatedUnion('kind', [
+  // kind ∈ club.create | club.update | team.create | team.link |
+  //        person.create | roster.add | entrant.create | entrant.member.add
+  //   each: { kind, ref (stable synthetic key), before?, after, sourceRows: number[] }
+]);
+
+ImportIssue = z.object({
+  rowNo:    z.number().int(),
+  column:   z.string().optional(),
+  severity: z.enum(['error','warn']),
+  code:     z.string(),          // 'DIVISION_NOT_FOUND','AMBIGUOUS_PERSON','BAD_POSITION',…
+  message:  z.string(),
+});
+
+ImportPlan = z.object({
+  ops:    z.array(ImportOp),
+  stats:  z.object({ clubs, teams, persons, entrants, rosters }),  // counts by effect
+  issues: z.array(ImportIssue),
+});
+```
+
+`planImport` is `(rows, snapshot, config) → ImportPlan`, pure and total: no throw, all
+problems surface as `issues`. `error`-severity issues block commit for their rows; `warn`
+lets them through. Refs inside ops are stable synthetic keys (e.g. `club:acme`,
+`team:acme/u12`) so a later op can depend on an earlier op's not-yet-existent id — the app
+resolves refs → real uuids as it executes the plan in dependency order.
+
+## 4. Matching / dedupe / idempotence rules (normative)
+
+Re-uploading the same file must be a **no-op**. Rules (every rule cites this section in
+code, per PROMPT-00 §3):
+
+- **Club** — match by `external_ref`; else by folded `name` (`lower(btrim(...))`). Miss ⇒
+  `club.create`. Hit with differing `short_name`/`colors` ⇒ `club.update` (only supplied
+  fields; blanks never overwrite). `logo_path` is **not** set by row import — only by the
+  bulk-logo path (§5).
+- **Team** — identity `(club_id, folded name)`; clubless teams keyed on `(org_id, folded
+  name)`. Miss ⇒ `team.create` (+ `team.link` to its club). Existing team with no club and
+  a club now supplied ⇒ `team.link`.
+- **Person** — match within org by `external_ref`; else `(folded full_name + dob)`.
+  Ambiguous (same folded name, no dob, ≥2 candidates): `lenient` ⇒ `warn AMBIGUOUS_PERSON`
+  + `person.create` (default); `strict` ⇒ `error` (organiser resolves via the persons
+  merge endpoint, doc 08 §3). Match hit ⇒ no create; still `roster.add` if not on the
+  team's roster.
+- **Entrant / roster** — a row with `divisionSlug` places the team into that division:
+  find-or-create `entrant(kind='team', team_id)` in the division (`entrant.create`), then
+  `roster.add` / `entrant.member.add` the player with `squad_number`, `position` (validated
+  vs the division's `position_catalog`, doc 02 §3 — bad ⇒ `error BAD_POSITION`), `is_captain`.
+  **Import never creates divisions** (`config.createDivisions=false`); unknown
+  `divisionSlug` ⇒ `error DIVISION_NOT_FOUND` (organiser sets up divisions/formats first —
+  that stays a deliberate structural act).
+- **Idempotence** — `planImport(rows, snapshotAfterCommit, config).ops == []`. This is the
+  property test in the prompt: apply a plan, rebuild the snapshot, re-plan the same rows ⇒
+  zero ops.
+
+## 5. Bulk logo upload
+
+Separate multipart endpoint (logos are bytes, not spreadsheet cells — kept off the row
+path so a file import and a logo drop compose independently). N image files →
+club matching:
+
+1. **filename-stem match** — `logo` file stem, folded, == club `short_name` or `name`.
+2. **manual re-map** — the preview UI lets the organiser fix any unmatched/mismatched file
+   against a club dropdown before assigning.
+3. **any-order / randomized** mode (idea 25 Nov) — assign the N files to N unlogo'd clubs
+   in order for the "even if it's just randomized" case; still shown for confirmation.
+
+Each accepted file → Storage write → set `clubs.logo_path`; child teams inherit via the §2
+resolver (no per-team copy). Validation: MIME + size caps; **content-hash dedupe** — two
+uploads of identical bytes reuse one stored object (the "don't re-upload" ask). Assignment
+is idempotent: re-dropping the same file for the same club is a no-op.
+
+## 6. API surface (extends doc 08)
+
+Under `/api/v1`, `handler()` wrapper (≤~20 lines: parse Zod → auth → use-case → shape),
+`{ ok, data|error, requestId }` envelope, typed `EngineError` codes → HTTP (doc 08 §1).
+
+```
+# Import (org-scoped; session or API key with write scope)
+POST   /api/v1/imports                     multipart file → { importId, plan }  (dry-run; writes nothing)
+POST   /api/v1/imports/{id}/commit         apply plan; Idempotency-Key header (doc 08 §4);
+                                           transactional under withTenant; emits audit rows
+GET    /api/v1/imports/{id}                stored parse + last plan (re-preview without re-upload)
+
+# Clubs
+GET/POST         /api/v1/clubs             list / create   (?cursor=&limit= per doc 08 §1)
+GET/PATCH/DELETE /api/v1/clubs/{id}
+POST             /api/v1/clubs/logos       multipart, bulk → match + assign (§5)
+
+# Filter + export (satisfies "filter/toggle by club" + "unified participant overview")
+GET  /api/v1/divisions/{id}/entrants?club_id=…            # club filter on existing list
+GET  /api/v1/participants/export?format=csv|xlsx&club_id=…&division_id=…
+                                            # one sheet, club + division columns; empty-spot
+                                            # placeholders preserved (idea 30 Jan)
+```
+
+The entrants **CSV bulk import** hook doc 08 §3 already reserved
+(`POST /divisions/{id}/entrants # + bulk import (CSV)`) becomes a thin division-scoped alias
+that funnels into the same planner with `divisionSlug` pinned. The persons **merge** hook
+(doc 08 §3) is the resolution path for `strict` ambiguous-person errors.
+
+**Commit audit:** commit writes a `division_events` row (`type: 'participants_imported'`,
+payload = plan stats + importId) for each touched division and an org-level audit entry;
+hash-chained per the 011 pattern (doc 07 note 2). Nothing in the ledger is scoring data —
+this is structural, same family as `fixtures_generated`.
+
+## 7. Entitlements (extends doc 10)
+
+New `feature_key`s, same machinery (`plan_entitlements` → overrides → `requireFeature`/
+`withinLimit` at the service layer, 402 `PaymentRequiredError` with `feature_key` for the
+contextual paywall, doc 10 §2–3):
+
+| feature_key | Community | Pro | Business |
+|---|---|---|---|
+| `import.bulk` (spreadsheet import > small cap) | ≤ 20 rows/file | ✓ | ✓ |
+| `logos.bulk` (multi-file logo assign) | ✗ (one at a time) | ✓ | ✓ |
+| `clubs.hierarchy` (Club parent + group/filter-by-club) | ✗ | ✓ | ✓ |
+
+Rationale: a small club can hand-add 16 entrants free (matches `entrants.per_division.max`
+= 16 Community); the 100+-team / 17-club pain that motivates this is squarely Pro. Aligns
+with the existing `exports` (Pro) and `stats.club_championship` (Pro) keys — `clubs.hierarchy`
+is the structural prerequisite the club-championship stat already assumed. Downgrade
+behaviour per doc 10 §2.4: existing clubs/imported data never deleted; over-cap import
+simply rejected going forward.
+
+## 8. UI notes (`apps/web`, non-normative)
+
+- **Import wizard:** upload → **column mapper** (auto-detect headers, remember the mapping
+  per org) → **preview table grouped by club** with create/update/skip/link badges per row
+  and the `ImportIssue[]` list (errors block, warns are acknowledgeable) → **Commit**.
+  The preview *is* the `ImportPlan` rendered — no surprise writes.
+- **Logo grid:** drag-drop many files; each card shows matched club + a re-map dropdown +
+  an "assign remaining in order" toggle; assign is one action.
+- **Club filter/toggle** on the participants and schedule pages (a `club_id` facet beside
+  the existing division facet). Club detail view lists its teams across divisions.
+
+## 9. Edge cases checklist
+
+- **Placeholder / empty-spot rows** — a team with no players imports fine; export keeps
+  "Empty Spot N" labels (idea 30 Jan explicitly wants these in the Excel export, not blank).
+- **Duplicate player across teams/divisions** — one `person`, multiple `roster`/
+  `entrant_member` rows; never a duplicate person (the whole point of §4 person matching).
+- **Minors** — `person.create` sets `consent` defaults false (`minorConsentDefault`, doc 06
+  §4.7); DOB collected but never exposed publicly (doc 07 `persons.dob` note).
+- **Partial failure** — commit is a single transaction; any op failure rolls the whole
+  commit back (no half-imported state). The Idempotency-Key makes the retry safe.
+- **Large files** — 10k-row upload streamed/chunked on parse, not buffered whole; the
+  planner runs on the resulting rows in memory (pure, fast); commit batches inserts.
+- **Mixed create + update** — one file can create some clubs/teams and update others; the
+  plan diff handles both, ordered by ref dependency (clubs → teams → persons → entrants →
+  rosters).

--- a/engine/Jul3/02-referee-officials-assignment.md
+++ b/engine/Jul3/02-referee-officials-assignment.md
@@ -1,0 +1,151 @@
+# Jul3/02 — Referee & Officials Assignment Engine
+
+Turns the `officials.assignment` entitlement stub ([10-pro-entitlements.md](../10-pro-entitlements.md)
+§Platform) into a real assignment engine. Sits beside fixture generation
+([05-formats-progression-tiebreakers.md](../05-formats-progression-tiebreakers.md) §2.6,
+PROMPT-09) and the scheduling console (PROMPT-17). Design only.
+
+## 1. Motivation & scope
+
+The single largest cluster in the idea list — organisers hand-assign officials for 85+
+games and it eats hours:
+
+- **Block-stay before break** (29 Jun) — "game1 pitch1, game2 pitch1, game3 pitch1, break"
+  not pitch1→pitch2→pitch3; staying on one pitch cuts turnaround.
+- **Assign to pool/group, not just division** (20 Jun; 23 May; 27 May) — "50 teams, 16
+  pools; I can't open every pool"; officials only ref within their pool/group.
+- **Phased auto-assign** (17 Jun ×2) — auto Phase-1 now, Phase-2 once Phase-1 known;
+  "Assign is greyed out for later phases until teams are known."
+- **By ranking / by result** (3 Jun ×3) — "4th in group G refs game X"; "winner of game X
+  refs game Y."
+- **Team-as-referee stays in division** (27 May) — coach-refs shouldn't be sent to another
+  category or a distant field.
+- **Judges *and* referees** (25 Dec ×2) — two official roles per fixture, separate sections.
+- **Fairness caps** (29 May) — max assignments/day; distribute across whole tournament vs
+  per-day.
+- **Manual drag** (7 Jan) — copy/swap via modifier key; **hide ref names** publicly (25 Jun).
+
+**In scope:** an officials model (people + roles), a pure assignment pass
+(`assignOfficials`) with constraints + fairness objective, phased/result-based sourcing,
+team-as-referee, API + console hooks, consent-gated public display. **Out:** the drag-drop
+board mechanics themselves (PROMPT-17 owns the grid — this feeds cards into it); pay/roster
+HR.
+
+## 2. Domain model (schema delta on doc 07)
+
+Officials are org-scoped people who may or may not be `persons` already (a team acting as
+referee reuses its `entrant`). Roles are **sport-labelled** (doc 13 §labels:
+Umpire/Referee/Arbiter) — reuse that catalog.
+
+```sql
+create table officials (
+  id          uuid primary key default gen_random_uuid(),
+  org_id      uuid not null references organizations(id) on delete cascade,
+  person_id   uuid references persons(id) on delete set null,  -- null = standalone official
+  entrant_id  uuid references entrants(id) on delete set null, -- set = team-as-referee (27 May)
+  display_name text not null,
+  role_keys   jsonb not null default '["referee"]',            -- ['referee','judge','scorer']
+  home_pool_id uuid references pools(id) on delete set null,   -- constrain to a pool (20 Jun)
+  max_per_day int,                                             -- fairness cap (29 May)
+  created_at  timestamptz not null default now()
+);
+create index officials_org_idx on officials(org_id);
+
+-- assignment of an official to a fixture in a role (multiple roles per fixture: 25 Dec)
+create table fixture_officials (
+  fixture_id  uuid not null references fixtures(id) on delete cascade,
+  official_id uuid not null references officials(id) on delete cascade,
+  org_id      uuid not null,
+  role_key    text not null,                 -- 'referee' | 'judge' | ...
+  source      text not null default 'manual' check (source in ('manual','auto')),
+  locked      boolean not null default false,-- pinned; auto pass treats as obstacle
+  primary key (fixture_id, role_key, official_id)
+);
+```
+
+`fixtures.officials jsonb` (doc 07) stays as the denormalized read cache; `fixture_officials`
+is the write source. Public read view nulls names when `officials.hide_names` (25 Jun) —
+consent filtering lives in the doc 07 note-4 views.
+
+## 3. The assignment pass (pure, in `@seazn/engine`)
+
+Same shape as the calendar pass (doc 05 §2.6): pure, deterministic, seeded, never silently
+drops a constraint.
+
+```ts
+assignOfficials(input: {
+  fixtures:  ScheduledFixture[],      // with scheduled_at, court, pool, stage
+  officials: OfficialSpec[],          // role_keys, home_pool, max_per_day, entrant_id?
+  locked:    FixtureOfficial[],       // pinned assignments = fixed obstacles
+  policy:    AssignPolicy,
+  rngSeed:   string,
+}) => { assignments: FixtureOfficial[], conflicts: OfficialConflict[] }
+```
+
+`AssignPolicy`:
+```ts
+{ roles: ['referee','judge'],                    // required roles per fixture (25 Dec)
+  poolLock: boolean,                             // official only refs own home_pool (20 Jun)
+  blockStay: boolean,                            // prefer same court across a block (29 Jun)
+  fairness: 'tournament' | 'per_day',            // distribution basis (29 May)
+  teamRefKeepDivision: boolean,                  // 27 May
+  sourcing?: RankSourcing | ResultSourcing,      // 3 Jun: by group rank / by winner-loser
+  restMinMinutes?: number }                       // official can't ref two overlapping/adjacent
+```
+
+**Hard constraints** (violations → `conflict`, never assigned): no official in two fixtures
+at overlapping times; team-as-referee never officiates its own fixture, never plays and
+refs simultaneously (cross-check the person→entrant map, doc 05 §2.6 overlap machinery);
+poolLock when set; role coverage (each required role filled or flagged).
+
+**Soft objective** (minimise, seeded-greedy then local swap): fairness spread (variance of
+per-official counts within basis), block-stay bonus (same court as official's previous
+fixture in the block), travel penalty (distance between consecutive courts —
+`teamRefKeepDivision` = large penalty for leaving division/field).
+
+**Sourcing** for later stages (3 Jun, 17 Jun): officials can be *derived* from results —
+`RankSourcing {fromStage, take: [{poolRank}]}` (4th of group G → official) or
+`ResultSourcing {fromFixture, side: 'winner'|'loser'}`. These resolve **only when the
+source stage/fixture is decided** — which is why the console can offer "auto-assign Phase 1
+now, Phase 2 when Phase 1 finishes" instead of greying it out (17 Jun). The pass takes
+already-resolved officials; the *sourcing resolver* (also pure) turns standings/outcomes
+into an `OfficialSpec[]` for the next phase.
+
+**Determinism/idempotence:** re-run with all outputs locked ⇒ zero moves (property, mirrors
+PROMPT-17 §3).
+
+## 4. API (extends doc 08)
+
+```
+GET/POST         /api/v1/officials                     # list/create; role_keys, home_pool, caps
+GET/PATCH/DELETE /api/v1/officials/{id}
+POST             /api/v1/officials/import              # bulk (reuses Jul3/01 planner shape)
+POST             /api/v1/divisions/{id}/officials/auto # propose only → {assignments, conflicts}
+POST             /api/v1/divisions/{id}/officials/apply# transactional persist + division_events
+PATCH            /api/v1/fixtures/{id}/officials       # manual set/move/lock (drag-drop, 7 Jan)
+POST             /api/v1/stages/{id}/officials/source  # resolve rank/result sourcing → specs
+```
+
+`auto` calls the engine pass with locked assignments as obstacles (same contract as
+`schedule/auto`, doc 12 §4). `apply` emits `division_events: officials_assigned`. Conflict
+taxonomy: `conflict.official_overlap`, `conflict.team_ref_self` block; `warn.pool_leak`,
+`warn.fairness`, `warn.travel` warn (mirrors doc 12 §2 block/warn split).
+
+## 5. Entitlements (extends doc 10)
+
+Promote the existing `officials.assignment` (Pro) to cover manual + auto. New sub-keys:
+`officials.auto` (constraint solver + phased/sourcing) = Pro; `officials.roles_multi`
+(judge + referee both) = Pro; manual single-role assignment available Community (matches
+"basic scheduling" tier). Hidden-names is a public-read toggle, all plans.
+
+## 6. Edge cases
+
+- Team-as-referee whose team is eliminated/withdrawn → drops from the official pool for
+  later phases (sourcing resolver skips withdrawn entrants).
+- Not enough officials for a slot → `conflict` surfaced, slot left empty (never
+  double-book) — organiser fills manually.
+- Rescheduled fixture (rain, PROMPT-17 re-flow) → its locked official moves with it; auto
+  re-flow re-checks overlap.
+- Break/block definition = contiguous fixtures on a court between two gaps ≥ policy break;
+  block-stay optimises within a block only (29 Jun exact ask).
+- Hide-names must also strip officials from `.ics` and public API, not just UI.

--- a/engine/Jul3/03-schedule-undo-and-locking.md
+++ b/engine/Jul3/03-schedule-undo-and-locking.md
@@ -1,0 +1,135 @@
+# Jul3/03 — Schedule Undo, Versioning & Safe Destructive Ops
+
+Adds reversible editing and guarded destructive actions to the division/schedule
+lifecycle. Builds on the structural ledger `division_events`
+([07-greenfield-schema.md](../07-greenfield-schema.md), [05-formats-progression-tiebreakers.md](../05-formats-progression-tiebreakers.md)
+§5) and the scheduling console (PROMPT-17). Design only.
+
+## 1. Motivation & scope
+
+Recurring, high-anxiety asks — organisers fear one click wiping days of work:
+
+- **UNDO like Word** (16 Jun ×1) — "I'm on my 5th schedule version; try a change but revert
+  if it doesn't work, without ruining earlier work."
+- **Lock fixtures locally** (22 Jun ×2) — two-site tournament; restart fixtures on site A
+  must not delete site B.
+- **Confirm before clear + move the button** (18 May ×1) — accidental "Clear schedule"
+  wipes matches on *other* venues too; separate it from "Schedule."
+- **Filtered clear** (4 Jul ×2; 23 Apr) — clear by group/bracket/round/court only, not all.
+- **Remove all teams in a pool, keep the pool** (2 Jul) — experiment with groupings without
+  altering structure.
+
+**In scope:** an undo/redo stack over structural edits, per-fixture/scope locking, a
+scoped-clear operation (filter-aware), snapshot "save points," all built on the existing
+append-only ledger. **Out:** score-event undo (already exists — `core.void`, doc 02 §6);
+generic multi-user OT/CRDT (single-writer structural aggregate, doc 02 §8).
+
+## 2. Model — undo as ledger navigation, not deletion
+
+The division already has an append-only, hash-chained `division_events` ledger. Undo does
+**not** delete rows; it appends inverse events and moves a watermark. Two columns added:
+
+```sql
+alter table divisions
+  add column schedule_locked boolean not null default false,   -- whole-division freeze
+  add column edit_watermark  bigint;                            -- current undo position
+
+alter table fixtures
+  add column locked boolean not null default false,             -- per-fixture pin (22 Jun)
+  add column schedule_source text;                              -- 'auto'|'manual' (doc 12 §3)
+
+-- named save points an organiser can restore to (16 Jun "go back to last version")
+create table division_checkpoints (
+  id          uuid primary key default gen_random_uuid(),
+  division_id uuid not null references divisions(id) on delete cascade,
+  org_id      uuid not null,
+  seq         bigint not null,               -- division_events watermark captured
+  label       text not null,                 -- 'before rain reshuffle'
+  created_by  uuid references users(id) on delete set null,
+  created_at  timestamptz not null default now()
+);
+```
+
+Every reversible structural action already writes a `division_events` row
+(`fixtures_generated`, `schedule_edited`, `fixture_moved`, `officials_assigned`, …). Undo =
+append the paired inverse event (`fixture_moved` ↔ `fixture_moved` with swapped payload;
+`fixtures_generated` ↔ `fixtures_cleared`) and advance `edit_watermark` backward. Redo
+re-applies. The ledger stays gapless and hash-verified — audit intact (doc 07 note 2).
+
+## 3. Reversible-action contract (pure, in `@seazn/engine`)
+
+Each structural mutation declares its inverse so undo is mechanical, not bespoke:
+
+```ts
+interface ReversibleOp<P> {
+  type: DivisionEventType;
+  apply(state: DivisionScheduleState, payload: P): DivisionScheduleState;
+  invert(payload: P, prevState: DivisionScheduleState): { type; payload };  // the undo event
+}
+```
+
+`fold(division_events up to watermark)` = current schedule state (same disposable-cache
+principle as `MatchState`, doc 02 §6). The engine exposes `undo(state, ledger, watermark)`
+and `redo(...)` as pure functions returning the next event to append + new watermark. The
+app persists the appended event under the division aggregate lock (doc 02 §8) — undo is a
+normal single-writer append, so it is concurrency-safe by construction.
+
+**Guardrail:** score events are downstream of fixtures. Undoing a `fixtures_generated` that
+has *decided* fixtures beneath it is blocked (`error UNDO_BLOCKED_HAS_RESULTS`) unless the
+organiser explicitly force-clears results first — never silently discard a scoresheet.
+
+## 4. Locking (two-site safety — 22 Jun)
+
+- **Per-fixture `locked`** — auto/clear passes treat locked fixtures as immovable obstacles
+  (already the PROMPT-17 §3 `lockedAssignments` input — this wires the persisted flag into
+  it). Regenerate/clear skips locked rows.
+- **Scope lock** — lock by court/venue/pool: a stored predicate, not a column per fixture,
+  applied as "these match a locked scope → obstacle." Lets site B stay frozen while site A
+  regenerates (the exact 22-Jun scenario).
+- Locked fixtures render with a pin badge (PROMPT-17 board already has pin/lock toggle).
+
+## 5. Scoped clear + remove-teams-in-pool (2 Jul, 4 Jul)
+
+`clearSchedule(scope)` where `scope = {stageId?, poolIds?, rounds?, courts?, excludeLocked:
+true}` — mirrors the *generation* filters so you clear exactly what you can generate (4 Jul
+ask). Always `excludeLocked` by default. Emits one `schedule_cleared` event carrying the
+scope (fully undoable via §3).
+
+`removeEntrantsFromPool(poolId)` (2 Jul) — detaches entrants from a pool's
+`group_assignment` and deletes that pool's *undecided* fixtures, **keeping the pool and
+stage**. Blocked if any pool fixture is decided (same results-guard as §3). Undoable.
+
+## 6. API (extends doc 08 / doc 12)
+
+```
+POST /api/v1/divisions/{id}/undo            # → appends inverse event, returns new state + watermark
+POST /api/v1/divisions/{id}/redo
+GET  /api/v1/divisions/{id}/history         # ledger slice: label, actor, time, undoable?
+POST /api/v1/divisions/{id}/checkpoints     # save point {label}
+POST /api/v1/divisions/{id}/restore         # {checkpointId} → undo to that watermark (guarded)
+POST /api/v1/schedule/clear                 # {scope} scoped clear (§5) — confirmation required client-side
+PATCH /api/v1/fixtures/{id}                 # {locked} pin/unpin (existing route, new field)
+POST /api/v1/pools/{id}/clear-entrants      # remove-teams-in-pool (§5)
+```
+
+`clear` and `restore` are the two "dangerous" endpoints — server requires an explicit
+`confirm: true` body flag (double-submit guard) so a stray call can't wipe; UI adds the
+confirm modal + moves the button away from "Schedule" (18 May).
+
+## 7. Entitlements (extends doc 10)
+
+Undo/redo + confirm-clear = **all plans** (safety is not a paywall). Named checkpoints /
+version history depth (>1 restore point) and scope-locking for multi-site = Pro
+(`schedule.versioning`). Aligns with `scheduling.constraints` being Pro.
+
+## 8. Edge cases
+
+- Undo after publish (doc 12): unpublished edits are invisible; undo across a publish
+  boundary re-publishes the restored state on next publish, never silently changes the live
+  public schedule.
+- Concurrent editors: undo is a division-lock append; a stale client redo that conflicts
+  gets `409` + refetch (optimistic token = ledger seq, doc 02 §8).
+- Watermark not at ledger head (user undid, then makes a new edit) → truncate redo branch:
+  append a `branch_reset` marker; older redo events remain in the immutable ledger but are
+  no longer reachable (linear history, Word-like).
+- Restore never deletes checkpoints created after it — you can redo forward to them.

--- a/engine/Jul3/04-scheduling-constraints-v2.md
+++ b/engine/Jul3/04-scheduling-constraints-v2.md
@@ -1,0 +1,129 @@
+# Jul3/04 — Scheduling Constraints v2 & AI-Assisted Planning
+
+Extends the calendar pass ([05-formats-progression-tiebreakers.md](../05-formats-progression-tiebreakers.md)
+§2.6) and the scheduling console (doc 12, PROMPT-17) with the constraint family organisers
+keep asking for, plus a natural-language planning assist. Design only.
+
+## 1. Motivation & scope
+
+- **Cross-category player clash** (22 May; 8 Jun; 29 Jun) — a player in two teams across
+  categories must not be scheduled twice at once; today the clash detector only works
+  *within* one category, and duplicate-name players in different categories aren't linked.
+- **Min break / no back-to-back** (4 Jun ×1; 14 Apr; 20 Oct) — "at least one break between a
+  team's matches"; different break per group/division (20 Oct).
+- **Per-team / per-group start windows** (14 Apr; 10 May) — "team XY no earlier than 9:30
+  even if the tournament starts at 8:00"; category starts later for logistics.
+- **Fair field distribution** (14 Apr) — don't dump one team on field 4 all day; alternate
+  fields.
+- **Block vs mixed scheduling** (29 May) — divisions play in parallel, not whole slots
+  reserved for one division.
+- **Bulk time shift** (10 Jun ×1; 5 Sep ×3; 26 Jun ×1) — push all pitches back 15 min at
+  once; postpone all courts.
+- **No fixed times mode** (26 Sep ×3; 9 Jun; 8 Dec) — flexible/self-scheduled long-running
+  events.
+- **Min/max wait reporting** (16 Sep ×3) — surface the worst rest/wait a team faces.
+- **AI planning** (29 Jun) — natural-language constraints ("no player plays two teams at
+  once, spread breaks evenly") that compile into the solver.
+
+**In scope:** a richer `SchedulingConstraints` spec, the person-link that makes
+cross-category clash work, solver objective additions, bulk-shift + no-fixed-time modes,
+wait-time diagnostics, and an AI layer that *only* emits validated constraint objects. **Out:**
+the solver core rewrite — this extends the existing greedy+repair pass, doesn't replace it.
+
+## 2. The cross-category link (root cause of the #1 clash complaint)
+
+The 22-May report: same person entered under two categories as two name strings; the
+in-division clash check never links them. The v2 model already has org-scoped `persons`
+(doc 02 §3) — the fix is to make clash detection operate on **person identity across
+divisions**, not name strings:
+
+```ts
+// built once per competition from entrant_members ⋈ persons (doc 07)
+PersonScheduleMap = Map<personId, { entrantId, divisionId }[]>
+```
+
+The calendar pass already accepts sibling-division assignments + a person→entrant map for
+overlap warnings (doc 05 §2.6, PROMPT-17 §3). This doc makes that map **competition-wide and
+person-keyed**, and promotes cross-division person overlap from `warn` to a configurable
+`hard` constraint. No schema change — it's a query + a policy flag.
+
+## 3. Constraint spec (types-first, validated by the solver)
+
+```ts
+SchedulingConstraints = z.object({
+  restMin:        z.number().int().optional(),      // min minutes between a team's fixtures
+  restByGroup:    z.record(z.string(), z.number()).optional(),  // per pool/division (20 Oct)
+  noBackToBack:   z.boolean().default(false),       // ≥1 fixture gap (4 Jun)
+  startWindows:   z.array(z.object({                // per team/group/division (14 Apr, 10 May)
+                    target: z.object({ kind: z.enum(['entrant','pool','division']), id }),
+                    notBefore: z.string().optional(), notAfter: z.string().optional() })).default([]),
+  fieldFairness:  z.enum(['off','balance','rotate']).default('off'),  // 14 Apr
+  parallelism:    z.enum(['block','mixed']).default('mixed'),         // 29 May
+  crossPersonClash: z.enum(['warn','hard']).default('warn'),          // §2
+  sessionWindows: z.array(z.object({ start, end, courtIds })).default([]), // existing
+  blackouts:      z.array(z.object({ courtId, start, end })).default([]),  // existing
+});
+```
+
+Solver additions (all soft unless marked hard; the pass stays greedy-place → local-repair,
+never silently drops — doc 05 §2.6):
+- `restMin`/`noBackToBack` → hard reject placements violating rest; repair by shifting.
+- `startWindows` → hard lower/upper bound per target.
+- `fieldFairness` → soft objective: minimise per-team court-count variance (`balance`) or
+  force round-robin over courts (`rotate`).
+- `parallelism=mixed` → allow different divisions in the same slot (removes the "whole slot
+  reserved for one division" behaviour).
+- `crossPersonClash=hard` → treat person double-booking like a court clash.
+
+## 4. Bulk shift, no-fixed-time, wait diagnostics
+
+- **Bulk shift** (10 Jun / 5 Sep / 26 Jun): `shiftSchedule({scope, deltaMinutes})` — pure
+  transform over selected fixtures' `scheduled_at`; scope = all / court / division (mirrors
+  the scoped-clear filters, Jul3/03 §5). One `division_events: schedule_shifted`, undoable
+  (Jul3/03). Solves "push everything back 15 min" and "postpone all courts."
+- **No-fixed-time mode**: division flag `scheduling_mode = 'timed' | 'flexible'`. Flexible
+  divisions generate fixtures with `scheduled_at = null`, ordered but not clock-slotted;
+  public schedule shows order + "not yet scheduled"; results still record. Covers
+  club-ladder / multi-week events (26 Sep, 8 Dec) — pairs with the ladder format
+  (Jul3/08).
+- **Wait diagnostics** (16 Sep): pure `scheduleReport(assignments) → { perEntrant: {minGap,
+  maxGap, maxWait}, worst: [...] }` shown in the console before publish — no schema, a
+  derived read model.
+
+## 5. AI-assisted planning (29 Jun)
+
+A thin, **safe** layer — the model never touches the DB or invents a schedule; it only
+translates prose into the validated `SchedulingConstraints` object, which the deterministic
+solver then honours:
+
+```
+organiser prose ──▶ LLM (tool-constrained) ──▶ SchedulingConstraints (Zod-validated)
+                                              └▶ rejected if it fails schema/eligibility
+constraints ──▶ engine calendar pass (pure) ──▶ proposal + conflicts (organiser approves)
+```
+
+- The LLM output is parsed by the *same* Zod schema (§3); anything unparseable is refused,
+  not guessed. Determinism/audit unaffected — the schedule still comes from the pure solver.
+- Use the latest Claude model via the Anthropic SDK; server-side only; the prompt is the
+  constraint schema + a few examples. This is the one place an LLM enters the engine
+  surface, and it stays advisory (proposes constraints, human applies).
+- Entitlement `scheduling.ai` = Pro/Business.
+
+## 6. API & entitlements
+
+- `PUT /api/v1/divisions/{id}/schedule-settings` gains the §3 fields (extends doc 12 §4).
+- `POST /api/v1/schedule/shift` (bulk), `GET /api/v1/divisions/{id}/schedule/report`.
+- `POST /api/v1/divisions/{id}/schedule/ai-constraints` (prose → constraints, propose only).
+- Entitlements (extends doc 10 `scheduling.constraints` Pro): `restMin`/`startWindows`/
+  `fieldFairness`/`crossPersonClash=hard` under `scheduling.constraints` (Pro); bulk shift +
+  wait report = all plans; `scheduling.ai` = Pro.
+
+## 7. Edge cases
+
+- Over-constrained instance (no feasible schedule) → solver returns best-effort +
+  `conflicts[]` listing which constraints couldn't be met; never fabricate an invalid slot.
+- `startWindows` + rest together can be infeasible → report the binding constraint.
+- Cross-person clash needs `persons` linked; unlinked duplicate names still `warn` (the
+  merge/link path is Jul3/01 §4 person matching / doc 08 persons-merge).
+- Flexible-mode fixtures excluded from court/rest solving (no clock) but still counted for
+  cross-person "can't be in two live matches" once a result is being entered.

--- a/engine/Jul3/05-custom-points-and-standings.md
+++ b/engine/Jul3/05-custom-points-and-standings.md
@@ -1,0 +1,133 @@
+# Jul3/05 — Custom Points Systems, Standings Carry-Over & Manual Rank Control
+
+Extends the standings fold + tiebreaker cascade
+([05-formats-progression-tiebreakers.md](../05-formats-progression-tiebreakers.md) §3–4,
+PROMPT-08) with configurable competition-points, phase carry-over, manual rank override, and
+richer forfeit/decision handling. Design only.
+
+## 1. Motivation & scope
+
+- **Custom points systems** — netball "Win 5 / Draw 3 / losing-but-≥50% 1 / else 0" (26
+  Jan); rugby-style "bonus point for not losing by >X" (7 Jan); "2 pts win-by-one, 1 pt
+  lose-by-one" (22 Oct); forfeit points config (20 Jan).
+- **Standings carry-over** (14 Apr handball; 25 Nov ×; 16 Sep) — Phase-1 results carry into
+  Phase-2 groups instead of teams replaying from zero.
+- **Manual rank override** (24 Oct; 3 Jun) — final-placement games decide 3rd/4th; organiser
+  sets positions not from raw points.
+- **Tie alert** (10 Jun ×1) — warn when teams tie on *all* criteria before KO (today it
+  silently breaks ties alphabetically).
+- **Forfeit / walkover / no-show** (20 Jan; 2 Jun) — mark forfeit with configurable points
+  for each side; double-forfeit/unplayed without fake scores (8 Dec ×1).
+- **Penalty-shootout result** (28 Jun ×1; 7 Jul; 12 Jun) — record the decider + show it.
+- **UEFA circular H2H override** (3 Sep) — choose overall GD vs mini-table GD in a 3-way tie.
+- **Fair-play score** (3 Sep) — track a fair-play metric for a fair-play cup.
+
+**In scope:** a `PointsRule` config on the stage, carry-over qualification, a rank-lock/
+override mechanism, forfeit/abandon points config, penalty-decider capture, extra tiebreaker
+metrics. **Out:** new sport match grammars (Jul3/09); these ride the existing StandingsDelta
+plumbing (doc 02 §7).
+
+## 2. Points rule (config, not code)
+
+The sport module contributes a default `PointsRule`; the division may override it. A rule is
+declarative and evaluated by the competition engine per decided fixture:
+
+```ts
+PointsRule = z.object({
+  base: z.object({ win: z.number(), draw: z.number(), loss: z.number() }),  // 3/1/0 default
+  bonuses: z.array(z.object({                          // ordered, additive
+    when: z.enum(['loss_margin_lte','win_margin_gte','score_ratio_gte',
+                  'draw','forfeit_win','forfeit_loss','no_result']),
+    param: z.number().optional(),                      // X for margin/ratio rules
+    points: z.number(),
+  })).default([]),
+  forfeit: z.object({ winnerPoints: z.number(), loserPoints: z.number(),
+                      awardScore: z.tuple([z.number(), z.number()]).optional() }),  // 20 Jan
+});
+```
+
+Examples encode the exact asks:
+- Netball (26 Jan): `base {win:5,draw:3,loss:0}, bonuses:[{when:'score_ratio_gte',param:0.5,
+  points:1}]` applied to the losing side.
+- Rugby (7 Jan): `bonuses:[{when:'loss_margin_lte',param:7,points:1}, {when:'win_margin_gte',
+  ...}]`.
+- One-goal (22 Oct): `bonuses:[{when:'win_margin_gte',param:1... }]` variant.
+
+Rule stored on `stages.config.points`. Sport modules already emit margins/ratios in
+`StandingsDelta.metrics` (doc 02 §7) — the rule reads those, so **no sport-module changes**.
+Fractional points allowed (Ludosport, Jul3/09) — `points` is a number, standings sum keeps a
+decimal metric.
+
+## 3. Carry-over qualification (14 Apr, 25 Nov, 16 Sep)
+
+The stage graph already has a `qualification` spec (doc 02 §5). Add a carry mode:
+
+```ts
+qualification = { from_stage, take: [...],
+                  carry: 'none' | 'points' | 'full' }   // NEW
+```
+
+- `carry:'points'` — seeded entrants arrive in the new pool with their prior-stage points
+  (and chosen metrics) as an opening StandingsDelta; head-to-head games already played are
+  *not* replayed (16 Sep: "3 teams from each group advance, don't play each other again").
+- `carry:'full'` — also carries the played-fixture results (for GD/H2H) so the second-phase
+  table is a true continuation.
+
+Implemented as a synthetic opening delta folded before new fixtures — the standings fold is
+already additive (doc 02 §7), so carry-over is data, not new fold logic. Recorded as a
+`division_events: standings_carried` row (auditable).
+
+## 4. Manual rank override & rank-lock (24 Oct, 3 Jun)
+
+`standings_snapshots.rows[].rank_locked` already exists in the model (doc 02 §7). Expose it:
+
+```
+POST /api/v1/stages/{id}/standings/override
+  { rows: [{ entrant_id, rank, locked: true, reason }] }   -- 3rd/4th from a placement game
+```
+
+Locked ranks are pinned; the cascade ranks only the un-locked remainder around them. Emits
+`division_events: rank_overridden` (actor + reason, hash-chained). Public view shows the
+final order; the override is audit-visible to staff. This is how "winner of 3rd-place game =
+3rd" is set without faking points (24 Oct exact ask).
+
+## 5. Tiebreaker additions (extends doc 05 §4)
+
+The cascade is already a configurable, sport-fed ordered list. Add:
+- **Tie-exhaustion alert** (10 Jun): when two rows remain equal after the *entire* cascade,
+  the fold sets `rows[].tie_unbroken = true` and emits a `warn` — the console shows an alert
+  before KO seeding instead of silently going alphabetical. `tiebreakers.custom` (Pro,
+  doc 10) lets the organiser add a decider (drawing of lots / manual) as the final step.
+- **Circular H2H mode** (3 Sep): a cascade flag `h2h_scope: 'mini_table' | 'overall'` for
+  the ≥3-way-tie head-to-head step (UEFA mini-table default; override to overall GD).
+- **Fair-play metric** (3 Sep): sport modules that emit cards already contribute
+  `fair_play` in `metrics`; expose it as a selectable cascade step and a standalone
+  fair-play-cup standings view.
+
+## 6. Forfeit, abandonment, penalty decider
+
+- **Forfeit/walkover**: a `core.forfeit {winnerEntrantId}` event (already terminal, doc 02
+  §6) → outcome + points from `PointsRule.forfeit`. Double-forfeit / unplayed:
+  `core.no_result` → both sides get `no_result` bonus points (0 default) with **no fake
+  score** (8 Dec exact ask — round-robin best-of-7 no longer forces a 4–0).
+- **Penalty shootout** (28 Jun, 12 Jun): sport modules with shootouts (football) already
+  carry a `shootout` payload in the outcome; surface it in the summary + presentation slide
+  and in standings when a format counts shootout wins. Set-based "just enter 3–1" (23 Apr)
+  and tennis "6–4 6–4 / tiebreak" (2 Jun, 25 Jun) are the set-module's granularity toggle
+  (doc 14) — cross-referenced, owned there.
+
+## 7. Entitlements
+
+- Base points config (win/draw/loss numbers) = all plans. Bonus rules + carry-over +
+  circular-H2H mode + manual override = Pro (`tiebreakers.custom` already Pro, doc 10; add
+  `standings.custom_points`, `standings.carry_over`).
+- Tie-unbroken alert = all plans (safety/clarity).
+
+## 8. Edge cases
+
+- Points rule change mid-stage → recompute is a pure refold of decided fixtures (standings
+  are disposable, doc 02 §7); emit an audit event; never silently reorder a locked rank.
+- Carry-over + manual override interacting: override wins (it's the final structural word).
+- Bonus rules referencing metrics a sport doesn't emit → validation error at stage config
+  (fail closed, PROMPT-00 §3 "bad configs can never reach play").
+- Negative/fractional points sum correctly (Jul3/09 generic sports).

--- a/engine/Jul3/06-exports-and-print.md
+++ b/engine/Jul3/06-exports-and-print.md
@@ -1,0 +1,110 @@
+# Jul3/06 — Rich Exports & Print Templates
+
+Turns the `exports` entitlement ([10-pro-entitlements.md](../10-pro-entitlements.md) §Platform)
+into a real templated document system: timetables, scoresheets, roster forms, standings,
+match reports — PDF and spreadsheet. Reads the public/read models (doc 07 note 4, doc 09).
+Design only.
+
+## 1. Motivation & scope
+
+Heavily-voted "old-school paper" cluster:
+
+- **Pretty timetable PDF** (2 Jul ×2) — the online layout is well-structured; the PDF isn't;
+  referees/teams want a nice printable overview.
+- **Volleyball scoresheet** (12 Jun ×3) — point-by-point columns per set, signature lines,
+  final result, two matches per A4.
+- **Club colours / team names on scoresheets** (10 Jun; 8 Jun) — refs identify teams + kit
+  clashes before KO.
+- **Roster form** (13 May) — team name + player list (name/DOB/number) to sign at start.
+- **Landscape standings** (29 May) — names/rankings stay readable.
+- **Match report sheet** (18 Mar ×3; 30 Sep ×5; 20 Oct ×2) — per-pitch, one pitch per page.
+- **Results export group+KO** (7 Jul ×3), **by team** (4 Jul), **tables+fixtures like the
+  slideshow** (20 Oct ×2), **Excel with Empty-Spot names** (30 Jan), **participant overview
+  with club/division column** (17 Mar ×1) — the last two overlap Jul3/01 §6 export.
+
+**In scope:** a template registry (per document type × sport), deterministic render inputs,
+PDF + XLSX renderers, per-pitch/per-team/per-division scoping, branding (club colours,
+sponsor logos, tournament name). **Out:** the presentation/slideshow big-screen slides (doc
+09 / Jul3/07-presentation-adjacent — different surface); live rendering.
+
+## 2. Architecture — pure view-models, effectful renderers
+
+Engine stays I/O-free (README rule 1). The split:
+
+```
+packages/engine/exports/   buildDocModel(kind, data, opts) → DocModel   ← pure, deterministic
+apps/web/src/server/       DocModel → PDF (renderer) / XLSX (writer)     ← the I/O half
+```
+
+`DocModel` is a serialisable, layout-agnostic description (sections, tables, rows, cells,
+signature blocks, colour swatches) — *what* to print, not pixels. The renderer (a server-only
+lib, e.g. React-PDF/Playwright-print for PDF, a sheet writer for XLSX) turns it into bytes.
+Because the model is pure, a golden test asserts the model, not the PDF (stable, diffable).
+
+```ts
+DocModel = z.object({
+  kind: z.enum(['timetable','scoresheet','roster','standings','match_report','participants']),
+  title: z.string(),                 // tournament + division name (1 Sep ask: show it)
+  meta: z.object({ printedAt: z.string(), footerNote: z.string().optional() }),
+  branding: z.object({ colors, logos, sponsors }).optional(),   // Pro
+  sections: z.array(DocSection),     // headings (prelim vs KO separation, 1 Sep), tables, forms
+  pageBreaks: z.enum(['auto','per_pitch','per_team','per_division']).default('auto'),
+});
+```
+
+## 3. Template registry (per kind, sport-aware)
+
+Each `SportModule` may contribute template fragments (a volleyball scoresheet needs
+set-columns; a football report needs goal/card lines) — same plugin principle as position
+catalogs (doc 02 §3):
+
+```ts
+SportModule.exportTemplates?: {
+  scoresheet?: (fixture, lineups) => DocSection,   // volleyball: per-set point columns + signatures
+  matchReport?: (fixture, state) => DocSection,
+}
+```
+
+Sport-neutral kinds (timetable, standings, roster, participants) live in the engine core.
+Volleyball scoresheet (12 Jun) = the set-based module's `scoresheet` fragment with point-by-
+point columns, two-per-page via `pageBreaks` + a `columns:2` section hint.
+
+## 4. Scoping (per-pitch / per-team / per-division)
+
+The recurring "one pitch per page," "by team," "export just my group" asks are one knob:
+`buildDocModel(kind, data, { scope, pageBreaks })` where `scope` filters fixtures/entrants
+(court / entrant / pool / division) using the same filter vocabulary as scoped-clear
+(Jul3/03 §5) and the `?club_id=`/`?division_id=` API params (Jul3/01 §6). `pageBreaks:
+'per_pitch'` starts each court on a fresh page (30 Sep, 20 Oct exact ask). Empty-spot
+placeholder entrants render their label, never blank (30 Jan) — both PDF and XLSX.
+
+## 5. API (extends doc 08)
+
+```
+GET /api/v1/divisions/{id}/exports/{kind}?format=pdf|xlsx&scope=…&pageBreaks=…
+GET /api/v1/competitions/{id}/exports/timetable?format=pdf&pretty=true
+GET /api/v1/participants/export?format=csv|xlsx&club_id=…&division_id=…   (defined in Jul3/01 §6)
+```
+
+Cacheable like public reads (doc 08 §6) keyed on the read watermark; regenerated on data
+change. Large exports stream. Branding fields nulled for non-Pro at the model layer (doc 10
+§2.3 — server-side, not client-hidden).
+
+## 6. Entitlements (extends doc 10)
+
+`exports` (Pro) already gates CSV/PDF. Split for fairness:
+- Basic CSV/XLSX participant + results export = Pro (as today).
+- **Branded / templated PDF** (club colours, sponsor logos, pretty timetable, custom
+  scoresheet layouts) = Pro `exports.branded`. Landscape/portrait + page-break scoping = all
+  export-enabled plans (it's a layout flag, not a feature).
+
+## 7. Edge cases
+
+- Unfinished tournament: timetable/roster export before results exist (fixtures with TBD
+  feeds render "Winner of QF1" labels, matching the bracket display).
+- Signature/blank scoresheets: a "blank" flag renders the form with no scores (for manual
+  filling when no printer for data-entry, 7 Apr awards ask analog).
+- Very wide standings (volleyball 10 metrics, 22 Feb) → landscape + horizontal fit; never
+  clip names (29 May).
+- Deterministic `printedAt` supplied via the export request time (kept out of the pure model
+  as a `meta` input, so goldens stay stable — no `Date.now()` in engine, PROMPT-00 §3).

--- a/engine/Jul3/07-player-stats.md
+++ b/engine/Jul3/07-player-stats.md
@@ -1,0 +1,109 @@
+# Jul3/07 — Player Statistics Engine
+
+Turns the `stats.player` entitlement ([10-pro-entitlements.md](../10-pro-entitlements.md)
+§Sport depth) into a real derived-stats layer over the score-event ledger. Reads events,
+writes nothing new to the truth (doc 02 §6). Design only.
+
+## 1. Motivation & scope
+
+- **Real-time player stats, goals + assists auto** (16 Apr; 29 Dec ×2; 10 Feb ×2; 16 Apr
+  hockey points=goals+assists) — no manual post-match calculation.
+- **Top scorers** (9 Jun; 25 July) — golden-boot table.
+- **Player / man-of-the-match, MVP** (7 Jul ×2; 7 Jan) — award per fixture, aggregated.
+- **Stats per division** (7 Jan) — separate tables per division (small top division does
+  male + female MVP).
+- **Stats on the front-end / referee-entered** (7 Jan) — refs pick scorer + MOTM live.
+- **Player number shown when picking scorer** (9 Sep ×4; 11 Jun; 10 July; 19 May) — the
+  scorer dropdown must show shirt numbers, not just names.
+- **Sortable player rankings** (27 Nov ×2) — sort by any metric.
+
+**In scope:** a per-sport stat schema, a pure aggregator folding score-events → player/team
+stat tables, MOTM/award events, division-scoped leaderboards, the scorer-picker number fix.
+**Out:** cross-competition ratings/Elo (doc 16 Tier 2, separate); the scoring UI itself
+(doc 13 scorer console — this defines what it emits and reads).
+
+## 2. Stats are a derived fold, never a source of truth
+
+The ledger already carries fine-grained events (`football.goal`, `cricket.ball`,
+`volleyball.rally`) gated by scoring-granularity entitlements (doc 10, doc 14). Player stats
+are **another disposable projection** of those events — like `match_states` and
+`standings_snapshots` (doc 02 §6–7). No new truth table; a cache:
+
+```sql
+create table player_stat_snapshots (
+  division_id uuid not null references divisions(id) on delete cascade,
+  person_id   uuid not null references persons(id) on delete cascade,
+  org_id      uuid not null,
+  sport_key   text not null,
+  stats       jsonb not null,          -- sport-keyed: {goals,assists,points} / {runs,wkts,avg} / {mvp_awards}
+  computed_through_seq bigint not null, -- watermark over contributing fixtures
+  updated_at  timestamptz not null default now(),
+  primary key (division_id, person_id)
+);
+```
+
+Rebuildable at any time by refolding events → CI consistency check (same discipline as
+standings, doc 02 §7).
+
+## 3. Sport-declared stat model (plugin, like position catalog)
+
+Each `SportModule` declares which events feed which player metrics and how to aggregate —
+scoring math stays in the module; the engine just folds:
+
+```ts
+SportModule.playerStats?: {
+  metrics: [{ key:'goals', label:'Goals', from:'football.goal', agg:'count' },
+            { key:'assists', label:'Assists', from:'football.goal', field:'assistPersonId', agg:'count' },
+            { key:'points', label:'Points', derive:(s)=> s.goals + s.assists }],  // 16 Apr hockey
+  awards?: [{ key:'motm', label:'Man of the Match', from:'core.award', unique:'per_fixture' }],
+}
+```
+
+- Football: goals, assists, points, cards. Cricket: runs, wickets, average, economy,
+  strike-rate (fine events already exist, doc 04). Set sports: points won/aces.
+- `points = goals + assists` (16 Apr, 29 Dec) is a declared `derive` — auto, no manual sum.
+- `aggregatePlayerStats(events, roster, model) → StatRow[]` is pure + deterministic.
+
+## 4. Awards / MOTM (7 Jul, 7 Jan)
+
+A generic `core.award {fixtureId, personId, key:'motm'}` event (append-only, undoable via
+`core.void` like any event, doc 02 §6). Refs enter it from the scorer console (7 Jan
+front-end ask). Aggregated into `stats.mvp_awards` and a division MOTM leaderboard. Division-
+scoped so a small top division can run its own male/female MVP (7 Jan exact ask) — stats are
+keyed by `division_id`.
+
+## 5. Scorer-picker shows numbers (the most-repeated stat bug)
+
+9 Sep (×4), 11 Jun, 10 July, 19 May: shirt numbers are stored (`entrant_members.squad_number`,
+doc 07) but the goal-scorer dropdown shows only names. Fix is read-model shape: the lineup
+API returns `{ personId, fullName, squadNumber }` and the picker renders `#7 — Name`
+(configurable to number-order sort, 19 May). Pure UI/read change; no engine math. Documented
+here because it's the top stat-adjacent complaint and belongs with the stats prompt.
+
+## 6. API (extends doc 08)
+
+```
+POST /api/v1/fixtures/{id}/events            # core.award (MOTM) rides the existing scoring endpoint
+GET  /api/v1/divisions/{id}/stats/players?metric=goals&sort=desc   # leaderboard, sortable (27 Nov)
+GET  /api/v1/persons/{id}/stats?division_id=…                       # a player's card stats
+GET  /api/v1/public/.../divisions/{slug}/stats                      # consent-filtered public leaderboard
+```
+
+Public stats obey consent (doc 06 §4.7 — minors' names/photos gated) via the doc 07 note-4
+views. Player-profile stats on public cards = `dashboard.player_profiles` (Pro, doc 10).
+
+## 7. Entitlements (extends doc 10)
+
+`stats.player` (Pro) gates leaderboards + player cards + MOTM aggregation, consistent with
+fine-grained scoring being Pro (doc 10 §Sport depth — stats need the fine events anyway).
+The scorer-picker number display = all plans (it's a bug fix, not a feature). MOTM *entry* is
+available wherever scoring is; the aggregated *tables* are `stats.player`.
+
+## 8. Edge cases
+
+- Voided goal event → stats refold drops it (never double-count, never strand an assist).
+- Player in two teams/divisions → stats keyed per division; a cross-division total is a
+  separate opt-in aggregate (touches `stats.club_championship`, doc 10).
+- Own-goal / assist-less goal → `assistPersonId` optional; aggregator counts only present.
+- Ball-by-ball off (Community) → coarse summaries yield team totals but not per-player;
+  leaderboards show "requires detailed scoring" rather than wrong zeros.

--- a/engine/Jul3/08-format-extensions.md
+++ b/engine/Jul3/08-format-extensions.md
@@ -1,0 +1,114 @@
+# Jul3/08 — Format Engine Extensions
+
+Extends the stage-graph format engines
+([05-formats-progression-tiebreakers.md](../05-formats-progression-tiebreakers.md) §2,
+PROMPT-09) with the format shapes the idea list keeps requesting. Design only.
+
+## 1. Motivation & scope
+
+- **Americano / Mexicano** (21 May, ALL-CAPS urgency) — padel rotating-partner formats;
+  "almost all our games are this type."
+- **Custom / non-power-of-2 brackets** (7 Jan) — repechage, placement games, byes to chosen
+  seeds; 6-team playoff shapes.
+- **Cross-format loser drop** (4 Jul; 8 Apr) — Champions-League losers fall into Europa
+  League; qualifier losers into a repechage.
+- **Independent pool progression** (16 Jun ×3; 10 May; 13 June) — finish one pool and open
+  its bracket without waiting for slower pools.
+- **Auto-progress + early slot fill** (16 Sep ×2 auto-advance; 16 Sep ×4 / 12 Aug fill next
+  match as soon as the entrant is known) — no organiser button; show a team its next
+  fixture the moment it's determined.
+- **More than 2 group encounters** (7 Aug ×2) — triple/quad round robin.
+- **Ladder / long-run open play** (7 Nov; 8 Dec; 9 Jun) — weeks-long ladder, self-scheduled.
+- **Hammes model** (20 Jan) — swiss-like "1v2, 3v4, re-rank each round, avoid rematch."
+- **Assign a team into multiple phases / any prior phase** (27 Nov; 16 Sep ×3; 3 Jun) — pull
+  4thA into a later match without illegal rematch.
+- **Placement / final-rank from specific games** (3 Jun ×2; 17 May bracket 3/4 alphabetical
+  bug) — "winner of game X = 15th place."
+
+**In scope:** new stage `kind`s (americano, ladder) + config extensions on existing kinds
+(RR legs>2, custom brackets, cross-feed, per-pool completion, auto-advance), placement
+resolution. **Out:** new *sports* (Jul3/09); scheduling of these (doc 05 §2.6 handles slots).
+
+## 2. Round-robin: legs > 2 (7 Aug)
+
+`league`/`group` `config.legs` already exists (single/double RR, doc 02 §5). Lift the cap:
+`legs: n` → circle method repeated `n` times with home/away balancing across all legs
+(triple RR = 2 home/1 away split, documented). Pure change to `roundrobin.ts` (PROMPT-09
+§1); property `completeness = n(n−1)/2 · legs` already generalises.
+
+## 3. Americano / Mexicano (21 May)
+
+A new stage kind `americano` — individuals rotate partners each round; points are personal,
+not team. Config `{ courtCount, rounds, mode:'americano'|'mexicano' }`:
+- **Americano**: fixed rotation so everyone partners/opposes everyone as evenly as possible
+  (a resolvable combinatorial schedule, seeded).
+- **Mexicano**: pairings for round r+1 derived from the round-r standings (1+4 vs 2+3
+  style) — a re-rank-each-round generator, same family as Swiss `pairRound` (PROMPT-09 §2),
+  so it reuses the score-group + no-rematch machinery.
+Entrants are `kind:'individual'`; the round produces `pair` entrants on the fly for each
+fixture. Standings are per-person points (ties into Jul3/05 fractional points).
+
+## 4. Custom brackets & cross-format feeds (7 Jan, 4 Jul, 8 Apr)
+
+Extend `bracket.ts` (PROMPT-09 §3):
+- **Non-power-of-2**: explicit bye placement to chosen seeds (already "byes to top seeds as
+  awards" — generalise to organiser-chosen byes) so 6/12/24-team brackets work; repechage =
+  a second bracket fed by first-round losers.
+- **Cross-format loser feed**: the fixture `feeds` wiring already has `loser_to` (doc 02
+  §6). Allow `loser_to` to target a fixture in a **different stage** (CL QF loser →
+  EL QF slot). Pure wiring; the progression walker already follows feeds. This is the exact
+  4-Jul / 8-Apr ask.
+- **Placement games** (3 Jun, 17 May): a fixture may declare `places: [15,16]` — its
+  winner/loser resolve to explicit final ranks, fed into the manual-rank mechanism
+  (Jul3/05 §4) instead of alphabetical. Fixes the "3rd/4th decided alphabetically" bug.
+
+## 5. Independent pool progression & auto-advance (16 Jun, 16 Sep, 12 Aug)
+
+Progression is already a per-division aggregate that fires "stage completed → generate next"
+(doc 02 §8). Two refinements:
+- **Per-pool completion**: allow a *pool* (not the whole stage) to be marked complete and
+  release the fixtures that depend only on it. Qualification specs that reference a single
+  pool (`{from_stage, pool:'A', take:[...]}`) resolve as soon as pool A finishes — pool B
+  can lag (16 Jun exact ask). Guard: cross-pool KO waits for all its source pools.
+- **Auto-advance**: a division flag `auto_progress: true` fires progression automatically
+  when the guard is satisfied — no organiser button (16 Sep). Emits `division_events:
+  stage_auto_advanced`.
+- **Early slot fill** (16 Sep ×4, 12 Aug): a bracket fixture's slot is populated the instant
+  *its* feeding fixture decides, independent of sibling fixtures in the same round. The feed
+  resolver runs per decided fixture, not per completed round — so a team sees its next match
+  as soon as its opponent's *source* is known (partial fill shows "Winner QF1 vs TBD").
+
+## 6. Ladder / long-run format (7 Nov, 8 Dec, 9 Jun)
+
+New stage kind `ladder` — open standings, players issue/accept challenges over a long
+window; no pre-generated full fixture list. Pairs with flexible scheduling (Jul3/04 §4
+`scheduling_mode:'flexible'`, `scheduled_at=null`). Config `{ challengeRange, decayDays }`.
+Result of a challenge reorders the ladder (a small ranking rule). Minimal engine surface —
+mostly a standings + fixture-on-demand mode; deferred detail acceptable, flag as its own
+follow-up if it grows.
+
+## 7. Hammes model (20 Jan)
+
+`swiss` with a config preset: `{ pairing:'rank_adjacent', avoidRematch:true }` — round 1
+seeds 1v2/3v4; each subsequent round re-ranks and pairs adjacent, skipping prior opponents
+(exactly the Swiss no-rematch backtracking already in `swiss.ts`, PROMPT-09 §2). So Hammes
+is a named Swiss variant, not new code — document the preset.
+
+## 8. API & entitlements
+
+- Stage config extensions ride the existing `POST /api/v1/divisions/{id}/stages` (doc 08
+  §3) — new `kind`s + config fields, validated by the format engine's schema.
+- Entitlements (extends doc 10 `stages.per_division.max`, `formats.double_elim`): new
+  `formats.americano`, `formats.custom_bracket`, `formats.cross_feed`, `formats.ladder`,
+  `auto_progress` — group under Pro (`formats.advanced`); basic RR/KO/group+KO stays
+  Community.
+
+## 9. Edge cases
+
+- Cross-format feed cycles → validate the stage graph is a DAG at config time (fail closed).
+- Per-pool release + a cross-pool KO → KO fixtures stay TBD until all source pools done;
+  never seed a bracket from a half-finished pool set.
+- Americano with a court/player count that can't rotate evenly → best-effort + a `warn`
+  (some pairings repeat), never silently drop a player from a round.
+- Assign-same-team-multiple-phases (27 Nov): relax the "entrant used once" guard to
+  per-stage; the rematch-avoidance is the generator's job (16 Sep), not a blanket block.

--- a/engine/Jul3/09-new-sports-and-generic-scoring.md
+++ b/engine/Jul3/09-new-sports-and-generic-scoring.md
@@ -1,0 +1,107 @@
+# Jul3/09 — New Sport Modules & Generic Configurable Scoring
+
+Adds the long tail of requested sports via one **generic points-based module** plus a few
+thin presets, and fixes score-label/format gaps. Rides the `SportModule` contract
+([03-engine-architecture.md](../03-engine-architecture.md), PROMPT-03) — no engine-core
+change. Design only.
+
+## 1. Motivation & scope
+
+- **Whole new sports** — Tchoukball (29 May), golf (7 Aug), running/race (30 Apr), Raketlon
+  (27 Feb), Ludosport (1 Oct), darts (28 Nov), baseball (29 July), Kinball 3-team (2 Feb),
+  Mölkky/skittles, netball (26 Jan), hockey.
+- **Generic scoring needs** — floating-point + negative scores (1 Oct Ludosport; 15 Mar ×1
+  half/minus scores); rename `PLD/W/D/L/PTS/PF/PA/PD` (11 Oct ×3 sumo-robot; 29 July baseball
+  "Runs" not "Goals"); rename scoring methods (8 Apr); multi-event rank collation (17 Mar;
+  16 Mar multi-sport school league); corner count as a decider (4 Apr); darts leg-diff /
+  average columns (28 Nov).
+- **Score granularity toggles** — enter set match as "3–1" only (23 Apr); tennis real scores
+  "6–4 6–4" + tiebreak (2 Jun, 25 Jun); overall-set-score vs per-game (owned by doc 14, ref'd).
+
+**In scope:** a `generic` configurable module (metrics, labels, points, decimals/negatives),
+presets for the simple sports, a multi-event ranking aggregator, and a metric-label override
+layer. **Out:** deep bespoke rules engines for golf handicaps / cricket DLS (cricket already
+has its module, doc 04/05) — golf/race land as generic-score presets first, deepen later.
+
+## 2. The `generic` module (covers most of the tail)
+
+Most requested "sports" are really *configurable scoring shells*: N entrants, one or more
+numeric metrics, a points rule, a ranking. One module, config-driven (same contract as
+football/cricket, PROMPT-03):
+
+```ts
+GenericCfg = z.object({
+  metrics: z.array(z.object({                 // e.g. hits, style, runs, legs, points
+    key: z.string(), label: z.string(),
+    kind: z.enum(['int','decimal','signed']), // decimal → Ludosport floats; signed → minus scores
+    higherWins: z.boolean().default(true),
+  })),
+  decidedBy: z.string(),                       // which metric decides the fixture
+  labels: z.record(z.string(), z.string()).optional(),  // rename PLD/W/D/L/PTS/PF/PA (11 Oct)
+  points: z.lazy(() => PointsRule),            // reuse Jul3/05 §2
+});
+```
+
+- **Ludosport** (1 Oct): `metrics:[{key:'hits',kind:'decimal'},{key:'style',kind:'decimal'}]`,
+  fractional points — the `decimal` kind is exactly the "floating point values" ask.
+- **Sumo-robot / non-sports** (11 Oct): `labels:{PTS:'Score',PF:'Wins'}` renames columns.
+- **Baseball** (29 July): a generic preset with `metrics:[{key:'runs',label:'Runs'}]` —
+  "Runs" not "Goals" is a label, not a code change. (A deeper innings module can come later.)
+- **Darts** (28 Nov): `metrics:[{key:'legs'},{key:'legDiff'}]`, leg-difference as a
+  tiebreaker metric + average column.
+- **Race/running** (30 Apr): finishing position/time as the metric; rank ascending
+  (`higherWins:false`) — ties into §4 multi-event.
+
+The generic module emits `generic.result {metrics}` and `generic.adjust` events, folds to a
+`StandingsDelta` from the declared metrics, and feeds the tiebreaker cascade (doc 05 §4) and
+custom points (Jul3/05). Conformance suite (PROMPT-03 kit) applies unchanged.
+
+## 3. Thin presets vs full modules
+
+- **Generic presets** (ship first, cheap): baseball, darts, netball, Tchoukball, race,
+  Ludosport, Mölkky — each a `sport_variants` row over `generic` with metrics/labels/points.
+- **Full modules** (only where match grammar is genuinely different): golf (stroke/stableford
+  scoring over holes, handicaps) and Kinball (3-entrant fixtures) need real modules — golf
+  has a per-hole ledger, Kinball breaks the two-sided fixture assumption. Flag both as their
+  own follow-up prompts; deliver the generic presets now.
+
+## 4. Multi-event / multi-sport combined ranking (17 Mar, 16 Mar)
+
+"Score participants by rank across events and collate an overall winner" (17 Mar) and "same
+teams compete in football + basketball + handball, combine" (16 Mar):
+
+- Model as a **competition-level aggregate** over sibling divisions (each event = a
+  division). A `combined_ranking` config on the competition: `{ divisions:[...], scoring:
+  'rank_points'|'sum_points', rankPoints:[10,8,6,...] }`.
+- Pure `combineRankings(divisionStandings[], config) → CombinedRow[]` — reads each division's
+  final standings (already computed) and folds to an overall table. No new truth; a derived
+  read model, sibling to `stats.club_championship` (doc 10, doc 06 §4.4).
+- The 16-Mar "independent group stages per sport, manual assignment, no dependency on prior
+  results" is satisfied by multiple divisions each with `qualification:'all'` + this
+  combiner — no forced progression between sports.
+
+## 5. Kinball / 3-team fixtures (2 Feb)
+
+Genuinely breaks the 2-sided fixture aggregate (doc 02 §6). Scoped note only: needs
+`fixture` to allow N entrants (an `entrant_slots` array) and the sport module to score a
+multi-party contest. Non-trivial — flag as its own design + prompt; do **not** fold into the
+generic module (which assumes 2 sides). Documented so the ask isn't lost.
+
+## 6. API & entitlements
+
+- New sports/variants seed via the registry-sync into `sports` / `sport_variants` (doc 07);
+  divisions bind them like any sport (doc 02 §4).
+- Metric-label overrides are division config → flow to standings/exports/dashboard labels.
+- Entitlements: generic sports available same as built-in sports; `generic.custom_metrics`
+  (>N metrics, custom labels) and `combined_ranking` = Pro (aligns with
+  `stats.club_championship` Pro, doc 10).
+
+## 7. Edge cases
+
+- Signed/decimal metrics must sum correctly in standings + points (Jul3/05 §2 numbers).
+- Rename labels must not break existing tiebreaker keys — labels are display-only; the
+  metric `key` stays canonical (rename `PF`'s label, not its identity).
+- Ascending-rank sports (race, golf) invert winner logic — `higherWins:false` handled in the
+  fold and the cascade comparator.
+- A generic preset requesting a metric the UI has no input for → the scorer console renders
+  a generic numeric pad from `metrics` (data-driven, no bespoke UI per sport).

--- a/engine/Jul3/PROMPT-21-clubs-and-bulk-import.md
+++ b/engine/Jul3/PROMPT-21-clubs-and-bulk-import.md
@@ -1,0 +1,65 @@
+# PROMPT-21 — Clubs & Bulk Participant Import
+
+**Read first:** `engine/Jul3/01-clubs-and-bulk-import.md` (normative); `engine/07-greenfield-schema.md`
+§conventions + §notes 1–4; `engine/08-api-design.md` §1, §3, §4; `engine/10-pro-entitlements.md`
+§2–3; `engine/06-divisions-and-eligibility.md` §4.4 (club championship), §4.7 (consent).
+Preamble: PROMPT-00. **Depends:** PROMPT-10 (schema), PROMPT-11 (api-v1). Promotes the
+doc 16 §Tier-3 "Imports" backlog line; keep the old-engine rule (PROMPT-00 §5) — this is
+additive, deletes nothing.
+
+## Task
+
+1. **Schema migration** (per Jul3/01 §2): `clubs` table + `teams.club_id` FK + indexes;
+   generic `set_org_from_parent()` trigger + direct RLS policy per the 010 pattern;
+   `team_display_v` view resolving effective logo/colour (team → club fallback) and folded
+   into the doc 07 note-4 public read views. Extend `check:rls` coverage to `clubs`.
+
+2. **Engine planner** `packages/engine/import/` — **pure, no I/O** (README rule 1,
+   PROMPT-00 §3): Zod schemas + inferred types `ImportRow`, `ImportSnapshot`, `ImportConfig`,
+   `ImportOp`, `ImportIssue`, `ImportPlan` (Jul3/01 §3); `planImport(rows, snapshot, config)
+   → ImportPlan`, total (never throws — all problems become `issues`), deterministic. Match/
+   dedupe/idempotence exactly per Jul3/01 §4; every rule comments its spec section
+   (`// Jul3/01 §4 person match`). Ops carry stable synthetic refs so cross-op dependencies
+   resolve at execute time.
+
+3. **App server layer** (`apps/web/src/server/`, server-only — the only writer):
+   - CSV/XLSX parser → header-mapped `ImportRow[]` (streamed for large files, Jul3/01 §9).
+   - `POST /api/v1/imports` (multipart) → parse + fetch `ImportSnapshot` + `planImport` →
+     `{ importId, plan }`; **dry-run, writes nothing**. Persist the parse + plan for re-preview.
+   - `POST /api/v1/imports/{id}/commit` → execute plan ops in ref-dependency order inside one
+     `withTenant` transaction (rollback-all on any failure); `Idempotency-Key` header
+     (doc 08 §4, Redis 24 h); emit `division_events: participants_imported` + org audit
+     (011 hash chain). `GET /api/v1/imports/{id}` re-previews.
+   - `POST /api/v1/clubs/logos` (multipart, bulk) — match per Jul3/01 §5 (filename-stem →
+     manual re-map → any-order), content-hash dedupe, set `clubs.logo_path`, idempotent.
+   - `clubs` CRUD; `?club_id=` filter on `divisions/{id}/entrants`; `GET
+     /participants/export?format=csv|xlsx` (club + division columns, empty-spot placeholders
+     preserved). Wire the doc 08 §3 `divisions/{id}/entrants` CSV hook as a division-pinned
+     alias into the same planner.
+
+4. **Entitlements** (Jul3/01 §7): seed `import.bulk`, `logos.bulk`, `clubs.hierarchy` in
+   `plan_entitlements`; enforce with `requireFeature`/`withinLimit` at the use-cases (402
+   `PaymentRequiredError` carrying `feature_key`); Community capped at 20 rows/file.
+
+5. **UI** (`apps/web`): import wizard (upload → column mapper with remembered mapping →
+   preview table grouped by club with per-row create/update/skip/link badges + issue list →
+   Commit); bulk-logo grid (drag-drop, per-club re-map dropdown, assign-remaining toggle);
+   club filter facet + club detail (teams across divisions) on participants/schedule pages.
+   Keyboard-accessible (a11y required, matches PROMPT-17 bar).
+
+## Acceptance
+
+- **Property (fast-check):** `planImport` idempotent — apply a plan, rebuild the snapshot,
+  re-plan the same rows ⇒ `ops == []`; dedupe never emits a second `club.create`/
+  `person.create` for a matching entity; unknown `divisionSlug` always yields
+  `error DIVISION_NOT_FOUND` and never an op.
+- **Golden:** a sample 3-club × 4-team × 11-player XLSX → expected `ImportPlan` (stats +
+  op kinds); committing it then re-committing the same file = no-op (zero new rows).
+- **E2E (Playwright):** upload → preview shows a seeded issue (bad position) → fix →
+  commit → clubs/teams/persons/entrants/rosters present with club parentage; bulk-logo drop
+  → every child team renders the club badge via `team_display_v`; participants export has a
+  club column with empty-spot rows intact; Community org blocked at row 21 with a 402
+  carrying `import.bulk`.
+- `npm test` + `npm run lint` green. Update `engine/README.md` (doc index + prompt index)
+  and, if any rule here refined Jul3/01, update Jul3/01 in the same PR (PROMPT-00 §4 — docs
+  and code may not drift).

--- a/engine/Jul3/PROMPT-22-referee-officials-assignment.md
+++ b/engine/Jul3/PROMPT-22-referee-officials-assignment.md
@@ -1,0 +1,37 @@
+# PROMPT-22 — Referee & Officials Assignment Engine
+
+**Read first:** `engine/Jul3/02-referee-officials-assignment.md` (normative);
+`engine/05-formats-progression-tiebreakers.md` §2.6; `engine/12-scheduling-ux.md` §2, §4;
+`engine/13-roles-and-scorer.md` (role labels); `engine/07-greenfield-schema.md` §conventions.
+Preamble: PROMPT-00. **Depends:** PROMPT-09 (calendar pass), PROMPT-11 (api), PROMPT-17
+(board consumes cards). Promotes the doc 10 `officials.assignment` stub.
+
+## Task
+1. **Schema** (Jul3/02 §2): `officials`, `fixture_officials` tables; RLS/org_id trigger per
+   010; `check:rls` coverage; keep `fixtures.officials` as denormalized read cache; public
+   view nulls names when hidden (doc 07 note 4).
+2. **Engine pass** `packages/engine/officials/` — **pure, deterministic, seeded**:
+   `assignOfficials(input) → {assignments, conflicts}` per Jul3/02 §3; hard constraints
+   (overlap, team-ref-self, poolLock, role coverage), soft objective (fairness, block-stay,
+   travel/keep-division). Plus the pure **sourcing resolver** (rank/result → OfficialSpec[])
+   for phased assignment. Every rule cites `// Jul3/02 §3`. Property: all-locked re-run = 0
+   moves (mirror PROMPT-17 §3).
+3. **API** (Jul3/02 §4): `officials` CRUD + import; `divisions/{id}/officials/auto` (propose,
+   engine call with locked obstacles) + `/apply` (txn + `division_events: officials_assigned`);
+   `fixtures/{id}/officials` PATCH (manual set/move/lock); `stages/{id}/officials/source`.
+   Conflict taxonomy block/warn per Jul3/02 §4.
+4. **Entitlements** (Jul3/02 §5): `officials.auto`, `officials.roles_multi` = Pro; manual
+   single-role Community. 402 with `feature_key`.
+5. **Console** (`apps/web`): officials palette + auto/apply actions feeding the PROMPT-17
+   board (cards, pin/lock, conflict badges); phased "assign Phase 1 now / Phase 2 when ready"
+   affordance; hide-names toggle; a11y (keyboard move).
+
+## Acceptance
+- Property (fast-check, ≤64 fixtures): no official double-booked; team-ref never officiates
+  own fixture nor while playing; poolLock respected; all-locked idempotence.
+- Golden: 24-fixture, 2-court day, 6 officials, block-stay on → each official stays on one
+  court within a block, fairness spread ≤1; a phased case where Phase-2 officials resolve
+  only after Phase-1 decided.
+- E2E: auto-assign → drag a ref into an overlap (blocked) → lock two → re-flow → apply →
+  public schedule hides names.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes.

--- a/engine/Jul3/PROMPT-23-schedule-undo-and-locking.md
+++ b/engine/Jul3/PROMPT-23-schedule-undo-and-locking.md
@@ -1,0 +1,34 @@
+# PROMPT-23 — Schedule Undo, Versioning & Safe Destructive Ops
+
+**Read first:** `engine/Jul3/03-schedule-undo-and-locking.md` (normative);
+`engine/05-formats-progression-tiebreakers.md` §5 (division ledger); `engine/02-domain-model.md`
+§6, §8; `engine/07-greenfield-schema.md` notes 1–3; `engine/12-scheduling-ux.md` §3.
+Preamble: PROMPT-00. **Depends:** PROMPT-08 (progression ledger), PROMPT-17 (console/board).
+
+## Task
+1. **Schema** (Jul3/03 §2): `divisions.schedule_locked/edit_watermark`, `fixtures.locked/
+   schedule_source`, `division_checkpoints` table; RLS/org_id + `check:rls`.
+2. **Engine** `packages/engine/history/` — **pure**: the `ReversibleOp` registry (Jul3/03 §3)
+   declaring `invert` for each structural `division_events` type; `undo`/`redo` as pure
+   functions `(state, ledger, watermark) → {eventToAppend, newWatermark}`; `fold(events ≤
+   watermark) → DivisionScheduleState`. Results-guard: block undo past decided fixtures
+   (`UNDO_BLOCKED_HAS_RESULTS`). Cite `// Jul3/03 §3`.
+3. **Scoped ops** (Jul3/03 §5): pure `clearSchedule(scope)` + `removeEntrantsFromPool(poolId)`
+   returning the events to append; `excludeLocked` default true; results-guard.
+4. **App/API** (Jul3/03 §6): `undo`/`redo`/`history`/`checkpoints`/`restore` endpoints
+   (division-lock append, optimistic seq → 409 on stale); `schedule/clear` + `pools/{id}/
+   clear-entrants` requiring `confirm:true`; `fixtures/{id}` PATCH `locked`. All emit
+   ledger events; hash-chain intact.
+5. **Locking** (Jul3/03 §4): wire persisted `fixtures.locked` + scope-lock predicate into
+   PROMPT-17's `lockedAssignments` obstacle input (two-site safety).
+6. **UI**: undo/redo buttons + history panel + named checkpoints; confirm modal on clear,
+   button moved away from "Schedule" (doc 18-May ask); pin/lock badges.
+
+## Acceptance
+- Property: `apply → undo → redo` round-trips to identical state; undo never mutates ledger
+  rows (append-only); watermark truncation linearises history (Word-like).
+- Golden: generate 8-team schedule → move 3 fixtures → undo×3 = original → redo×3 = moved;
+  scoped clear of pool A leaves pool B + locked fixtures intact.
+- E2E: two-site division — regenerate site A with site B locked → site B fixtures unchanged;
+  clear without confirm rejected; restore to a checkpoint (guarded past results).
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes.

--- a/engine/Jul3/PROMPT-24-scheduling-constraints-v2.md
+++ b/engine/Jul3/PROMPT-24-scheduling-constraints-v2.md
@@ -1,0 +1,39 @@
+# PROMPT-24 — Scheduling Constraints v2 & AI-Assisted Planning
+
+**Read first:** `engine/Jul3/04-scheduling-constraints-v2.md` (normative);
+`engine/05-formats-progression-tiebreakers.md` §2.6; `engine/12-scheduling-ux.md` §2, §4;
+`engine/02-domain-model.md` §3 (persons). Preamble: PROMPT-00. **Depends:** PROMPT-09
+(calendar), PROMPT-17 (schedule-settings + console). Extends, does not replace, the solver.
+
+## Task
+1. **Constraint schema** (Jul3/04 §3): extend `SchedulingConstraints` (Zod) with `restMin`/
+   `restByGroup`, `noBackToBack`, `startWindows`, `fieldFairness`, `parallelism`,
+   `crossPersonClash`. Validate at schedule-settings PUT.
+2. **Solver additions** `packages/engine/scheduling/calendar.ts` — **pure**: enforce new
+   hard constraints (rest, start-windows, cross-person-clash=hard) as placement rejections
+   with repair; new soft objectives (field fairness, parallelism=mixed). Cross-division
+   **person-keyed** overlap map (Jul3/04 §2) built from `entrant_members ⋈ persons`. Never
+   silently drop — surface `conflicts`. Cite `// Jul3/04 §3`.
+3. **Bulk shift + flexible mode + report** (Jul3/04 §4): pure `shiftSchedule({scope,delta})`
+   and `scheduleReport(assignments) → {perEntrant, worst}`; division `scheduling_mode`
+   flag (`timed`|`flexible`, `scheduled_at=null` fixtures).
+4. **AI layer** (Jul3/04 §5): `POST /divisions/{id}/schedule/ai-constraints` — prose → LLM
+   (Anthropic SDK, latest model, **server-only**) → **Zod-parsed** `SchedulingConstraints`;
+   unparseable = refuse. Model never writes DB or schedules; the pure solver does. Propose-
+   only, human applies.
+5. **API** (Jul3/04 §6): schedule-settings fields; `schedule/shift`; `schedule/report`;
+   `ai-constraints`. **Entitlements**: constraint solver Pro (`scheduling.constraints`);
+   bulk-shift + report all plans; `scheduling.ai` Pro.
+6. **UI**: constraint editor; wait-time report before publish; bulk-shift dialog; AI prose
+   box showing the parsed constraints for approval (never auto-apply).
+
+## Acceptance
+- Property: no schedule places a person (via any entrant) in two overlapping fixtures when
+  `crossPersonClash=hard`; rest/start-window bounds hold; over-constrained instance returns
+  best-effort + non-empty `conflicts` (never an invalid slot).
+- Golden: player entered in two divisions is never double-booked; a `notBefore:09:30` team
+  never slotted earlier; bulk-shift +15m moves all in scope, undoable (PROMPT-23).
+- E2E: enter prose "no player plays two teams at once, ≥1 break between games, U8 start
+  09:00" → parsed constraints shown → apply → solver honours them; infeasible case reports
+  the binding constraint.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes.

--- a/engine/Jul3/PROMPT-25-custom-points-and-standings.md
+++ b/engine/Jul3/PROMPT-25-custom-points-and-standings.md
@@ -1,0 +1,36 @@
+# PROMPT-25 — Custom Points, Standings Carry-Over & Manual Rank Control
+
+**Read first:** `engine/Jul3/05-custom-points-and-standings.md` (normative);
+`engine/05-formats-progression-tiebreakers.md` §3–4; `engine/02-domain-model.md` §5–7;
+`engine/04-sport-scoring-specs.md` §per-sport (forfeit/no-result). Preamble: PROMPT-00.
+**Depends:** PROMPT-08 (standings + cascade). Rides existing StandingsDelta plumbing — no
+sport-module changes.
+
+## Task
+1. **Points rule** (Jul3/05 §2): `PointsRule` Zod on `stages.config.points`; pure evaluator
+   reading `StandingsDelta.metrics` (margins/ratios/forfeit/no_result) → competition points;
+   support fractional/negative. Sport default + division override. Cite `// Jul3/05 §2`.
+2. **Carry-over** (Jul3/05 §3): extend `qualification` with `carry: none|points|full`;
+   synthetic opening delta folded before new fixtures; no replay of prior H2H; emit
+   `division_events: standings_carried`.
+3. **Manual rank override** (Jul3/05 §4): `POST /stages/{id}/standings/override` setting
+   `rank_locked` rows; cascade ranks only unlocked remainder around locks; emit
+   `rank_overridden` (actor+reason, hash-chained).
+4. **Cascade additions** (Jul3/05 §5): tie-exhaustion → `rows[].tie_unbroken` + `warn`;
+   `h2h_scope: mini_table|overall`; fair-play as selectable step + fair-play standings view.
+5. **Decisions** (Jul3/05 §6): `core.forfeit` / `core.no_result` events → outcome + points
+   from rule; no fake scores; surface penalty-shootout decider in summary/slide.
+6. **Entitlements**: base win/draw/loss = all plans; bonuses + carry-over + circular-H2H +
+   override = Pro (`standings.custom_points`, `standings.carry_over`, existing
+   `tiebreakers.custom`); tie-unbroken alert all plans.
+
+## Acceptance
+- Property: points evaluator is a pure fold — reordering decided fixtures yields identical
+  standings; fractional/negative sums exact; a rule referencing a missing metric fails at
+  stage-config (fail closed).
+- Golden: netball 5/3/1 + losing-≥50% bonus reproduces a hand table; carry-over of top-3
+  from each of 2 groups into a super-pool with prior H2H not replayed; 3rd/4th set by
+  placement-game override (not alphabetical).
+- E2E: two teams tie through the whole cascade → alert shown before KO seeding; forfeit
+  awards configured points, no invented score; double-forfeit gives both `no_result` points.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes.

--- a/engine/Jul3/PROMPT-26-exports-and-print.md
+++ b/engine/Jul3/PROMPT-26-exports-and-print.md
@@ -1,0 +1,33 @@
+# PROMPT-26 — Rich Exports & Print Templates
+
+**Read first:** `engine/Jul3/06-exports-and-print.md` (normative); `engine/09-public-dashboard.md`
+(read models); `engine/07-greenfield-schema.md` note 4 (public views); `engine/03-engine-architecture.md`
+(module plugin points). Preamble: PROMPT-00. **Depends:** PROMPT-08 (standings), PROMPT-12
+(read models). Sport-fragment hooks depend on the sport modules (PROMPT-04..07, 16).
+
+## Task
+1. **Engine** `packages/engine/exports/` — **pure**: `DocModel` Zod schema (Jul3/06 §2) +
+   `buildDocModel(kind, data, opts) → DocModel` for the sport-neutral kinds (timetable,
+   standings, roster, participants). `printedAt` is an input, not `Date.now()` (PROMPT-00
+   §3). Scope + `pageBreaks` (`per_pitch|per_team|per_division`) per Jul3/06 §4. Cite
+   `// Jul3/06 §2`.
+2. **Sport fragments** (Jul3/06 §3): optional `SportModule.exportTemplates` (scoresheet,
+   matchReport) → `DocSection`; implement the **volleyball point-by-point scoresheet** with
+   signature lines + two-per-page (12 Jun exact ask) in the set-based module.
+3. **Renderers** (`apps/web`, server-only — the I/O half): `DocModel → PDF` and `→ XLSX`;
+   branding (club colours via `team_display_v` from Jul3/01 §2, sponsor logos, tournament
+   title, prelim/KO headings, printed-date footer — 1 Sep asks). Empty-spot labels never
+   blank (30 Jan). Stream large exports.
+4. **API** (Jul3/06 §5): `divisions/{id}/exports/{kind}`, `competitions/{id}/exports/
+   timetable?pretty=true`; cache on read watermark; branding nulled for non-Pro at the model
+   layer.
+5. **Entitlements** (Jul3/06 §6): `exports` (Pro) for CSV/XLSX; `exports.branded` (Pro) for
+   templated/branded PDF; layout flags (landscape, page-break scope) all export plans.
+
+## Acceptance
+- Golden: `buildDocModel` output for a timetable, a landscape standings, a roster, and a
+  volleyball scoresheet asserted as stable `DocModel` JSON (not pixels).
+- E2E: export pretty timetable PDF (tournament name + prelim/KO headings + footer date);
+  scoresheets `pageBreaks=per_pitch` → each court starts a new page; participants XLSX has
+  club + division columns with Empty-Spot rows intact; non-Pro gets unbranded output.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes.

--- a/engine/Jul3/PROMPT-27-player-stats.md
+++ b/engine/Jul3/PROMPT-27-player-stats.md
@@ -1,0 +1,33 @@
+# PROMPT-27 — Player Statistics Engine
+
+**Read first:** `engine/Jul3/07-player-stats.md` (normative); `engine/02-domain-model.md`
+§6–7 (ledger/derived caches); `engine/14-score-granularity.md`; `engine/06-divisions-and-eligibility.md`
+§4.7 (consent); `engine/10-pro-entitlements.md` §Sport depth. Preamble: PROMPT-00.
+**Depends:** PROMPT-04..07 (fine events), PROMPT-11 (api), PROMPT-18 (scorer console emits).
+
+## Task
+1. **Schema** (Jul3/07 §2): `player_stat_snapshots` (disposable cache); RLS/org_id +
+   `check:rls`; rebuildable from events (CI consistency check like standings).
+2. **Engine** `packages/engine/stats/` — **pure**: `SportModule.playerStats` declaration
+   (metrics/from/agg/derive, awards) per Jul3/07 §3; `aggregatePlayerStats(events, roster,
+   model) → StatRow[]`, deterministic; football goals/assists/points(derive)/cards +
+   set-sports points/aces. Cite `// Jul3/07 §3`. Voided events excluded.
+3. **Awards** (Jul3/07 §4): `core.award {personId, key:'motm'}` event on the existing scoring
+   endpoint; aggregate to division-scoped MOTM leaderboard.
+4. **Scorer-picker numbers** (Jul3/07 §5): lineup read model returns `squadNumber`; picker
+   renders `#7 — Name` + number-order sort option (fixes 9 Sep ×4 / 11 Jun / 10 Jul / 19 May).
+5. **API** (Jul3/07 §6): `divisions/{id}/stats/players?metric=&sort=`, `persons/{id}/stats`,
+   public consent-filtered `divisions/{slug}/stats`.
+6. **Entitlements** (Jul3/07 §7): `stats.player` (Pro) for leaderboards/cards/MOTM tables;
+   scorer-picker numbers all plans; MOTM entry wherever scoring is enabled.
+
+## Acceptance
+- Property: stats are a pure fold — refold(events) == snapshot; a `core.void` on a goal
+  drops the goal and its assist; player in two divisions has per-division tables that don't
+  bleed.
+- Golden: a football fixture ledger → goals/assists/points table with `points=goals+assists`
+  (16 Apr); MOTM award appears in the division leaderboard.
+- E2E: ref enters goal + scorer via `#number` picker → top-scorer table updates; enters MOTM
+  → MVP table updates; Community (ball-by-ball off) shows "requires detailed scoring" not
+  wrong zeros; minor's name gated on public leaderboard.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes.

--- a/engine/Jul3/PROMPT-28-format-extensions.md
+++ b/engine/Jul3/PROMPT-28-format-extensions.md
@@ -1,0 +1,37 @@
+# PROMPT-28 — Format Engine Extensions
+
+**Read first:** `engine/Jul3/08-format-extensions.md` (normative);
+`engine/05-formats-progression-tiebreakers.md` §2 (roundrobin/swiss/bracket) + §6
+(invariants); `engine/02-domain-model.md` §5–6, §8 (stage graph, feeds, progression).
+Preamble: PROMPT-00. **Depends:** PROMPT-09 (generators), PROMPT-08 (progression). Ties to
+Jul3/04 (flexible scheduling) and Jul3/05 (fractional points, placement ranks).
+
+## Task
+1. **RR legs>2** (Jul3/08 §2): lift the `legs` cap in `roundrobin.ts`; home/away balance
+   across all legs; property `completeness = n(n−1)/2·legs`.
+2. **Americano/Mexicano** (Jul3/08 §3): new `americano` stage kind; even rotation
+   (americano) + rank-derived pairing reusing swiss `pairRound` (mexicano); on-the-fly `pair`
+   entrants; per-person points.
+3. **Custom brackets + cross-format feeds** (Jul3/08 §4): organiser-chosen byes /
+   non-power-of-2 in `bracket.ts`; allow `loser_to`/`winner_to` to target a fixture in a
+   **different stage** (CL→EL); `places:[..]` fixtures resolving to explicit final ranks
+   (into Jul3/05 §4 override). Validate the feed graph is a DAG (fail closed).
+4. **Independent pools + auto-advance + early slot fill** (Jul3/08 §5): per-pool completion
+   releasing pool-only dependents; `auto_progress` division flag; feed resolver runs
+   per-decided-fixture (partial "Winner QF1 vs TBD"), not per-round. Emit `stage_auto_advanced`.
+5. **Ladder + Hammes** (Jul3/08 §6–7): `ladder` stage kind (challenge-based, flexible
+   schedule) — minimal viable; `swiss` `pairing:'rank_adjacent'` preset (Hammes), no new code.
+6. **API/entitlements** (Jul3/08 §8): stage config extensions via existing stages endpoint;
+   `formats.advanced` (americano/custom_bracket/cross_feed/ladder/auto_progress) = Pro.
+
+## Acceptance
+- Property: triple-RR completeness/balance; americano rotation covers pairings evenly for
+  feasible counts; cross-format feed graph rejected if cyclic; per-decided-fixture fill never
+  seeds a KO slot before its source decides.
+- Golden: 6-team custom bracket with chosen byes matches an expected layout; CL QF loser
+  lands in the EL QF slot; pool A completes and opens its dependent fixtures while pool B is
+  unfinished; Hammes 5-round on 8 entrants, zero rematches.
+- E2E: `auto_progress` on → finishing a group auto-generates the next stage (no button);
+  a team sees its next-round fixture the moment its opponent's source is decided.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes. Ladder/Kinball
+  deep-dives, if they grow, split into their own follow-up prompts (noted in Jul3/08 §6, §9).

--- a/engine/Jul3/PROMPT-29-new-sports-and-generic-scoring.md
+++ b/engine/Jul3/PROMPT-29-new-sports-and-generic-scoring.md
@@ -1,0 +1,37 @@
+# PROMPT-29 — Generic Configurable Sport Module & New-Sport Presets
+
+**Read first:** `engine/Jul3/09-new-sports-and-generic-scoring.md` (normative);
+`engine/03-engine-architecture.md` (SportModule contract) + PROMPT-03 conformance kit;
+`engine/04-sport-scoring-specs.md` §9 (generic/invariants); `engine/14-score-granularity.md`.
+Preamble: PROMPT-00. **Depends:** PROMPT-03 (contract). Reuses Jul3/05 `PointsRule`.
+
+## Task
+1. **Generic module** `sports/generic/` (Jul3/09 §2) — **pure**, PROMPT-03-conformant:
+   `GenericCfg` Zod (metrics with `kind: int|decimal|signed`, `higherWins`, `decidedBy`,
+   `labels`, `points`); events `generic.result {metrics}`, `generic.adjust`; fold →
+   `StandingsDelta` from declared metrics; feeds cascade (doc 05 §4) + custom points
+   (Jul3/05). `arbitraryEvent` generator + full conformance suite.
+2. **Presets** (Jul3/09 §3): `sport_variants` rows over `generic` for baseball (Runs),
+   darts (legs + legDiff + average), netball, Tchoukball, race (ascending), Ludosport
+   (decimal hits+style, fractional points), Mölkky. Each documented with its metrics/labels/
+   points.
+3. **Metric-label overrides** (Jul3/09 §6): division-config label map flowing to standings/
+   exports/dashboard; canonical metric `key` unchanged (rename display only).
+4. **Multi-event combined ranking** (Jul3/09 §4): pure `combineRankings(divisionStandings[],
+   config) → CombinedRow[]`; competition-level `combined_ranking` config
+   (`rank_points|sum_points`); derived read model, no new truth. Satisfies 16-Mar
+   independent-group-stages-per-sport via multiple `qualification:'all'` divisions + combiner.
+5. **Data-driven scorer pad** (Jul3/09 §7): scorer console renders a numeric pad from
+   `metrics` (no bespoke UI per generic sport); decimal/signed inputs supported.
+6. **Entitlements/registry** (Jul3/09 §6): generic sports seed via registry-sync; generic
+   sports free like built-ins; `generic.custom_metrics` + `combined_ranking` = Pro.
+
+## Acceptance
+- `conformanceSuite(generic)` green; goldens: Ludosport fixture with fractional hits+style
+  decides correctly and sums fractional points; darts leg-diff tiebreak; a race division
+  ranks ascending; a relabelled table shows `Runs`/`Score` while keeping canonical keys.
+- Golden: two-division "football + basketball" competition combined via `rank_points` →
+  overall table; no forced progression between the two sports.
+- `npm test` + `npm run lint` green; update `engine/README.md` indexes. Golf (per-hole/
+  handicap) and Kinball (3-entrant fixture) are **out of scope here** — flagged as their own
+  follow-up design+prompt in Jul3/09 §3, §5.


### PR DESCRIPTION
## What

Mines the **3 Jul 2026 organiser feature-request intake** into the Engine v2 design corpus under a new `engine/Jul3/` folder. **Docs only — no product code.**

- **`00-idea-backlog.md`** — full intake captured, every cluster mapped to where it's designed (Grabbed / Deferred-to-corpus / Not-yet-designed), with dates + vote counts.
- **9 design docs + 9 implementation prompts** (PROMPT-21..29), each matching the existing corpus convention (Read-first / Depends / Task / Acceptance; types-first Zod; cite spec §; pure engine / no I/O):

| # | Cluster | Design | Prompt |
|---|---------|--------|--------|
| 1 | Clubs & bulk import *(headline ask)* | 01 | 21 |
| 2 | Referee/officials assignment engine | 02 | 22 |
| 3 | Schedule undo, versioning & safe destructive ops | 03 | 23 |
| 4 | Scheduling constraints v2 + AI planning | 04 | 24 |
| 5 | Custom points, carry-over & manual rank | 05 | 25 |
| 6 | Rich exports & print templates | 06 | 26 |
| 7 | Player statistics engine | 07 | 27 |
| 8 | Format engine extensions | 08 | 28 |
| 9 | Generic sport module & new-sport presets | 09 | 29 |

## Why

The headline 3-Jul request (single full import: teams+players+parent-club+bulk logos) plus the whole idea list had no home in the corpus — "Imports" was a one-line Tier-3 backlog item and there was no `clubs` table. This promotes the high-leverage clusters to full design + prompt, and records the rest so nothing is lost.

## Design notes

- Each doc **extends** the existing corpus (07 schema, 08 API, 10 entitlements) rather than forking it; new tables follow the 010 `org_id`/RLS pattern and 011 hash-chain audit.
- Every planner is **pure / event-sourced / deterministic** per the engine ground rules (README rule 1, PROMPT-00 §3). The one LLM touchpoint (AI scheduling, doc 04) only emits Zod-validated constraint objects — the schedule still comes from the deterministic solver.
- Deferred clusters (registration, offline PWA, player accounts, comms, branding, i18n, org ops) are mapped to their existing homes in `00-idea-backlog.md`.

## Scope

Planning artifacts only. No `packages/engine` / `apps/web` / migration changes — those are delivered later by running the individual prompts. Suggested build order noted in `00-idea-backlog.md` (referees → undo → custom points highest pure-engine leverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167pEsHzfZ8KyB3Bz6sDKfn