### PR TITLE
feat: simulation & property-test harness (PROMPT-14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,17 @@ jobs:
           git diff --exit-code openapi/v1.json || {
             echo "openapi/v1.json is stale — run 'npm run openapi:gen' and commit."; exit 1; }
       - run: npm test --workspace apps/web
-      - run: npm test --workspace packages/engine
+      # Engine suite includes the PROMPT-14 simulation harness (SIM_RUNS
+      # defaults to 200 divisions per sport×format when CI=true) and the
+      # coverage gate (≥90% lines; 100% on core/ and tiebreakers.ts).
+      - run: npm run test:coverage --workspace packages/engine
+      - name: Simulation failure artifacts (repro with `npm run sim:replay -- <seedToken>`)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-failures
+          path: packages/engine/sim-failures/
+          if-no-files-found: ignore
 
   # -------------------------------------------------------------------------
   # Security gate (doc 07 §4): secret scan + dependency audit. Secret leaks

--- a/.github/workflows/sim-nightly.yml
+++ b/.github/workflows/sim-nightly.yml
@@ -1,0 +1,44 @@
+# Nightly deep simulation — PROMPT-14 §3. Same harness as the CI gate, at
+# 10 000 divisions per sport×format (vs 200 in CI). Failures upload the seed +
+# event-stream artifact; reproduce locally with:
+#   npm run sim:replay -- <sport:format:seed>
+name: Simulation (nightly)
+
+on:
+  schedule:
+    - cron: "17 2 * * *" # 02:17 UTC daily
+  workflow_dispatch:
+    inputs:
+      sim_runs:
+        description: "Divisions per sport×format"
+        required: false
+        default: "10000"
+
+concurrency:
+  group: sim-nightly
+  cancel-in-progress: true
+
+jobs:
+  simulate:
+    name: Deep simulation (SIM_RUNS=${{ inputs.sim_runs || '10000' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Run the simulation + chaos harness
+        run: npm run sim --workspace packages/engine
+        env:
+          SIM_RUNS: ${{ inputs.sim_runs || '10000' }}
+      - name: Simulation failure artifacts (repro with `npm run sim:replay -- <seedToken>`)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-failures-nightly
+          path: packages/engine/sim-failures/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ node_modules/
 
 # testing
 coverage/
+# PROMPT-14 simulation failure artifacts (uploaded by CI, replayed via sim:replay)
+sim-failures/
 
 # next.js
 .next/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test:watch": "npm run test:watch --workspace apps/web",
     "test:coverage": "npm run test:coverage --workspace apps/web",
     "test:smoke": "node --experimental-strip-types scripts/smoke.ts",
+    "sim": "npm run sim --workspace packages/engine",
+    "sim:replay": "npm run sim:replay --workspace packages/engine --",
     "engine:check": "node --experimental-strip-types scripts/engine-check.ts",
     "engine:boundary": "node --experimental-strip-types scripts/engine-boundary.ts",
     "db:apply": "node --experimental-strip-types scripts/apply-db.ts",

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -16,6 +16,9 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "sim": "vitest run src/testkit/simulation.test.ts src/testkit/chaos.test.ts",
+    "sim:replay": "node --experimental-strip-types scripts/sim-replay.ts",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/engine/scripts/sim-replay.ts
+++ b/packages/engine/scripts/sim-replay.ts
@@ -1,0 +1,74 @@
+// Deterministic simulation replay — PROMPT-14 §3.
+//
+//   npm run sim:replay -- <sport:format:seed>
+//   npm run sim:replay -- sim-failures/<artifact>.json
+//
+// Re-runs the exact division a CI failure artifact points at (same seed ⇒ same
+// entrant count, fixture ids, event ids, injection), re-checks the global
+// invariants and the double-run determinism property, and exits non-zero when
+// the failure reproduces.
+import { readFileSync } from "node:fs";
+import { builtinModules } from "../src/sports/index.ts";
+import {
+  assertDivisionInvariants,
+  parseSeedToken,
+  simOptionsFor,
+  simulateDivision,
+  SimInvariantError,
+} from "../src/testkit/simulation.ts";
+
+const arg = process.argv[2];
+if (arg === undefined) {
+  console.error("usage: npm run sim:replay -- <sport:format:seed | path/to/failure.json>");
+  process.exit(2);
+}
+
+const token = arg.endsWith(".json")
+  ? (JSON.parse(readFileSync(arg, "utf8")) as { seedToken: string }).seedToken
+  : arg;
+const { sport, format, seed } = parseSeedToken(token);
+const module = builtinModules.find((m) => m.key === sport);
+if (module === undefined) {
+  console.error(`unknown sport "${sport}" — shipped: ${builtinModules.map((m) => m.key).join(", ")}`);
+  process.exit(2);
+}
+
+const opts = simOptionsFor(module, format, seed);
+console.log(`replaying ${token} …`);
+
+try {
+  const sim = simulateDivision(opts);
+  const fixtures = sim.stages.reduce((acc, stage) => acc + stage.fixtures.length, 0);
+  const events = sim.stages.reduce(
+    (acc, stage) => acc + stage.fixtures.reduce((a, f) => a + f.events.length, 0),
+    0,
+  );
+  console.log(
+    `  entrants=${sim.entrants.length} stages=[${sim.stages.map((s) => `${s.id}:${s.kind}`).join(", ")}] fixtures=${fixtures} events=${events}`,
+  );
+  if (sim.injection !== undefined) {
+    console.log(
+      `  void injection: fixture=${sim.injection.fixtureId} event=${sim.injection.voidedEventId} applied=${sim.injection.applied}${sim.injection.rejectedCode === undefined ? "" : ` rejected=${sim.injection.rejectedCode}`} outcomeChanged=${sim.injection.outcomeChanged}`,
+    );
+  }
+  console.log(`  champion=${sim.champion} finalRanks=[${sim.finalRanks.slice(0, 8).join(", ")}${sim.finalRanks.length > 8 ? ", …" : ""}]`);
+
+  assertDivisionInvariants(sim, module, opts.cfg);
+  console.log("  invariants: OK");
+
+  const replay = simulateDivision(opts);
+  if (JSON.stringify(replay) !== JSON.stringify(sim)) {
+    console.error("  determinism: FAILED — the same seed produced a different division");
+    process.exit(1);
+  }
+  console.log("  determinism: OK (double run byte-identical)");
+} catch (error) {
+  console.error("  failure reproduced:");
+  if (error instanceof SimInvariantError) {
+    console.error(`  ${error.message}`);
+    if (error.detail !== undefined) console.error(`  detail: ${JSON.stringify(error.detail)}`);
+  } else {
+    console.error(error);
+  }
+  process.exit(1);
+}

--- a/packages/engine/src/competition/stage.ts
+++ b/packages/engine/src/competition/stage.ts
@@ -265,9 +265,15 @@ export function bracketRanks(
     }
   }
 
-  // The deciding game: the latest-round decided final.
+  // The deciding game: the latest-round settled final that produced a winner.
+  // A voided final (DE bracket reset skipped because the WB champion won GF1,
+  // spec 05 §2.4) is settled for completion but decides nothing — without the
+  // winner filter it would shadow GF1 and leave the champion undefined.
   const decidedFinals = fixtures
-    .filter((fixture) => fixture.isFinal === true && SETTLED.has(fixture.status))
+    .filter(
+      (fixture) =>
+        fixture.isFinal === true && SETTLED.has(fixture.status) && fixture.winner !== undefined,
+    )
     .sort((a, b) => b.round - a.round);
   const grandFinal = decidedFinals[0];
 

--- a/packages/engine/src/competition/tiebreakers.gaps.test.ts
+++ b/packages/engine/src/competition/tiebreakers.gaps.test.ts
@@ -1,0 +1,159 @@
+// Edge-path coverage for the tiebreaker engine — PROMPT-14 §4 (100% line gate
+// on competition/tiebreakers.ts): malformed-ledger throws, direct-encounter
+// branches, display formatting, non-swiss `direct` refinement, the seed
+// fallback, and every validateCascade rejection.
+import { describe, expect, it } from "vitest";
+import { EngineError } from "../core/errors.ts";
+import type { StandingsDelta } from "../core/types.ts";
+import type { FixtureResult, StandingsRow } from "./standings.ts";
+import {
+  buchholz,
+  buildSwissTable,
+  directEncounter,
+  pointsToText,
+  rankStandings,
+  validateCascade,
+  type SwissTable,
+} from "./tiebreakers.ts";
+
+function row(entrantId: string, points: number, metrics: Record<string, number> = {}): StandingsRow {
+  return { entrantId, played: 1, won: 0, drawn: 0, lost: 0, points, metrics };
+}
+
+function delta(entrantId: string, points: number, won = 0): StandingsDelta {
+  return { entrantId, played: 1, won, drawn: won === 1 ? 0 : 1, lost: 0, points, metrics: {} };
+}
+
+describe("Swiss ledger error paths", () => {
+  const table: SwissTable = [
+    { entrant: "A", score: 2, games: [{ opponent: "ghost", result: "win", scored: 2 }] },
+  ];
+
+  it("rejects a tiebreak query for an entrant outside the table", () => {
+    expect(() => buchholz(table, "nobody")).toThrow(/not in the Swiss table/);
+  });
+
+  it("rejects a card referencing an opponent outside the table", () => {
+    expect(() => buchholz(table, "A")).toThrow(/unknown opponent/);
+  });
+
+  it("rejects building a ledger from results outside the entrant set", () => {
+    const results: FixtureResult[] = [[delta("A", 2, 1), delta("Z", 0)]];
+    expect(() => buildSwissTable(["A"], results)).toThrow(/outside the entrant set/);
+  });
+});
+
+describe("directEncounter branches", () => {
+  const table: SwissTable = [
+    {
+      entrant: "A",
+      score: 2,
+      games: [
+        { opponent: "B", result: "win", scored: 2 },
+        { opponent: "C", result: "loss", scored: 0 },
+      ],
+    },
+    {
+      entrant: "B",
+      score: 0,
+      games: [{ opponent: "A", result: "loss", scored: 0 }],
+    },
+    {
+      entrant: "C",
+      score: 2,
+      games: [{ opponent: "A", result: "win", scored: 2 }],
+    },
+    { entrant: "D", score: 0, games: [] },
+  ];
+
+  it("+1 when a out-scored b head-to-head, −1 mirrored, 0 when never met", () => {
+    expect(directEncounter(table, "A", "B")).toBe(1);
+    expect(directEncounter(table, "A", "C")).toBe(-1);
+    expect(directEncounter(table, "B", "D")).toBe(0);
+  });
+});
+
+describe("pointsToText", () => {
+  it("renders half-points conventionally", () => {
+    expect(pointsToText(0)).toBe("0");
+    expect(pointsToText(1)).toBe("½");
+    expect(pointsToText(2)).toBe("1");
+    expect(pointsToText(5)).toBe("2½");
+    expect(pointsToText(4)).toBe("2");
+  });
+});
+
+describe("`direct` refinement outside a Swiss stage", () => {
+  it("splits a tie by head-to-head points from the fixture results", () => {
+    // Three-way tie: the b–c result contributes nothing to a's direct score.
+    const results: FixtureResult[] = [
+      [delta("b", 3, 1), delta("a", 0)],
+      [delta("b", 3, 1), delta("c", 0)],
+    ];
+    const ranked = rankStandings([row("a", 3), row("b", 3), row("c", 3)], {
+      cascade: ["points", "direct"],
+      results,
+    });
+    expect(ranked.rows[0]?.entrantId).toBe("b");
+  });
+
+  it("scores an entrant missing from the Swiss ledger as 0 and stays deterministic", () => {
+    const ranked = rankStandings([row("b", 3), row("a", 3)], {
+      cascade: ["points", "direct"],
+      swiss: [],
+    });
+    // Nobody separable by direct — the seed→id fallback keeps a total order.
+    expect(ranked.rows.map((entry) => entry.entrantId)).toEqual(["a", "b"]);
+    expect(ranked.rows.map((entry) => entry.rank)).toEqual([1, 2]);
+  });
+});
+
+describe("residual-tie seed fallback (no lots in the cascade)", () => {
+  it("orders an unresolvable tie by seed", () => {
+    const ranked = rankStandings([row("a", 3), row("b", 3)], {
+      cascade: ["points"],
+      seeds: new Map([
+        ["a", 2],
+        ["b", 1],
+      ]),
+    });
+    expect(ranked.rows.map((entry) => entry.entrantId)).toEqual(["b", "a"]);
+    expect(ranked.lotsGroups).toEqual([]);
+  });
+});
+
+describe("validateCascade rejections (spec 05 §4.1)", () => {
+  const cases: [string, Parameters<typeof validateCascade>[0]][] = [
+    ["goal/run difference", ["diff"]],
+    ["goals/runs-for", ["for"]],
+    ["fair_play", ["fair_play"]],
+    ["NRR ledger", ["nrr"]],
+    ["sets won/lost", ["set_ratio"]],
+    ["points won/lost", ["point_ratio"]],
+  ];
+
+  it.each(cases)("rejects %s keys the sport does not maintain", (_label, cascade) => {
+    let thrown: unknown;
+    try {
+      validateCascade(cascade, { metrics: [] });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(EngineError.is(thrown, "CONFIG_INVALID")).toBe(true);
+  });
+
+  it("accepts ratio keys when the sport maintains their ledgers", () => {
+    const metric = (key: string) => ({ key, label: key, direction: "desc" as const });
+    expect(() =>
+      validateCascade(["nrr"], {
+        metrics: ["runs_for", "balls_faced_eff", "runs_against", "balls_bowled_eff"].map(metric),
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateCascade(["set_ratio"], { metrics: ["sets_won", "sets_lost"].map(metric) }),
+    ).not.toThrow();
+    expect(() =>
+      validateCascade(["point_ratio"], { metrics: ["points_won", "points_lost"].map(metric) }),
+    ).not.toThrow();
+  });
+});

--- a/packages/engine/src/competition/tiebreakers.ts
+++ b/packages/engine/src/competition/tiebreakers.ts
@@ -376,6 +376,8 @@ function h2hBlock(
   let miniClasses: StandingsRow[][] = [miniRows];
   for (const key of block) {
     const cmp = COMPARATORS[h2hToPlain(key)];
+    // h2hToPlain maps onto points/diff/for, all registered — defensive only.
+    /* v8 ignore next */
     if (cmp === undefined) continue;
     miniClasses = miniClasses.flatMap((mini) => {
       if (mini.length <= 1) return [mini];

--- a/packages/engine/src/testkit/chaos.test.ts
+++ b/packages/engine/src/testkit/chaos.test.ts
@@ -1,0 +1,160 @@
+// Chaos scorer — PROMPT-14 §2. Interleaves invalid events (wrong phase,
+// unknown entrant, post-decision, malformed/unknown core payloads) into valid
+// streams for every shipped module and asserts:
+//   1. every injection is rejected with a typed EngineError code, and
+//   2. the ledger is never corrupted — refolding the valid stream afterwards
+//      reproduces the baseline state and outcome exactly.
+import { describe, expect, it } from "vitest";
+import { EngineError, EngineErrorCode } from "../core/errors.ts";
+import { foldMatch, type EventEnvelope } from "../core/events.ts";
+import type { LineupPair } from "../core/types.ts";
+import type { AnySportModule, ModuleEvent } from "../sport/module.ts";
+import { builtinModules } from "../sports/index.ts";
+import { defaultLineupPair, makeEnvelope } from "./helpers.ts";
+import { deriveSeed, SIM_CONFIGS } from "./simulation.ts";
+import { mulberry32 } from "../core/rng.ts";
+
+const CHAOS_SEEDS = Number(process.env.SIM_RUNS ?? (process.env.CI ? 200 : 25));
+
+interface DecidedStream {
+  events: EventEnvelope[];
+  decidedAt: number; // index of the event that decided the match
+}
+
+// Walk the module's generator until the match decides (like the simulator's
+// playFixture, but the chaos suite needs the decision index).
+function decidedStream(
+  module: AnySportModule,
+  cfg: unknown,
+  lineups: LineupPair,
+  seed: number,
+): DecidedStream | null {
+  const generate = module.arbitraryEvent;
+  if (!generate) throw new Error(`module "${module.key}" lacks arbitraryEvent`);
+  const rng = mulberry32(seed);
+  let state = module.init(cfg, lineups);
+  const events: EventEnvelope[] = [];
+  for (let i = 0; i < 600; i++) {
+    const next = generate.call(module, state, rng) as ModuleEvent | null;
+    if (next === null) break;
+    const env = makeEnvelope(events.length, next);
+    state = module.apply(state, env);
+    events.push(env);
+    if (module.outcome(state) !== null) return { events, decidedAt: events.length - 1 };
+  }
+  return null;
+}
+
+// Rebuild an envelope stream with contiguous seqs after an insertion.
+function withInserted(
+  events: readonly EventEnvelope[],
+  index: number,
+  event: ModuleEvent,
+): EventEnvelope[] {
+  const spliced = [...events.slice(0, index), null, ...events.slice(index)];
+  return spliced.map((entry, i) =>
+    entry === null
+      ? { ...makeEnvelope(i, event), id: `chaos-${i}` }
+      : { ...entry, seq: i, id: `e-${i}` },
+  );
+}
+
+function expectTypedRejection(
+  module: AnySportModule,
+  cfg: unknown,
+  lineups: LineupPair,
+  events: readonly EventEnvelope[],
+  label: string,
+): void {
+  let thrown: unknown;
+  try {
+    foldMatch(module, cfg, lineups, events);
+  } catch (err) {
+    thrown = err;
+  }
+  expect(EngineError.is(thrown), `${label}: expected a typed EngineError, got ${String(thrown)}`).toBe(
+    true,
+  );
+  expect(() => EngineErrorCode.parse((thrown as EngineError).code)).not.toThrow();
+}
+
+for (const module of builtinModules) {
+  const cfg = module.configSchema.parse(SIM_CONFIGS[module.key] ?? {});
+  const lineups = defaultLineupPair(module.positions);
+  const postDecisionSafe = new Set(["core.note", "core.finalize", ...(module.postDecisionTypes ?? [])]);
+
+  describe(`chaos scorer — ${module.key}@${module.version}`, () => {
+    it(
+      "rejects every interleaved invalid event with a typed code; ledger survives",
+      { timeout: Math.max(60_000, CHAOS_SEEDS * 150) },
+      () => {
+      let exercised = 0;
+      for (let seed = 1; seed <= CHAOS_SEEDS && exercised < CHAOS_SEEDS; seed++) {
+        const stream = decidedStream(module, cfg, lineups, deriveSeed(seed, module.key, "chaos"));
+        if (stream === null) continue;
+        exercised++;
+        const { events, decidedAt } = stream;
+        const baseline = JSON.stringify(foldMatch(module, cfg, lineups, events));
+        const rng = mulberry32(deriveSeed(seed, module.key, "chaos-pick"));
+        const mid = Math.floor(rng() * (decidedAt + 1));
+
+        // Unknown entrant — a forfeit by someone not in the fixture.
+        expectTypedRejection(
+          module,
+          cfg,
+          lineups,
+          withInserted(events, mid, {
+            type: "core.forfeit",
+            payload: { by: "intruder", reason: "chaos" },
+          }),
+          "unknown entrant",
+        );
+
+        // Wrong phase — finalize before the match has decided.
+        expectTypedRejection(
+          module,
+          cfg,
+          lineups,
+          withInserted(events, 0, { type: "core.finalize", payload: {} }),
+          "finalize before decision",
+        );
+
+        // Post-decision — replay the deciding event after the decision.
+        const decider = events[decidedAt] as EventEnvelope;
+        if (!postDecisionSafe.has(decider.type)) {
+          expectTypedRejection(
+            module,
+            cfg,
+            lineups,
+            [...events, { ...decider, id: `e-${events.length}`, seq: events.length }],
+            "post-decision replay",
+          );
+        }
+
+        // Unknown core namespace event.
+        expectTypedRejection(
+          module,
+          cfg,
+          lineups,
+          withInserted(events, mid, { type: "core.chaos", payload: {} }),
+          "unknown core event",
+        );
+
+        // Malformed core payload — forfeit without its required fields.
+        expectTypedRejection(
+          module,
+          cfg,
+          lineups,
+          withInserted(events, mid, { type: "core.forfeit", payload: {} }),
+          "malformed core payload",
+        );
+
+        // Ledger never corrupted: the valid stream still folds byte-identically.
+        expect(JSON.stringify(foldMatch(module, cfg, lineups, events))).toBe(baseline);
+      }
+        // The generator must reach decisions or the suite proves nothing.
+        expect(exercised).toBeGreaterThan(0);
+      },
+    );
+  });
+}

--- a/packages/engine/src/testkit/index.ts
+++ b/packages/engine/src/testkit/index.ts
@@ -1,7 +1,9 @@
 // @seazn/engine/testkit — conformance suite factories for module authors —
 // spec 03 §2 (kernel guarantees), §6 (determinism & simulation), spec 04 §9
-// (cross-sport invariants). Tournament-level simulation helpers land with
-// PROMPT-14.
+// (cross-sport invariants) — plus the tournament simulation harness
+// (PROMPT-14): full-division property simulation across every stage-graph
+// template, with seeded exact replay (sim:replay).
 
 export * from "./helpers.ts";
 export * from "./conformance.ts";
+export * from "./simulation.ts";

--- a/packages/engine/src/testkit/simulation.test.ts
+++ b/packages/engine/src/testkit/simulation.test.ts
@@ -1,0 +1,183 @@
+// Tournament simulation harness — PROMPT-14. Every registered sport module ×
+// every stage-graph template runs SIM_RUNS seeded full divisions; each division
+// is checked against the global invariants and (on a slice) exact replay
+// determinism. Failures dump a reproduction artifact: `npm run sim:replay --
+// <seedToken>` re-runs that exact division.
+//
+// Budget: SIM_RUNS env — CI defaults to 200 per sport×format, local runs to 25,
+// the nightly workflow_dispatch/cron job passes 10000.
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { builtinModules } from "../sports/index.ts";
+import type { AnySportModule } from "../sport/module.ts";
+import {
+  assertDivisionInvariants,
+  canVoidFixtureEvent,
+  FORMAT_TEMPLATES,
+  SIM_CONFIGS,
+  simOptionsFor,
+  simulateDivision,
+  SimInvariantError,
+  type FormatTemplate,
+  type SimulationResult,
+} from "./simulation.ts";
+
+const SIM_RUNS = Number(process.env.SIM_RUNS ?? (process.env.CI ? 200 : 25));
+
+const FAILURE_DIR = new URL("../../sim-failures", import.meta.url).pathname;
+
+// Dump the failing division (seed token + full event streams) for exact
+// offline reproduction, then rethrow (PROMPT-14 §3).
+function dumpFailure(token: string, error: unknown, sim?: SimulationResult): void {
+  mkdirSync(FAILURE_DIR, { recursive: true });
+  const file = join(FAILURE_DIR, `${token.replaceAll(":", "_")}.json`);
+  writeFileSync(
+    file,
+    JSON.stringify(
+      {
+        seedToken: token,
+        replay: `npm run sim:replay -- ${token}`,
+        error: error instanceof Error ? { name: error.name, message: error.message } : String(error),
+        detail: error instanceof SimInvariantError ? error.detail : undefined,
+        simulation: sim,
+      },
+      null,
+      2,
+    ),
+  );
+  // eslint-disable-next-line no-console
+  console.error(`simulation failure artifact written: ${file}`);
+}
+
+function runOne(module: AnySportModule, format: FormatTemplate, seed: number): SimulationResult {
+  const opts = simOptionsFor(module, format, seed);
+  const token = `${module.key}:${format}:${seed}`;
+  let sim: SimulationResult | undefined;
+  try {
+    sim = simulateDivision(opts);
+    assertDivisionInvariants(sim, module, opts.cfg);
+    if (seed % 10 === 1) {
+      // Deterministic replay: same seed ⇒ identical fixture ids, event ids and
+      // final standings (PROMPT-14 §1).
+      const replay = simulateDivision(opts);
+      expect(JSON.stringify(replay)).toBe(JSON.stringify(sim));
+    }
+    if (sim.injection !== undefined && !sim.injection.applied) {
+      expect(sim.injection.rejectedCode).toBeTruthy();
+    }
+    return sim;
+  } catch (error) {
+    dumpFailure(token, error, sim);
+    throw error;
+  }
+}
+
+for (const module of builtinModules) {
+  describe(`simulation — ${module.key}@${module.version}`, () => {
+    for (const format of FORMAT_TEMPLATES) {
+      it(
+        `${format}: ${SIM_RUNS} seeded divisions hold the global invariants`,
+        // Nightly runs pass SIM_RUNS=10000 — budget the timeout accordingly.
+        { timeout: Math.max(60_000, SIM_RUNS * 300) },
+        () => {
+          for (let seed = 1; seed <= SIM_RUNS; seed++) {
+            runOne(module, format, seed);
+          }
+        },
+      );
+    }
+  });
+}
+
+describe("rank_locked guard (PROMPT-14 §1)", () => {
+  const generic = builtinModules.find((m) => m.key === "generic") as AnySportModule;
+
+  it("blocks a void once the fixture's stage has completed", () => {
+    const sim = simulateDivision({
+      module: generic,
+      cfg: SIM_CONFIGS["generic"],
+      format: "group_knockout",
+      seed: 7,
+      entrantCount: 8,
+    });
+    // Every stage in a finished division has completed — any further void
+    // attempt must be refused with the rank_locked code.
+    for (const stage of sim.stages) {
+      expect(canVoidFixtureEvent(sim.divisionEvents, stage.id)).toEqual({
+        ok: false,
+        code: "rank_locked",
+      });
+    }
+    // While a stage is still open (its stage_completed not yet emitted), the
+    // same fixture may be voided.
+    const beforeCompletion = sim.divisionEvents.filter((e) => e.type === "stage_opened");
+    expect(beforeCompletion.length).toBeGreaterThan(0);
+    expect(canVoidFixtureEvent([{ type: "stage_opened", stageId: "groups" }], "groups")).toEqual({
+      ok: true,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mutation canaries — PROMPT-14 acceptance: a deliberately seeded engine bug
+// must be caught. Each canary corrupts one aspect of an otherwise-valid
+// division the way a source mutation would, and the invariant checker fires.
+// ---------------------------------------------------------------------------
+describe("mutation canaries — the harness catches seeded engine bugs", () => {
+  const generic = builtinModules.find((m) => m.key === "generic") as AnySportModule;
+  const cfg = SIM_CONFIGS["generic"];
+  const valid = () =>
+    JSON.parse(
+      JSON.stringify(
+        simulateDivision({
+          module: generic,
+          cfg,
+          format: "league",
+          seed: 11,
+          entrantCount: 6,
+        }),
+      ),
+    ) as SimulationResult;
+
+  it("accepts the unmutated division (canary baseline)", () => {
+    expect(() => assertDivisionInvariants(valid(), generic, cfg)).not.toThrow();
+  });
+
+  it("catches a flipped ranking comparator (points order inverted)", () => {
+    const sim = valid();
+    const stage = sim.stages[0];
+    const pool = stage?.tables?.pools[0];
+    if (!stage || !pool) throw new Error("league simulation lost its pool table");
+    // A flipped `points` comparator ranks the table bottom-up: same rows, same
+    // rank numbers 1..n, reversed order — exactly what a mutated cascade emits.
+    const reversed = [...pool.rows].reverse().map((row, i) => ({ ...row, rank: i + 1 }));
+    (pool as unknown as { rows: typeof reversed }).rows = reversed;
+    expect(() => assertDivisionInvariants(sim, generic, cfg)).toThrow(SimInvariantError);
+    expect(() => assertDivisionInvariants(sim, generic, cfg)).toThrow(/contradicts points/);
+  });
+
+  it("catches a standingsDelta that stops conserving points", () => {
+    const sim = valid();
+    const fixture = sim.stages[0]?.fixtures.find((f) => f.result !== undefined);
+    if (!fixture?.result) throw new Error("league simulation lost its results");
+    (fixture.result[0] as { points: number }).points += 1;
+    expect(() => assertDivisionInvariants(sim, generic, cfg)).toThrow(/points/);
+  });
+
+  it("catches a fold that miscounts played fixtures", () => {
+    const sim = valid();
+    const fixture = sim.stages[0]?.fixtures.find((f) => f.result !== undefined);
+    if (!fixture?.result) throw new Error("league simulation lost its results");
+    // Keep the fixture total inside the declared set but corrupt the played
+    // tally — the ledger-sum invariant must notice the divergence.
+    (fixture.result[0] as { played: number }).played = 0;
+    expect(() => assertDivisionInvariants(sim, generic, cfg)).toThrow(/played counts/);
+  });
+
+  it("catches a champion outside the entrant set", () => {
+    const sim = valid();
+    (sim as { champion: string }).champion = "ghost";
+    expect(() => assertDivisionInvariants(sim, generic, cfg)).toThrow(/not an entrant/);
+  });
+});

--- a/packages/engine/src/testkit/simulation.ts
+++ b/packages/engine/src/testkit/simulation.ts
@@ -1,0 +1,1133 @@
+// Tournament & property-simulation harness — PROMPT-14, spec 03 §6, spec 04
+// §9, spec 05 §6. Simulates a FULL division for any sport module × any
+// stage-graph template: generate fixtures, drive every match with the module's
+// arbitraryEvent stream, progress stages through qualification, and check the
+// global invariants (assertDivisionInvariants). Everything derives from one
+// 32-bit seed, so `sport:format:seed` reproduces a run exactly (sim:replay).
+import {
+  completeBracketStage,
+  completeTableStage,
+  isBracketStageComplete,
+  isTableStageComplete,
+  openStage,
+  type BracketFixture,
+  type BracketStage,
+  type DivisionEvent,
+  type TableFixture,
+  type TableStage,
+} from "../competition/stage.ts";
+import {
+  qualificationSize,
+  resolveQualification,
+  type QualificationSpec,
+  type StageTables,
+} from "../competition/qualification.ts";
+import type { FixtureResult } from "../competition/standings.ts";
+import { EngineError } from "../core/errors.ts";
+import { foldMatch, type EventEnvelope } from "../core/events.ts";
+import { mulberry32, type Rng } from "../core/rng.ts";
+import type { EntrantId, LineupPair, MatchOutcome, StageCtx, StageKind } from "../core/types.ts";
+import {
+  generateDoubleElim,
+  generateSingleElim,
+  generateStepladder,
+  type BracketFixtureGen,
+  type BracketSlotRef,
+} from "../scheduling/bracket.ts";
+import { generateRoundRobin, roundRobinFixtureCount } from "../scheduling/roundrobin.ts";
+import {
+  pairKey,
+  pairRound,
+  type Colour,
+  type SwissStanding,
+} from "../scheduling/swiss.ts";
+import type { AnySportModule, ModuleEvent, TiebreakerKey } from "../sport/module.ts";
+import { lineupFromCatalog, TEST_INSTANT } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Templates & options
+// ---------------------------------------------------------------------------
+
+// The five stage-graph templates the harness exercises (PROMPT-14 §1).
+export const FORMAT_TEMPLATES = [
+  "league",
+  "group_knockout",
+  "swiss_knockout",
+  "double_elim",
+  "stepladder",
+] as const;
+export type FormatTemplate = (typeof FORMAT_TEMPLATES)[number];
+
+// Per-sport simulation configs. Most modules default-parse ({}); generic has
+// no defaults (v1 semantics are explicit), cricket is shortened to 5-over
+// innings so ball-by-ball streams stay affordable at CI run counts.
+export const SIM_CONFIGS: Record<string, unknown> = {
+  generic: {
+    resultMode: "score",
+    allowDraws: true,
+    points: { w: 3, d: 1, l: 0 },
+    progressScore: false,
+  },
+  cricket: { ballsPerInnings: 30 },
+};
+
+export interface SimOptions {
+  module: AnySportModule;
+  cfg?: unknown; // raw config, parsed through module.configSchema (default {})
+  format: FormatTemplate;
+  seed: number; // master seed — determines entrant count, streams, injection
+  entrantCount?: number; // override the seed-derived count (2–64)
+  maxEventsPerFixture?: number; // stream budget per attempt (default 600)
+  injectVoid?: boolean; // mid-tournament random void injection (PROMPT-14 §1)
+}
+
+export interface SimFixtureRecord {
+  id: string;
+  stageId: string;
+  poolId?: string;
+  roundNo?: number;
+  home?: EntrantId;
+  away?: EntrantId;
+  status: "decided" | "walkover" | "void";
+  events: EventEnvelope[]; // empty for walkover/void (structural decisions)
+  outcome: MatchOutcome | null;
+  result?: FixtureResult; // table stages: the [home, away] standings deltas
+  winner?: EntrantId;
+  loser?: EntrantId;
+  isFinal?: boolean;
+  round?: number; // bracket stages
+}
+
+export interface SimStageRecord {
+  id: string;
+  kind: StageKind;
+  entrants: EntrantId[];
+  fixtures: SimFixtureRecord[];
+  tables?: StageTables;
+  cascade?: TiebreakerKey[]; // table stages: the ranking cascade applied
+  finalRanks: EntrantId[];
+  qualification?: { spec: QualificationSpec; seeds: EntrantId[] }; // feed to the next stage
+}
+
+export interface SimInjectionRecord {
+  fixtureId: string;
+  voidedEventId: string;
+  applied: boolean; // false = the refold rejected the void; ledger unchanged
+  rejectedCode?: string; // EngineError code when rejected
+  outcomeChanged: boolean;
+}
+
+export interface SimulationResult {
+  seedToken: string; // `${sport}:${format}:${seed}` — sim:replay input
+  sport: string;
+  format: FormatTemplate;
+  seed: number;
+  entrants: EntrantId[];
+  stages: SimStageRecord[];
+  divisionEvents: DivisionEvent[];
+  champion: EntrantId;
+  finalRanks: EntrantId[];
+  injection?: SimInjectionRecord;
+}
+
+// An invariant violation — carries enough context for the failure artifact.
+export class SimInvariantError extends Error {
+  readonly detail?: unknown;
+  constructor(message: string, detail?: unknown) {
+    super(message);
+    this.name = "SimInvariantError";
+    this.detail = detail;
+  }
+}
+
+export function makeSeedToken(sport: string, format: FormatTemplate, seed: number): string {
+  return `${sport}:${format}:${seed}`;
+}
+
+// The canonical options for a seed token — the CI suite and sim:replay MUST
+// build runs through this so a token reproduces the exact division (including
+// the every-4th-seed void injection).
+export function simOptionsFor(
+  module: AnySportModule,
+  format: FormatTemplate,
+  seed: number,
+): SimOptions {
+  const cfg = SIM_CONFIGS[module.key];
+  return {
+    module,
+    ...(cfg === undefined ? {} : { cfg }),
+    format,
+    seed,
+    injectVoid: seed % 4 === 0,
+  };
+}
+
+export function parseSeedToken(token: string): { sport: string; format: FormatTemplate; seed: number } {
+  const parts = token.split(":");
+  if (parts.length !== 3) throw new Error(`bad seed token "${token}" (want sport:format:seed)`);
+  const [sport, format, seedStr] = parts as [string, string, string];
+  if (!(FORMAT_TEMPLATES as readonly string[]).includes(format)) {
+    throw new Error(`bad seed token "${token}": unknown format "${format}"`);
+  }
+  const seed = Number(seedStr);
+  if (!Number.isInteger(seed)) throw new Error(`bad seed token "${token}": seed not an integer`);
+  return { sport, format: format as FormatTemplate, seed };
+}
+
+// ---------------------------------------------------------------------------
+// Seed derivation — one master seed fans out to per-purpose streams via FNV-1a.
+// ---------------------------------------------------------------------------
+
+export function deriveSeed(seed: number, ...parts: readonly (string | number)[]): number {
+  let hash = (seed >>> 0) ^ 0x811c9dc5;
+  for (const part of parts) {
+    const text = String(part);
+    for (let i = 0; i < text.length; i++) {
+      hash = Math.imul(hash ^ text.charCodeAt(i), 0x01000193) >>> 0;
+    }
+    hash = Math.imul(hash ^ 0x1f, 0x01000193) >>> 0; // part separator
+  }
+  return hash >>> 0;
+}
+
+// Entrant count 2–64 (PROMPT-14 §1), skewed small so O(n²) round robins stay
+// affordable at CI run counts while the tail still reaches 64.
+export function drawEntrantCount(seed: number): number {
+  const rng = mulberry32(deriveSeed(seed, "entrants"));
+  return Math.min(64, 2 + Math.floor(rng() * rng() * 63));
+}
+
+const SWISS_ONLY_KEYS: ReadonlySet<TiebreakerKey> = new Set([
+  "buchholz",
+  "buchholz_cut1",
+  "sberger",
+  "direct",
+]);
+
+// The stage cascade: the module's official cascade, minus Swiss-ledger keys
+// outside a swiss stage (they need the assembled ledger, spec 05 §4.1).
+function stageCascade(module: AnySportModule, swiss: boolean): TiebreakerKey[] {
+  return module.defaultTiebreakers.filter((key) => swiss || !SWISS_ONLY_KEYS.has(key));
+}
+
+// ---------------------------------------------------------------------------
+// Fixture play — walk the module's arbitraryEvent generator to a decision.
+// ---------------------------------------------------------------------------
+
+function envelope(
+  fixtureId: string,
+  seq: number,
+  event: ModuleEvent,
+  voids?: string,
+): EventEnvelope {
+  return {
+    id: `${fixtureId}-e${seq}`,
+    fixtureId,
+    seq,
+    type: event.type,
+    payload: event.payload,
+    recordedAt: TEST_INSTANT,
+    recordedBy: "sim",
+    ...(voids === undefined ? {} : { voids }),
+  };
+}
+
+interface PlayedMatch {
+  events: EventEnvelope[];
+  state: unknown;
+  outcome: MatchOutcome;
+}
+
+const DECISIVE_KINDS: ReadonlySet<MatchOutcome["kind"]> = new Set(["win", "award"]);
+
+// Play one fixture to completion. `decisive` (bracket fixtures) additionally
+// requires a win/award — indecisive attempts (draw/tie/no_result, or a stream
+// that exhausts its budget) replay from a derived seed, like a real knockout
+// replays an abandoned tie. Deterministic: seed ⇒ identical stream.
+function playFixture(
+  module: AnySportModule,
+  cfg: unknown,
+  lineups: LineupPair,
+  fixtureId: string,
+  seed: number,
+  opts: { maxEvents: number; decisive: boolean },
+): PlayedMatch {
+  const generate = module.arbitraryEvent;
+  if (!generate) throw new Error(`module "${module.key}" does not implement arbitraryEvent`);
+
+  const MAX_ATTEMPTS = 100;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const rng = mulberry32(deriveSeed(seed, "fixture", fixtureId, attempt));
+    let state = module.init(cfg, lineups);
+    const events: EventEnvelope[] = [];
+    for (let i = 0; i < opts.maxEvents; i++) {
+      const next = generate.call(module, state, rng) as ModuleEvent | null;
+      if (next === null) break;
+      const env = envelope(fixtureId, events.length, next);
+      state = module.apply(state, env);
+      events.push(env);
+    }
+    const outcome = module.outcome(state) as MatchOutcome | null;
+    if (outcome === null) continue; // budget exhausted undecided — replay
+    if (opts.decisive && !DECISIVE_KINDS.has(outcome.kind)) continue; // knockout replay
+    return { events, state, outcome };
+  }
+  throw new SimInvariantError(
+    `fixture "${fixtureId}" never reached a ${opts.decisive ? "decisive " : ""}outcome in ${MAX_ATTEMPTS} attempts`,
+    { fixtureId, sport: module.key },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Void injection — PROMPT-14 §1: void a random event mid-tournament, refold.
+// ---------------------------------------------------------------------------
+
+// Division-level void guard (spec 05 §3): once a stage has completed — its
+// final ranks are locked and may already have seeded the next stage — a void
+// that could reopen a fixture is refused. This is the rule the persistence
+// adapter enforces; the simulator and its tests assert it here.
+export function canVoidFixtureEvent(
+  divisionEvents: readonly DivisionEvent[],
+  stageId: string,
+): { ok: true } | { ok: false; code: "rank_locked" } {
+  const completed = divisionEvents.some(
+    (event) => event.type === "stage_completed" && event.stageId === stageId,
+  );
+  return completed ? { ok: false, code: "rank_locked" } : { ok: true };
+}
+
+// Void a seeded-random event of a just-played fixture and refold. Three legal
+// outcomes, all asserted valid downstream:
+//  - the refold throws a typed EngineError (e.g. voiding core.start makes a
+//    later event WRONG_PHASE) ⇒ the void is rejected, ledger unchanged;
+//  - the refold leaves the match undecided ⇒ the scorer keeps scoring — the
+//    generator resumes on the refolded state until a (compatible) decision;
+//  - the refolded decision differs ⇒ downstream progression recomputes.
+function injectVoidIntoMatch(
+  module: AnySportModule,
+  cfg: unknown,
+  lineups: LineupPair,
+  fixtureId: string,
+  played: PlayedMatch,
+  rng: Rng,
+  opts: { maxEvents: number; decisive: boolean },
+): { match: PlayedMatch; record: SimInjectionRecord } {
+  const target = played.events[Math.floor(rng() * played.events.length)] as EventEnvelope;
+  const voidEnv = envelope(fixtureId, played.events.length, { type: "core.void", payload: {} }, target.id);
+  const events = [...played.events, voidEnv];
+
+  const rejected = (code: string): { match: PlayedMatch; record: SimInjectionRecord } => ({
+    match: played,
+    record: {
+      fixtureId,
+      voidedEventId: target.id,
+      applied: false,
+      rejectedCode: code,
+      outcomeChanged: false,
+    },
+  });
+
+  let state: unknown;
+  try {
+    state = foldMatch(module, cfg, lineups, events);
+  } catch (err) {
+    if (EngineError.is(err)) return rejected(err.code); // typed rejection — ledger stays
+    throw err;
+  }
+
+  // Refold OK — if the void reopened the match, keep scoring to a decision.
+  let outcome = module.outcome(state) as MatchOutcome | null;
+  const generate = module.arbitraryEvent as NonNullable<AnySportModule["arbitraryEvent"]>;
+  for (let i = events.length; outcome === null && i < events.length + opts.maxEvents; i++) {
+    const next = generate.call(module, state, rng) as ModuleEvent | null;
+    if (next === null) break;
+    const env = envelope(fixtureId, i, next);
+    state = module.apply(state, env);
+    events.push(env);
+    outcome = module.outcome(state) as MatchOutcome | null;
+  }
+  if (outcome === null || (opts.decisive && !DECISIVE_KINDS.has(outcome.kind))) {
+    // Can't complete the reopened match within budget/constraints — a real
+    // scorer would re-record; the simulator treats the void as rejected.
+    return rejected("SIM_UNDECIDED");
+  }
+
+  return {
+    match: { events, state, outcome },
+    record: {
+      fixtureId,
+      voidedEventId: target.id,
+      applied: true,
+      outcomeChanged: JSON.stringify(outcome) !== JSON.stringify(played.outcome),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The division simulator
+// ---------------------------------------------------------------------------
+
+interface SimContext {
+  module: AnySportModule;
+  cfg: unknown;
+  seed: number;
+  maxEvents: number;
+  lineups: Map<EntrantId, ReturnType<typeof lineupFromCatalog>>;
+  divisionEvents: DivisionEvent[];
+  // Void injection: fires once, at the `injectAt`-th fixture played.
+  injectAt: number; // -1 = no injection
+  fixturesPlayed: number;
+  injection?: SimInjectionRecord;
+}
+
+function lineupPairFor(ctx: SimContext, home: EntrantId, away: EntrantId): LineupPair {
+  let homeLineup = ctx.lineups.get(home);
+  if (homeLineup === undefined) {
+    homeLineup = lineupFromCatalog(ctx.module.positions, home);
+    ctx.lineups.set(home, homeLineup);
+  }
+  let awayLineup = ctx.lineups.get(away);
+  if (awayLineup === undefined) {
+    awayLineup = lineupFromCatalog(ctx.module.positions, away);
+    ctx.lineups.set(away, awayLineup);
+  }
+  return { home: homeLineup, away: awayLineup };
+}
+
+// Play a fixture inside a stage, applying the one-shot void injection when its
+// turn comes (only while the stage is still open — the rank_locked guard).
+function playInStage(
+  ctx: SimContext,
+  stageId: string,
+  fixtureId: string,
+  home: EntrantId,
+  away: EntrantId,
+  decisive: boolean,
+): PlayedMatch {
+  const lineups = lineupPairFor(ctx, home, away);
+  let match = playFixture(ctx.module, ctx.cfg, lineups, fixtureId, ctx.seed, {
+    maxEvents: ctx.maxEvents,
+    decisive,
+  });
+
+  if (ctx.fixturesPlayed === ctx.injectAt && ctx.injection === undefined) {
+    const guard = canVoidFixtureEvent(ctx.divisionEvents, stageId);
+    if (guard.ok) {
+      const rng = mulberry32(deriveSeed(ctx.seed, "inject", fixtureId));
+      const injected = injectVoidIntoMatch(ctx.module, ctx.cfg, lineups, fixtureId, match, rng, {
+        maxEvents: ctx.maxEvents,
+        decisive,
+      });
+      match = injected.match;
+      ctx.injection = injected.record;
+    }
+  }
+  ctx.fixturesPlayed++;
+  return match;
+}
+
+// The [home, away] standings deltas of a decided table fixture.
+function tableResult(
+  ctx: SimContext,
+  match: PlayedMatch,
+  stageCtx: StageCtx,
+): FixtureResult {
+  const [home, away] = ctx.module.standingsDelta(match.outcome, ctx.cfg, stageCtx, match.state);
+  return [home, away];
+}
+
+function toRecord(
+  stageId: string,
+  fixtureId: string,
+  home: EntrantId,
+  away: EntrantId,
+  match: PlayedMatch,
+  extra: Partial<SimFixtureRecord> = {},
+): SimFixtureRecord {
+  const outcome = match.outcome;
+  const winner =
+    outcome.kind === "win" || outcome.kind === "award" ? outcome.winner : undefined;
+  const loser =
+    outcome.kind === "win" ? outcome.loser : outcome.kind === "award" ? (outcome.winner === home ? away : home) : undefined;
+  return {
+    id: fixtureId,
+    stageId,
+    home,
+    away,
+    status: "decided",
+    events: match.events,
+    outcome,
+    ...(winner === undefined ? {} : { winner }),
+    ...(loser === undefined ? {} : { loser }),
+    ...extra,
+  };
+}
+
+// --- Table stages (league / group / swiss) ---------------------------------
+
+interface PlayedTableStage {
+  record: SimStageRecord;
+  tables: StageTables;
+  finalRanks: EntrantId[];
+}
+
+function playRoundRobinStage(
+  ctx: SimContext,
+  stageId: string,
+  kind: Extract<StageKind, "league" | "group">,
+  pools: readonly { poolId: string; entrants: readonly EntrantId[] }[],
+  seeds: ReadonlyMap<EntrantId, number>,
+): PlayedTableStage {
+  ctx.divisionEvents.push(...openStage(stageId));
+
+  const allEntrants = pools.flatMap((pool) => [...pool.entrants]);
+  const records: SimFixtureRecord[] = [];
+  const tableFixtures: TableFixture[] = [];
+
+  for (const pool of pools) {
+    const schedule = generateRoundRobin({ entrants: pool.entrants, seeds });
+    if (schedule.fixtures.length !== roundRobinFixtureCount(pool.entrants.length)) {
+      throw new SimInvariantError(
+        `round robin incomplete: pool "${pool.poolId}" produced ${schedule.fixtures.length} fixtures for ${pool.entrants.length} entrants`,
+      );
+    }
+    for (const fixture of schedule.fixtures) {
+      const fixtureId = `${stageId}-${pool.poolId}-${fixture.id}`;
+      const match = playInStage(ctx, stageId, fixtureId, fixture.home, fixture.away, false);
+      const stageCtx: StageCtx = { kind, roundNo: fixture.roundNo, poolId: pool.poolId };
+      const result = tableResult(ctx, match, stageCtx);
+      records.push(
+        toRecord(stageId, fixtureId, fixture.home, fixture.away, match, {
+          poolId: pool.poolId,
+          roundNo: fixture.roundNo,
+          result,
+        }),
+      );
+      tableFixtures.push({
+        id: fixtureId,
+        poolId: pool.poolId,
+        roundNo: fixture.roundNo,
+        status: "decided",
+        result,
+      });
+    }
+  }
+
+  const stage: TableStage = {
+    id: stageId,
+    kind,
+    entrants: allEntrants,
+    cascade: stageCascade(ctx.module, false),
+    seeds,
+    rngSeed: deriveSeed(ctx.seed, "lots", stageId),
+  };
+  if (!isTableStageComplete(stage, tableFixtures)) {
+    throw new SimInvariantError(`stage "${stageId}" not complete after playing every fixture`);
+  }
+  const completed = completeTableStage(stage, tableFixtures);
+  ctx.divisionEvents.push(...completed.events);
+
+  const done = completed.events.find((e) => e.type === "stage_completed");
+  const finalRanks = done?.type === "stage_completed" ? done.finalRanks : [];
+  return {
+    record: {
+      id: stageId,
+      kind,
+      entrants: allEntrants,
+      fixtures: records,
+      tables: completed.tables,
+      cascade: [...stage.cascade],
+      finalRanks,
+    },
+    tables: completed.tables,
+    finalRanks,
+  };
+}
+
+function playSwissStage(
+  ctx: SimContext,
+  stageId: string,
+  entrants: readonly EntrantId[],
+  seeds: ReadonlyMap<EntrantId, number>,
+): PlayedTableStage {
+  ctx.divisionEvents.push(...openStage(stageId));
+  const chess = ctx.module.key === "boardgame";
+  const targetRounds = Math.min(entrants.length - 1, Math.max(1, Math.ceil(Math.log2(entrants.length))));
+
+  const records: SimFixtureRecord[] = [];
+  const tableFixtures: TableFixture[] = [];
+  const results: FixtureResult[] = [];
+  const played = new Set<string>();
+  const colours = new Map<EntrantId, Colour[]>();
+  const byes = new Set<EntrantId>();
+  const floats = new Map<EntrantId, number>();
+  const points = new Map<EntrantId, number>(entrants.map((id) => [id, 0]));
+
+  let roundsPlayed = 0;
+  for (let round = 1; round <= targetRounds; round++) {
+    const standings: SwissStanding[] = entrants.map((id) => ({
+      entrantId: id,
+      score: points.get(id) ?? 0,
+      rank: seeds.get(id) ?? Number.MAX_SAFE_INTEGER,
+    }));
+    const paired = pairRound(standings, { played, colours, byes, floats }, { chess });
+    if (paired.pairings.length === 0 && entrants.length >= 2) break; // no legal matching left
+    if (paired.bye !== undefined) byes.add(paired.bye);
+    for (const id of paired.floated) floats.set(id, (floats.get(id) ?? 0) + 1);
+
+    for (let board = 0; board < paired.pairings.length; board++) {
+      const pairing = paired.pairings[board] as { home: EntrantId; away: EntrantId };
+      const key = pairKey(pairing.home, pairing.away);
+      if (played.has(key)) {
+        throw new SimInvariantError(`swiss rematch paired: ${key} in round ${round}`);
+      }
+      played.add(key);
+      if (chess) {
+        colours.set(pairing.home, [...(colours.get(pairing.home) ?? []), "W"]);
+        colours.set(pairing.away, [...(colours.get(pairing.away) ?? []), "B"]);
+      }
+
+      const fixtureId = `${stageId}-r${round}-b${board + 1}`;
+      const match = playInStage(ctx, stageId, fixtureId, pairing.home, pairing.away, false);
+      const stageCtx: StageCtx = { kind: "swiss", roundNo: round };
+      const result = tableResult(ctx, match, stageCtx);
+      results.push(result);
+      points.set(pairing.home, (points.get(pairing.home) ?? 0) + result[0].points);
+      points.set(pairing.away, (points.get(pairing.away) ?? 0) + result[1].points);
+      records.push(
+        toRecord(stageId, fixtureId, pairing.home, pairing.away, match, {
+          roundNo: round,
+          result,
+        }),
+      );
+      tableFixtures.push({ id: fixtureId, roundNo: round, status: "decided", result });
+    }
+    roundsPlayed = round;
+  }
+
+  const stage: TableStage = {
+    id: stageId,
+    kind: "swiss",
+    entrants: [...entrants],
+    cascade: stageCascade(ctx.module, true),
+    swiss: true,
+    seeds,
+    rngSeed: deriveSeed(ctx.seed, "lots", stageId),
+    rounds: roundsPlayed,
+  };
+  if (roundsPlayed === 0 || !isTableStageComplete(stage, tableFixtures)) {
+    throw new SimInvariantError(`swiss stage "${stageId}" has no complete rounds`);
+  }
+  const completed = completeTableStage(stage, tableFixtures);
+  ctx.divisionEvents.push(...completed.events);
+  const done = completed.events.find((e) => e.type === "stage_completed");
+  const finalRanks = done?.type === "stage_completed" ? done.finalRanks : [];
+  return {
+    record: {
+      id: stageId,
+      kind: "swiss",
+      entrants: [...entrants],
+      fixtures: records,
+      tables: completed.tables,
+      cascade: [...stage.cascade],
+      finalRanks,
+    },
+    tables: completed.tables,
+    finalRanks,
+  };
+}
+
+// --- Bracket stages (knockout / double_elim / stepladder) -------------------
+
+interface PlayedBracketStage {
+  record: SimStageRecord;
+  finalRanks: EntrantId[];
+}
+
+function playBracketStage(
+  ctx: SimContext,
+  stageId: string,
+  kind: Extract<StageKind, "knockout" | "double_elim" | "stepladder">,
+  generated: readonly BracketFixtureGen[],
+  seeds: ReadonlyMap<EntrantId, number>,
+): PlayedBracketStage {
+  ctx.divisionEvents.push(...openStage(stageId));
+
+  const byId = new Map<string, BracketFixture>();
+  const records: SimFixtureRecord[] = [];
+  const bracketFixtures: BracketFixture[] = [];
+
+  const resolveRef = (ref: BracketSlotRef): EntrantId | undefined => {
+    const source = byId.get(ref.fixtureId);
+    if (source === undefined) {
+      throw new SimInvariantError(`orphan feed: "${ref.fixtureId}" referenced before generation`, ref);
+    }
+    return ref.side === "winner" ? source.winner : source.loser;
+  };
+
+  for (const gen of generated) {
+    const fixtureId = `${stageId}-${gen.id}`;
+    const home = gen.home ?? (gen.homeFrom ? resolveRef(gen.homeFrom) : undefined);
+    const away = gen.away ?? (gen.awayFrom ? resolveRef(gen.awayFrom) : undefined);
+    const base: BracketFixture = {
+      id: fixtureId,
+      round: gen.round,
+      ...(gen.bracket === undefined ? {} : { bracket: gen.bracket }),
+      ...(gen.isFinal === undefined ? {} : { isFinal: gen.isFinal }),
+      ...(gen.thirdPlace === undefined ? {} : { thirdPlace: gen.thirdPlace }),
+      ...(home === undefined ? {} : { home }),
+      ...(away === undefined ? {} : { away }),
+      status: "scheduled",
+    };
+    const recordBase: SimFixtureRecord = {
+      id: fixtureId,
+      stageId,
+      status: "void",
+      events: [],
+      outcome: null,
+      round: gen.round,
+      ...(gen.isFinal === undefined ? {} : { isFinal: gen.isFinal }),
+      ...(home === undefined ? {} : { home }),
+      ...(away === undefined ? {} : { away }),
+    };
+
+    // DE bracket-reset decider: played only when the LB champion won GF1 —
+    // otherwise voided (void counts as settled for completion, spec 05 §2.4).
+    const skipConditional =
+      gen.conditional === true &&
+      (() => {
+        const gf1 = gen.homeFrom ? byId.get(gen.homeFrom.fixtureId) : undefined;
+        // GF1 home = WB champion; if the WB champion won, no reset is needed.
+        return gf1 !== undefined && gf1.winner !== undefined && gf1.winner === gf1.home;
+      })();
+
+    if (gen.award !== undefined) {
+      // Bye — auto-decided at generation: the entrant is awarded through.
+      const fixture: BracketFixture = { ...base, status: "walkover", winner: gen.award };
+      byId.set(gen.id, fixture);
+      bracketFixtures.push(fixture);
+      records.push({ ...recordBase, status: "walkover", winner: gen.award });
+    } else if (skipConditional) {
+      const fixture: BracketFixture = { ...base, status: "void" };
+      byId.set(gen.id, fixture);
+      bracketFixtures.push(fixture);
+      records.push(recordBase);
+    } else if (home !== undefined && away !== undefined) {
+      const match = playInStage(ctx, stageId, fixtureId, home, away, true);
+      const winner = (match.outcome as { winner: EntrantId }).winner;
+      const loser = winner === home ? away : home;
+      const fixture: BracketFixture = { ...base, status: "decided", winner, loser };
+      byId.set(gen.id, fixture);
+      bracketFixtures.push(fixture);
+      records.push({
+        ...toRecord(stageId, fixtureId, home, away, match, {
+          round: gen.round,
+          ...(gen.isFinal === undefined ? {} : { isFinal: gen.isFinal }),
+        }),
+      });
+    } else if (home !== undefined || away !== undefined) {
+      // One feed produced nobody (void/bye cascade) — the present side walks over.
+      const winner = (home ?? away) as EntrantId;
+      const fixture: BracketFixture = { ...base, status: "walkover", winner };
+      byId.set(gen.id, fixture);
+      bracketFixtures.push(fixture);
+      records.push({ ...recordBase, status: "walkover", winner });
+    } else {
+      const fixture: BracketFixture = { ...base, status: "void" };
+      byId.set(gen.id, fixture);
+      bracketFixtures.push(fixture);
+      records.push(recordBase);
+    }
+  }
+
+  const stage: BracketStage = { id: stageId, kind, seeds };
+  if (!isBracketStageComplete(stage, bracketFixtures)) {
+    throw new SimInvariantError(`bracket stage "${stageId}" not complete after playing every fixture`);
+  }
+  const completed = completeBracketStage(stage, bracketFixtures);
+  ctx.divisionEvents.push(...completed.events);
+
+  const entrants = new Set<EntrantId>();
+  for (const fixture of bracketFixtures) {
+    if (fixture.home !== undefined) entrants.add(fixture.home);
+    if (fixture.away !== undefined) entrants.add(fixture.away);
+    if (fixture.winner !== undefined) entrants.add(fixture.winner);
+  }
+
+  return {
+    record: {
+      id: stageId,
+      kind,
+      entrants: [...entrants],
+      fixtures: records,
+      finalRanks: completed.finalRanks,
+    },
+    finalRanks: completed.finalRanks,
+  };
+}
+
+// --- Qualification glue -----------------------------------------------------
+
+function qualify(
+  stageRecord: SimStageRecord,
+  spec: QualificationSpec,
+  tables: StageTables,
+): EntrantId[] {
+  const seeds = resolveQualification(spec, tables);
+  stageRecord.qualification = { spec, seeds };
+  if (seeds.length !== qualificationSize(spec)) {
+    throw new SimInvariantError(
+      `qualification produced ${seeds.length} seeds, spec wants ${qualificationSize(spec)}`,
+      { spec },
+    );
+  }
+  if (new Set(seeds).size !== seeds.length) {
+    throw new SimInvariantError(`qualification seeds not distinct`, { seeds });
+  }
+  return seeds;
+}
+
+const seedMap = (order: readonly EntrantId[]): Map<EntrantId, number> =>
+  new Map(order.map((id, i) => [id, i + 1]));
+
+// ---------------------------------------------------------------------------
+// simulateDivision — the entry point.
+// ---------------------------------------------------------------------------
+
+export function simulateDivision(opts: SimOptions): SimulationResult {
+  const module = opts.module;
+  const cfg = module.configSchema.parse(opts.cfg ?? {});
+  const seed = opts.seed;
+  const n = opts.entrantCount ?? drawEntrantCount(seed);
+  if (n < 2 || n > 64) throw new Error(`entrantCount ${n} outside 2–64`);
+
+  const entrants: EntrantId[] = Array.from({ length: n }, (_, i) =>
+    `t${String(i + 1).padStart(2, "0")}`,
+  );
+  const seeds = seedMap(entrants);
+
+  const ctx: SimContext = {
+    module,
+    cfg,
+    seed,
+    maxEvents: opts.maxEventsPerFixture ?? 600,
+    lineups: new Map(),
+    divisionEvents: [],
+    injectAt: opts.injectVoid === true ? deriveSeed(seed, "injectAt") % 3 : -1,
+    fixturesPlayed: 0,
+  };
+
+  const stages: SimStageRecord[] = [];
+  let finalRanks: EntrantId[] = [];
+
+  switch (opts.format) {
+    case "league": {
+      const stage = playRoundRobinStage(ctx, "league", "league", [{ poolId: "P1", entrants }], seeds);
+      stages.push(stage.record);
+      finalRanks = stage.finalRanks;
+      break;
+    }
+
+    case "group_knockout": {
+      // Pools of ~4 dealt by seed; single pool below 8 entrants.
+      const poolCount = Math.max(1, Math.floor(n / 4));
+      const pools = Array.from({ length: poolCount }, (_, p) => ({
+        poolId: `P${p + 1}`,
+        entrants: entrants.filter((_, i) => i % poolCount === p),
+      }));
+      const groups = playRoundRobinStage(ctx, "groups", "group", pools, seeds);
+      stages.push(groups.record);
+
+      const spec: QualificationSpec =
+        poolCount === 1
+          ? { from: "groups", topN: Math.min(4, n) }
+          : {
+              from: "groups",
+              take: [1, 2].flatMap((rank) =>
+                pools.map((pool) => ({ pool: pool.poolId, rank })),
+              ),
+            };
+      const qualified = qualify(groups.record, spec, groups.tables);
+      const koSeeds = seedMap(qualified);
+      const ko = playBracketStage(
+        ctx,
+        "ko",
+        "knockout",
+        generateSingleElim({ entrants: qualified, seeds: koSeeds }).fixtures,
+        koSeeds,
+      );
+      stages.push(ko.record);
+      finalRanks = ko.finalRanks;
+      break;
+    }
+
+    case "swiss_knockout": {
+      const swiss = playSwissStage(ctx, "swiss", entrants, seeds);
+      stages.push(swiss.record);
+
+      const spec: QualificationSpec = { from: "swiss", topN: Math.min(4, n) };
+      const qualified = qualify(swiss.record, spec, swiss.tables);
+      const koSeeds = seedMap(qualified);
+      const ko = playBracketStage(
+        ctx,
+        "ko",
+        "knockout",
+        generateSingleElim({ entrants: qualified, seeds: koSeeds }).fixtures,
+        koSeeds,
+      );
+      stages.push(ko.record);
+      finalRanks = ko.finalRanks;
+      break;
+    }
+
+    case "double_elim": {
+      const bracketReset = mulberry32(deriveSeed(seed, "reset"))() < 0.5;
+      const de = playBracketStage(
+        ctx,
+        "de",
+        "double_elim",
+        generateDoubleElim({ entrants, seeds, bracketReset }).fixtures,
+        seeds,
+      );
+      stages.push(de.record);
+      finalRanks = de.finalRanks;
+      break;
+    }
+
+    case "stepladder": {
+      const sl = playBracketStage(
+        ctx,
+        "sl",
+        "stepladder",
+        generateStepladder({ entrants, seeds }).fixtures,
+        seeds,
+      );
+      stages.push(sl.record);
+      finalRanks = sl.finalRanks;
+      break;
+    }
+  }
+
+  const champion = finalRanks[0];
+  if (champion === undefined) {
+    throw new SimInvariantError("champion undefined: empty final ranks", { finalRanks });
+  }
+
+  return {
+    seedToken: makeSeedToken(module.key, opts.format, seed),
+    sport: module.key,
+    format: opts.format,
+    seed,
+    entrants,
+    stages,
+    divisionEvents: ctx.divisionEvents,
+    champion,
+    finalRanks,
+    ...(ctx.injection === undefined ? {} : { injection: ctx.injection }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Global invariants — PROMPT-14 §1.
+// ---------------------------------------------------------------------------
+
+const TERMINAL: ReadonlySet<SimFixtureRecord["status"]> = new Set([
+  "decided",
+  "walkover",
+  "void",
+]);
+
+function fail(sim: SimulationResult, message: string, detail?: unknown): never {
+  throw new SimInvariantError(`[${sim.seedToken}] ${message}`, detail);
+}
+
+export function assertDivisionInvariants(
+  sim: SimulationResult,
+  module: AnySportModule,
+  rawCfg?: unknown,
+): void {
+  const cfg = module.configSchema.parse(rawCfg ?? {}) as unknown;
+  const entrantSet = new Set(sim.entrants);
+
+  // Champion well-defined.
+  if (!entrantSet.has(sim.champion)) fail(sim, `champion "${sim.champion}" is not an entrant`);
+  if (new Set(sim.finalRanks).size !== sim.finalRanks.length) {
+    fail(sim, "final ranks contain duplicates", sim.finalRanks);
+  }
+  for (const id of sim.finalRanks) {
+    if (!entrantSet.has(id)) fail(sim, `final rank lists non-entrant "${id}"`);
+  }
+
+  // Every fixture terminal; event envelopes well-formed and globally unique.
+  const allEventIds = new Set<string>();
+  const allowedTotals = module.declaredPointsSets(cfg) as readonly number[];
+  for (const stage of sim.stages) {
+    for (const fixture of stage.fixtures) {
+      if (!TERMINAL.has(fixture.status)) {
+        fail(sim, `fixture "${fixture.id}" ended non-terminal: ${fixture.status}`);
+      }
+      fixture.events.forEach((event, i) => {
+        if (event.seq !== i) fail(sim, `fixture "${fixture.id}" seq gap at ${i} (got ${event.seq})`);
+        if (allEventIds.has(event.id)) fail(sim, `duplicate event id "${event.id}"`);
+        allEventIds.add(event.id);
+      });
+      if (fixture.status === "decided" && fixture.outcome === null) {
+        fail(sim, `decided fixture "${fixture.id}" has no outcome`);
+      }
+    }
+
+    // Table-stage invariants: conservation, played counts, ledger sums, ranks.
+    if (stage.tables !== undefined) {
+      const counted = stage.fixtures.filter(
+        (fixture) => fixture.status === "decided" && fixture.result !== undefined,
+      );
+      let expectPlayed = 0;
+      let expectPoints = 0;
+      let expectWon = 0;
+      let expectLost = 0;
+      const ledger = new Map<string, number>();
+      for (const fixture of counted) {
+        const [home, away] = fixture.result as FixtureResult;
+        const total = home.points + away.points;
+        if (!allowedTotals.includes(total)) {
+          fail(
+            sim,
+            `fixture "${fixture.id}" points total ${total} outside declared set [${allowedTotals.join(", ")}]`,
+            fixture.outcome,
+          );
+        }
+        expectPlayed += home.played + away.played;
+        expectPoints += total;
+        expectWon += home.won + away.won;
+        expectLost += home.lost + away.lost;
+        for (const delta of [home, away]) {
+          for (const [key, value] of Object.entries(delta.metrics)) {
+            if (!Number.isInteger(value)) {
+              fail(sim, `fixture "${fixture.id}" metric "${key}" not an integer ledger entry`);
+            }
+            ledger.set(key, (ledger.get(key) ?? 0) + value);
+          }
+        }
+      }
+
+      const rows = stage.tables.pools.flatMap((pool) => [...pool.rows]);
+      const sum = (pick: (row: (typeof rows)[number]) => number): number =>
+        rows.reduce((acc, row) => acc + pick(row), 0);
+      if (sum((row) => row.played) !== expectPlayed) {
+        fail(sim, `stage "${stage.id}" played counts diverge from fixtures`);
+      }
+      if (sum((row) => row.points) !== expectPoints) {
+        fail(sim, `stage "${stage.id}" points not conserved across the fold`);
+      }
+      if (sum((row) => row.won) !== expectWon || sum((row) => row.lost) !== expectLost) {
+        fail(sim, `stage "${stage.id}" won/lost tallies diverge from fixtures`);
+      }
+      for (const [key, value] of ledger) {
+        // Swiss cascade columns are materialised display metrics, not fixture
+        // ledger sums — only fixture-sourced keys are conserved.
+        const folded = rows.reduce((acc, row) => acc + (row.metrics[key] ?? 0), 0);
+        if (folded !== value) {
+          fail(sim, `stage "${stage.id}" ledger "${key}" not conserved (${folded} ≠ ${value})`);
+        }
+      }
+
+      for (const pool of stage.tables.pools) {
+        const ranks = pool.rows.map((row) => row.rank);
+        const want = pool.rows.map((_, i) => i + 1);
+        if (JSON.stringify([...ranks].sort((a, b) => (a ?? 0) - (b ?? 0))) !== JSON.stringify(want)) {
+          fail(sim, `stage "${stage.id}" pool "${pool.pool}" ranks not a total order 1..n`, ranks);
+        }
+        // Cascade sanity (the comparator-flip catcher): every builtin cascade
+        // ranks on points first, so rank order must be non-increasing in points.
+        if (stage.cascade?.[0] === "points") {
+          const sorted = [...pool.rows].sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+          for (let i = 1; i < sorted.length; i++) {
+            const prev = sorted[i - 1] as (typeof sorted)[number];
+            const here = sorted[i] as (typeof sorted)[number];
+            if (here.points > prev.points) {
+              fail(
+                sim,
+                `stage "${stage.id}" pool "${pool.pool}" rank order contradicts points (rank ${prev.rank}: ${prev.points} < rank ${here.rank}: ${here.points})`,
+              );
+            }
+          }
+        }
+      }
+    }
+
+    // Swiss structural invariants: no rematch, ≤1 fixture per entrant per round.
+    if (stage.kind === "swiss" || stage.kind === "league" || stage.kind === "group") {
+      const pairs = new Map<string, number>();
+      const perRound = new Map<string, Set<EntrantId>>();
+      for (const fixture of stage.fixtures) {
+        if (fixture.home === undefined || fixture.away === undefined) continue;
+        const key = `${fixture.poolId ?? ""}|${pairKey(fixture.home, fixture.away)}`;
+        pairs.set(key, (pairs.get(key) ?? 0) + 1);
+        const roundKey = `${fixture.poolId ?? ""}|${fixture.roundNo ?? 0}`;
+        const inRound = perRound.get(roundKey) ?? new Set<EntrantId>();
+        if (inRound.has(fixture.home) || inRound.has(fixture.away)) {
+          fail(sim, `stage "${stage.id}" entrant plays twice in round ${fixture.roundNo}`);
+        }
+        inRound.add(fixture.home);
+        inRound.add(fixture.away);
+        perRound.set(roundKey, inRound);
+      }
+      for (const [key, count] of pairs) {
+        if (count > 1) fail(sim, `stage "${stage.id}" pair met ${count} times: ${key}`);
+      }
+    }
+
+    // Bracket invariants: eliminations require losses; champion (nearly) unbeaten.
+    if (stage.kind === "knockout" || stage.kind === "double_elim" || stage.kind === "stepladder") {
+      const losses = new Map<EntrantId, number>();
+      for (const fixture of stage.fixtures) {
+        if (fixture.loser !== undefined) {
+          losses.set(fixture.loser, (losses.get(fixture.loser) ?? 0) + 1);
+        }
+      }
+      const isChampionStage = stage.finalRanks[0] === sim.champion;
+      if (isChampionStage) {
+        const championLosses = losses.get(sim.champion) ?? 0;
+        const cap = stage.kind === "double_elim" ? 2 : 0;
+        if (championLosses > cap) {
+          fail(sim, `champion "${sim.champion}" has ${championLosses} losses in a ${stage.kind}`);
+        }
+        for (const id of stage.entrants) {
+          if (id === sim.champion) continue;
+          if ((losses.get(id) ?? 0) < 1) {
+            fail(sim, `non-champion "${id}" was never beaten in ${stage.kind} "${stage.id}"`);
+          }
+        }
+      }
+    }
+
+    // Qualification counts (spec 05 §6): output size = next stage's input size.
+    if (stage.qualification !== undefined) {
+      const { spec, seeds } = stage.qualification;
+      if (seeds.length !== qualificationSize(spec)) {
+        fail(sim, `stage "${stage.id}" qualification size mismatch`, stage.qualification);
+      }
+      for (const id of seeds) {
+        if (!entrantSet.has(id)) fail(sim, `qualified non-entrant "${id}"`);
+      }
+    }
+  }
+
+  // Division ledger sanity: stages opened before completed, exactly once each.
+  const opened = new Set<string>();
+  const completed = new Set<string>();
+  for (const event of sim.divisionEvents) {
+    if (event.type === "stage_opened") {
+      if (opened.has(event.stageId)) fail(sim, `stage "${event.stageId}" opened twice`);
+      opened.add(event.stageId);
+    }
+    if (event.type === "stage_completed") {
+      if (!opened.has(event.stageId)) fail(sim, `stage "${event.stageId}" completed before opening`);
+      if (completed.has(event.stageId)) fail(sim, `stage "${event.stageId}" completed twice`);
+      completed.add(event.stageId);
+    }
+  }
+  for (const stage of sim.stages) {
+    if (!completed.has(stage.id)) fail(sim, `stage "${stage.id}" never completed`);
+  }
+}

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/**/index.ts"],
+      // PROMPT-14 §4 gate: ≥90% lines across the engine; the fold kernel and
+      // the tiebreaker cascade must be fully covered.
+      thresholds: {
+        lines: 90,
+        "src/core/**/*.ts": { lines: 100 },
+        "src/competition/tiebreakers.ts": { lines: 100 },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- **Tournament simulator** (`packages/engine/src/testkit/simulation.ts`): every sport module × five stage-graph templates (league, group+KO, swiss+KO, double-elim, stepladder). Seed-derived entrant counts (2–64), fixtures driven by each module's `arbitraryEvent` stream, stages progressed through real qualification. One `sport:format:seed` token reproduces a division exactly.
- **Global invariants** per division: terminal fixture statuses, no orphan feeds, champion well-defined, points conservation vs `declaredPointsSets`, played/won/lost/ledger sums, rank total order + points monotonicity, swiss no-rematch, qualification counts, deterministic replay.
- **Void injection**: every 4th seed voids a random event mid-stage and refolds; rejected voids carry a typed `EngineError` code; post-completion voids blocked by the `rank_locked` guard.
- **Chaos scorer** (`chaos.test.ts`): unknown-entrant / wrong-phase / post-decision / malformed-core events interleaved into valid streams for every module — all rejected with typed codes, ledger refolds byte-identical.
- **Budgeted CI profile**: `SIM_RUNS` env (CI 200 per sport×format ≈ 24 s, local 25, nightly 10 000 via new `sim-nightly.yml`). Failures dump seed + event streams to `sim-failures/`, uploaded as a CI artifact; `npm run sim:replay -- <seedToken|artifact.json>` reproduces deterministically.
- **Coverage gate**: ≥90 % lines engine-wide (actual 94.8 %), 100 % on `core/` and `competition/tiebreakers.ts`.

## Engine bug caught by the harness
`bracketRanks` treated a voided DE bracket-reset final (settled, no winner) as the deciding game and mis-crowned the grand-final loser (`football:double_elim:1`: champion t06 instead of t05). Fixed: the deciding final must carry a winner.

## Acceptance (PROMPT-14)
- CI job green: 476 engine tests incl. 7 000 simulated divisions at `SIM_RUNS=200`.
- Mutation canaries (flipped comparator, non-conserving delta, miscounted fold, ghost champion) all caught; verified live by reverting the `stage.ts` fix — `sim:replay` exits 1 with the wrong champion.
- `sim:replay` reproduces failures deterministically from token or artifact JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)