### PR TITLE
feat(engine): carrom sport module (PROMPT-16)

### DIFF
--- a/engine/sports/carrom.md
+++ b/engine/sports/carrom.md
@@ -1,56 +1,96 @@
 # Carrom — Engine & Scoring Architecture
 
 Module: `carrom` (own module — points-race grammar, unlike boardgame or set-based) ·
-Implementation: PROMPT-16. **Verify every rule below against the current ICF "Laws of
-Carrom" before implementing** — community variants differ widely; ship ICF as the system
-preset, keep everything configurable.
+Implementation: PROMPT-16. Rules below are **verified against the ICF "Laws of Carrom"**
+(law numbers cited; source: the ICF laws PDF mirrored at iakc.org, retrieved 2026-07-05).
+ICF ships as the system preset (`icf` variant); everything stays configurable.
 
-## 1. Match structure (ICF baseline)
-- **Board** (one rack of 19 coins: 9 white, 9 black, 1 red queen) → **Game** (first to
-  25 points, or highest score after 8 boards) → **Match** (best of `bestOf` games; ICF
-  commonly 3, finals sometimes 5... cfg).
-- Singles or doubles → entrant kind `individual | pair` (doubles partners sit opposite).
+## 1. Match structure (ICF, verified)
+- **Board** (one rack of 19 coins: 9 white, 9 black, 1 red queen — Law 41a) → **Game**
+  ("A game shall be of 25 points or eight boards. The player who reaches 25 points first
+  or leads at the conclusion of the eighth board shall be the winner" — Law 56a) →
+  **Match** ("All matches shall be decided only by the best of three games" — Law 57;
+  `bestOf` cfg for finals etc.).
+- Tied after the eighth board: "an extra board shall be played to decide the winner"
+  (Law 56b, with a fresh toss for break) — cfg `tieBoard: 'extra'` (default). House rule
+  `'draw'` closes the game drawn instead (enables drawn matches in leagues).
+- Singles or doubles → entrant kind `individual | pair` (doubles partners sit opposite,
+  Law 39b–d).
 
 ```
-Cfg { gameTo: 25, maxBoards: 8, bestOf: 3,
-      queenPoints: 3, queenCapAt: 22,      // at ≥22 pts queen scores 0 (ICF "no queen benefit at 22+")
-      pointsPerCoin: 1,
-      points: {win: 2, loss: 0, draw?: 1} }  // competition points per match
+Cfg { gameTo: 25, maxBoards: 8, bestOf: 3,        // Laws 56a, 57
+      queenPoints: 3, queenCapAt: 22,             // Laws 52(b)(i), 54
+      pointsPerCoin: 1,                           // Law 52(b)(ii)
+      queenFollowsBoard: false,                   // Law 53(b)/(c) — see §2
+      tieBoard: 'extra',                          // Law 56b ('draw' = house rule)
+      points: {win: 2, loss: 0, draw: 1} }        // competition points per match
 ```
+Variants: `icf` (defaults above) and `club-29` — documented club/family rules
+(mastersofgames.com "Rules of Carrom"): game to 29, queen worth 5, no queen benefit
+once 24 is reached → `{gameTo: 29, queenPoints: 5, queenCapAt: 24}`.
 
 ## 2. Event model — board-level fidelity is the right default
 Strike-by-strike scoring is umpire-grade and impractical courtside; the natural unit is
 the **board result**:
 ```
-Ev  board.summary { winner: entrantId,
-                    opponentCoinsLeft: 0..9,   // winner's board points = coinsLeft × pointsPerCoin
-                    queenTo: entrantId|null }  // who pocketed+covered the queen
-    game.adjust  { entrantId, delta, reason }  // umpire penalty/foul adjustments
-    (fine fidelity later: strike {pocketed[], foul?, due?} — Pro `scoring.strike_by_strike`, reserved)
+Ev  carrom.toss  { firstBreak }                   // Laws 39/42; breaker takes white (Law 43)
+    carrom.board.summary { winner: entrantId,
+                    opponentCoinsLeft: 0..9,      // winner's points = coinsLeft × pointsPerCoin (Law 53a)
+                    queenTo: entrantId|null }     // who pocketed+covered the queen
+    carrom.game.adjust { entrantId, delta≠0, reason } // umpire penalty/foul adjustments
+    (fine fidelity later: carrom.strike {striker, pocketed[], foul?, due?} —
+     typed placeholder shipped, apply() rejects it; Pro key `scoring.strike_by_strike`)
 ```
+**Deviation (PROMPT-16):** the prompt asked for a `core.start {firstBreak}` payload, but
+core event payloads are kernel-owned strict-empty objects (spec 03 §2), so the toss is a
+pre-start sport event — the `cricket.toss` precedent.
+
 Fold:
 ```
-boardPoints(winner) = opponentCoinsLeft + (queenTo == winner && score(winner) < queenCapAt ? queenPoints : 0)
+queenCredited = (queenTo == winner) || (queenFollowsBoard && queenTo != null)
+boardPoints(winner) = opponentCoinsLeft × pointsPerCoin
+                    + (queenCredited && preBoardScore(winner) < queenCapAt ? queenPoints : 0)
 gameScore accumulates per board; game decided at ≥ gameTo, or after maxBoards → higher score
-  (equal after maxBoards → tie-board per cfg: extra board | game drawn)
-match decided at ⌈bestOf/2⌉ games
+  (equal after maxBoards → tie-board per cfg: extra board (ICF) | game drawn)
+match decided at ⌈bestOf/2⌉ game wins; with drawn games (house rule) the match falls to
+  a games-won comparison after bestOf games, equal → drawn match
 ```
-Validation: `opponentCoinsLeft ≤ 9`; `queenTo` must be winner or null (queen pocketed by
-loser but board lost ⇒ queen credited to board winner per ICF — **verify**; make it an
-explicit cfg switch `queenFollowsBoard: true`).
+**Queen rules, verified:**
+- "Queen: 3 points up to and including 21 points" (Law 52(b)(i)); "The player loses the
+  advantage of getting the credit of an additional 3 points for covering the Queen, once
+  he has reached the score of 22 points" (Law 54). The bonus is therefore checked against
+  the **pre-board score** — a board's own coin points never lift the winner past the cap
+  for that board's queen. Boundary: at 21 the queen still counts; at 22 it scores 0.
+- "The player is entitled to be credited with the value of the Queen, only if he wins the
+  board" (Law 53b); "The player who loses the board is not credited with the value of the
+  Queen, even if he has pocketed and covered the Queen" (Law 53c). So a loser-covered
+  queen scores for **nobody** under ICF — the earlier draft's guess that she transfers to
+  the board winner was wrong. `queenFollowsBoard: true` implements that transfer as an
+  explicit house-rule switch (default **false** = ICF).
+- Maximum per board: 12 points (9 coins + queen — Law 55).
+
+Validation: `opponentCoinsLeft ∈ 0..9` (integer); `winner`/`queenTo` must be fixture
+entrants; `game.adjust` may not take a score below zero.
 
 ## 3. State machine
 ```
-pre → board[1] → board[2] … (game check after each board) → game[k+1] … → decided
+pre (toss?) → board[1] → board[2] … (game check after each board) → game[k+1] … → decided
 ```
-State: `{ games: [{boards: [...], score: {a,b}}], currentGame, breaker }` — **break
-alternates each board**, first break to the toss/白 winner (`core.start` payload
-`{firstBreak}`); track it for display and fine-fidelity later.
+State: `{ games: [{boards: [...], score: {a,b}, winner}], gamesWon, firstBreak }` —
+**break alternation, verified (Law 49a):** the toss winner breaks board 1; "the turn to
+break shall pass alternately during the game"; in game 2 the other player breaks first;
+in game 3 it returns to the first player. Doubles: the turn passes to the right (Law
+49b) — a per-player rotation inside the pair, not modelled at board fidelity. Law 56b's
+fresh toss before an extra board is **not modelled** (no mid-match toss event); the
+alternation simply continues. Each board records its breaker for display and for fine
+fidelity later.
 
 ## 4. Standings & tiebreakers
-Metrics ledger (integers): `matches_won, games_won, games_lost, boards_won, boards_lost,
-points_for, points_against`.
-Default cascade: `points → matches_won → game_ratio → board_ratio → points_ratio → h2h → lots`
+Metrics ledger (integers): games won/lost ride the shared `sets_won`/`sets_lost`
+comparator keys (labelled "Games won/lost" — the badminton precedent), board points ride
+`points_won`/`points_lost`, and `boards_won`/`boards_lost` feed the carrom-specific
+`board_ratio` key (added to the comparator registry with PROMPT-16).
+Default cascade: `points → wins → set_ratio (games) → board_ratio → point_ratio → h2h_points → lots`
 (ratios cross-multiplied — 05 §4.3). No official federation cascade is universal —
 document ours as house-standard, overridable.
 
@@ -59,14 +99,18 @@ None (catalog empty; doubles = pair entrant, order irrelevant). PlayerProfile at
 `{ style?: 'straight'|'cut', hand?: 'L'|'R' }` — display only.
 
 ## 6. Fidelity & entitlements
-Community: `board.summary` scoring. Pro: strike-by-strike (reserved key
-`scoring.strike_by_strike`), foul/due tracking, per-player queen-cover stats, board-time
-clock. Public dashboard: game/board scoreboard boxes (reuse set-based UI pattern —
-boards render like sets).
+Community (tier 0): `carrom.board.summary` scoring. Tier 1 adds `carrom.toss` and
+`carrom.game.adjust`. Pro: strike-by-strike (reserved key `scoring.strike_by_strike`,
+typed placeholder `CarromStrike` shipped, tiers 2/3 declared when it lands), foul/due
+tracking, per-player queen-cover stats, board-time clock. Public dashboard: game/board
+scoreboard boxes (reuse set-based UI pattern — boards render like sets).
 
 ## 7. Edge cases
-- Game reaching maxBoards tied → cfg: sudden-death board (ICF) vs drawn game.
-- `queenCapAt` boundary: player at 21 wins board with queen +3 +2 coins → 26, capped
-  display at "wins game"; player at 22 gets coins only.
-- Walkover/forfeit mid-match: remaining games awarded (`award` outcome, method walkover).
+- Game reaching maxBoards tied → cfg: sudden-death board(s) (ICF Law 56b) vs drawn game.
+- `queenCapAt` boundary: player at 21 wins board with queen +3 +1 coin → 25, game won;
+  player at 22 gets coins only (goldens cover both).
+- Walkover/forfeit: `award` outcome to the opponent (win/loss match points); the ledger
+  keeps only the games/boards actually played.
+- Abandonment: `no_result` outcome with completed games recorded in the ledger; both
+  sides take the draw share of match points (PROMPT-16 §4).
 - Doubles substitution: not allowed mid-match (ICF) — lineup locked at `core.start`.

--- a/packages/engine/src/competition/display.test.ts
+++ b/packages/engine/src/competition/display.test.ts
@@ -61,6 +61,7 @@ describe("DERIVED_METRICS", () => {
     expect(DERIVED_METRICS.map((m) => m.key)).toEqual([
       "nrr",
       "set_ratio",
+      "board_ratio",
       "point_ratio",
       "buchholz_cut1",
       "buchholz",

--- a/packages/engine/src/competition/display.ts
+++ b/packages/engine/src/competition/display.ts
@@ -23,6 +23,7 @@ export interface DerivedMetricSpec {
 export const DERIVED_METRICS: readonly DerivedMetricSpec[] = [
   { key: "nrr", label: "NRR", decimals: 3 },
   { key: "set_ratio", label: "Ratio", decimals: 2 },
+  { key: "board_ratio", label: "Board ratio", decimals: 2 },
   { key: "point_ratio", label: "Pts ratio", decimals: 2 },
   { key: "buchholz_cut1", label: "Buchholz Cut-1", decimals: 1 },
   { key: "buchholz", label: "Buchholz", decimals: 1 },
@@ -54,6 +55,8 @@ export function derivedMetricText(row: StandingsRow, key: TiebreakerKey): string
     }
     case "set_ratio":
       return ratioText(metric(row, "sets_won"), metric(row, "sets_lost"), 2);
+    case "board_ratio":
+      return ratioText(metric(row, "boards_won"), metric(row, "boards_lost"), 2);
     case "point_ratio":
       return ratioText(metric(row, "points_won"), metric(row, "points_lost"), 2);
     case "buchholz":
@@ -88,6 +91,7 @@ const TIE_BREAK_LABELS: Record<string, string> = {
   fair_play: "fair play",
   nrr: "net run rate",
   set_ratio: "set ratio",
+  board_ratio: "board ratio",
   point_ratio: "point ratio",
   h2h_points: "head-to-head",
   h2h_diff: "head-to-head difference",

--- a/packages/engine/src/competition/tiebreakers.ts
+++ b/packages/engine/src/competition/tiebreakers.ts
@@ -287,6 +287,14 @@ const COMPARATORS: Partial<Record<TiebreakerKey, Comparator>> = {
       metricOf(b, ["sets_won"]),
       metricOf(b, ["sets_lost"]),
     ),
+  // Carrom boards won/lost (carrom.md §4) — same cross-multiplied form.
+  board_ratio: (a, b) =>
+    compareRatio(
+      metricOf(a, ["boards_won"]),
+      metricOf(a, ["boards_lost"]),
+      metricOf(b, ["boards_won"]),
+      metricOf(b, ["boards_lost"]),
+    ),
   point_ratio: (a, b) =>
     compareRatio(
       metricOf(a, ["points_won"]),
@@ -610,6 +618,9 @@ export function validateCascade(
         break;
       case "set_ratio":
         if (!has("sets_won") || !has("sets_lost")) reject(key, "sets won/lost");
+        break;
+      case "board_ratio":
+        if (!has("boards_won") || !has("boards_lost")) reject(key, "boards won/lost");
         break;
       case "point_ratio":
         if (!has("points_won") || !has("points_lost")) reject(key, "points won/lost");

--- a/packages/engine/src/scheduling/roundrobin.test.ts
+++ b/packages/engine/src/scheduling/roundrobin.test.ts
@@ -93,7 +93,9 @@ describe("generateRoundRobin — invariants (spec 05 §6)", () => {
     );
   });
 
-  it("uniqueness: every pair meets exactly once per leg, ≤1 fixture per entrant per round", () => {
+  // Heavy property test: sits near vitest's 5s default under full-suite
+  // worker contention — budget it explicitly (chaos.test.ts precedent).
+  it("uniqueness: every pair meets exactly once per leg, ≤1 fixture per entrant per round", { timeout: 20_000 }, () => {
     fc.assert(
       fc.property(nArb, legsArb, (n, legs) => {
         const schedule = generateRoundRobin({ entrants: field(n), config: { legs } });

--- a/packages/engine/src/sport/module.ts
+++ b/packages/engine/src/sport/module.ts
@@ -28,6 +28,7 @@ export type TiebreakerKey =
   | "for"
   | "nrr"
   | "set_ratio"
+  | "board_ratio"
   | "point_ratio"
   | "buchholz"
   | "buchholz_cut1"

--- a/packages/engine/src/sports/carrom/carrom.test.ts
+++ b/packages/engine/src/sports/carrom/carrom.test.ts
@@ -1,0 +1,313 @@
+// Carrom goldens + conformance — engine/sports/carrom.md, PROMPT-16.
+// ICF law citations (Laws 49, 52–57) refer to the ICF "Laws of Carrom";
+// carrom.md §1–7 carries the verified text.
+import { describe, expect, it } from "vitest";
+import { EngineError } from "../../core/errors.ts";
+import { foldMatch, type EventEnvelope } from "../../core/events.ts";
+import type { LineupPair, StageCtx } from "../../core/types.ts";
+import { conformanceSuite, defaultLineupPair, makeEnvelope } from "../../testkit/index.ts";
+import { carrom, CARROM_TIEBREAKERS, type CarromState } from "./carrom.ts";
+
+const lineups: LineupPair = defaultLineupPair(carrom.positions); // entrants H / A
+const cfg = carrom.configSchema.parse({});
+const league: StageCtx = { kind: "league" };
+
+function stream(...specs: Array<[type: string, payload?: unknown]>): EventEnvelope[] {
+  return specs.map(([type, payload], i) => makeEnvelope(i, { type, payload: payload ?? {} }));
+}
+function fold(events: EventEnvelope[], config = cfg): CarromState {
+  return foldMatch(carrom, config, lineups, events) as CarromState;
+}
+
+// One board-summary spec: [winner, opponentCoinsLeft, queenTo].
+type BoardSpec = [winner: string, coins: number, queenTo?: string | null];
+function boards(...specs: BoardSpec[]): Array<[string, unknown]> {
+  return specs.map(([winner, opponentCoinsLeft, queenTo]) => [
+    "carrom.board.summary",
+    { winner, opponentCoinsLeft, queenTo: queenTo ?? null },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Golden (a) — game won exactly at 25 via the queen bonus (Laws 52–54, 56a).
+// ---------------------------------------------------------------------------
+describe("carrom golden: game won exactly at 25 via queen bonus", () => {
+  const state = fold(
+    stream(["core.start"], ...boards(["H", 9], ["H", 9], ["H", 2], ["H", 2, "H"])),
+  );
+
+  it("banks 20 + 2 coins + queen 3 = 25 and closes the game", () => {
+    const game = state.games[0]!;
+    expect(game.score).toEqual({ home: 25, away: 0 });
+    expect(game.winner).toBe("home");
+    expect(game.boards[3]).toMatchObject({ points: 5, queenScored: true });
+    expect(state.gamesWon).toEqual({ home: 1, away: 0 });
+    expect(state.outcome).toBeNull(); // best-of-3: match still live
+    expect(carrom.summary(state).headline).toBe("1 — 0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden (b) — the queenCapAt boundary (Law 52(b)(i): 3 points up to and
+// including 21; Law 54: no queen benefit once 22 is reached). The bonus is
+// checked against the PRE-board score.
+// ---------------------------------------------------------------------------
+describe("carrom golden: queen cap boundary", () => {
+  it("21 → queen still counts (21 + 1 coin + 3 = 25, game won)", () => {
+    const state = fold(
+      stream(["core.start"], ...boards(["H", 9], ["H", 9], ["H", 3], ["H", 1, "H"])),
+    );
+    const game = state.games[0]!;
+    expect(game.score.home).toBe(25);
+    expect(game.winner).toBe("home");
+    expect(game.boards[3]).toMatchObject({ points: 4, queenScored: true });
+  });
+
+  it("22 → queen scores 0, coins only — the game continues", () => {
+    const state = fold(
+      stream(["core.start"], ...boards(["H", 9], ["H", 9], ["H", 4], ["H", 1, "H"])),
+    );
+    const game = state.games[0]!;
+    expect(game.score.home).toBe(23); // 22 + 1 coin, no queen
+    expect(game.winner).toBeNull();
+    expect(game.boards[3]).toMatchObject({ points: 1, queenScored: false });
+    expect(state.outcome).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Law 53(b)/(c) — a loser-covered queen scores for nobody under ICF; the
+// queenFollowsBoard house rule credits the board winner instead.
+// ---------------------------------------------------------------------------
+describe("carrom: loser-covered queen (Law 53)", () => {
+  const events = stream(["core.start"], ...boards(["H", 5, "A"]));
+
+  it("ICF default: winner gets coins only", () => {
+    const state = fold(events);
+    expect(state.games[0]!.score.home).toBe(5);
+    expect(state.games[0]!.boards[0]).toMatchObject({ points: 5, queenScored: false });
+  });
+
+  it("queenFollowsBoard: true credits the queen to the board winner", () => {
+    const state = fold(events, carrom.configSchema.parse({ queenFollowsBoard: true }));
+    expect(state.games[0]!.score.home).toBe(8);
+    expect(state.games[0]!.boards[0]).toMatchObject({ points: 8, queenScored: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden (c) — 8-board game decided on points (Law 56a: leader after the
+// eighth board wins).
+// ---------------------------------------------------------------------------
+describe("carrom golden: 8-board game decided on points", () => {
+  const eight: BoardSpec[] = [
+    ["H", 3], ["A", 2], ["H", 3], ["A", 2],
+    ["H", 3], ["A", 2], ["H", 3], ["A", 2],
+  ];
+  const state = fold(stream(["core.start"], ...boards(...eight)));
+
+  it("closes the game for the leader 12–8 after board 8", () => {
+    const game = state.games[0]!;
+    expect(game.boards).toHaveLength(8);
+    expect(game.score).toEqual({ home: 12, away: 8 });
+    expect(game.winner).toBe("home");
+    expect(state.gamesWon).toEqual({ home: 1, away: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden (d) — best-of-3 with a tie-board. ICF (Law 56b): an extra sudden-
+// death board; house rule 'draw': the game is drawn and a drawn match is
+// possible.
+// ---------------------------------------------------------------------------
+describe("carrom golden: best-of-3 with a tie-board", () => {
+  const tiedEight: BoardSpec[] = [
+    ["H", 3], ["A", 3], ["H", 3], ["A", 3],
+    ["H", 3], ["A", 3], ["H", 3], ["A", 3],
+  ];
+
+  it("ICF 'extra': 12–12 after 8 boards → a ninth board decides (Law 56b)", () => {
+    const open = fold(stream(["core.start"], ...boards(...tiedEight)));
+    expect(open.games[0]!.winner).toBeNull(); // still open past maxBoards
+    const state = fold(stream(["core.start"], ...boards(...tiedEight, ["A", 2])));
+    const game = state.games[0]!;
+    expect(game.boards).toHaveLength(9);
+    expect(game.winner).toBe("away");
+    expect(game.score).toEqual({ home: 12, away: 14 });
+  });
+
+  it("'draw' policy: the game is drawn; 1-1 plus a drawn game → drawn match", () => {
+    const drawCfg = carrom.configSchema.parse({ tieBoard: "draw" });
+    const game2: BoardSpec[] = [["H", 9], ["H", 9], ["H", 9]]; // 27 ≥ 25
+    const game3: BoardSpec[] = [["A", 9], ["A", 9], ["A", 9]];
+    const state = fold(
+      stream(["core.start"], ...boards(...tiedEight, ...game2, ...game3)),
+      drawCfg,
+    );
+    expect(state.games[0]!.winner).toBe("draw");
+    expect(state.gamesDrawn).toBe(1);
+    expect(state.gamesWon).toEqual({ home: 1, away: 1 });
+    expect(state.outcome).toEqual({ kind: "draw" });
+    const [home, away] = carrom.standingsDelta(state.outcome!, drawCfg, league, state);
+    expect([home.points, away.points]).toEqual([1, 1]);
+    expect(home).toMatchObject({ drawn: 1, metrics: { sets_won: 1, sets_lost: 1 } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden (e) — walkover: award outcome, completed games stand in the ledger.
+// ---------------------------------------------------------------------------
+describe("carrom golden: walkover", () => {
+  const state = fold(
+    stream(["core.start"], ...boards(["H", 5, "H"]), [
+      "core.forfeit",
+      { by: "A", reason: "no-show" },
+    ]),
+  );
+
+  it("awards the match to the opponent", () => {
+    expect(state.outcome).toEqual({ kind: "award", winner: "H" });
+  });
+
+  it("pays win/loss points; the ledger keeps only what was played", () => {
+    const [home, away] = carrom.standingsDelta(state.outcome!, cfg, league, state);
+    expect(home).toMatchObject({ won: 1, points: 2 });
+    expect(away).toMatchObject({ lost: 1, points: 0 });
+    expect(home.metrics).toMatchObject({ boards_won: 1, points_won: 8, sets_won: 0 });
+    expect(home.points + away.points).toBe(2); // inside declaredPointsSets
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Abandonment — PROMPT-16 §4: no_result, completed games recorded.
+// ---------------------------------------------------------------------------
+describe("carrom: abandonment → no_result", () => {
+  const game1: BoardSpec[] = [["H", 9], ["H", 9], ["H", 9]]; // H takes game 1
+  const state = fold(
+    stream(["core.start"], ...boards(...game1, ["A", 4]), [
+      "core.abandon",
+      { reason: "venue flooded" },
+    ]),
+  );
+
+  it("records no_result with the completed game in the ledger", () => {
+    expect(state.outcome).toEqual({ kind: "no_result" });
+    expect(state.gamesWon).toEqual({ home: 1, away: 0 });
+    const [home, away] = carrom.standingsDelta(state.outcome!, cfg, league, state);
+    expect([home.points, away.points]).toEqual([1, 1]); // shared draw points
+    expect(home.metrics).toMatchObject({ sets_won: 1, boards_won: 3, boards_lost: 1 });
+    expect(away.metrics).toMatchObject({ sets_won: 0, boards_won: 1 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Break alternation — Law 49(a): alternates each board; each game's first
+// break alternates between the players; the toss sets game 1.
+// ---------------------------------------------------------------------------
+describe("carrom: break alternation (Law 49)", () => {
+  it("toss winner breaks board 1; alternation runs across boards and games", () => {
+    const game1: BoardSpec[] = [["A", 9], ["A", 9], ["A", 9]]; // A takes game 1
+    const state = fold(
+      stream(
+        ["carrom.toss", { firstBreak: "A" }],
+        ["core.start"],
+        ...boards(...game1, ["H", 2]),
+      ),
+    );
+    const breakers = state.games[0]!.boards.map((board) => board.breaker);
+    expect(breakers).toEqual(["away", "home", "away"]); // game 1 alternates from A
+    expect(state.games[1]!.boards[0]!.breaker).toBe("home"); // game 2 opens with H
+  });
+
+  it("rejects a toss after core.start or a second toss", () => {
+    expect(() =>
+      fold(stream(["core.start"], ["carrom.toss", { firstBreak: "A" }])),
+    ).toThrow(EngineError);
+    expect(() =>
+      fold(
+        stream(["carrom.toss", { firstBreak: "A" }], ["carrom.toss", { firstBreak: "H" }]),
+      ),
+    ).toThrow(EngineError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Umpire adjustments + reserved strike fidelity.
+// ---------------------------------------------------------------------------
+describe("carrom: game.adjust and reserved strike events", () => {
+  it("applies a penalty delta and can decide the game", () => {
+    const state = fold(
+      stream(["core.start"], ...boards(["H", 9], ["H", 9], ["H", 6]), [
+        "carrom.game.adjust",
+        { entrantId: "H", delta: 1, reason: "opponent foul" },
+      ]),
+    );
+    expect(state.games[0]!.score.home).toBe(25);
+    expect(state.games[0]!.winner).toBe("home");
+  });
+
+  it("rejects an adjustment below zero and a zero delta", () => {
+    expect(() =>
+      fold(
+        stream(["core.start"], [
+          "carrom.game.adjust",
+          { entrantId: "H", delta: -1, reason: "foul" },
+        ]),
+      ),
+    ).toThrow(EngineError);
+    expect(() =>
+      fold(
+        stream(["core.start"], [
+          "carrom.game.adjust",
+          { entrantId: "H", delta: 0, reason: "foul" },
+        ]),
+      ),
+    ).toThrow(EngineError);
+  });
+
+  it("rejects the reserved carrom.strike event", () => {
+    expect(() =>
+      fold(stream(["core.start"], ["carrom.strike", { striker: "H", pocketed: ["white"] }])),
+    ).toThrow(/reserved/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation edges.
+// ---------------------------------------------------------------------------
+describe("carrom: board validation", () => {
+  it("rejects opponentCoinsLeft outside 0..9 and unknown entrants", () => {
+    expect(() => fold(stream(["core.start"], ...boards(["H", 10])))).toThrow(EngineError);
+    expect(() => fold(stream(["core.start"], ...boards(["X", 5])))).toThrow(EngineError);
+    expect(() =>
+      fold(stream(["core.start"], [
+        "carrom.board.summary",
+        { winner: "H", opponentCoinsLeft: 5, queenTo: "X" },
+      ])),
+    ).toThrow(EngineError);
+  });
+
+  it("declares the house-standard cascade (carrom.md §4)", () => {
+    expect(carrom.defaultTiebreakers).toEqual(CARROM_TIEBREAKERS);
+    expect(CARROM_TIEBREAKERS).toEqual([
+      "points",
+      "wins",
+      "set_ratio",
+      "board_ratio",
+      "point_ratio",
+      "h2h_points",
+      "lots",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conformance — spec 04 §9 (PROMPT-03 kit) at the ICF default and under the
+// tie-board 'draw' house rule (drawn matches reachable).
+// ---------------------------------------------------------------------------
+conformanceSuite(carrom);
+conformanceSuite(carrom, { cfg: { tieBoard: "draw" }, label: "tie-board draw" });
+conformanceSuite(carrom, {
+  cfg: { gameTo: 29, queenPoints: 5, queenCapAt: 24 },
+  label: "club-29",
+});

--- a/packages/engine/src/sports/carrom/carrom.ts
+++ b/packages/engine/src/sports/carrom/carrom.ts
@@ -1,0 +1,616 @@
+// Carrom SportModule — engine/sports/carrom.md (PROMPT-16), verified against
+// the ICF "Laws of Carrom" (law numbers cited inline; carrom.md §1–7 carries
+// the full citations). Points-race grammar: a match is best-of `bestOf` games
+// (Law 57), a game is first-to-`gameTo` points or the leader after `maxBoards`
+// boards (Law 56a), a board banks the winner's points in one `board.summary`
+// event — strike-by-strike fidelity is reserved (carrom.md §6, Pro key
+// `scoring.strike_by_strike`), see CarromStrike below.
+import { z } from "zod";
+import { EngineError } from "../../core/errors.ts";
+import type { CoreEv, EventEnvelope } from "../../core/events.ts";
+import type { Rng } from "../../core/rng.ts";
+import {
+  EntrantId,
+  type LineupPair,
+  type MatchOutcome,
+  type ScoreSummary,
+  type StageKind,
+  type StandingsDelta,
+} from "../../core/types.ts";
+import type { PositionCatalog } from "../../sport/catalog.ts";
+import type { ModuleEvent, SportModule, TiebreakerKey } from "../../sport/module.ts";
+
+// ---------------------------------------------------------------------------
+// Cfg — carrom.md §1 (ICF Laws 52, 54, 56, 57)
+// ---------------------------------------------------------------------------
+
+export const CarromPoints = z.object({
+  win: z.number().int().nonnegative().default(2),
+  loss: z.number().int().nonnegative().default(0),
+  draw: z.number().int().nonnegative().default(1),
+});
+
+export const CarromCfg = z
+  .object({
+    gameTo: z.number().int().positive().default(25), // Law 56a
+    maxBoards: z.number().int().positive().default(8), // Law 56a
+    bestOf: z.number().int().positive().default(3), // Law 57
+    queenPoints: z.number().int().nonnegative().default(3), // Law 52(b)(i)
+    // Queen scores only while the winner's PRE-board score is < queenCapAt:
+    // "3 points up to and including 21 points" (Law 52(b)(i)), lost "once he
+    // has reached the score of 22 points" (Law 54). Board coin points never
+    // feed their own board's queen check — carrom.md §2.
+    queenCapAt: z.number().int().positive().default(22),
+    pointsPerCoin: z.number().int().positive().default(1), // Law 52(b)(ii)
+    // Law 53(b)/(c): the queen is credited only to the player who covered her
+    // AND won the board; a loser-covered queen scores for nobody. true = house
+    // rule crediting the board winner regardless of who covered.
+    queenFollowsBoard: z.boolean().default(false),
+    // Game tied after maxBoards: 'extra' = sudden-death board(s) (Law 56b),
+    // 'draw' = the game is drawn (house rule; enables drawn matches).
+    tieBoard: z.enum(["extra", "draw"]).default("extra"),
+    points: CarromPoints.default({ win: 2, loss: 0, draw: 1 }), // competition points
+  })
+  .refine((cfg) => cfg.bestOf % 2 === 1, {
+    message: "bestOf must be odd (a decider must exist)",
+  })
+  .refine((cfg) => cfg.queenCapAt <= cfg.gameTo, {
+    message: "queenCapAt must not exceed gameTo",
+  });
+export type CarromCfg = z.infer<typeof CarromCfg>;
+
+// ---------------------------------------------------------------------------
+// Ev — carrom.md §2. Board-level fidelity is the shipping default.
+// ---------------------------------------------------------------------------
+
+// Toss winner's choice of first break (Law 39/42; breaker takes white, Law 43).
+// Deviation from PROMPT-16's `core.start {firstBreak}`: core payloads are
+// kernel-owned strict-empty (spec 03 §2), so the toss is a sport event before
+// core.start — the cricket.toss precedent. Absent a toss, home breaks first.
+export const CarromToss = z.strictObject({ firstBreak: EntrantId });
+export type CarromToss = z.infer<typeof CarromToss>;
+
+export const CarromBoardSummary = z.strictObject({
+  winner: EntrantId,
+  opponentCoinsLeft: z.number().int().min(0).max(9), // winner's coin points ×pointsPerCoin (Law 53a)
+  queenTo: EntrantId.nullable(), // who pocketed AND covered the queen (null = board lost with queen on… impossible, or untracked)
+});
+export type CarromBoardSummary = z.infer<typeof CarromBoardSummary>;
+
+// Umpire penalty/adjustment to the current game score (Laws 51/55 write-offs
+// and penalties surface here at board fidelity).
+export const CarromGameAdjust = z.strictObject({
+  entrantId: EntrantId,
+  delta: z
+    .number()
+    .int()
+    .refine((delta) => delta !== 0, { message: "delta must be non-zero" }),
+  reason: z.string().min(1),
+});
+export type CarromGameAdjust = z.infer<typeof CarromGameAdjust>;
+
+// RESERVED — Pro strike-by-strike fidelity (carrom.md §6, entitlement key
+// `scoring.strike_by_strike`, doc 10). Typed placeholder only: apply()
+// rejects `carrom.strike` until the fine-fidelity prompt lands, and the
+// fidelity ladder declares no tier for it.
+export const CarromStrike = z.strictObject({
+  striker: EntrantId,
+  pocketed: z.array(z.enum(["white", "black", "queen"])),
+  foul: z.boolean().optional(),
+  due: z.boolean().optional(),
+});
+export type CarromStrike = z.infer<typeof CarromStrike>;
+
+export const CarromEv = z.union([CarromToss, CarromBoardSummary, CarromGameAdjust]);
+export type CarromEv = z.infer<typeof CarromEv>;
+
+// ---------------------------------------------------------------------------
+// State — carrom.md §3
+// ---------------------------------------------------------------------------
+
+type Side = "home" | "away";
+
+export interface CarromBoardRecord {
+  winner: Side;
+  points: number; // coin points + queen bonus banked by the winner
+  queenTo: Side | null;
+  queenScored: boolean; // queen bonus actually credited (cap + Law 53 rules)
+  breaker: Side; // who broke this board (display / fine fidelity later)
+}
+
+export interface CarromGameState {
+  boards: CarromBoardRecord[];
+  score: { home: number; away: number };
+  winner: Side | "draw" | null; // null = game open
+}
+
+export interface CarromState {
+  cfg: CarromCfg;
+  entrants: { home: string; away: string };
+  phase: "pre" | "live" | "done" | "final" | "abandoned";
+  tossTaken: boolean;
+  firstBreak: Side; // first break of game 1 (toss; Law 42)
+  games: CarromGameState[]; // last entry is the open game while live
+  gamesWon: { home: number; away: number };
+  gamesDrawn: number;
+  outcome: MatchOutcome | null;
+}
+
+function opponent(side: Side): Side {
+  return side === "home" ? "away" : "home";
+}
+
+function invalid(message: string, data?: unknown): never {
+  throw new EngineError("INVALID_EVENT", message, data);
+}
+
+function wrongPhase(message: string, data?: unknown): never {
+  throw new EngineError("WRONG_PHASE", message, data);
+}
+
+function sideOf(state: CarromState, entrantId: string): Side {
+  if (entrantId === state.entrants.home) return "home";
+  if (entrantId === state.entrants.away) return "away";
+  invalid(`unknown entrant "${entrantId}"`, { entrantId });
+}
+
+function parsePayload<T>(schema: z.ZodType<T>, payload: unknown, type: string): T {
+  const parsed = schema.safeParse(payload);
+  if (!parsed.success) invalid(`invalid ${type} payload`, { issues: parsed.error.issues });
+  return parsed.data;
+}
+
+const majority = (bestOf: number): number => Math.ceil(bestOf / 2);
+
+function openGame(state: CarromState): { game: CarromGameState; index: number } {
+  const index = state.games.length - 1;
+  const game = state.games[index];
+  if (game === undefined || game.winner !== null) {
+    // Unreachable while live — a new game opens the moment the previous one
+    // decides and the match is still undecided.
+    wrongPhase("no open game");
+  }
+  return { game, index };
+}
+
+// Law 49(a): the first break of game 1 goes to the toss winner, the turn to
+// break alternates each board within a game, and each game's first break
+// alternates between the players (game 2 → the other player, game 3 → back).
+// Law 56b's extra-board toss is not modelled (no mid-match toss event); the
+// alternation simply continues — carrom.md §3.
+function breakerOf(firstBreak: Side, gameIndex: number, boardIndex: number): Side {
+  return (gameIndex + boardIndex) % 2 === 0 ? firstBreak : opponent(firstBreak);
+}
+
+// ---------------------------------------------------------------------------
+// Decisions — carrom.md §2 fold
+// ---------------------------------------------------------------------------
+
+// Game decision after a score change (Law 56): first to gameTo, or the leader
+// once maxBoards boards are done; tied after maxBoards → tieBoard policy
+// ('extra' keeps playing sudden-death boards, 'draw' closes the game drawn).
+function decideGame(game: CarromGameState, cfg: CarromCfg): Side | "draw" | null {
+  const { home, away } = game.score;
+  const leader: Side | null = home > away ? "home" : away > home ? "away" : null;
+  if (leader !== null && game.score[leader] >= cfg.gameTo) return leader;
+  if (game.boards.length >= cfg.maxBoards) {
+    if (leader !== null) return leader;
+    return cfg.tieBoard === "draw" ? "draw" : null;
+  }
+  return null;
+}
+
+// Banks a decided game and decides the match at ⌈bestOf/2⌉ game wins (Law 57),
+// or by games-won comparison once all bestOf games are played (drawn games
+// under tieBoard 'draw' consume a slot without producing a winner).
+function bankGame(state: CarromState, gameIndex: number, result: Side | "draw"): CarromState {
+  const games = state.games.map((game, i) =>
+    i === gameIndex ? { ...game, winner: result } : game,
+  );
+  const gamesWon = { ...state.gamesWon };
+  let gamesDrawn = state.gamesDrawn;
+  if (result === "draw") gamesDrawn += 1;
+  else gamesWon[result] += 1;
+
+  let next: CarromState = { ...state, games, gamesWon, gamesDrawn };
+  const decideMatch = (winnerSide: Side): CarromState => ({
+    ...next,
+    phase: "done",
+    outcome: {
+      kind: "win",
+      winner: next.entrants[winnerSide],
+      loser: next.entrants[opponent(winnerSide)],
+      method: "regulation",
+    },
+  });
+
+  if (gamesWon.home >= majority(state.cfg.bestOf)) return decideMatch("home");
+  if (gamesWon.away >= majority(state.cfg.bestOf)) return decideMatch("away");
+  if (games.length >= state.cfg.bestOf) {
+    if (gamesWon.home > gamesWon.away) return decideMatch("home");
+    if (gamesWon.away > gamesWon.home) return decideMatch("away");
+    return { ...next, phase: "done", outcome: { kind: "draw" } };
+  }
+  // Match still open — open the next game.
+  next = {
+    ...next,
+    games: [...games, { boards: [], score: { home: 0, away: 0 }, winner: null }],
+  };
+  return next;
+}
+
+// Re-evaluates the open game after a score change and cascades into the match
+// decision when the game closes.
+function settle(state: CarromState, gameIndex: number): CarromState {
+  const game = state.games[gameIndex] as CarromGameState;
+  const result = decideGame(game, state.cfg);
+  return result === null ? state : bankGame(state, gameIndex, result);
+}
+
+// ---------------------------------------------------------------------------
+// Event application
+// ---------------------------------------------------------------------------
+
+function applyToss(state: CarromState, payload: CarromToss): CarromState {
+  if (state.phase !== "pre") wrongPhase("toss must precede core.start");
+  if (state.tossTaken) invalid("toss already recorded");
+  return { ...state, tossTaken: true, firstBreak: sideOf(state, payload.firstBreak) };
+}
+
+function applyBoard(state: CarromState, payload: CarromBoardSummary): CarromState {
+  if (state.phase !== "live") wrongPhase(`board summary not allowed in phase "${state.phase}"`);
+  const winnerSide = sideOf(state, payload.winner);
+  const queenSide = payload.queenTo === null ? null : sideOf(state, payload.queenTo);
+  const { game, index } = openGame(state);
+
+  const preBoardScore = game.score[winnerSide];
+  const coinPoints = payload.opponentCoinsLeft * state.cfg.pointsPerCoin;
+  // Law 53(b)/(c): queen credit needs the coverer to win the board — unless
+  // the queenFollowsBoard house rule hands her to the board winner anyway.
+  const queenCredited =
+    queenSide === winnerSide || (state.cfg.queenFollowsBoard && queenSide !== null);
+  // Law 52(b)(i)/54: the bonus is checked against the PRE-board score — coin
+  // points of this board never lift the winner past the cap for its own queen.
+  const queenScored = queenCredited && preBoardScore < state.cfg.queenCapAt;
+  const boardPoints = coinPoints + (queenScored ? state.cfg.queenPoints : 0);
+
+  const board: CarromBoardRecord = {
+    winner: winnerSide,
+    points: boardPoints,
+    queenTo: queenSide,
+    queenScored,
+    breaker: breakerOf(state.firstBreak, index, game.boards.length),
+  };
+  const updated: CarromGameState = {
+    ...game,
+    boards: [...game.boards, board],
+    score: { ...game.score, [winnerSide]: preBoardScore + boardPoints },
+  };
+  const next = {
+    ...state,
+    games: state.games.map((entry, i) => (i === index ? updated : entry)),
+  };
+  return settle(next, index);
+}
+
+function applyAdjust(state: CarromState, payload: CarromGameAdjust): CarromState {
+  if (state.phase !== "live") wrongPhase(`adjustment not allowed in phase "${state.phase}"`);
+  const side = sideOf(state, payload.entrantId);
+  const { game, index } = openGame(state);
+  const score = game.score[side] + payload.delta;
+  if (score < 0) invalid("adjustment would take the game score below zero", { score });
+  const updated: CarromGameState = { ...game, score: { ...game.score, [side]: score } };
+  const next = {
+    ...state,
+    games: state.games.map((entry, i) => (i === index ? updated : entry)),
+  };
+  return settle(next, index);
+}
+
+// Walkover — carrom.md §7: the match is awarded to the opponent; completed
+// games stand in the ledger.
+function applyForfeit(state: CarromState, by: string): CarromState {
+  const winnerSide = opponent(sideOf(state, by));
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase("match already over");
+  }
+  return {
+    ...state,
+    phase: "done",
+    outcome: { kind: "award", winner: state.entrants[winnerSide] },
+  };
+}
+
+// Abandonment — PROMPT-16 §4: `no_result`, with completed games recorded (the
+// ledger metrics keep whatever was actually played).
+function applyAbandon(state: CarromState): CarromState {
+  if (state.phase === "done" || state.phase === "final" || state.phase === "abandoned") {
+    wrongPhase("match already over");
+  }
+  return { ...state, phase: "abandoned", outcome: { kind: "no_result" } };
+}
+
+// ---------------------------------------------------------------------------
+// Ledger — carrom.md §4. Comparator-registry keys: games ride the sets_won/
+// sets_lost keys (set_ratio, the badminton "games" precedent), board points
+// ride points_won/points_lost (point_ratio); boards_won/boards_lost feed the
+// carrom-specific board_ratio key. Integers only (spec 04 §9.4).
+// ---------------------------------------------------------------------------
+
+function sideLedger(state: CarromState, side: Side): Record<string, number> {
+  let boardsWon = 0;
+  let boardsLost = 0;
+  let pointsFor = 0;
+  let pointsAgainst = 0;
+  for (const game of state.games) {
+    for (const board of game.boards) {
+      if (board.winner === side) {
+        boardsWon += 1;
+        pointsFor += board.points;
+      } else {
+        boardsLost += 1;
+        pointsAgainst += board.points;
+      }
+    }
+  }
+  return {
+    sets_won: state.gamesWon[side],
+    sets_lost: state.gamesWon[opponent(side)],
+    boards_won: boardsWon,
+    boards_lost: boardsLost,
+    points_won: pointsFor,
+    points_lost: pointsAgainst,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Positions — carrom.md §5: catalog empty (doubles = pair entrant).
+// ---------------------------------------------------------------------------
+
+const positions: PositionCatalog = {
+  groups: [],
+  lineup: { size: 1, benchMax: 0 },
+};
+
+// carrom.md §4 — house-standard cascade (no universal federation cascade):
+// points → matches won → game ratio → board ratio → point ratio → h2h → lots.
+export const CARROM_TIEBREAKERS: TiebreakerKey[] = [
+  "points",
+  "wins",
+  "set_ratio",
+  "board_ratio",
+  "point_ratio",
+  "h2h_points",
+  "lots",
+];
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+export const carrom: SportModule<CarromCfg, CarromEv, CarromState> = {
+  key: "carrom",
+  version: "1.0.0",
+  configSchema: CarromCfg,
+  eventSchema: CarromEv,
+  positions,
+  variants: {
+    // ICF Laws of Carrom (Laws 52–57) — the system default.
+    icf: {},
+    // Documented club/family rules (mastersofgames.com "Rules of Carrom"):
+    // game to 29, queen worth 5, no queen benefit at 24+ — carrom.md §1.
+    "club-29": { gameTo: 29, queenPoints: 5, queenCapAt: 24 },
+  },
+
+  init(cfg, lineups: LineupPair): CarromState {
+    return {
+      cfg,
+      entrants: { home: lineups.home.entrantId, away: lineups.away.entrantId },
+      phase: "pre",
+      tossTaken: false,
+      firstBreak: "home",
+      games: [],
+      gamesWon: { home: 0, away: 0 },
+      gamesDrawn: 0,
+      outcome: null,
+    };
+  },
+
+  apply(state, ev: EventEnvelope<CarromEv | CoreEv>): CarromState {
+    switch (ev.type) {
+      case "core.start":
+        if (state.phase !== "pre") wrongPhase("already started");
+        return {
+          ...state,
+          phase: "live",
+          games: [{ boards: [], score: { home: 0, away: 0 }, winner: null }],
+        };
+      case "carrom.toss":
+        return applyToss(state, parsePayload(CarromToss, ev.payload, ev.type));
+      case "carrom.board.summary":
+        return applyBoard(state, parsePayload(CarromBoardSummary, ev.payload, ev.type));
+      case "carrom.game.adjust":
+        return applyAdjust(state, parsePayload(CarromGameAdjust, ev.payload, ev.type));
+      case "carrom.strike":
+        // Reserved fine fidelity — carrom.md §6, key `scoring.strike_by_strike`.
+        return invalid("carrom.strike is reserved and not yet implemented");
+      case "core.forfeit":
+        return applyForfeit(state, (ev.payload as { by: string }).by);
+      case "core.abandon":
+        return applyAbandon(state);
+      case "core.finalize":
+        if (state.outcome === null) wrongPhase("cannot finalize an undecided fixture");
+        return { ...state, phase: "final" };
+      case "core.note":
+        return state;
+      default:
+        invalid(`unknown event type "${ev.type}"`);
+    }
+  },
+
+  outcome: (state) => state.outcome,
+
+  // §9.5 — defined at every prefix; boards render like sets (carrom.md §6).
+  summary(state): ScoreSummary {
+    const current = state.games.find((game) => game.winner === null);
+    const line = (side: Side): string => {
+      const games = `${state.gamesWon[side]}`;
+      return current === undefined ? games : `${games} (${current.score[side]})`;
+    };
+    const breaker =
+      state.phase === "live" && current !== undefined
+        ? state.entrants[
+            breakerOf(state.firstBreak, state.games.length - 1, current.boards.length)
+          ]
+        : null;
+    return {
+      headline: `${state.gamesWon.home} — ${state.gamesWon.away}`,
+      perSide: [
+        { entrantId: state.entrants.home, line: line("home") },
+        { entrantId: state.entrants.away, line: line("away") },
+      ],
+      detail: {
+        games: state.games.map((game) => ({
+          score: { ...game.score },
+          winner: game.winner === null || game.winner === "draw"
+            ? game.winner
+            : state.entrants[game.winner],
+          boards: game.boards.map((board) => ({
+            winner: state.entrants[board.winner],
+            points: board.points,
+            queenTo: board.queenTo === null ? null : state.entrants[board.queenTo],
+            queenScored: board.queenScored,
+            breaker: state.entrants[board.breaker],
+          })),
+        })),
+        firstBreak: state.entrants[state.firstBreak],
+        ...(breaker === null ? {} : { breaker }),
+        ...(state.phase === "abandoned" ? { abandoned: true } : {}),
+      },
+    };
+  },
+
+  standingsDelta(outcome, cfg, _ctx, state): [StandingsDelta, StandingsDelta] {
+    const build = (
+      side: Side,
+      w: number,
+      d: number,
+      l: number,
+      pts: number,
+    ): StandingsDelta => ({
+      entrantId: state.entrants[side],
+      played: 1,
+      won: w,
+      drawn: d,
+      lost: l,
+      points: pts,
+      metrics: sideLedger(state, side),
+    });
+
+    switch (outcome.kind) {
+      case "win": {
+        const winnerSide = sideOf(state, outcome.winner);
+        const winner = build(winnerSide, 1, 0, 0, cfg.points.win);
+        const loser = build(opponent(winnerSide), 0, 0, 1, cfg.points.loss);
+        return winnerSide === "home" ? [winner, loser] : [loser, winner];
+      }
+      case "draw":
+        return [
+          build("home", 0, 1, 0, cfg.points.draw),
+          build("away", 0, 1, 0, cfg.points.draw),
+        ];
+      case "award": {
+        // Walkover — carrom.md §7: match points as a win; the ledger keeps
+        // only what was actually played (no phantom boards).
+        const winnerSide = sideOf(state, outcome.winner);
+        const winner = build(winnerSide, 1, 0, 0, cfg.points.win);
+        const loser = build(opponent(winnerSide), 0, 0, 1, cfg.points.loss);
+        return winnerSide === "home" ? [winner, loser] : [loser, winner];
+      }
+      case "no_result":
+        // Abandonment — PROMPT-16 §4: shared (draw) points, completed games
+        // recorded in the ledger.
+        return [
+          build("home", 0, 0, 0, cfg.points.draw),
+          build("away", 0, 0, 0, cfg.points.draw),
+        ];
+      default:
+        invalid(`carrom module cannot rank outcome "${outcome.kind}"`);
+    }
+  },
+
+  metrics: [
+    // doc 09 §2: games won/lost as columns; boards and raw points are
+    // ledger-only ratio operands (carrom.md §4).
+    { key: "sets_won", label: "Games won", direction: "desc" },
+    { key: "sets_lost", label: "Games lost", direction: "asc" },
+    { key: "boards_won", label: "Boards won", direction: "desc", display: false },
+    { key: "boards_lost", label: "Boards lost", direction: "asc", display: false },
+    { key: "points_won", label: "Points for", direction: "desc", display: false },
+    { key: "points_lost", label: "Points against", direction: "asc", display: false },
+  ],
+  defaultTiebreakers: CARROM_TIEBREAKERS,
+
+  // Drawn matches exist only under the tieBoard 'draw' house rule, and only in
+  // table stages — ICF play ('extra') always produces a winner.
+  supportsDraws(cfg, stage: StageKind) {
+    return (
+      cfg.tieBoard === "draw" &&
+      (stage === "league" || stage === "group" || stage === "swiss")
+    );
+  },
+
+  // §9.3 — {win+loss (win & walkover), 2·draw (drawn match & no_result)}.
+  declaredPointsSets(cfg) {
+    return [...new Set([cfg.points.win + cfg.points.loss, cfg.points.draw * 2])];
+  },
+
+  // carrom.md §6 — board-level fidelity ships; strike-by-strike is reserved
+  // (`scoring.strike_by_strike`) and gets tiers 2/3 when it lands.
+  fidelityTiers: [
+    { tier: 0, eventTypes: ["carrom.board.summary"] },
+    { tier: 1, eventTypes: ["carrom.board.summary", "carrom.toss", "carrom.game.adjust"] },
+  ],
+  officialLabel: { scorer: "Umpire" }, // ICF laws officiate through an Umpire
+
+  // spec 03 §6 — deterministic generator: optional toss, start, then boards
+  // with occasional umpire adjustments, forfeits and abandonments.
+  arbitraryEvent(state, rng: Rng): ModuleEvent<CarromEv> | null {
+    const randomEntrant = () => (rng() < 0.5 ? state.entrants.home : state.entrants.away);
+    if (state.phase === "pre") {
+      if (!state.tossTaken && rng() < 0.5) {
+        return { type: "carrom.toss", payload: { firstBreak: randomEntrant() } };
+      }
+      return { type: "core.start", payload: {} };
+    }
+    if (state.phase !== "live") return null;
+
+    const roll = rng();
+    if (roll < 0.02) {
+      return { type: "core.forfeit", payload: { by: randomEntrant(), reason: "no-show" } };
+    }
+    if (roll < 0.04) {
+      return { type: "core.abandon", payload: { reason: "venue closed" } };
+    }
+    if (roll < 0.09) {
+      const current = state.games.find((game) => game.winner === null);
+      const side: Side = rng() < 0.5 ? "home" : "away";
+      const score = current?.score[side] ?? 0;
+      // Negative deltas only where the score can absorb them.
+      const delta = score > 0 && rng() < 0.5 ? -1 : 1;
+      return {
+        type: "carrom.game.adjust",
+        payload: { entrantId: state.entrants[side], delta, reason: "umpire penalty" },
+      };
+    }
+    const winner = randomEntrant();
+    const loser = winner === state.entrants.home ? state.entrants.away : state.entrants.home;
+    const queenRoll = rng();
+    const queenTo = queenRoll < 0.55 ? winner : queenRoll < 0.75 ? loser : null;
+    const opponentCoinsLeft = 1 + Math.floor(rng() * 9); // 1..9
+    return {
+      type: "carrom.board.summary",
+      payload: { winner, opponentCoinsLeft, queenTo },
+    };
+  },
+};

--- a/packages/engine/src/sports/carrom/index.ts
+++ b/packages/engine/src/sports/carrom/index.ts
@@ -1,0 +1,15 @@
+// Carrom SportModule — engine/sports/carrom.md (PROMPT-16).
+export {
+  carrom,
+  CarromCfg,
+  CarromEv,
+  CarromToss,
+  CarromBoardSummary,
+  CarromGameAdjust,
+  CarromStrike,
+  CarromPoints,
+  CARROM_TIEBREAKERS,
+  type CarromState,
+  type CarromGameState,
+  type CarromBoardRecord,
+} from "./carrom.ts";

--- a/packages/engine/src/sports/index.ts
+++ b/packages/engine/src/sports/index.ts
@@ -10,6 +10,7 @@ import type { SportRegistry } from "../sport/registry.ts";
 import { football } from "./football/index.ts";
 import { cricket } from "./cricket/index.ts";
 import { boardgame } from "./boardgame/index.ts";
+import { carrom } from "./carrom/index.ts";
 import { generic } from "./generic/index.ts";
 import { volleyball } from "./setbased/volleyball.ts";
 import { badminton } from "./setbased/badminton.ts";
@@ -20,6 +21,7 @@ export const builtinModules: readonly AnySportModule[] = [
   football,
   cricket,
   boardgame,
+  carrom,
   generic,
   volleyball,
   badminton,


### PR DESCRIPTION
## Summary

Implements `sports/carrom/` per `engine/sports/carrom.md` (PROMPT-16). Every rule was verified against the ICF "Laws of Carrom" before implementation; law numbers are cited inline in code and doc.

### ICF verification highlights
- **Law 52b/54** — queen worth 3 "up to and including 21 points", lost once 22 is reached: the bonus is checked against the **pre-board** score; goldens cover both boundaries (21 → counts, 22 → scores 0).
- **Law 53b/c** — queen credited only if the coverer *wins* the board; a loser-covered queen scores for **nobody**. This corrects the design doc's earlier guess (transfer to board winner), which is now the explicit `queenFollowsBoard: true` house-rule switch (default false = ICF).
- **Law 56** — game of 25 points or 8 boards; tied after the 8th → extra board (`tieBoard: 'extra'` default) or drawn game (house rule). **Law 57** — best of 3 games. **Law 49a** — break alternates each board, and each game's first break alternates between players; tracked per board.

### Module
- Cfg schema + variants `icf` (system default) and `club-29` (documented family rules — mastersofgames.com: game to 29, queen 5, no benefit at 24+).
- Events `carrom.board.summary`, `carrom.game.adjust`, `carrom.toss`; `carrom.strike` ships as a **typed placeholder only** (apply rejects it; reserved Pro key `scoring.strike_by_strike`).
- Outcomes: `award` walkover; `no_result` abandonment with completed games recorded in the ledger.
- Standings: integer ledger; house-standard cascade `points → wins → set_ratio (games) → board_ratio → point_ratio → h2h_points → lots`, with a new cross-multiplied `board_ratio` comparator key (module contract, tiebreaker registry, display columns).

### Deviations (recorded in carrom.md)
- Toss is a sport event, not a `core.start {firstBreak}` payload — core payloads are kernel-owned strict-empty (spec 03 §2, `cricket.toss` precedent).
- Games/points ride the shared `sets_won`/`points_won` comparator keys (badminton precedent); boards get the new `board_ratio` key.
- Law 56b's fresh toss before an extra board is not modelled; alternation continues.
- `roundrobin.test.ts`: explicit 20s budget on one heavy property test — the added carrom suites tipped it past vitest's 5s default under full-suite worker contention (passes alone; main was borderline).

## Acceptance
- `conformanceSuite(carrom)` green at icf, tie-board-draw and club-29 configs; all five prompt goldens green (25-via-queen finish, queen at 22+ scores 0, 8-board points decision, best-of-3 with tie-board, walkover).
- Engine: 524 tests green (carrom auto-included in chaos + simulation harnesses); web: 68 green; typecheck + lint clean.
- `engine/sports/carrom.md` updated with verified ICF citations (Laws 39–57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)