### PR TITLE
feat: entitlements v2 matrix + enforcement (PROMPT-13)

### DIFF
--- a/apps/web/src/app/api/orgs/[id]/entitlements/route.ts
+++ b/apps/web/src/app/api/orgs/[id]/entitlements/route.ts
@@ -45,6 +45,18 @@ export async function GET(
     const [{ seasons_count }] = await sql<{ seasons_count: number }[]>`
       select count(*)::int as seasons_count from seasons where org_id = ${orgId}`;
 
+    // v2 usage (PROMPT-13): what the UI compares against the v2 quota keys.
+    // Statuses counted mirror competitions.max_active enforcement.
+    const [v2] = await sql<
+      { competitions_active_count: number; dashboards_public_count: number }[]
+    >`
+      select
+        count(*) filter (where status in ('draft','published','live'))::int
+          as competitions_active_count,
+        count(*) filter (where visibility = 'public')::int
+          as dashboards_public_count
+      from competitions where org_id = ${orgId}`;
+
     const entitlements = Object.fromEntries(
       rows.map((r) =>
         r.bool_value !== null
@@ -58,7 +70,11 @@ export async function GET(
       status,
       trial_end: sub?.trial_end ?? null,
       current_period_end: sub?.current_period_end ?? null,
-      usage: { seasons_count },
+      usage: {
+        seasons_count,
+        competitions_active_count: v2?.competitions_active_count ?? 0,
+        dashboards_public_count: v2?.dashboards_public_count ?? 0,
+      },
       entitlements,
     };
   });

--- a/apps/web/src/components/upgrade-gate.tsx
+++ b/apps/web/src/components/upgrade-gate.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { featureReason } from "@/lib/feature-copy";
+
+interface Props {
+  /** Entitlement feature key, e.g. "scoring.ball_by_ball" (doc 10 §1). */
+  feature: string;
+  /**
+   * Where the paywall sends the user. Defaults to billing; pass a
+   * plan-comparison anchor when the touchpoint has one.
+   */
+  href?: string;
+  /** Compact renders a one-line pill (for toolbars/toggles); default is a card. */
+  compact?: boolean;
+}
+
+/**
+ * THE upgrade-moment component (doc 10 §3): one contextual paywall, rendered
+ * exactly where a limit bites — adding a 2nd division, toggling ball-by-ball,
+ * publishing a 2nd dashboard, enabling DLS, creating an API key. The copy
+ * derives from the same feature_key the 402 response carries, so a blocked
+ * server call and a pre-emptively gated control read identically.
+ */
+export function UpgradeGate({ feature, href = "/settings/billing", compact = false }: Props) {
+  const reason = featureReason(feature);
+
+  if (compact) {
+    return (
+      <Link
+        href={href}
+        data-feature={feature}
+        className="inline-flex items-center gap-1.5 rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 hover:bg-purple-100"
+      >
+        <LockIcon />
+        {reason} <span className="font-semibold underline">Upgrade →</span>
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      data-feature={feature}
+      className="rounded-lg border border-purple-200 bg-purple-50 p-4 text-sm text-purple-900"
+    >
+      <p className="flex items-center gap-2 font-medium">
+        <LockIcon />
+        {reason}
+      </p>
+      <p className="mt-2">
+        <Link href={href} className="font-semibold text-purple-700 underline">
+          See plans & upgrade →
+        </Link>
+      </p>
+    </div>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      className="h-3.5 w-3.5 shrink-0"
+    >
+      <path d="M8 1a3.5 3.5 0 0 0-3.5 3.5V6H4a1.5 1.5 0 0 0-1.5 1.5v5A1.5 1.5 0 0 0 4 14h8a1.5 1.5 0 0 0 1.5-1.5v-5A1.5 1.5 0 0 0 12 6h-.5V4.5A3.5 3.5 0 0 0 8 1Zm2 5H6V4.5a2 2 0 1 1 4 0V6Z" />
+    </svg>
+  );
+}

--- a/apps/web/src/lib/feature-copy.ts
+++ b/apps/web/src/lib/feature-copy.ts
@@ -1,0 +1,41 @@
+// Human copy for entitlement feature keys (doc 10 §3 — upgrade moments).
+// Isomorphic on purpose: the 402 handlers (server) and <UpgradeGate> (client)
+// read the same map so the paywall reason is identical everywhere.
+
+const FEATURE_REASONS: Record<string, string> = {
+  // Structure & scale
+  "orgs.max_owned": "You've reached the number of clubs your plan can own.",
+  "members.max": "You've reached your plan's team-member seats.",
+  "scorers.max": "You've reached your plan's scorer seats.",
+  "competitions.max_active": "Your plan's active-competition limit is reached.",
+  "divisions.per_competition.max": "Adding another division needs a bigger plan.",
+  "entrants.per_division.max": "This division is at your plan's entrant limit.",
+  "stages.per_division.max": "Adding another stage needs a bigger plan.",
+  "formats.double_elim": "Double-elimination brackets are a Pro format.",
+  // Sport depth
+  "scoring.ball_by_ball": "Ball-by-ball scoring is a Pro feature.",
+  "scoring.rally_by_rally": "Rally-by-rally scoring is a Pro feature.",
+  "scoring.match_timeline": "Match timelines (scorers, cards, minutes) are a Pro feature.",
+  "cricket.dls": "DLS revised targets are a Pro feature — a manual umpire target still works.",
+  "stats.player": "Player stats and scorecard entry are a Pro feature.",
+  "stats.club_championship": "Club championship tables are a Pro feature.",
+  "tiebreakers.custom": "Custom tiebreaker order is a Pro feature.",
+  "eligibility.enforced": "Enforced eligibility locks are a Pro feature.",
+  // Public & realtime
+  "dashboard.public.max": "Your plan hosts one public dashboard at a time.",
+  "dashboard.branding": "Custom dashboard branding is a Pro feature.",
+  "dashboard.player_profiles": "Public player profiles are a Pro feature.",
+  realtime: "Live push updates are a Pro feature.",
+  // Platform
+  "api.access": "API keys are a Pro feature.",
+  "api.write": "Write access via the API needs the Business plan.",
+  webhooks: "Webhooks need the Business plan.",
+  exports: "CSV/PDF exports are a Pro feature.",
+  "scheduling.constraints": "The scheduling constraints solver is a Pro feature.",
+  "officials.assignment": "Officials assignment is a Pro feature.",
+};
+
+/** Human, contextual sentence for a 402 / paywall. Never throws. */
+export function featureReason(featureKey: string): string {
+  return FEATURE_REASONS[featureKey] ?? "This feature needs a plan upgrade.";
+}

--- a/apps/web/src/lib/http.ts
+++ b/apps/web/src/lib/http.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { ZodError } from "zod";
-import { AuthError, HttpError } from "@/lib/errors";
+import { AuthError, HttpError, PaymentRequiredError } from "@/lib/errors";
+import { featureReason } from "@/lib/feature-copy";
 import * as Sentry from "@sentry/nextjs";
 
 export { HttpError, PaymentRequiredError } from "@/lib/errors";
@@ -20,6 +21,19 @@ export function handler<T>(fn: () => Promise<T>) {
         return NextResponse.json(
           { ok: false, error: err.message },
           { status: 401 },
+        );
+      }
+      if (err instanceof PaymentRequiredError) {
+        // Upgrade-moment contract (doc 10 §3): feature_key + human reason
+        // let the client render a contextual paywall (<UpgradeGate>).
+        return NextResponse.json(
+          {
+            ok: false,
+            error: err.message,
+            feature_key: err.featureKey,
+            reason: featureReason(err.featureKey),
+          },
+          { status: 402 },
         );
       }
       if (err instanceof HttpError) {

--- a/apps/web/src/server/api-v1/http.ts
+++ b/apps/web/src/server/api-v1/http.ts
@@ -9,6 +9,7 @@ import { ZodError, type ZodType } from "zod";
 import * as Sentry from "@sentry/nextjs";
 import { EngineError, type EngineErrorCode } from "@seazn/engine/core";
 import { AuthError, HttpError, PaymentRequiredError } from "@/lib/errors";
+import { featureReason } from "@/lib/feature-copy";
 
 // EngineError.code → HTTP status (doc 08 §1, spec 03 §7). Central map — the
 // only place engine codes meet HTTP. SEQ_CONFLICT is the optimistic-concurrency
@@ -105,8 +106,13 @@ export async function v1<T>(fn: () => Promise<T | Reply<T>>): Promise<NextRespon
       return errorResponse(requestId, status, err.code, err.message, extra);
     }
     if (err instanceof PaymentRequiredError) {
+      // Upgrade-moment contract (doc 10 §3): feature_key drives the contextual
+      // paywall (<UpgradeGate>), reason is the human sentence. `feature` kept
+      // for pre-PROMPT-13 clients.
       return errorResponse(requestId, 402, "PAYMENT_REQUIRED", err.message, {
         feature: err.featureKey,
+        feature_key: err.featureKey,
+        reason: featureReason(err.featureKey),
       });
     }
     if (err instanceof AuthError) {

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -66,6 +66,8 @@ export const Competition = z.object({
   branding: z.record(z.string(), z.unknown()),
   status: CompetitionStatus,
   created_at: z.string(),
+  /** doc 10 §2.4 — true when over-quota after a downgrade (read-only). */
+  frozen: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/public-site/__tests__/consent.test.ts
+++ b/apps/web/src/server/public-site/__tests__/consent.test.ts
@@ -60,8 +60,18 @@ interface PublicScene {
   bob: string; // no consent
 }
 
-async function seedPublicScene(): Promise<PublicScene> {
+async function seedPublicScene(
+  opts: { playerProfiles?: boolean } = {},
+): Promise<PublicScene> {
   const { auth, orgId } = await seedOrg();
+  // Consent is the variable under test here; grant the Pro read feature
+  // (doc 10 §1 dashboard.player_profiles, PROMPT-13) unless a test is
+  // explicitly probing the entitlement split.
+  if (opts.playerProfiles !== false) {
+    await sql`
+      insert into org_entitlement_overrides (org_id, feature_key, bool_value, reason)
+      values (${orgId}, 'dashboard.player_profiles', true, 'test')`;
+  }
   const alice = await seedPerson(orgId, "Alice Wonder", {
     public_name: true,
     public_photo: true,
@@ -148,6 +158,11 @@ describe.skipIf(!HAS_DB)("public read model — consent matrix (doc 06 §4.7)", 
 describe.skipIf(!HAS_DB)("public read model — visibility (doc 09 §1)", () => {
   it("public + unlisted are served (with visibility flag); private never appears", async () => {
     const { auth, orgId } = await seedOrg();
+    // Three active competitions exceed the community quota (PROMPT-13);
+    // visibility, not quotas, is under test — lift the limit for this org.
+    await sql`
+      insert into org_entitlement_overrides (org_id, feature_key, int_value, reason)
+      values (${orgId}, 'competitions.max_active', null, 'test')`;
     await createCompetition(auth, { name: "Open", visibility: "public", branding: {} });
     await createCompetition(auth, { name: "Hidden Link", visibility: "unlisted", branding: {} });
     await createCompetition(auth, { name: "Secret", visibility: "private", branding: {} });
@@ -168,10 +183,28 @@ describe.skipIf(!HAS_DB)("entitlement split (doc 09 §4, doc 10)", () => {
 
     await sql`
       insert into org_entitlement_overrides (org_id, feature_key, bool_value, reason)
-      values (${scene.orgId}, 'branding', true, 'test')`;
+      values (${scene.orgId}, 'dashboard.branding', true, 'test')`;
     const [after] = await sql<{ branding: Record<string, unknown> }[]>`
       select branding from public_competitions_v where id = ${scene.competitionId}`;
     expect(after.branding).toEqual({ logo: "logos/x.png", banner: "banners/x.png" });
+  });
+
+  it("nulls photos + player-card links without dashboard.player_profiles (PROMPT-13)", async () => {
+    const scene = await seedPublicScene({ playerProfiles: false });
+    const [entrant] = await sql<{ members: Record<string, unknown>[] }[]>`
+      select members from public_entrants_v where division_id = ${scene.divisionId}`;
+    // Even fully-consented Alice: consent makes it publishable, the
+    // entitlement makes it published — community gets neither photo nor link.
+    for (const member of entrant.members) {
+      expect(member["photo"]).toBeNull();
+      expect(member["person_id"]).toBeNull();
+    }
+    // Names still follow consent alone (initials never need a plan).
+    expect(entrant.members.map((m) => m["name"]).sort()).toEqual(["Alice Wonder", "B.B."]);
+    // Player cards 404: the view has no rows for this org.
+    const players = await sql<{ id: string }[]>`
+      select id from public_players_v where org_id = ${scene.orgId}`;
+    expect(players).toHaveLength(0);
   });
 
   it("community orgs hold at most one public competition (dashboard.public.max)", async () => {

--- a/apps/web/src/server/usecases/__tests__/entitlement-freeze.test.ts
+++ b/apps/web/src/server/usecases/__tests__/entitlement-freeze.test.ts
@@ -1,0 +1,52 @@
+// PROMPT-13 item 3: unit-test the freeze selector — which N resources stay
+// active after a downgrade (doc 10 §2.4: most recently active first). Pure.
+import { describe, expect, it } from "vitest";
+import { selectFrozen, type FreezeCandidate } from "../entitlement-freeze";
+
+const c = (id: string, lastActiveAt: string): FreezeCandidate => ({ id, lastActiveAt });
+
+describe("selectFrozen (doc 10 §2.4)", () => {
+  const candidates = [
+    c("oldest", "2026-01-01T00:00:00Z"),
+    c("middle", "2026-03-01T00:00:00Z"),
+    c("newest", "2026-06-01T00:00:00Z"),
+  ];
+
+  it("keeps the N most recently active; the rest freeze", () => {
+    expect(selectFrozen(candidates, 2)).toEqual(new Set(["oldest"]));
+    expect(selectFrozen(candidates, 1)).toEqual(new Set(["oldest", "middle"]));
+  });
+
+  it("freezes nothing when within quota or unlimited", () => {
+    expect(selectFrozen(candidates, 3)).toEqual(new Set());
+    expect(selectFrozen(candidates, 99)).toEqual(new Set());
+    expect(selectFrozen(candidates, null)).toEqual(new Set());
+    expect(selectFrozen([], 0)).toEqual(new Set());
+  });
+
+  it("limit 0 freezes everything (feature absent from the plan)", () => {
+    expect(selectFrozen(candidates, 0)).toEqual(
+      new Set(["oldest", "middle", "newest"]),
+    );
+  });
+
+  it("input order never matters", () => {
+    const shuffled = [candidates[2], candidates[0], candidates[1]];
+    expect(selectFrozen(shuffled, 2)).toEqual(selectFrozen(candidates, 2));
+  });
+
+  it("ties break deterministically on id", () => {
+    const tied = [c("b", "2026-01-01T00:00:00Z"), c("a", "2026-01-01T00:00:00Z")];
+    // Same instant: 'a' sorts first (stays active), 'b' freezes — every run.
+    expect(selectFrozen(tied, 1)).toEqual(new Set(["b"]));
+    expect(selectFrozen([...tied].reverse(), 1)).toEqual(new Set(["b"]));
+  });
+
+  it("accepts Date objects as lastActiveAt", () => {
+    const dates = [
+      { id: "x", lastActiveAt: new Date("2026-01-01") },
+      { id: "y", lastActiveAt: new Date("2026-02-01") },
+    ];
+    expect(selectFrozen(dates, 1)).toEqual(new Set(["x"]));
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/entitlements-v2.test.ts
+++ b/apps/web/src/server/usecases/__tests__/entitlements-v2.test.ts
@@ -1,0 +1,318 @@
+// PROMPT-13 acceptance: (1) matrix test — feature_key × plan asserted at the
+// ENFORCEMENT POINT (the use-case call), not just hasFeature; (2) downgrade
+// simulation — pro → community keeps data, over-quota freezes, coarse scoring
+// still works. Real Postgres required (RLS, triggers); skipped without
+// DATABASE_URL — CI runs them against its service container. Redis is
+// intentionally absent here: every entitlement read exercises the documented
+// fail-open path (cache miss → Postgres).
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { football } from "@seazn/engine/sports/football";
+import { cricket } from "@seazn/engine/sports/cricket";
+import { sql } from "@/lib/db";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition, patchCompetition, listCompetitions, getCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages, generateStageFixtures } from "../stages";
+import { scoreEvent } from "../scoring";
+import { createApiKey } from "../api-keys";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+type Plan = "community" | "pro" | "business";
+
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+async function seedOrg(plan: Plan): Promise<{ auth: AuthCtx }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Ent " + suffix}, ${"ent-" + suffix})
+    returning id`;
+  // No subscription row = community (the resolver's fallback).
+  if (plan !== "community") {
+    await sql`
+      insert into subscriptions (org_id, plan_key, status)
+      values (${orgId}, ${plan}, 'active')
+      on conflict (org_id) do update set plan_key = ${plan}`;
+  }
+  await sql`
+    insert into sports (key, name, module_version, position_catalog) values
+      ('generic',  'Generic',  '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })}),
+      ('football', 'Football', ${football.version}, ${sql.json(football.positions as never)}),
+      ('cricket',  'Cricket',  ${cricket.version}, ${sql.json(cricket.positions as never)})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system) values
+      ('generic',  'score',   'Score',   ${sql.json(GENERIC_CONFIG)}, true),
+      ('football', 'default', 'Default', ${sql.json({})}, true),
+      ('cricket',  't20',     'T20',     ${sql.json(cricket.variants.t20 as never)}, true)
+    on conflict do nothing`;
+  return { auth: { orgId, via: "session", userId: null, role: "owner", keyId: null } };
+}
+
+async function setPlan(orgId: string, plan: Plan): Promise<void> {
+  await sql`
+    insert into subscriptions (org_id, plan_key, status)
+    values (${orgId}, ${plan}, 'active')
+    on conflict (org_id) do update set plan_key = ${plan}`;
+  await invalidateOrgEntitlements(orgId);
+}
+
+async function makeCompetition(
+  auth: AuthCtx,
+  name: string,
+  visibility: "private" | "public" = "private",
+) {
+  return createCompetition(auth, { name, visibility, branding: {} });
+}
+
+async function makeDivision(auth: AuthCtx, competitionId: string, sport: string, config: object) {
+  return createDivision(auth, competitionId, {
+    name: `Div ${randomUUID().slice(0, 6)}`,
+    sport_key: sport,
+    variant_key: sport === "generic" ? "score" : sport === "football" ? "default" : "t20",
+    config,
+    eligibility: [],
+  } as never);
+}
+
+/** division + 2 entrants + generated league fixture — the scoring probe rig. */
+async function makeFixture(auth: AuthCtx, competitionId: string, sport: string, config: object) {
+  const division = await makeDivision(auth, competitionId, sport, config);
+  const entrants = await createEntrants(auth, division.id, [
+    { kind: "individual", display_name: "A", seed: 1, members: [] },
+    { kind: "individual", display_name: "B", seed: 2, members: [] },
+  ] as never);
+  const [stage] = await createStages(auth, division.id, {
+    seq: 1, kind: "league", name: "L", config: {},
+  } as never);
+  const { fixtures } = await generateStageFixtures(auth, stage.id);
+  return { division, entrants, fixtureId: fixtures[0].id };
+}
+
+// ---------------------------------------------------------------------------
+// The matrix: feature_key × plan, probed at the enforcement point. `probe`
+// performs the just-over-the-limit action; deny must be a 402 carrying
+// exactly this feature_key (the UpgradeGate contract, doc 10 §3).
+// ---------------------------------------------------------------------------
+const MATRIX: { feature: string; plan: Plan; allowed: boolean }[] = [
+  { feature: "competitions.max_active",       plan: "community", allowed: false },
+  { feature: "competitions.max_active",       plan: "pro",       allowed: true },
+  { feature: "dashboard.public.max",          plan: "community", allowed: false },
+  { feature: "dashboard.public.max",          plan: "pro",       allowed: true },
+  { feature: "divisions.per_competition.max", plan: "community", allowed: false },
+  { feature: "divisions.per_competition.max", plan: "pro",       allowed: true },
+  { feature: "stages.per_division.max",       plan: "community", allowed: false },
+  { feature: "stages.per_division.max",       plan: "pro",       allowed: true },
+  { feature: "entrants.per_division.max",     plan: "community", allowed: false },
+  { feature: "entrants.per_division.max",     plan: "pro",       allowed: true },
+  { feature: "formats.double_elim",           plan: "community", allowed: false },
+  { feature: "formats.double_elim",           plan: "pro",       allowed: true },
+  { feature: "scoring.match_timeline",        plan: "community", allowed: false },
+  { feature: "scoring.match_timeline",        plan: "pro",       allowed: true },
+  { feature: "cricket.dls",                   plan: "community", allowed: false },
+  { feature: "cricket.dls",                   plan: "pro",       allowed: true },
+  { feature: "api.access",                    plan: "community", allowed: false },
+  { feature: "api.access",                    plan: "pro",       allowed: true },
+  { feature: "api.write",                     plan: "pro",       allowed: false },
+  { feature: "api.write",                     plan: "business",  allowed: true },
+];
+
+async function probe(feature: string, auth: AuthCtx): Promise<() => Promise<unknown>> {
+  switch (feature) {
+    case "competitions.max_active": {
+      await makeCompetition(auth, "C1");
+      await makeCompetition(auth, "C2");
+      return () => makeCompetition(auth, "C3"); // 3rd active
+    }
+    case "dashboard.public.max": {
+      await makeCompetition(auth, "P1", "public");
+      return () => makeCompetition(auth, "P2", "public"); // 2nd public
+    }
+    case "divisions.per_competition.max": {
+      const comp = await makeCompetition(auth, "D");
+      await makeDivision(auth, comp.id, "generic", GENERIC_CONFIG);
+      return () => makeDivision(auth, comp.id, "generic", GENERIC_CONFIG); // 2nd division
+    }
+    case "stages.per_division.max": {
+      const comp = await makeCompetition(auth, "S");
+      const division = await makeDivision(auth, comp.id, "generic", GENERIC_CONFIG);
+      await createStages(auth, division.id, [
+        { seq: 1, kind: "league", name: "S1", config: {} },
+        { seq: 2, kind: "knockout", name: "S2", config: {} },
+      ] as never);
+      return () => // 3rd stage
+        createStages(auth, division.id, { seq: 3, kind: "knockout", name: "S3", config: {} } as never);
+    }
+    case "entrants.per_division.max": {
+      const comp = await makeCompetition(auth, "E");
+      const division = await makeDivision(auth, comp.id, "generic", GENERIC_CONFIG);
+      await createEntrants(
+        auth,
+        division.id,
+        Array.from({ length: 16 }, (_, i) => ({
+          kind: "individual" as const, display_name: `E${i}`, seed: i + 1, members: [],
+        })) as never,
+      );
+      return () => // 17th entrant
+        createEntrants(auth, division.id, [
+          { kind: "individual", display_name: "E17", seed: 17, members: [] },
+        ] as never);
+    }
+    case "formats.double_elim": {
+      const comp = await makeCompetition(auth, "DE");
+      const division = await makeDivision(auth, comp.id, "generic", GENERIC_CONFIG);
+      return () =>
+        createStages(auth, division.id, { seq: 1, kind: "double_elim", name: "DE", config: {} } as never);
+    }
+    case "scoring.match_timeline": {
+      const comp = await makeCompetition(auth, "F");
+      const { entrants, fixtureId } = await makeFixture(auth, comp.id, "football", {});
+      return () => // Tier-2 attributed event (a card, valid pre-kickoff)
+        scoreEvent(auth, fixtureId, {
+          expected_seq: 0,
+          type: "football.card",
+          payload: { by: entrants[0].id, color: "yellow" },
+        });
+    }
+    case "cricket.dls": {
+      const comp = await makeCompetition(auth, "CR");
+      const { fixtureId } = await makeFixture(auth, comp.id, "cricket", {
+        dls: { enabled: true, edition: "standard" },
+      });
+      return () => // revise WITHOUT a manual target ⇒ fold computes DLS
+        scoreEvent(auth, fixtureId, {
+          expected_seq: 0,
+          type: "cricket.revise",
+          payload: { oversPerSide: 10 },
+        });
+    }
+    case "api.access":
+      return () => createApiKey(auth, { name: "k", scopes: ["read"] });
+    case "api.write":
+      return () => createApiKey(auth, { name: "k", scopes: ["read", "write"] });
+    default:
+      throw new Error(`no probe for ${feature}`);
+  }
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("entitlements v2 matrix (doc 10 §1/§2)", () => {
+  it.each(MATRIX)("$feature × $plan → allowed=$allowed", async ({ feature, plan, allowed }) => {
+    const { auth } = await seedOrg(plan);
+    const act = await probe(feature, auth);
+    if (allowed) {
+      await expect(act()).resolves.toBeDefined();
+    } else {
+      await expect(act()).rejects.toMatchObject({ status: 402, featureKey: feature });
+    }
+  });
+
+  it("cricket.revise with a MANUAL umpire target is always allowed (doc 10 §1)", async () => {
+    const { auth } = await seedOrg("community");
+    const comp = await makeCompetition(auth, "CRM");
+    const { fixtureId } = await makeFixture(auth, comp.id, "cricket", {
+      dls: { enabled: true, edition: "standard" },
+    });
+    const out = await scoreEvent(auth, fixtureId, {
+      expected_seq: 0,
+      type: "cricket.revise",
+      payload: { oversPerSide: 10, target: 95 },
+    });
+    expect(out.seq).toBe(1);
+  });
+
+  it("coarse scoring never needs a plan: community appends a football goal", async () => {
+    const { auth } = await seedOrg("community");
+    const comp = await makeCompetition(auth, "FG");
+    const { entrants, fixtureId } = await makeFixture(auth, comp.id, "football", {});
+    await scoreEvent(auth, fixtureId, { expected_seq: 0, type: "core.start", payload: {} });
+    const out = await scoreEvent(auth, fixtureId, {
+      expected_seq: 1,
+      type: "football.goal",
+      payload: { by: entrants[0].id },
+    });
+    expect(out.seq).toBe(2);
+  });
+});
+
+describe.skipIf(!HAS_DB)("downgrade simulation (doc 10 §2.4)", () => {
+  it("pro → community: data kept, over-quota frozen, coarse scoring still works", async () => {
+    const { auth } = await seedOrg("pro");
+
+    // Three active competitions under Pro. B carries real play (a generic
+    // fixture we keep scoring, plus a football division with fine events).
+    const compA = await makeCompetition(auth, "Alpha");
+    const compB = await makeCompetition(auth, "Beta");
+    const compC = await makeCompetition(auth, "Gamma");
+    const rigGeneric = await makeFixture(auth, compB.id, "generic", GENERIC_CONFIG);
+    const rigFootball = await makeFixture(auth, compB.id, "football", {});
+
+    // Fine event under Pro: allowed (and stays visible after the downgrade).
+    await scoreEvent(auth, rigFootball.fixtureId, {
+      expected_seq: 0,
+      type: "football.card",
+      payload: { by: rigFootball.entrants[0].id, color: "yellow" },
+    });
+    await scoreEvent(auth, rigGeneric.fixtureId, {
+      expected_seq: 0, type: "core.start", payload: {},
+    });
+
+    // Deterministic activity order: A oldest, C newer, B newest (score events).
+    await sql`update competitions set created_at = now() - interval '2 hours' where id = ${compA.id}`;
+    await sql`update competitions set created_at = now() - interval '1 hour' where id = ${compC.id}`;
+
+    await setPlan(auth.orgId, "community");
+
+    // Nothing deleted; the least recently active competition freezes.
+    const { items } = await listCompetitions(auth, { cursor: null, limit: 50 });
+    expect(items).toHaveLength(3);
+    const byId = new Map(items.map((c) => [c.id, c]));
+    expect(byId.get(compA.id)?.frozen).toBe(true);
+    expect(byId.get(compB.id)?.frozen).toBe(false);
+    expect(byId.get(compC.id)?.frozen).toBe(false);
+    expect((await getCompetition(auth, compA.id)).frozen).toBe(true);
+
+    // Frozen = read-only: no new structure, no renames…
+    await expect(makeDivision(auth, compA.id, "generic", GENERIC_CONFIG)).rejects.toMatchObject({
+      status: 402, featureKey: "competitions.max_active",
+    });
+    await expect(patchCompetition(auth, compA.id, { name: "Alpha 2" })).rejects.toMatchObject({
+      status: 402, featureKey: "competitions.max_active",
+    });
+
+    // …but coarse scoring in the surviving competitions still works,
+    await scoreEvent(auth, rigGeneric.fixtureId, {
+      expected_seq: 1,
+      type: "generic.result",
+      payload: { p1Score: 2, p2Score: 1 },
+    });
+    // …while NEW fine events are rejected (history stays in the ledger).
+    await expect(
+      scoreEvent(auth, rigFootball.fixtureId, {
+        expected_seq: 1,
+        type: "football.card",
+        payload: { by: rigFootball.entrants[1].id, color: "yellow" },
+      }),
+    ).rejects.toMatchObject({ status: 402, featureKey: "scoring.match_timeline" });
+
+    // Retiring a frozen competition is the sanctioned way back under quota.
+    await patchCompetition(auth, compA.id, { status: "archived" });
+    const after = await listCompetitions(auth, { cursor: null, limit: 50 });
+    expect(after.items.every((c) => !c.frozen)).toBe(true);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/fidelity.test.ts
+++ b/apps/web/src/server/usecases/__tests__/fidelity.test.ts
@@ -1,0 +1,70 @@
+// PROMPT-13: the event-type → feature map must DERIVE from each module's
+// fidelityTiers declaration (doc 14 §4), not a hand-kept table. Pure — no DB.
+import { describe, expect, it } from "vitest";
+import { builtinModules } from "@seazn/engine/sports";
+import type { AnySportModule } from "@seazn/engine/sport";
+import { requiredFeatureForEvent } from "../fidelity";
+
+const byKey = new Map(builtinModules.map((m) => [m.key, m]));
+const football = byKey.get("football")!;
+const cricket = byKey.get("cricket")!;
+const boardgame = byKey.get("boardgame")!;
+const generic = byKey.get("generic")!;
+const volleyball = byKey.get("volleyball")!;
+
+describe("requiredFeatureForEvent (doc 14 §4 derivation)", () => {
+  // [module key, eventType, required feature | null]
+  const cases: [string, string, string | null][] = [
+    // Tier 0/1 always passes — coarse scoring is never paywalled (doc 14 §3).
+    ["cricket", "cricket.innings.summary", null],
+    ["cricket", "cricket.toss", null],
+    ["cricket", "cricket.revise", null], // fidelity-free; the DLS gate is separate
+    ["football", "football.goal", null], // Tier 1 final score AND Tier 2 timeline → free
+    ["football", "football.period", null],
+    ["volleyball", "volleyball.set.summary", null],
+    ["boardgame", "boardgame.result", null],
+    ["generic", "generic.result", null],
+    // Fine-grained tiers carry their declared entitlement (doc 10 §1).
+    ["cricket", "cricket.ball", "scoring.ball_by_ball"],
+    ["cricket", "cricket.player.line", "stats.player"], // the Tier-2 scorecard
+    ["football", "football.card", "scoring.match_timeline"],
+    ["football", "football.sub", "scoring.match_timeline"],
+    ["volleyball", "volleyball.rally", "scoring.rally_by_rally"],
+  ];
+
+  it.each(cases)("%s: %s → %s", (moduleKey, eventType, expected) => {
+    const sportModule = byKey.get(moduleKey) as AnySportModule;
+    expect(requiredFeatureForEvent(sportModule, eventType)).toBe(expected);
+  });
+
+  it("core.* events are always free", () => {
+    for (const sportModule of [cricket, football, volleyball, boardgame, generic]) {
+      expect(requiredFeatureForEvent(sportModule, "core.start")).toBeNull();
+      expect(requiredFeatureForEvent(sportModule, "core.void")).toBeNull();
+      expect(requiredFeatureForEvent(sportModule, "core.finalize")).toBeNull();
+    }
+  });
+
+  it("unknown event types are not paywalled (the module 422s them instead)", () => {
+    expect(requiredFeatureForEvent(football, "football.nonsense")).toBeNull();
+  });
+
+  it("every declared tier>1 event type across shipped modules resolves to a feature", () => {
+    // Guards the doc 10 §1 contract: a module may not declare a paid tier
+    // without naming the entitlement that unlocks it.
+    for (const sportModule of [cricket, football, volleyball, boardgame, generic]) {
+      const free = new Set(
+        sportModule.fidelityTiers.filter((t) => t.tier <= 1).flatMap((t) => t.eventTypes),
+      );
+      for (const tier of sportModule.fidelityTiers.filter((t) => t.tier > 1)) {
+        for (const type of tier.eventTypes) {
+          if (free.has(type)) continue; // coarse alias — free by design
+          expect(
+            requiredFeatureForEvent(sportModule, type),
+            `${sportModule.key}:${type}`,
+          ).toBeTruthy();
+        }
+      }
+    }
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/integration.test.ts
+++ b/apps/web/src/server/usecases/__tests__/integration.test.ts
@@ -310,6 +310,14 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
       insert into org_entitlement_overrides (org_id, feature_key, bool_value)
       values (${auth.orgId}, 'api.access', true)
       on conflict (org_id, feature_key) do update set bool_value = true`;
+    // Write scopes are the Business rung (doc 10 §1 api.write, PROMPT-13).
+    await expect(
+      createApiKey(auth, { name: "ci", scopes: ["read", "write"] }),
+    ).rejects.toMatchObject({ featureKey: "api.write" });
+    await sql`
+      insert into org_entitlement_overrides (org_id, feature_key, bool_value)
+      values (${auth.orgId}, 'api.write', true)
+      on conflict (org_id, feature_key) do update set bool_value = true`;
     const key = await createApiKey(auth, { name: "ci", scopes: ["read", "write"] });
     expect(key.secret.startsWith("sk_live_")).toBe(true);
     const [stored] = await sql<{ key_hash: string }[]>`

--- a/apps/web/src/server/usecases/api-keys.ts
+++ b/apps/web/src/server/usecases/api-keys.ts
@@ -37,6 +37,9 @@ export async function createApiKey(
 ): Promise<ApiKeyRow & { secret: string }> {
   requireSession(auth);
   await requireFeature(auth.orgId, "api.access"); // 402 for non-Pro orgs
+  // Doc 10 §1 Pro→Business ladder: write scopes (and webhooks, when they
+  // land) need `api.write` — Business only.
+  if (input.scopes.includes("write")) await requireFeature(auth.orgId, "api.write");
   const secret = mintApiKeySecret();
   const row = await withTenant(auth.orgId, async (tx) => {
     const [created] = await tx<ApiKeyRow[]>`

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -8,6 +8,11 @@ import { withinLimit } from "@/lib/entitlements";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { page, type ListQuery, type Page } from "@/server/api-v1/http";
 import type { CreateCompetition, PatchCompetition } from "@/server/api-v1/schemas";
+import {
+  ACTIVE_COMPETITION_STATUSES,
+  assertCompetitionNotFrozen,
+  frozenCompetitionIds,
+} from "./entitlement-freeze";
 
 export interface CompetitionRow {
   id: string;
@@ -21,6 +26,8 @@ export interface CompetitionRow {
   branding: unknown;
   status: string;
   created_at: string;
+  /** doc 10 §2.4 — over-quota after a downgrade: read-only, never deleted. */
+  frozen?: boolean;
 }
 
 const COLS = [
@@ -52,8 +59,22 @@ export async function listCompetitions(
       : await tx<CompetitionRow[]>`
           select ${tx(COLS)} from competitions
           order by created_at desc, id desc limit ${query.limit + 1}`;
-    return page(rows, query.limit);
+    const frozen = await frozenCompetitionIds(auth.orgId, tx);
+    return page(rows.map((r) => ({ ...r, frozen: frozen.has(r.id) })), query.limit);
   });
+}
+
+// Doc 10 §1: `competitions.max_active` — draft/published/live competitions
+// count; completed/archived don't. Enforced at the write (doc 10 §2 rule 1).
+async function assertActiveQuota(auth: AuthCtx): Promise<void> {
+  const count = await withTenant(auth.orgId, async (tx) => {
+    const [{ n }] = await tx<{ n: number }[]>`
+      select count(*)::int as n from competitions
+      where status in ${tx([...ACTIVE_COMPETITION_STATUSES])}`;
+    return n;
+  });
+  const { ok } = await withinLimit(auth.orgId, "competitions.max_active", count + 1);
+  if (!ok) throw new PaymentRequiredError("competitions.max_active");
 }
 
 // Doc 10 §1: `dashboard.public.max` — Community holds 1 public competition at
@@ -77,6 +98,7 @@ export async function createCompetition(
   input: CreateCompetition,
 ): Promise<CompetitionRow> {
   const slug = input.slug ?? slugify(input.name);
+  await assertActiveQuota(auth);
   if (input.visibility === "public") await assertPublicQuota(auth);
   return withTenant(auth.orgId, async (tx) => {
     const [existing] = await tx`select 1 from competitions where slug = ${slug}`;
@@ -97,8 +119,20 @@ export async function getCompetition(auth: AuthCtx, id: string): Promise<Competi
     const [row] = await tx<CompetitionRow[]>`
       select ${tx(COLS)} from competitions where id = ${id}`;
     if (!row) throw new HttpError(404, "competition not found");
-    return row;
+    const frozen = await frozenCompetitionIds(auth.orgId, tx);
+    return { ...row, frozen: frozen.has(row.id) };
   });
+}
+
+// A frozen competition is read-only — but retiring it (status → completed/
+// archived) must stay possible, or the org could never get back under quota.
+function isRetirePatch(patch: PatchCompetition): boolean {
+  const keys = Object.keys(patch);
+  return (
+    keys.length === 1 &&
+    keys[0] === "status" &&
+    (patch.status === "completed" || patch.status === "archived")
+  );
 }
 
 export async function patchCompetition(
@@ -106,6 +140,7 @@ export async function patchCompetition(
   id: string,
   patch: PatchCompetition,
 ): Promise<CompetitionRow> {
+  if (!isRetirePatch(patch)) await assertCompetitionNotFrozen(auth.orgId, id);
   if (patch.visibility === "public") await assertPublicQuota(auth, id);
   return withTenant(auth.orgId, async (tx) => {
     if (patch.slug) {

--- a/apps/web/src/server/usecases/divisions.ts
+++ b/apps/web/src/server/usecases/divisions.ts
@@ -3,11 +3,13 @@ import "server-only";
 // variant config and PINS the sport module version (doc 02 §4) so a running
 // division always replays under the rules it started with.
 import { withTenant } from "@/lib/db";
-import { HttpError } from "@/lib/errors";
+import { HttpError, PaymentRequiredError } from "@/lib/errors";
+import { withinLimit } from "@/lib/entitlements";
 import { EngineError } from "@seazn/engine/core";
 import { resolveModule } from "@/server/engine-db";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { CreateDivision, PatchDivision } from "@/server/api-v1/schemas";
+import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { slugify } from "./competitions";
 
 export interface DivisionRow {
@@ -49,6 +51,14 @@ export async function createDivision(
   return withTenant(auth.orgId, async (tx) => {
     const [comp] = await tx`select 1 from competitions where id = ${competitionId}`;
     if (!comp) throw new HttpError(404, "competition not found");
+    await assertCompetitionNotFrozen(auth.orgId, competitionId, tx);
+
+    // Doc 10 §1: `divisions.per_competition.max` (Community's real bite: 1).
+    // Count in the same tx as the insert (doc 10 §2 rule 1).
+    const [{ n }] = await tx<{ n: number }[]>`
+      select count(*)::int as n from divisions where competition_id = ${competitionId}`;
+    const quota = await withinLimit(auth.orgId, "divisions.per_competition.max", n + 1);
+    if (!quota.ok) throw new PaymentRequiredError("divisions.per_competition.max");
 
     // Sport catalog carries the latest shipped module version; the division
     // pins it now and forever (doc 02 §4).

--- a/apps/web/src/server/usecases/entitlement-freeze.ts
+++ b/apps/web/src/server/usecases/entitlement-freeze.ts
@@ -1,0 +1,86 @@
+import "server-only";
+// Downgrade behaviour (doc 10 §2.4): existing data is NEVER deleted; resources
+// over the new plan's quota become read-only, flagged `frozen` in read models.
+// Which N stay active is decided in exactly one place — the selector below:
+// most recently active first (last score event, else creation time).
+import type postgres from "postgres";
+import { withTenant } from "@/lib/db";
+import { getLimit } from "@/lib/entitlements";
+import { PaymentRequiredError } from "@/lib/errors";
+
+type Tx = postgres.TransactionSql;
+
+// Competition statuses that count against `competitions.max_active`.
+export const ACTIVE_COMPETITION_STATUSES = ["draft", "published", "live"] as const;
+
+export interface FreezeCandidate {
+  id: string;
+  lastActiveAt: string | Date;
+}
+
+/**
+ * Pure freeze selector: given all candidates and the plan limit, return the
+ * ids that must freeze. Keeps the `limit` most recently active; ties break on
+ * id so the same inputs always freeze the same rows. limit null = unlimited.
+ */
+export function selectFrozen(
+  candidates: readonly FreezeCandidate[],
+  limit: number | null,
+): Set<string> {
+  if (limit === null || candidates.length <= limit) return new Set();
+  const sorted = [...candidates].sort((a, b) => {
+    const ta = new Date(a.lastActiveAt).getTime();
+    const tb = new Date(b.lastActiveAt).getTime();
+    if (ta !== tb) return tb - ta; // most recently active first
+    return a.id < b.id ? -1 : 1;
+  });
+  return new Set(sorted.slice(Math.max(limit, 0)).map((c) => c.id));
+}
+
+// Activity = latest score event anywhere in the competition, else created_at.
+async function loadCandidates(tx: Tx): Promise<FreezeCandidate[]> {
+  const rows = await tx<{ id: string; last_active: string }[]>`
+    select c.id,
+           greatest(c.created_at, coalesce(max(e.recorded_at), c.created_at)) as last_active
+    from competitions c
+    left join divisions d on d.competition_id = c.id
+    left join fixtures f on f.division_id = d.id
+    left join score_events e on e.fixture_id = f.id
+    where c.status in ${tx([...ACTIVE_COMPETITION_STATUSES])}
+    group by c.id, c.created_at`;
+  return rows.map((r) => ({ id: r.id, lastActiveAt: r.last_active }));
+}
+
+/**
+ * The org's frozen competition ids (empty for in-quota orgs — the common case
+ * costs one count query). Pass the ambient `tx` when already inside
+ * withTenant; otherwise a tenant tx is opened.
+ */
+export async function frozenCompetitionIds(orgId: string, tx?: Tx): Promise<Set<string>> {
+  const limit = await getLimit(orgId, "competitions.max_active");
+  if (limit === null) return new Set();
+  const run = async (t: Tx): Promise<Set<string>> => {
+    const [{ n }] = await t<{ n: number }[]>`
+      select count(*)::int as n from competitions
+      where status in ${t([...ACTIVE_COMPETITION_STATUSES])}`;
+    if (n <= limit) return new Set();
+    return selectFrozen(await loadCandidates(t), limit);
+  };
+  return tx ? run(tx) : withTenant(orgId, run);
+}
+
+/**
+ * Write guard for anything living under a competition (divisions, stages,
+ * entrants, scoring, edits). Frozen ⇒ 402 carrying the quota key, so the UI
+ * shows the same contextual paywall as a blocked create.
+ */
+export async function assertCompetitionNotFrozen(
+  orgId: string,
+  competitionId: string,
+  tx?: Tx,
+): Promise<void> {
+  const frozen = await frozenCompetitionIds(orgId, tx);
+  if (frozen.has(competitionId)) {
+    throw new PaymentRequiredError("competitions.max_active");
+  }
+}

--- a/apps/web/src/server/usecases/entrants.ts
+++ b/apps/web/src/server/usecases/entrants.ts
@@ -4,10 +4,12 @@ import "server-only";
 // person the tenant can't see doesn't exist.
 import type postgres from "postgres";
 import { withTenant } from "@/lib/db";
-import { HttpError } from "@/lib/errors";
+import { HttpError, PaymentRequiredError } from "@/lib/errors";
+import { withinLimit } from "@/lib/entitlements";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { z } from "zod";
 import type { CreateEntrant, PatchEntrant, EntrantMemberInput } from "@/server/api-v1/schemas";
+import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 
 type Tx = postgres.TransactionSql;
 type MemberInput = z.infer<typeof EntrantMemberInput>;
@@ -79,9 +81,17 @@ export async function createEntrants(
   inputs: CreateEntrant[],
 ): Promise<EntrantRow[]> {
   return withTenant(auth.orgId, async (tx) => {
-    const [division] = await tx<{ status: string }[]>`
-      select status from divisions where id = ${divisionId}`;
+    const [division] = await tx<{ status: string; competition_id: string }[]>`
+      select status, competition_id from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
+    await assertCompetitionNotFrozen(auth.orgId, division.competition_id, tx);
+
+    // Doc 10 §1: `entrants.per_division.max` (16/64/256) — the whole batch
+    // must fit; count in the same tx as the inserts (doc 10 §2 rule 1).
+    const [{ n }] = await tx<{ n: number }[]>`
+      select count(*)::int as n from entrants where division_id = ${divisionId}`;
+    const quota = await withinLimit(auth.orgId, "entrants.per_division.max", n + inputs.length);
+    if (!quota.ok) throw new PaymentRequiredError("entrants.per_division.max");
 
     const rows: EntrantRow[] = [];
     for (const input of inputs) {

--- a/apps/web/src/server/usecases/fidelity.ts
+++ b/apps/web/src/server/usecases/fidelity.ts
@@ -1,0 +1,29 @@
+// Scoring-fidelity → entitlement mapping (doc 14 §4, doc 10 §2 rule 2).
+// Derived from each SportModule's own `fidelityTiers` declaration — never a
+// hand-kept table — so a new module (or a new fine event type) is gated the
+// moment it declares itself. Pure: safe to unit-test without a DB.
+import type { AnySportModule } from "@seazn/engine/sport";
+
+/**
+ * The feature key an org must hold to append `eventType` to a fixture of this
+ * module, or null when the event is free (doc 14 §1: Tier 0/1 always pass).
+ *
+ * An event type may appear in several tiers (football.goal is both the Tier 1
+ * final score and part of the Tier 2 timeline); the LOWEST tier that accepts
+ * it wins — coarse entry must never be blocked. Unknown types return null:
+ * the module's eventSchema rejects them downstream with a 422, which is the
+ * right error (not a paywall).
+ */
+export function requiredFeatureForEvent(
+  sportModule: AnySportModule,
+  eventType: string,
+): string | null {
+  if (eventType.startsWith("core.")) return null; // start/void/finalize… are free
+  let lowest: { tier: number; entitlement?: string } | null = null;
+  for (const t of sportModule.fidelityTiers) {
+    if (!t.eventTypes.includes(eventType)) continue;
+    if (lowest === null || t.tier < lowest.tier) lowest = t;
+  }
+  if (lowest === null || lowest.tier <= 1) return null;
+  return lowest.entitlement ?? null;
+}

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -7,12 +7,15 @@ import "server-only";
 import { withTenant } from "@/lib/db";
 import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
 import { rateLimit } from "@/lib/rate-limit";
-import { appendEvent } from "@/server/engine-db";
+import { requireFeature } from "@/lib/entitlements";
+import { appendEvent, resolveModule } from "@/server/engine-db";
 import { recomputeStandings } from "@/server/engine-db";
 import { publishFixtureUpdate } from "@/lib/realtime";
 import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { AppendEventRequest } from "@/server/api-v1/schemas";
+import { assertCompetitionNotFrozen } from "./entitlement-freeze";
+import { requiredFeatureForEvent } from "./fidelity";
 import { fillSlot } from "./stages";
 
 export interface ScoreOutcome {
@@ -47,6 +50,8 @@ export async function scoreEvent(
     if (replay) return replay; // retried request: same answer, no double write
   }
 
+  await assertEntitledToScore(auth, fixtureId, input);
+
   const result = await appendEvent(auth.orgId, fixtureId, input.expected_seq, {
     type: input.type,
     payload: input.payload,
@@ -74,6 +79,45 @@ export async function scoreEvent(
   void publishFixtureUpdate(fixtureId, "event");
   void invalidatePublicCache(auth.orgId, fixtureId);
   return out;
+}
+
+// Entitlement gates at THE scoring door (doc 10 §2 rules 2 & 4):
+//  - fidelity: the event-type → feature map derives from the pinned module's
+//    own fidelityTiers declaration (doc 14 §4) — Tier 0/1 always passes, so a
+//    downgraded org keeps coarse scoring;
+//  - cricket.dls: a `cricket.revise` WITHOUT a manual target under a
+//    dls-enabled config makes the fold compute a DLS target — Pro only. A
+//    manual umpire target is always allowed;
+//  - freeze: fixtures of an over-quota (frozen) competition are read-only.
+// Unknown fixtures fall through — appendEvent owns that error.
+async function assertEntitledToScore(
+  auth: AuthCtx,
+  fixtureId: string,
+  input: AppendEventRequest,
+): Promise<void> {
+  const ctx = await withTenant(auth.orgId, async (tx) => {
+    const [row] = await tx<
+      { sport_key: string; module_version: string; config: unknown; competition_id: string }[]
+    >`
+      select d.sport_key, d.module_version, d.config, d.competition_id
+      from fixtures f join divisions d on d.id = f.division_id
+      where f.id = ${fixtureId}`;
+    if (!row) return null;
+    await assertCompetitionNotFrozen(auth.orgId, row.competition_id, tx);
+    return row;
+  });
+  if (!ctx) return;
+
+  const sportModule = resolveModule(ctx.sport_key, ctx.module_version);
+  const feature = requiredFeatureForEvent(sportModule, input.type);
+  if (feature) await requireFeature(auth.orgId, feature);
+
+  if (input.type === "cricket.revise") {
+    const manualTarget = (input.payload as { target?: unknown } | null)?.target !== undefined;
+    const dlsEnabled =
+      (ctx.config as { dls?: { enabled?: boolean } } | null)?.dls?.enabled === true;
+    if (dlsEnabled && !manualTarget) await requireFeature(auth.orgId, "cricket.dls");
+  }
 }
 
 // A decided fixture feeds brackets (winner_to/loser_to slots) and refreshes

--- a/apps/web/src/server/usecases/stages.ts
+++ b/apps/web/src/server/usecases/stages.ts
@@ -5,7 +5,9 @@ import "server-only";
 import type postgres from "postgres";
 import { withTenant } from "@/lib/db";
 import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
-import { HttpError } from "@/lib/errors";
+import { HttpError, PaymentRequiredError } from "@/lib/errors";
+import { requireFeature, withinLimit } from "@/lib/entitlements";
+import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { EngineError } from "@seazn/engine/core";
 import {
   generateRoundRobin,
@@ -86,9 +88,23 @@ export async function createStages(
   input: CreateStages,
 ): Promise<StageRow[]> {
   const inputs: StageInput[] = Array.isArray(input) ? input : [input];
+  // Doc 10 §1: `formats.double_elim` is Pro — gate before any insert.
+  if (inputs.some((s) => s.kind === "double_elim")) {
+    await requireFeature(auth.orgId, "formats.double_elim");
+  }
   return withTenant(auth.orgId, async (tx) => {
-    const [division] = await tx`select 1 from divisions where id = ${divisionId}`;
+    const [division] = await tx<{ competition_id: string }[]>`
+      select competition_id from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
+    await assertCompetitionNotFrozen(auth.orgId, division.competition_id, tx);
+
+    // Doc 10 §1: `stages.per_division.max` (2/4/∞) — the batch must fit,
+    // counted in the same tx as the inserts (doc 10 §2 rule 1).
+    const [{ n }] = await tx<{ n: number }[]>`
+      select count(*)::int as n from stages where division_id = ${divisionId}`;
+    const quota = await withinLimit(auth.orgId, "stages.per_division.max", n + inputs.length);
+    if (!quota.ok) throw new PaymentRequiredError("stages.per_division.max");
+
     const rows: StageRow[] = [];
     for (const s of inputs) {
       const [dupe] = await tx`

--- a/development/00-phase-0-1-build-checklist.md
+++ b/development/00-phase-0-1-build-checklist.md
@@ -187,7 +187,7 @@ deliverable email live; marketing + legal pages published; a11y/perf gates green
 - [x] `PATCH /api/tournaments/[id]/public` — toggle is_public; generates slug on first make-public. ✓
 - [x] `/t/[slug]` — public read-only page: standings + bracket, polls 10s, no auth required. ✓ `src/app/t/[slug]/page.tsx`
 - [x] `src/components/public-tournament-view.tsx` — client standings + bracket, no edit controls. ✓
-- [x] "Powered by S.A.F.E Tournaments" badge on Community public pages; hidden on Pro+ (`branding` entitlement check). ✓
+- [x] "Powered by Seazn Club" badge on Community public pages; hidden on Pro+ (`branding` entitlement check). ✓
 - [x] SEO metadata on public tournament pages. ✓
 - [x] Add "Share" button in `LiveTournament` UI to toggle `is_public` and copy link. ✓ `SharePanel` in `live-tournament.tsx`
 

--- a/development/01-product-strategy.md
+++ b/development/01-product-strategy.md
@@ -89,7 +89,7 @@ Rejected for v1 (do not build):
 
 - **Self-serve (Community → Pro/Business):** product-led. Public tournament pages are the
   acquisition flywheel — every shared event markets the product. Add a tasteful
-  "Powered by S.A.F.E" on free public pages (`public_pages` entitlement controls removal).
+  "Powered by Seazn Club" on free public pages (`public_pages` entitlement controls removal).
 - **Sales-assisted (Enterprise):** "Book a demo" CTA, outbound to federations / school
   athletic associations / corporate event teams. Lighthouse logos → case studies.
 - **Content/SEO:** format explainers ("how Swiss pairing works"), sport-specific guides,

--- a/development/06-marketing-site.md
+++ b/development/06-marketing-site.md
@@ -64,7 +64,7 @@ src/app/
 
 - Read-only, shareable, **cacheable** view of a tournament: bracket, standings, schedule,
   results, optional live updates (realtime entitlement).
-- **Branding/entitlement-aware:** Free shows tasteful "Powered by S.A.F.E"; paid removes it;
+- **Branding/entitlement-aware:** Free shows tasteful "Powered by Seazn Club"; paid removes it;
   Business+ supports custom domain; Enterprise white-label (doc 01 `public_pages`).
 - **SEO:** SSR/ISR, Open Graph image (auto-generated bracket/score card via `@vercel/og` or
   worker), structured data (`SportsEvent` schema.org), unique titles/descriptions.

--- a/development/08-feature-roadmap.md
+++ b/development/08-feature-roadmap.md
@@ -70,7 +70,7 @@ doc 01; enforcement via doc 05.
 - Native apps only if push + app-store presence justify it.
 
 ### 3.10 White-label — Enterprise
-- Custom domain, logo, colors, remove all S.A.F.E branding, optional custom email sender.
+- Custom domain, logo, colors, remove all Seazn Club branding, optional custom email sender.
 
 ### 3.11 Internationalization (i18n)
 - Externalize strings; locale routing; date/number formatting (extend `ClientTime`); RTL

--- a/development/10-supabase-realtime.md
+++ b/development/10-supabase-realtime.md
@@ -22,7 +22,7 @@ Vercel, not Redis pub/sub for fan-out.
 
 Supabase Realtime offers two relevant mechanisms:
 
-| Mechanism | How it works | Fit for S.A.F.E |
+| Mechanism | How it works | Fit for Seazn Club |
 |-----------|--------------|-----------------|
 | **`postgres_changes`** | WAL replication pushes row INSERT/UPDATE/DELETE to subscribers | Zero server publish code, but sends **row payloads** to the client and requires RLS aligned with Supabase's JWT roles. Harder with custom cookie auth. |
 | **`broadcast`** | Explicit messages on a named channel; server publishes after writes | **Recommended.** Server controls what is sent; client refetches authoritative state via existing `/state` API. Minimal payload = no stale partial state. |

--- a/development/15-product-readiness-backlog.md
+++ b/development/15-product-readiness-backlog.md
@@ -56,7 +56,7 @@ illegal/abusive imagery, and brand risk.
 ## 4. Growth loops & lifecycle (beyond onboarding email)
 
 ### Scope
-- **Public-page flywheel (doc 06):** "Powered by S.A.F.E" + "Create your own" CTA on free
+- **Public-page flywheel (doc 06):** "Powered by Seazn Club" + "Create your own" CTA on free
   public pages; entitlement removes branding on paid.
 - **Invites/referrals:** incentivize inviting teammates/other organizers (e.g. extended
   trial or credit) — measure viral coefficient.
@@ -139,7 +139,7 @@ Cross-refs doc 04/06 — ensure these exist before public GA:
 - Security/trust page (compliance status, doc 04).
 
 ## 10. Branding & naming (pre-launch)
-- Confirm product name/trademark availability ("S.A.F.E"), domain, logo, OG imagery.
+- Confirm product name/trademark availability ("Seazn Club"), domain, logo, OG imagery.
 - Consistent brand kit shared between marketing and app (doc 06 design system).
 
 ## 11. Prioritization summary

--- a/development/README.md
+++ b/development/README.md
@@ -1,6 +1,6 @@
-# S.A.F.E Tournaments — Development & Productization Docs
+# Seazn Club — Development & Productization Docs
 
-This folder holds the **detailed technical design docs** for turning S.A.F.E Tournaments
+This folder holds the **detailed technical design docs** for turning Seazn Club
 from its current app state into an enterprise-grade SaaS product. Each document is a
 self-contained design that an engineer (or agent) can pick up and implement later.
 

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -179,6 +179,9 @@
                               },
                               "created_at": {
                                 "type": "string"
+                              },
+                              "frozen": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -544,6 +547,9 @@
                         },
                         "created_at": {
                           "type": "string"
+                        },
+                        "frozen": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -866,6 +872,9 @@
                         },
                         "created_at": {
                           "type": "string"
+                        },
+                        "frozen": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -1226,6 +1235,9 @@
                         },
                         "created_at": {
                           "type": "string"
+                        },
+                        "frozen": {
+                          "type": "boolean"
                         }
                       },
                       "required": [

--- a/supabase/migrations/012_entitlements_v2.sql
+++ b/supabase/migrations/012_entitlements_v2.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- 012 — Entitlements v2 (PROMPT-13, doc 10 §1)
+-- Seeds the full v2 feature matrix into plan_entitlements and the
+-- dark Business plan. v1 keys (seasons.max, tournaments.per_season.max,
+-- players.max, formats.all, branding, exports, realtime) stay until the
+-- PROMPT-15 cutover removes them. Idempotent.
+-- ============================================================
+
+-- Business = third plan; ships dark (is_public=false) until pricing decided.
+INSERT INTO plans (key, name, is_public) VALUES
+  ('business', 'Business', false)
+ON CONFLICT (key) DO NOTHING;
+
+-- ------------------------------------------------------------
+-- v2 matrix (doc 10 §1). int_value NULL = unlimited; a missing
+-- (plan, feature) row resolves to deny/0 in lib/entitlements.ts.
+-- Seat quotas (orgs.max_owned, members.max, scorers.max) are normative in
+-- doc 13 §5; enforcement of those lands with PROMPT-18 — values seeded now
+-- so the read endpoint and UI can show them.
+-- ------------------------------------------------------------
+INSERT INTO plan_entitlements (plan_key, feature_key, bool_value, int_value) VALUES
+  -- Structure & scale ------------------------------------------------------
+  ('community', 'orgs.max_owned',                null, 1),
+  ('pro',       'orgs.max_owned',                null, 5),
+  ('business',  'orgs.max_owned',                null, null),
+  ('community', 'members.max',                   null, 3),
+  ('pro',       'members.max',                   null, 10),
+  ('business',  'members.max',                   null, null),
+  ('community', 'scorers.max',                   null, 1),
+  ('pro',       'scorers.max',                   null, 1),
+  ('business',  'scorers.max',                   null, null),
+  ('community', 'competitions.max_active',       null, 2),
+  ('pro',       'competitions.max_active',       null, null),
+  ('business',  'competitions.max_active',       null, null),
+  ('community', 'divisions.per_competition.max', null, 1),
+  ('pro',       'divisions.per_competition.max', null, 10),
+  ('business',  'divisions.per_competition.max', null, null),
+  ('community', 'entrants.per_division.max',     null, 16),
+  ('pro',       'entrants.per_division.max',     null, 64),
+  ('business',  'entrants.per_division.max',     null, 256),
+  ('community', 'stages.per_division.max',       null, 2),
+  ('pro',       'stages.per_division.max',       null, 4),
+  ('business',  'stages.per_division.max',       null, null),
+  ('community', 'formats.double_elim',           false, null),
+  ('pro',       'formats.double_elim',           true,  null),
+  ('business',  'formats.double_elim',           true,  null),
+  -- Sport depth ------------------------------------------------------------
+  ('community', 'scoring.ball_by_ball',          false, null),
+  ('pro',       'scoring.ball_by_ball',          true,  null),
+  ('business',  'scoring.ball_by_ball',          true,  null),
+  ('community', 'scoring.rally_by_rally',        false, null),
+  ('pro',       'scoring.rally_by_rally',        true,  null),
+  ('business',  'scoring.rally_by_rally',        true,  null),
+  ('community', 'scoring.match_timeline',        false, null),
+  ('pro',       'scoring.match_timeline',        true,  null),
+  ('business',  'scoring.match_timeline',        true,  null),
+  ('community', 'cricket.dls',                   false, null),
+  ('pro',       'cricket.dls',                   true,  null),
+  ('business',  'cricket.dls',                   true,  null),
+  ('community', 'stats.player',                  false, null),
+  ('pro',       'stats.player',                  true,  null),
+  ('business',  'stats.player',                  true,  null),
+  ('community', 'stats.club_championship',       false, null),
+  ('pro',       'stats.club_championship',       true,  null),
+  ('business',  'stats.club_championship',       true,  null),
+  ('community', 'tiebreakers.custom',            false, null),
+  ('pro',       'tiebreakers.custom',            true,  null),
+  ('business',  'tiebreakers.custom',            true,  null),
+  ('community', 'eligibility.enforced',          false, null),
+  ('pro',       'eligibility.enforced',          true,  null),
+  ('business',  'eligibility.enforced',          true,  null),
+  -- Public & realtime ------------------------------------------------------
+  ('community', 'dashboard.public.max',          null, 1),
+  ('pro',       'dashboard.public.max',          null, null),
+  ('business',  'dashboard.public.max',          null, null),
+  ('community', 'dashboard.branding',            false, null),
+  ('pro',       'dashboard.branding',            true,  null),
+  ('business',  'dashboard.branding',            true,  null),
+  ('community', 'dashboard.player_profiles',     false, null),
+  ('pro',       'dashboard.player_profiles',     true,  null),
+  ('business',  'dashboard.player_profiles',     true,  null),
+  ('community', 'realtime',                      false, null),
+  ('pro',       'realtime',                      true,  null),
+  ('business',  'realtime',                      true,  null),
+  -- Platform (Pro → Business ladder) ---------------------------------------
+  ('community', 'api.access',                    false, null),
+  ('pro',       'api.access',                    true,  null),
+  ('business',  'api.access',                    true,  null),
+  ('community', 'api.write',                     false, null),
+  ('pro',       'api.write',                     false, null),
+  ('business',  'api.write',                     true,  null),
+  ('community', 'webhooks',                      false, null),
+  ('pro',       'webhooks',                      false, null),
+  ('business',  'webhooks',                      true,  null),
+  ('community', 'exports',                       false, null),
+  ('pro',       'exports',                       true,  null),
+  ('business',  'exports',                       true,  null),
+  ('community', 'scheduling.constraints',        false, null),
+  ('pro',       'scheduling.constraints',        true,  null),
+  ('business',  'scheduling.constraints',        true,  null),
+  ('community', 'officials.assignment',          false, null),
+  ('pro',       'officials.assignment',          true,  null),
+  ('business',  'officials.assignment',          true,  null),
+  -- v1 keys for the Business plan (v1 app paths resolve them until the
+  -- PROMPT-15 cutover; Business gets Pro's values = unlimited/enabled).
+  ('business',  'seasons.max',                   null, null),
+  ('business',  'tournaments.per_season.max',    null, null),
+  ('business',  'players.max',                   null, null),
+  ('business',  'formats.all',                   true,  null),
+  ('business',  'branding',                      true,  null)
+ON CONFLICT (plan_key, feature_key) DO NOTHING;

--- a/supabase/schema_v2.sql
+++ b/supabase/schema_v2.sql
@@ -539,12 +539,13 @@ create or replace function public_person_name(full_name text, consent jsonb) ret
     end
   $$;
 
--- Branding is a Pro read feature (doc 10 §1) — nulled here, server-side, for
--- non-entitled orgs. `visibility` rides along so pages can render unlisted
--- competitions with a noindex meta and keep them out of the sitemap.
+-- Branding is a Pro read feature (doc 10 §1, key `dashboard.branding` since
+-- PROMPT-13) — nulled here, server-side, for non-entitled orgs. `visibility`
+-- rides along so pages can render unlisted competitions with a noindex meta
+-- and keep them out of the sitemap.
 create or replace view public_competitions_v as
   select id, org_id, name, slug, description, starts_on, ends_on,
-         case when org_has_feature(org_id, 'branding') then branding
+         case when org_has_feature(org_id, 'dashboard.branding') then branding
               else '{}'::jsonb end as branding,
          status, created_at, visibility
   from competitions
@@ -602,14 +603,19 @@ create or replace view public_standings_v as
 -- `person_id` is exposed ONLY with public_name consent: it is the link target
 -- for the player card, and the card 404s without that consent (doc 06 §4.7) —
 -- so a roster row without consent gets initials and no link.
+-- Photos and player-card links are additionally Pro read features
+-- (doc 10 §1 `dashboard.player_profiles`, PROMPT-13): consent makes them
+-- publishable, the entitlement makes them published.
 create or replace view public_entrants_v as
   select e.id, e.division_id, e.kind, e.display_name, e.seed, e.status,
          coalesce(
            (select jsonb_agg(jsonb_build_object(
               'name',  public_person_name(p.full_name, p.consent),
               'photo', case when coalesce((p.consent->>'public_photo')::boolean, false)
+                             and org_has_feature(c.org_id, 'dashboard.player_profiles')
                             then p.photo_path else null end,
               'person_id', case when coalesce((p.consent->>'public_name')::boolean, false)
+                                 and org_has_feature(c.org_id, 'dashboard.player_profiles')
                                 then p.id else null end,
               'squad_number', em.squad_number,
               'position', em.default_position_key)
@@ -626,13 +632,16 @@ create or replace view public_entrants_v as
 
 -- Player card source (doc 09 §2): only persons who (a) gave public_name
 -- consent AND (b) are rostered in an entrant of a publicly visible
--- competition. Everyone else simply does not exist here — the card 404s.
+-- competition AND (c) whose org holds `dashboard.player_profiles`
+-- (doc 10 §1, PROMPT-13). Everyone else simply does not exist here — the
+-- card 404s.
 create or replace view public_players_v as
   select p.id, p.org_id, p.full_name as name,
          case when coalesce((p.consent->>'public_photo')::boolean, false)
               then p.photo_path else null end as photo
   from persons p
   where coalesce((p.consent->>'public_name')::boolean, false)
+    and org_has_feature(p.org_id, 'dashboard.player_profiles')
     and exists (
       select 1 from entrant_members em
       join entrants e     on e.id = em.entrant_id
@@ -655,8 +664,9 @@ grant select on public_competitions_v, public_divisions_v, public_fixtures_v,
                 public_standings_v, public_entrants_v, public_players_v,
                 public_stages_v, public_pools_v to app_user;
 
--- Doc 10 §1 public-dashboard quota (PROMPT-12 item 7; full matrix lands with
--- PROMPT-13): Community may hold 1 public competition at a time, Pro unlimited.
+-- Doc 10 §1 public-dashboard quota (PROMPT-12 item 7; the full v2 matrix is
+-- seeded by migrations/012_entitlements_v2.sql, which apply-db runs BEFORE
+-- this file): Community may hold 1 public competition at a time, Pro unlimited.
 insert into plan_entitlements (plan_key, feature_key, bool_value, int_value) values
   ('community', 'dashboard.public.max', null, 1),
   ('pro',       'dashboard.public.max', null, null)


### PR DESCRIPTION
## Summary

Implements `engine/prompts/PROMPT-13-entitlements-v2.md` per the normative matrix in `engine/10-pro-entitlements.md`.

- **Migration 012**: full doc 10 §1 matrix seeded into `plan_entitlements` for community/pro/business; `business` plan ships dark (`is_public=false`); v1 keys kept until PROMPT-15. Runs before `schema_v2.sql` in `db:apply` order so views can reference v2 keys.
- **Quota gates** (doc 10 §2 rule 1, count in same tx as insert): `competitions.max_active`, `divisions.per_competition.max`, `entrants.per_division.max` (batch must fit), `stages.per_division.max`, `formats.double_elim`. `dashboard.public.max` was already wired in PROMPT-12.
- **Fidelity gates**: `requiredFeatureForEvent` derives the event-type → feature map from each module's `fidelityTiers` declaration (doc 14 §4) — no hand-kept table. Lowest declaring tier wins (`football.goal` stays free); Tier 0/1 and `core.*` always pass. Enforced in `scoreEvent` before append.
- **`cricket.dls`**: `cricket.revise` without a manual target under a dls-enabled config → 402; manual umpire target always allowed.
- **Public read model**: views null branding via `dashboard.branding`; entrant photos, player-card links and `public_players_v` rows require `dashboard.player_profiles` — all server-side.
- **API keys**: write scopes now need `api.write` (Business rung) on top of `api.access`.
- **Downgrade freeze** (`entitlement-freeze.ts`, doc 10 §2.4): over-quota competitions become read-only with a `frozen` flag in read models; selector keeps the N most recently active (deterministic tie-break); status-only patch to completed/archived stays allowed as the way back under quota; nothing is ever deleted.
- **Upgrade moments**: both 402 handlers carry `feature_key` + human `reason` from a shared copy map; new `<UpgradeGate feature>` client component renders the same copy.
- `/api/orgs/[id]/entitlements` now returns the v2 key set plus `competitions_active_count` / `dashboards_public_count` usage.

## Acceptance coverage

- `entitlements-v2.test.ts`: 20-row table-driven matrix asserting allow/deny **at the enforcement point** with the exact `featureKey`; manual-DLS-always-allowed; coarse-scoring-free; downgrade simulation (pro → community keeps data, oldest competition freezes, frozen writes 402, coarse scoring still works, new fine events 402, archiving unfreezes).
- `fidelity.test.ts`: derivation table across all shipped modules + guard that every paid tier names its entitlement.
- `entitlement-freeze.test.ts`: freeze selector unit tests.
- Redis-down invariants untouched: tests run with no `REDIS_URL`, exercising the documented fail-open path.

## Deviations / notes

- `<UpgradeGate>` is built but not yet consumed — the doc 10 §3 touchpoint screens arrive with PROMPT-15/17/18; the 402 contract is ready for them.
- Seat quotas (`orgs.max_owned`, `members.max`, `scorers.max`) seeded now, enforced in PROMPT-18 per doc 13 §5; `stats.*`, `exports`, `tiebreakers.custom`, `eligibility.enforced`, `scheduling.constraints`, `officials.assignment` seeded, enforcement lands with their surfaces.
- DB integration suites skipped locally (no local Postgres; `.env.local` points at live Supabase) — CI smoke job runs them against its service container.
- Existing integration test updated: minting a write-scoped key now also needs an `api.write` override (the new Business rung working as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)