### PR TITLE
feat: scheduling console — auto pass, DnD board & start flows (PROMPT-17)

### DIFF
--- a/apps/web/src/app/api/v1/divisions/[id]/publish-schedule/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/publish-schedule/route.ts
@@ -1,0 +1,15 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { publishSchedule } from "@/server/usecases/schedule";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Publish the timetable (doc 12 §1.B step 4): division → scheduled,
+ *  schedule_published event, public schedule tab + .ics go live. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "write");
+    return publishSchedule(auth, id);
+  });
+}

--- a/apps/web/src/app/api/v1/divisions/[id]/schedule-settings/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/schedule-settings/route.ts
@@ -1,0 +1,25 @@
+import { v1, parseBody } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { PutScheduleSettings } from "@/server/api-v1/schemas";
+import { getScheduleSettings, putScheduleSettings } from "@/server/usecases/schedule";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Division scheduling settings (doc 12 §3/§4). */
+export async function GET(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "read");
+    return getScheduleSettings(auth, id);
+  });
+}
+
+/** Upsert the calendar-pass inputs; constraint fields are Pro (doc 12 §5). */
+export async function PUT(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "write");
+    const input = await parseBody(req, PutScheduleSettings);
+    return putScheduleSettings(auth, id, input);
+  });
+}

--- a/apps/web/src/app/api/v1/divisions/[id]/schedule/validate/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/schedule/validate/route.ts
@@ -1,0 +1,15 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { validateSchedule } from "@/server/usecases/schedule";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Full conflict report over the division's board (doc 12 §4 — board load
+ *  and the debounced re-validation after edits). */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "read");
+    return validateSchedule(auth, id);
+  });
+}

--- a/apps/web/src/app/api/v1/divisions/[id]/start/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/start/route.ts
@@ -1,0 +1,15 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { startDivision } from "@/server/usecases/schedule";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** The "start tournament" action (doc 12 §1 — both launch modes end here).
+ *  Quick-start generates the first stage's fixtures when none exist. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "write");
+    return startDivision(auth, id);
+  });
+}

--- a/apps/web/src/app/api/v1/stages/[id]/schedule/apply/route.ts
+++ b/apps/web/src/app/api/v1/stages/[id]/schedule/apply/route.ts
@@ -1,0 +1,17 @@
+import { v1, parseBody } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { ApplyScheduleRequest } from "@/server/api-v1/schemas";
+import { applySchedule } from "@/server/usecases/schedule";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Persist an assignment set (from auto or the board editor) transactionally;
+ *  blocking conflicts → 409 SCHEDULE_CONFLICT (doc 12 §2/§4). */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "stage", id, "write");
+    const input = await parseBody(req, ApplyScheduleRequest);
+    return applySchedule(auth, id, input);
+  });
+}

--- a/apps/web/src/app/api/v1/stages/[id]/schedule/auto/route.ts
+++ b/apps/web/src/app/api/v1/stages/[id]/schedule/auto/route.ts
@@ -1,0 +1,17 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { AutoScheduleRequest } from "@/server/api-v1/schemas";
+import { autoSchedule } from "@/server/usecases/schedule";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Run/re-run the pure calendar pass — propose only, nothing persisted
+ *  (doc 12 §4). Body optional: { only_unlocked?: boolean }. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "stage", id, "write");
+    const body = AutoScheduleRequest.parse(await req.json().catch(() => ({})));
+    return autoSchedule(auth, id, body.only_unlocked);
+  });
+}

--- a/apps/web/src/app/competitions/[id]/page.tsx
+++ b/apps/web/src/app/competitions/[id]/page.tsx
@@ -41,6 +41,9 @@ export default async function CompetitionPage({
               {competition.name}
             </h1>
           </div>
+          <Link href={`/competitions/${competition.id}/schedule`} className="btn btn-ghost">
+            Schedule board
+          </Link>
           {publicPath && (
             <Link href={publicPath} className="btn btn-ghost" target="_blank">
               View public page ↗

--- a/apps/web/src/app/competitions/[id]/schedule/page.tsx
+++ b/apps/web/src/app/competitions/[id]/schedule/page.tsx
@@ -1,0 +1,129 @@
+export const dynamic = "force-dynamic";
+// Competition-wide multi-division schedule board (doc 12 §2 / doc 06 §4.3):
+// every division's fixtures on one grid, division-coloured cards. Pro only
+// (doc 12 §5 — scheduling.multi_division).
+import Link from "next/link";
+import { Nav } from "@/components/nav";
+import { requireResourcePageAuth } from "@/server/page-auth";
+import { getCompetition } from "@/server/usecases/competitions";
+import { listDivisions } from "@/server/usecases/divisions";
+import { listStages } from "@/server/usecases/stages";
+import { listDivisionFixtures } from "@/server/usecases/fixtures";
+import { listEntrants } from "@/server/usecases/entrants";
+import { getScheduleSettings } from "@/server/usecases/schedule";
+import { hasFeature } from "@/lib/entitlements";
+import { withTenant } from "@/lib/db";
+import { ScheduleBoard } from "@/components/v2/schedule-board";
+import { feedLabels, type FeedRow } from "@/lib/schedule-board";
+import { UpgradeGate } from "@/components/upgrade-gate";
+
+const PALETTE = ["#7c3aed", "#0ea5e9", "#f59e0b", "#10b981", "#ef4444", "#ec4899", "#64748b"];
+
+export default async function CompetitionSchedulePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { auth, canEdit } = await requireResourcePageAuth("competition", id);
+  const competition = await getCompetition(auth, id);
+
+  const multiAllowed = await hasFeature(auth.orgId, "scheduling.multi_division");
+  if (!multiAllowed) {
+    return (
+      <>
+        <Nav />
+        <main className="mx-auto max-w-3xl px-4 py-8">
+          <h1 className="mb-4 text-xl font-semibold text-slate-900">
+            Competition schedule — {competition.name}
+          </h1>
+          <UpgradeGate feature="scheduling.multi_division" />
+        </main>
+      </>
+    );
+  }
+
+  const divisions = await listDivisions(auth, id);
+  const [boardEditable, constraints] = await Promise.all([
+    hasFeature(auth.orgId, "scheduling.board"),
+    hasFeature(auth.orgId, "scheduling.constraints"),
+  ]);
+  const perDivision = await Promise.all(
+    divisions.map(async (d) => ({
+      division: d,
+      stages: await listStages(auth, d.id),
+      fixtures: await listDivisionFixtures(auth, d.id),
+      entrants: await listEntrants(auth, d.id),
+    })),
+  );
+  const feedRows = await withTenant(auth.orgId, (tx) =>
+    tx<FeedRow[]>`
+      select f.id, f.round_no, f.seq_in_round, f.winner_to_fixture, f.winner_to_slot,
+             f.loser_to_fixture, f.loser_to_slot
+      from fixtures f join divisions d on d.id = f.division_id
+      where d.competition_id = ${id}`,
+  );
+
+  // Grid config: first division's settings, courts unioned across divisions.
+  const settings = await getScheduleSettings(auth, divisions[0]?.id ?? id);
+  const allCourts = [
+    ...new Set(
+      (
+        await Promise.all(divisions.map((d) => getScheduleSettings(auth, d.id)))
+      ).flatMap((s) => s.config.courts),
+    ),
+  ];
+
+  const frozen = competition.frozen ?? false;
+
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-7xl px-4 py-8">
+        <div className="mb-4">
+          <p className="text-xs text-slate-400">
+            <Link href="/dashboard" className="hover:text-purple-600">Competitions</Link>
+            {" / "}
+            <Link href={`/competitions/${id}`} className="hover:text-purple-600">
+              {competition.name}
+            </Link>
+          </p>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight text-slate-900">
+            Competition schedule — {competition.name}
+          </h1>
+        </div>
+
+        <ScheduleBoard
+          divisions={perDivision.map(({ division }, i) => ({
+            id: division.id,
+            name: division.name,
+            status: division.status,
+            color: PALETTE[i % PALETTE.length] as string,
+          }))}
+          stages={perDivision.flatMap(({ division, stages }) =>
+            stages.map((s) => ({
+              id: s.id,
+              division_id: division.id,
+              seq: s.seq,
+              kind: s.kind,
+              name: `${division.name} · ${s.name}`,
+              status: s.status,
+            })),
+          )}
+          fixtures={perDivision.flatMap(({ fixtures }) => fixtures)}
+          entrantNames={Object.fromEntries(
+            perDivision.flatMap(({ entrants }) => entrants.map((e) => [e.id, e.display_name])),
+          )}
+          feedLabels={feedLabels(feedRows)}
+          settings={{
+            division_id: divisions[0]?.id ?? id,
+            config: { ...settings.config, courts: allCourts.length > 0 ? allCourts : settings.config.courts },
+            tz: settings.tz,
+          }}
+          canEdit={canEdit && !frozen && boardEditable}
+          constraintsAllowed={constraints}
+        />
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/app/divisions/[id]/page.tsx
+++ b/apps/web/src/app/divisions/[id]/page.tsx
@@ -13,6 +13,7 @@ import { resolveModule } from "@/server/engine-db";
 import { withTenant } from "@/lib/db";
 import { EntrantsPanel } from "@/components/v2/entrants-panel";
 import { StagesPanel } from "@/components/v2/stages-panel";
+import { LaunchActions } from "@/components/v2/launch-actions";
 import { StandingsTable } from "@/components/public-site/standings-table";
 import { tieBreakLabel, type StandingsRow } from "@seazn/engine/competition";
 import type { MetricSpecLike } from "@/lib/public-site";
@@ -100,6 +101,8 @@ export default async function DivisionPage({
               {division.status}
             </span>
             {frozen && <span className="badge bg-sky-100 text-sky-700">read-only</span>}
+            <div className="flex-1" />
+            <LaunchActions divisionId={id} status={division.status} canEdit={editable} />
           </div>
         </div>
 
@@ -182,6 +185,7 @@ export default async function DivisionPage({
 
 function divisionStatusStyle(status: string): string {
   if (status === "active") return "bg-amber-100 text-amber-700";
+  if (status === "scheduled") return "bg-sky-100 text-sky-700";
   if (status === "completed") return "bg-emerald-100 text-emerald-700";
   return "bg-slate-100 text-slate-600";
 }

--- a/apps/web/src/app/divisions/[id]/schedule/page.tsx
+++ b/apps/web/src/app/divisions/[id]/schedule/page.tsx
@@ -1,0 +1,91 @@
+export const dynamic = "force-dynamic";
+// Drag-and-drop schedule board for one division (doc 12 §2, PROMPT-17).
+// Community renders it view-only (doc 12 §5 — scheduling.board).
+import Link from "next/link";
+import { Nav } from "@/components/nav";
+import { requireResourcePageAuth } from "@/server/page-auth";
+import { getDivision } from "@/server/usecases/divisions";
+import { getCompetition } from "@/server/usecases/competitions";
+import { listStages } from "@/server/usecases/stages";
+import { listDivisionFixtures } from "@/server/usecases/fixtures";
+import { listEntrants } from "@/server/usecases/entrants";
+import { getScheduleSettings } from "@/server/usecases/schedule";
+import { hasFeature } from "@/lib/entitlements";
+import { withTenant } from "@/lib/db";
+import { ScheduleBoard } from "@/components/v2/schedule-board";
+import { feedLabels, type FeedRow } from "@/lib/schedule-board";
+import { UpgradeGate } from "@/components/upgrade-gate";
+
+export default async function DivisionSchedulePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { auth, canEdit } = await requireResourcePageAuth("division", id);
+  const division = await getDivision(auth, id);
+  const [competition, stages, fixtures, entrants, settings, boardEditable, constraints] =
+    await Promise.all([
+      getCompetition(auth, division.competition_id),
+      listStages(auth, id),
+      listDivisionFixtures(auth, id),
+      listEntrants(auth, id),
+      getScheduleSettings(auth, id),
+      hasFeature(auth.orgId, "scheduling.board"),
+      hasFeature(auth.orgId, "scheduling.constraints"),
+    ]);
+
+  // Feed wiring for TBD card labels ("Winner of R1 #2" — doc 12 §2).
+  const feedRows = await withTenant(auth.orgId, (tx) =>
+    tx<FeedRow[]>`
+      select id, round_no, seq_in_round, winner_to_fixture, winner_to_slot,
+             loser_to_fixture, loser_to_slot
+      from fixtures where division_id = ${id}`,
+  );
+
+  const frozen = competition.frozen ?? false;
+  const editable = canEdit && !frozen && boardEditable;
+
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-7xl px-4 py-8">
+        <div className="mb-4">
+          <p className="text-xs text-slate-400">
+            <Link href="/dashboard" className="hover:text-purple-600">Competitions</Link>
+            {" / "}
+            <Link href={`/competitions/${competition.id}`} className="hover:text-purple-600">
+              {competition.name}
+            </Link>
+            {" / "}
+            <Link href={`/divisions/${id}`} className="hover:text-purple-600">
+              {division.name}
+            </Link>
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-3">
+            <h1 className="text-xl font-semibold tracking-tight text-slate-900">
+              Schedule — {division.name}
+            </h1>
+          </div>
+        </div>
+
+        {!boardEditable && canEdit && !frozen && (
+          <div className="mb-4">
+            <UpgradeGate feature="scheduling.board" compact />
+          </div>
+        )}
+
+        <ScheduleBoard
+          divisions={[{ id: division.id, name: division.name, status: division.status, color: "#7c3aed" }]}
+          stages={stages.map((s) => ({ id: s.id, division_id: id, seq: s.seq, kind: s.kind, name: s.name, status: s.status }))}
+          fixtures={fixtures}
+          entrantNames={Object.fromEntries(entrants.map((e) => [e.id, e.display_name]))}
+          feedLabels={feedLabels(feedRows)}
+          settings={{ division_id: id, config: settings.config, tz: settings.tz }}
+          canEdit={editable}
+          constraintsAllowed={constraints}
+        />
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/components/v2/launch-actions.tsx
+++ b/apps/web/src/components/v2/launch-actions.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+// The two division launch actions (doc 12 §1, PROMPT-17):
+//  A. Start tournament — quick-start: generate → sequence-slot → active.
+//  B. Schedule — plan-first: opens the drag-and-drop board (generate + auto
+//     pass live there); publish and start follow from the board.
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { UpgradeGate } from "@/components/upgrade-gate";
+
+interface Props {
+  divisionId: string;
+  status: string;
+  canEdit: boolean;
+}
+
+export function LaunchActions({ divisionId, status, canEdit }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paywall, setPaywall] = useState<string | null>(null);
+
+  async function start() {
+    setBusy(true);
+    setError(null);
+    try {
+      const out = await apiV1<{ generated: number }>(`/api/v1/divisions/${divisionId}/start`, {
+        method: "POST",
+      });
+      if (out.generated > 0) {
+        router.push(`/divisions/${divisionId}?tab=fixtures`);
+      }
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiV1Error && err.code === "PAYMENT_REQUIRED") {
+        setPaywall(String(err.extra.feature_key ?? ""));
+      } else {
+        setError(err instanceof Error ? err.message : "Failed to start");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {canEdit && (status === "setup" || status === "scheduled") && (
+        <button
+          type="button"
+          disabled={busy}
+          onClick={start}
+          className="btn btn-primary px-3 py-1.5 text-xs"
+          title="Quick-start: generate first-stage fixtures and open scoring now"
+        >
+          {busy ? "Starting…" : "Start tournament"}
+        </button>
+      )}
+      <Link href={`/divisions/${divisionId}/schedule`} className="btn btn-ghost px-3 py-1.5 text-xs">
+        Schedule
+      </Link>
+      {paywall && <UpgradeGate feature={paywall} compact />}
+      {error && <span className="text-xs text-red-600">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/src/components/v2/schedule-board.tsx
+++ b/apps/web/src/components/v2/schedule-board.tsx
@@ -1,0 +1,913 @@
+"use client";
+
+// Drag-and-drop schedule board (doc 12 §2, PROMPT-17): grid of courts × time
+// (day/week views), fixture cards with TBD feed labels and division colours,
+// optimistic drag + debounced re-validation, violation badges, pin/lock,
+// re-flow remaining, bulk shift/swap, realtime refresh on division:{id}, and
+// a keyboard-accessible move menu (select a card → move via controls).
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { UpgradeGate } from "@/components/upgrade-gate";
+import { dayKey, daySlots, toLocalInput, type FeedLabelPair } from "@/lib/schedule-board";
+
+const MIN = 60_000;
+
+export interface BoardDivision {
+  id: string;
+  name: string;
+  status: string;
+  color: string;
+}
+
+export interface BoardStage {
+  id: string;
+  division_id: string;
+  seq: number;
+  kind: string;
+  name: string;
+  status: string;
+}
+
+export interface BoardFixture {
+  id: string;
+  stage_id: string;
+  division_id: string;
+  round_no: number;
+  seq_in_round: number;
+  home_entrant_id: string | null;
+  away_entrant_id: string | null;
+  scheduled_at: string | null;
+  venue: string | null;
+  court_label: string | null;
+  status: string;
+  schedule_source: string;
+  schedule_locked: boolean;
+  outcome: unknown;
+}
+
+export interface BoardConfig {
+  startAt?: string | null;
+  matchMinutes: number;
+  gapMinutes: number;
+  courts: string[];
+  perEntrantMinRest: number;
+  blackouts: { court?: string; from: string; to: string }[];
+  sessionWindows: { from: string; to: string }[];
+  roundMinutes?: number | null;
+}
+
+export interface BoardConflict {
+  fixture_id: string;
+  code: string;
+  blocking: boolean;
+  detail?: string;
+}
+
+interface Props {
+  divisions: BoardDivision[];
+  stages: BoardStage[];
+  fixtures: BoardFixture[];
+  entrantNames: Record<string, string>;
+  feedLabels: Record<string, FeedLabelPair>;
+  settings: { division_id: string; config: BoardConfig; tz: string };
+  canEdit: boolean;
+  constraintsAllowed: boolean;
+}
+
+const CONFLICT_LABEL: Record<string, string> = {
+  "conflict.court": "court clash",
+  "warn.rest": "rest",
+  "warn.person_overlap": "person overlap",
+  "warn.order": "plays before feeder",
+  "warn.blackout": "blackout",
+  "warn.no_slot": "no slot",
+};
+
+type Override = { scheduled_at: string | null; court_label: string | null; schedule_locked: boolean };
+
+export function ScheduleBoard({
+  divisions,
+  stages,
+  fixtures,
+  entrantNames,
+  feedLabels,
+  settings,
+  canEdit,
+  constraintsAllowed,
+}: Props) {
+  const router = useRouter();
+  const single = divisions.length === 1 ? divisions[0] : null;
+  const cfg = settings.config;
+  const [overrides, setOverrides] = useState<Record<string, Override>>({});
+  const [conflicts, setConflicts] = useState<BoardConflict[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [paywall, setPaywall] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [selected, setSelected] = useState<string | null>(null); // keyboard move target
+  const [view, setView] = useState<"day" | "week">("day");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Server props are the source of truth; optimistic overrides melt away on
+  // each refresh (last-write-wins per fixture, doc 12 §6). Render-time state
+  // adjustment (the React "derive from props" pattern) — no effect cascade.
+  const [seenFixtures, setSeenFixtures] = useState(fixtures);
+  if (seenFixtures !== fixtures) {
+    setSeenFixtures(fixtures);
+    setOverrides({});
+  }
+
+  const board: BoardFixture[] = useMemo(
+    () =>
+      fixtures.map((f) => {
+        const o = overrides[f.id];
+        return o ? { ...f, ...o } : f;
+      }),
+    [fixtures, overrides],
+  );
+
+  const colorOf = useMemo(
+    () => Object.fromEntries(divisions.map((d) => [d.id, d.color])),
+    [divisions],
+  );
+  const conflictsByFixture = useMemo(() => {
+    const map: Record<string, BoardConflict[]> = {};
+    for (const c of conflicts) (map[c.fixture_id] ??= []).push(c);
+    return map;
+  }, [conflicts]);
+
+  const scheduled = board.filter((f) => f.scheduled_at !== null && f.court_label !== null);
+  const unscheduled = board.filter(
+    (f) => (f.scheduled_at === null || f.court_label === null) && f.status === "scheduled",
+  );
+
+  const days = useMemo(() => {
+    const set = new Set(scheduled.map((f) => dayKey(f.scheduled_at as string)));
+    if (set.size === 0 && cfg.startAt) set.add(dayKey(cfg.startAt));
+    if (set.size === 0) set.add(dayKey(new Date()));
+    return [...set].sort();
+  }, [scheduled, cfg.startAt]);
+  const [day, setDay] = useState<string>(days[0] as string);
+  if (!days.includes(day)) setDay(days[0] as string); // render-time adjust
+
+  // Courts: configured list plus anything already used on the board.
+  const courts = useMemo(() => {
+    const list = [...cfg.courts];
+    for (const f of scheduled) {
+      if (f.court_label && !list.includes(f.court_label)) list.push(f.court_label);
+    }
+    return list;
+  }, [cfg.courts, scheduled]);
+
+  // ------------------------------------------------------------------ actions
+
+  const runValidate = useCallback(async () => {
+    try {
+      const results = await Promise.all(
+        divisions.map((d) =>
+          apiV1<{ conflicts: BoardConflict[] }>(`/api/v1/divisions/${d.id}/schedule/validate`, {
+            method: "POST",
+          }),
+        ),
+      );
+      setConflicts(results.flatMap((r) => r.conflicts));
+    } catch {
+      /* validation is advisory — never break the board */
+    }
+  }, [divisions]);
+
+  const queueValidate = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => void runValidate(), 400);
+  }, [runValidate]);
+
+  // Full report on load and after every server refresh (doc 12 §4 — board
+  // load + after external edits). Debounced: state lands in a timer callback.
+  useEffect(() => {
+    queueValidate();
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [queueValidate, fixtures]);
+
+  function fail(err: unknown) {
+    if (err instanceof ApiV1Error && err.code === "PAYMENT_REQUIRED") {
+      setPaywall(String(err.extra.feature_key ?? ""));
+    } else if (err instanceof ApiV1Error && err.code === "SCHEDULE_CONFLICT") {
+      const list = (err.extra.conflicts as BoardConflict[] | undefined) ?? [];
+      setError(
+        `Blocked: ${list.map((c) => `${CONFLICT_LABEL[c.code] ?? c.code}${c.detail ? ` (${c.detail})` : ""}`).join("; ") || err.message}`,
+      );
+    } else {
+      setError(err instanceof Error ? err.message : "Failed");
+    }
+  }
+
+  async function moveCard(fixtureId: string, atIso: string | null, court: string | null) {
+    if (!canEdit) return;
+    setError(null);
+    const prev = board.find((f) => f.id === fixtureId);
+    if (!prev || prev.status !== "scheduled") return;
+    setOverrides((o) => ({
+      ...o,
+      [fixtureId]: {
+        scheduled_at: atIso,
+        court_label: court,
+        schedule_locked: prev.schedule_locked,
+      },
+    }));
+    try {
+      await apiV1(`/api/v1/fixtures/${fixtureId}`, {
+        method: "PATCH",
+        json: { scheduled_at: atIso, court_label: court },
+      });
+      queueValidate();
+      router.refresh();
+    } catch (err) {
+      setOverrides((o) => {
+        const rest = { ...o };
+        delete rest[fixtureId];
+        return rest;
+      });
+      fail(err);
+    }
+  }
+
+  async function togglePin(f: BoardFixture) {
+    if (!canEdit) return;
+    setError(null);
+    try {
+      await apiV1(`/api/v1/fixtures/${f.id}`, {
+        method: "PATCH",
+        json: { schedule_locked: !f.schedule_locked },
+      });
+      router.refresh();
+    } catch (err) {
+      fail(err);
+    }
+  }
+
+  async function autoRun(stageId: string, onlyUnlocked: boolean) {
+    setError(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      const out = await apiV1<{
+        assignments: { fixture_id: string; scheduled_at: string; court_label: string }[];
+        conflicts: BoardConflict[];
+      }>(`/api/v1/stages/${stageId}/schedule/auto`, {
+        method: "POST",
+        json: { only_unlocked: onlyUnlocked },
+      });
+      if (out.assignments.length === 0) {
+        setNotice("Nothing to schedule for this stage.");
+        return;
+      }
+      const applied = await apiV1<{ applied: number; conflicts: BoardConflict[] }>(
+        `/api/v1/stages/${stageId}/schedule/apply`,
+        {
+          method: "POST",
+          json: {
+            assignments: out.assignments.map((a) => ({
+              fixture_id: a.fixture_id,
+              scheduled_at: a.scheduled_at,
+              court_label: a.court_label,
+            })),
+            source: "auto",
+          },
+        },
+      );
+      setConflicts(applied.conflicts);
+      setNotice(
+        `Placed ${applied.applied} fixture(s)` +
+          (applied.conflicts.length > 0 ? ` — ${applied.conflicts.length} warning(s).` : "."),
+      );
+      router.refresh();
+    } catch (err) {
+      fail(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function act(path: string, done: string) {
+    setError(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      await apiV1(path, { method: "POST" });
+      setNotice(done);
+      router.refresh();
+    } catch (err) {
+      fail(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Bulk tools (doc 12 §2): shift the selected day ±N minutes / swap two courts.
+  async function shiftDay(minutes: number) {
+    setBusy(true);
+    setError(null);
+    try {
+      for (const f of scheduled) {
+        if (dayKey(f.scheduled_at as string) !== day || f.status !== "scheduled") continue;
+        await apiV1(`/api/v1/fixtures/${f.id}`, {
+          method: "PATCH",
+          json: {
+            scheduled_at: new Date(new Date(f.scheduled_at as string).getTime() + minutes * MIN).toISOString(),
+          },
+        });
+      }
+      router.refresh();
+      queueValidate();
+    } catch (err) {
+      fail(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function swapCourts(a: string, b: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      for (const f of scheduled) {
+        if (dayKey(f.scheduled_at as string) !== day || f.status !== "scheduled") continue;
+        if (f.court_label === a) {
+          await apiV1(`/api/v1/fixtures/${f.id}`, { method: "PATCH", json: { court_label: b } });
+        } else if (f.court_label === b) {
+          await apiV1(`/api/v1/fixtures/${f.id}`, { method: "PATCH", json: { court_label: a } });
+        }
+      }
+      router.refresh();
+      queueValidate();
+    } catch (err) {
+      fail(err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Realtime board refresh on division:{id} (doc 12 §6 — two organisers).
+  useEffect(() => {
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL) return;
+    let cancelled = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const channels: any[] = [];
+    (async () => {
+      try {
+        const { supabaseBrowser } = await import("@/lib/supabase-browser");
+        const sb = supabaseBrowser();
+        for (const d of divisions) {
+          if (cancelled) return;
+          channels.push(
+            sb
+              .channel(`division:${d.id}`)
+              .on("broadcast", { event: "schedule_changed" }, () => router.refresh())
+              .subscribe(),
+          );
+        }
+      } catch {
+        /* realtime is best-effort; the board still works without it */
+      }
+    })();
+    return () => {
+      cancelled = true;
+      for (const ch of channels) ch?.unsubscribe();
+    };
+  }, [divisions, router]);
+
+  // ------------------------------------------------------------------ grid math
+
+  const slotMinutes = cfg.matchMinutes + cfg.gapMinutes;
+  const dayFixtures = scheduled.filter((f) => dayKey(f.scheduled_at as string) === day);
+  const dayStartDefault = new Date(`${day}T08:00`).getTime();
+  const dayEndDefault = new Date(`${day}T22:00`).getTime();
+  const times = dayFixtures.map((f) => new Date(f.scheduled_at as string).getTime());
+  const gridFrom = times.length > 0 ? Math.min(...times, dayStartDefault) : dayStartDefault;
+  const gridTo =
+    times.length > 0
+      ? Math.max(...times.map((t) => t + cfg.matchMinutes * MIN), Math.min(dayEndDefault, gridFrom + 8 * 60 * MIN))
+      : dayEndDefault;
+  const slots = daySlots(gridFrom, gridTo, slotMinutes);
+
+  const selectedFixture = selected !== null ? (board.find((f) => f.id === selected) ?? null) : null;
+
+  // ------------------------------------------------------------------ render
+
+  return (
+    <div className="space-y-4">
+      {paywall && <UpgradeGate feature={paywall} />}
+      {notice && <p className="rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{notice}</p>}
+      {error && <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+
+      {/* Action bar */}
+      <div className="flex flex-wrap items-center gap-2">
+        {canEdit &&
+          stages
+            .filter((s) => s.status !== "complete")
+            .map((s) => (
+              <span key={s.id} className="inline-flex items-center gap-1">
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => autoRun(s.id, false)}
+                  className="btn btn-primary px-3 py-1.5 text-xs"
+                >
+                  Auto-schedule {stages.length > 1 ? s.name : ""}
+                </button>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => autoRun(s.id, true)}
+                  className="btn btn-ghost px-3 py-1.5 text-xs"
+                  title="Re-run the auto pass over unlocked fixtures only; pinned cards stay"
+                >
+                  Re-flow remaining
+                </button>
+              </span>
+            ))}
+        <div className="flex-1" />
+        {canEdit && single && single.status !== "active" && single.status !== "completed" && (
+          <>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => act(`/api/v1/divisions/${single.id}/publish-schedule`, "Schedule published — it is now on the public dashboard and .ics feeds.")}
+              className="btn btn-ghost px-3 py-1.5 text-xs"
+            >
+              Publish schedule
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => act(`/api/v1/divisions/${single.id}/start`, "Tournament started — scoring is open.")}
+              className="btn btn-primary px-3 py-1.5 text-xs"
+            >
+              Start tournament
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Division colour legend (competition-wide view, doc 06 §4.3) */}
+      {divisions.length > 1 && (
+        <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+          {divisions.map((d) => (
+            <span key={d.id} className="inline-flex items-center gap-1">
+              <span className="h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: d.color }} />
+              {d.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Day picker, view toggle, bulk tools */}
+      <div className="flex flex-wrap items-center gap-2">
+        {days.map((d) => (
+          <button
+            key={d}
+            type="button"
+            onClick={() => setDay(d)}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              d === day ? "bg-purple-600 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+            }`}
+          >
+            {new Date(`${d}T12:00`).toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" })}
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={() => setView(view === "day" ? "week" : "day")}
+          className="btn btn-ghost px-3 py-1 text-xs"
+        >
+          {view === "day" ? "Week view" : "Day view"}
+        </button>
+        {canEdit && view === "day" && (
+          <span className="ml-auto flex items-center gap-1 text-xs text-slate-500">
+            Shift day
+            <button type="button" disabled={busy} onClick={() => shiftDay(-15)} className="btn btn-ghost px-2 py-1 text-xs">−15m</button>
+            <button type="button" disabled={busy} onClick={() => shiftDay(15)} className="btn btn-ghost px-2 py-1 text-xs">+15m</button>
+            {courts.length >= 2 && (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => swapCourts(courts[0] as string, courts[1] as string)}
+                className="btn btn-ghost px-2 py-1 text-xs"
+                title={`Swap ${courts[0]} ↔ ${courts[1]} for this day`}
+              >
+                Swap {courts[0]}↔{courts[1]}
+              </button>
+            )}
+          </span>
+        )}
+      </div>
+
+      {/* Keyboard-accessible move panel (a11y — doc 12 / PROMPT-17 item 5) */}
+      {canEdit && selectedFixture && (
+        <MovePanel
+          fixture={selectedFixture}
+          courts={courts}
+          entrantNames={entrantNames}
+          feedLabels={feedLabels}
+          onMove={(atIso, court) => {
+            void moveCard(selectedFixture.id, atIso, court);
+            setSelected(null);
+          }}
+          onClose={() => setSelected(null)}
+        />
+      )}
+
+      {/* The grid */}
+      {view === "day" ? (
+        <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+          <table className="w-full border-collapse text-xs" aria-label="Schedule board">
+            <thead>
+              <tr>
+                <th className="w-16 border-b border-slate-200 bg-slate-50 px-2 py-2 text-left font-medium text-slate-500">Time</th>
+                {courts.map((c) => (
+                  <th key={c} className="border-b border-l border-slate-200 bg-slate-50 px-2 py-2 text-left font-medium text-slate-600">
+                    {c}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {slots.map((t) => (
+                <tr key={t}>
+                  <td className="border-b border-slate-100 px-2 py-1 align-top text-slate-400">
+                    {new Date(t).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+                  </td>
+                  {courts.map((court) => {
+                    const cell = dayFixtures.filter((f) => {
+                      const at = new Date(f.scheduled_at as string).getTime();
+                      return f.court_label === court && at >= t && at < t + slotMinutes * MIN;
+                    });
+                    return (
+                      <td
+                        key={court}
+                        className="h-10 border-b border-l border-slate-100 px-1 py-0.5 align-top"
+                        onDragOver={canEdit ? (e) => e.preventDefault() : undefined}
+                        onDrop={
+                          canEdit
+                            ? (e) => {
+                                e.preventDefault();
+                                const fid = e.dataTransfer.getData("text/fixture");
+                                if (fid) void moveCard(fid, new Date(t).toISOString(), court);
+                              }
+                            : undefined
+                        }
+                      >
+                        {cell.map((f) => (
+                          <FixtureCard
+                            key={f.id}
+                            fixture={f}
+                            entrantNames={entrantNames}
+                            feedLabels={feedLabels}
+                            conflicts={conflictsByFixture[f.id] ?? []}
+                            color={divisions.length > 1 ? colorOf[f.division_id] : undefined}
+                            canEdit={canEdit}
+                            selected={selected === f.id}
+                            onSelect={() => setSelected(selected === f.id ? null : f.id)}
+                            onTogglePin={() => void togglePin(f)}
+                          />
+                        ))}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-3 lg:grid-cols-4">
+          {days.map((d) => (
+            <section key={d} className="card p-3">
+              <h4 className="mb-2 text-xs font-semibold text-slate-600">
+                {new Date(`${d}T12:00`).toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })}
+              </h4>
+              <ul className="space-y-1">
+                {scheduled
+                  .filter((f) => dayKey(f.scheduled_at as string) === d)
+                  .sort((a, b) => (a.scheduled_at as string).localeCompare(b.scheduled_at as string))
+                  .map((f) => (
+                    <li key={f.id} className="flex items-center gap-2 text-xs text-slate-600">
+                      <span className="w-10 text-slate-400">
+                        {new Date(f.scheduled_at as string).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
+                      </span>
+                      <span className="truncate">{cardTitle(f, entrantNames, feedLabels)}</span>
+                      <span className="ml-auto text-slate-400">{f.court_label}</span>
+                    </li>
+                  ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+
+      {/* Unscheduled tray */}
+      {unscheduled.length > 0 && (
+        <section className="card p-3">
+          <h4 className="mb-2 text-xs font-semibold text-slate-600">
+            Unscheduled ({unscheduled.length}) — drag onto the board{canEdit ? "" : " (view-only)"}
+          </h4>
+          <div className="flex flex-wrap gap-1.5">
+            {unscheduled.map((f) => (
+              <FixtureCard
+                key={f.id}
+                fixture={f}
+                entrantNames={entrantNames}
+                feedLabels={feedLabels}
+                conflicts={conflictsByFixture[f.id] ?? []}
+                color={divisions.length > 1 ? colorOf[f.division_id] : undefined}
+                canEdit={canEdit}
+                selected={selected === f.id}
+                onSelect={() => setSelected(selected === f.id ? null : f.id)}
+                onTogglePin={() => void togglePin(f)}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Settings */}
+      <SettingsPanel
+        divisionId={settings.division_id}
+        config={cfg}
+        tz={settings.tz}
+        canEdit={canEdit}
+        constraintsAllowed={constraintsAllowed}
+        onSaved={() => {
+          setNotice("Scheduling settings saved.");
+          router.refresh();
+        }}
+        onError={fail}
+      />
+    </div>
+  );
+}
+
+function cardTitle(
+  f: BoardFixture,
+  names: Record<string, string>,
+  feeds: Record<string, FeedLabelPair>,
+): string {
+  const home = f.home_entrant_id
+    ? (names[f.home_entrant_id] ?? "?")
+    : (feeds[f.id]?.home ?? "TBD");
+  const away = f.away_entrant_id
+    ? (names[f.away_entrant_id] ?? "?")
+    : (feeds[f.id]?.away ?? "TBD");
+  return `${home} vs ${away}`;
+}
+
+function FixtureCard({
+  fixture,
+  entrantNames,
+  feedLabels,
+  conflicts,
+  color,
+  canEdit,
+  selected,
+  onSelect,
+  onTogglePin,
+}: {
+  fixture: BoardFixture;
+  entrantNames: Record<string, string>;
+  feedLabels: Record<string, FeedLabelPair>;
+  conflicts: BoardConflict[];
+  color?: string;
+  canEdit: boolean;
+  selected: boolean;
+  onSelect: () => void;
+  onTogglePin: () => void;
+}) {
+  const movable = canEdit && fixture.status === "scheduled";
+  const blocking = conflicts.some((c) => c.blocking);
+  return (
+    <div
+      draggable={movable}
+      onDragStart={(e) => e.dataTransfer.setData("text/fixture", fixture.id)}
+      className={`group mb-0.5 rounded border px-1.5 py-1 text-[11px] leading-tight ${
+        blocking
+          ? "border-red-300 bg-red-50"
+          : conflicts.length > 0
+            ? "border-amber-300 bg-amber-50"
+            : "border-slate-200 bg-white"
+      } ${selected ? "ring-2 ring-purple-400" : ""} ${movable ? "cursor-grab" : "opacity-80"}`}
+      style={color ? { borderLeftWidth: 3, borderLeftColor: color } : undefined}
+    >
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={onSelect}
+          aria-pressed={selected}
+          aria-label={`${cardTitle(fixture, entrantNames, feedLabels)} — round ${fixture.round_no}${canEdit ? ". Select to move via menu" : ""}`}
+          className="min-w-0 flex-1 truncate text-left font-medium text-slate-700 hover:text-purple-700"
+        >
+          {cardTitle(fixture, entrantNames, feedLabels)}
+        </button>
+        {canEdit && fixture.status === "scheduled" && (
+          <button
+            type="button"
+            onClick={onTogglePin}
+            aria-label={fixture.schedule_locked ? "Unlock (allow re-flow)" : "Pin/lock this slot"}
+            title={fixture.schedule_locked ? "Locked — survives re-flow" : "Pin this slot"}
+            className={fixture.schedule_locked ? "" : "opacity-30 group-hover:opacity-100"}
+          >
+            {fixture.schedule_locked ? "🔒" : "📌"}
+          </button>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-1 text-[10px] text-slate-400">
+        <span>R{fixture.round_no}</span>
+        {fixture.status !== "scheduled" && <span className="text-sky-600">{fixture.status}</span>}
+        {conflicts.map((c, i) => (
+          <span
+            key={i}
+            title={c.detail}
+            className={`rounded px-1 ${c.blocking ? "bg-red-100 text-red-700" : "bg-amber-100 text-amber-700"}`}
+          >
+            {CONFLICT_LABEL[c.code] ?? c.code}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Keyboard-accessible alternative to dragging: pick court + time, hit Move.
+function MovePanel({
+  fixture,
+  courts,
+  entrantNames,
+  feedLabels,
+  onMove,
+  onClose,
+}: {
+  fixture: BoardFixture;
+  courts: string[];
+  entrantNames: Record<string, string>;
+  feedLabels: Record<string, FeedLabelPair>;
+  onMove: (atIso: string | null, court: string | null) => void;
+  onClose: () => void;
+}) {
+  const [when, setWhen] = useState(
+    fixture.scheduled_at ? toLocalInput(fixture.scheduled_at) : "",
+  );
+  const [court, setCourt] = useState(fixture.court_label ?? courts[0] ?? "");
+  return (
+    <div
+      role="dialog"
+      aria-label={`Move ${cardTitle(fixture, entrantNames, feedLabels)}`}
+      className="flex flex-wrap items-end gap-2 rounded-lg border border-purple-200 bg-purple-50 p-3"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
+      }}
+    >
+      <p className="w-full text-xs font-medium text-purple-800">
+        Move: {cardTitle(fixture, entrantNames, feedLabels)}
+      </p>
+      <label className="block">
+        <span className="label">When</span>
+        <input
+          type="datetime-local"
+          value={when}
+          onChange={(e) => setWhen(e.target.value)}
+          className="input px-2 py-1 text-xs"
+          autoFocus
+        />
+      </label>
+      <label className="block">
+        <span className="label">Court</span>
+        <select value={court} onChange={(e) => setCourt(e.target.value)} className="input px-2 py-1 text-xs">
+          {courts.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        onClick={() => onMove(when ? new Date(when).toISOString() : null, court || null)}
+        className="btn btn-primary px-3 py-1.5 text-xs"
+      >
+        Move
+      </button>
+      <button type="button" onClick={onClose} className="btn btn-ghost px-3 py-1.5 text-xs">
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+function SettingsPanel({
+  divisionId,
+  config,
+  tz,
+  canEdit,
+  constraintsAllowed,
+  onSaved,
+  onError,
+}: {
+  divisionId: string;
+  config: BoardConfig;
+  tz: string;
+  canEdit: boolean;
+  constraintsAllowed: boolean;
+  onSaved: () => void;
+  onError: (err: unknown) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [startAt, setStartAt] = useState(config.startAt ? toLocalInput(config.startAt) : "");
+  const [matchMinutes, setMatchMinutes] = useState(config.matchMinutes);
+  const [gapMinutes, setGapMinutes] = useState(config.gapMinutes);
+  const [rest, setRest] = useState(config.perEntrantMinRest);
+  const [courtsText, setCourtsText] = useState(config.courts.join(", "));
+  const [zone, setZone] = useState(tz);
+  const [saving, setSaving] = useState(false);
+
+  if (!open) {
+    return (
+      <button type="button" onClick={() => setOpen(true)} className="text-xs text-purple-600 hover:underline">
+        Scheduling settings ({config.courts.length} court{config.courts.length === 1 ? "" : "s"}, {config.matchMinutes}
+        min matches{config.perEntrantMinRest > 0 ? `, ${config.perEntrantMinRest}min rest` : ""})
+      </button>
+    );
+  }
+
+  async function save() {
+    setSaving(true);
+    try {
+      const courts = courtsText.split(",").map((c) => c.trim()).filter(Boolean);
+      await apiV1(`/api/v1/divisions/${divisionId}/schedule-settings`, {
+        method: "PUT",
+        json: {
+          config: {
+            ...config,
+            startAt: startAt ? new Date(startAt).toISOString() : null,
+            matchMinutes,
+            gapMinutes,
+            perEntrantMinRest: rest,
+            courts: courts.length > 0 ? courts : ["Court 1"],
+          },
+          tz: zone,
+        },
+      });
+      setOpen(false);
+      onSaved();
+    } catch (err) {
+      onError(err);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const constrained = !constraintsAllowed;
+  return (
+    <section className="card space-y-2 p-4">
+      <h4 className="text-sm font-semibold text-slate-700">Scheduling settings</h4>
+      {constrained && <UpgradeGate feature="scheduling.constraints" compact />}
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="block">
+          <span className="label">First match</span>
+          <input type="datetime-local" value={startAt} onChange={(e) => setStartAt(e.target.value)} className="input px-2 py-1 text-xs" disabled={!canEdit} />
+        </label>
+        <label className="block">
+          <span className="label">Match (min)</span>
+          <input type="number" min={1} value={matchMinutes} onChange={(e) => setMatchMinutes(Number(e.target.value))} className="input w-20 px-2 py-1 text-xs" disabled={!canEdit} />
+        </label>
+        <label className="block">
+          <span className="label">Gap (min)</span>
+          <input type="number" min={0} value={gapMinutes} onChange={(e) => setGapMinutes(Number(e.target.value))} className="input w-20 px-2 py-1 text-xs" disabled={!canEdit} />
+        </label>
+        <label className="block">
+          <span className="label">Min rest (min)</span>
+          <input type="number" min={0} value={rest} onChange={(e) => setRest(Number(e.target.value))} className="input w-20 px-2 py-1 text-xs" disabled={!canEdit || constrained} />
+        </label>
+        <label className="block">
+          <span className="label">Courts (comma-separated)</span>
+          <input value={courtsText} onChange={(e) => setCourtsText(e.target.value)} className="input w-56 px-2 py-1 text-xs" disabled={!canEdit} />
+        </label>
+        <label className="block">
+          <span className="label">Timezone</span>
+          <input value={zone} onChange={(e) => setZone(e.target.value)} className="input w-36 px-2 py-1 text-xs" disabled={!canEdit} />
+        </label>
+        {canEdit && (
+          <button type="button" disabled={saving} onClick={save} className="btn btn-primary px-3 py-1.5 text-xs">
+            {saving ? "Saving…" : "Save"}
+          </button>
+        )}
+        <button type="button" onClick={() => setOpen(false)} className="btn btn-ghost px-3 py-1.5 text-xs">
+          Close
+        </button>
+      </div>
+      <p className="text-[11px] text-slate-400">
+        Blackouts and session windows are honoured by the auto pass and validator; multi-court,
+        rest, blackout and session constraints need the Pro constraint solver.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/components/v2/schedule-board.tsx
+++ b/apps/web/src/components/v2/schedule-board.tsx
@@ -37,7 +37,8 @@ export interface BoardFixture {
   seq_in_round: number;
   home_entrant_id: string | null;
   away_entrant_id: string | null;
-  scheduled_at: string | null;
+  /** ISO string over the wire, Date when it crosses straight from an RSC. */
+  scheduled_at: string | Date | null;
   venue: string | null;
   court_label: string | null;
   status: string;
@@ -592,7 +593,11 @@ export function ScheduleBoard({
               <ul className="space-y-1">
                 {scheduled
                   .filter((f) => dayKey(f.scheduled_at as string) === d)
-                  .sort((a, b) => (a.scheduled_at as string).localeCompare(b.scheduled_at as string))
+                  .sort(
+                    (a, b) =>
+                      new Date(a.scheduled_at as string).getTime() -
+                      new Date(b.scheduled_at as string).getTime(),
+                  )
                   .map((f) => (
                     <li key={f.id} className="flex items-center gap-2 text-xs text-slate-600">
                       <span className="w-10 text-slate-400">

--- a/apps/web/src/lib/feature-copy.ts
+++ b/apps/web/src/lib/feature-copy.ts
@@ -32,6 +32,8 @@ const FEATURE_REASONS: Record<string, string> = {
   webhooks: "Webhooks need the Business plan.",
   exports: "CSV/PDF exports are a Pro feature.",
   "scheduling.constraints": "The scheduling constraints solver is a Pro feature.",
+  "scheduling.board": "Editing the schedule board is a Pro feature — it stays view-only on Community.",
+  "scheduling.multi_division": "The competition-wide schedule board is a Pro feature.",
   "officials.assignment": "Officials assignment is a Pro feature.",
 };
 

--- a/apps/web/src/lib/realtime.ts
+++ b/apps/web/src/lib/realtime.ts
@@ -40,6 +40,44 @@ export async function publishFixtureUpdate(
 }
 
 /**
+ * Broadcast a schedule_changed event on `division:{id}` after a schedule
+ * write (doc 12 §2/§6 — two organisers on one board see each other's moves,
+ * last-write-wins per fixture). Fire-and-forget, never throws.
+ */
+export async function publishDivisionUpdate(
+  divisionId: string,
+  reason: "schedule" | "publish" | "start",
+): Promise<void> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) return;
+  try {
+    const res = await fetch(`${url}/realtime/v1/api/broadcast`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+        apikey: key,
+      },
+      body: JSON.stringify({
+        messages: [
+          {
+            topic: `division:${divisionId}`,
+            event: "schedule_changed",
+            payload: { v: Date.now(), reason, at: new Date().toISOString() },
+          },
+        ],
+      }),
+    });
+    if (!res.ok) {
+      console.warn(`[realtime] division broadcast failed (${res.status}) for ${divisionId}`);
+    }
+  } catch (err) {
+    console.warn("[realtime] division broadcast error:", err);
+  }
+}
+
+/**
  * Mint a short-lived JWT for Supabase Realtime subscriber auth.
  * Signed with SUPABASE_JWT_SECRET (same secret Supabase uses for its own JWTs).
  */

--- a/apps/web/src/lib/schedule-board.ts
+++ b/apps/web/src/lib/schedule-board.ts
@@ -1,0 +1,63 @@
+// Pure helpers for the schedule board (doc 12 §2). Isomorphic — used by the
+// server page (feed labels) and the client board (grid math); unit-testable
+// without React or a DB.
+
+export interface FeedRow {
+  id: string;
+  round_no: number;
+  seq_in_round: number;
+  winner_to_fixture: string | null;
+  winner_to_slot: number | null;
+  loser_to_fixture: string | null;
+  loser_to_slot: number | null;
+}
+
+export interface FeedLabelPair {
+  home?: string;
+  away?: string;
+}
+
+/**
+ * TBD card labels from the feed wiring: the fixture receiving a winner/loser
+ * shows "Winner of R1 #2" / "Loser of …" on the fed slot (doc 12 §2 — cards
+ * render feed labels until entrants resolve).
+ */
+export function feedLabels(rows: readonly FeedRow[]): Record<string, FeedLabelPair> {
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const labels: Record<string, FeedLabelPair> = {};
+  for (const source of rows) {
+    for (const [target, slot, side] of [
+      [source.winner_to_fixture, source.winner_to_slot, "Winner"],
+      [source.loser_to_fixture, source.loser_to_slot, "Loser"],
+    ] as const) {
+      if (!target || !slot || !byId.has(target)) continue;
+      const label = `${side} of R${source.round_no} #${source.seq_in_round}`;
+      const pair = (labels[target] ??= {});
+      if (slot === 1) pair.home = label;
+      else pair.away = label;
+    }
+  }
+  return labels;
+}
+
+/** Day key (YYYY-MM-DD, local) for grouping assignments into board days. */
+export function dayKey(isoOrDate: string | Date): string {
+  const d = new Date(isoOrDate);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Slot rows for a day grid: starts every `slotMinutes` from `fromMs` up to
+ *  (and excluding) `toMs`. */
+export function daySlots(fromMs: number, toMs: number, slotMinutes: number): number[] {
+  const out: number[] = [];
+  const step = Math.max(5, slotMinutes) * 60_000;
+  for (let t = fromMs; t < toMs; t += step) out.push(t);
+  return out;
+}
+
+export function toLocalInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/apps/web/src/lib/schedule-board.ts
+++ b/apps/web/src/lib/schedule-board.ts
@@ -56,7 +56,7 @@ export function daySlots(fromMs: number, toMs: number, slotMinutes: number): num
   return out;
 }
 
-export function toLocalInput(iso: string): string {
+export function toLocalInput(iso: string | Date): string {
   const d = new Date(iso);
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;

--- a/apps/web/src/server/api-v1/http.ts
+++ b/apps/web/src/server/api-v1/http.ts
@@ -16,6 +16,7 @@ import { featureReason } from "@/lib/feature-copy";
 // signal (409); everything the engine rejects as semantically invalid is 422.
 const ENGINE_HTTP: Record<EngineErrorCode, number> = {
   SEQ_CONFLICT: 409,
+  SCHEDULE_CONFLICT: 409,
   INVALID_EVENT: 422,
   WRONG_PHASE: 422,
   ALREADY_DECIDED: 422,
@@ -98,11 +99,21 @@ export async function v1<T>(fn: () => Promise<T | Reply<T>>): Promise<NextRespon
       const status = ENGINE_HTTP[err.code] ?? 422;
       if (status >= 500) Sentry.captureException(err);
       // 409 contract (doc 08 §4): the client resyncs from current_seq.
-      const extra =
+      let extra: Record<string, unknown> | undefined;
+      if (
         err.code === "SEQ_CONFLICT" &&
         typeof (err.data as { actualSeq?: unknown } | undefined)?.actualSeq === "number"
-          ? { current_seq: (err.data as { actualSeq: number }).actualSeq }
-          : undefined;
+      ) {
+        extra = { current_seq: (err.data as { actualSeq: number }).actualSeq };
+      }
+      // Blocking schedule conflicts (doc 12 §2): the client renders them as
+      // badges on the offending cards, so the 409 carries the list.
+      if (
+        err.code === "SCHEDULE_CONFLICT" &&
+        Array.isArray((err.data as { conflicts?: unknown } | undefined)?.conflicts)
+      ) {
+        extra = { conflicts: (err.data as { conflicts: unknown[] }).conflicts };
+      }
       return errorResponse(requestId, status, err.code, err.message, extra);
     }
     if (err instanceof PaymentRequiredError) {

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -69,9 +69,17 @@ export const ROUTES: RouteSpec[] = [
   { path: "/stages/{id}/generate", method: "post", summary: "Generate fixtures (idempotent, returns diff)", tag: "stages", response: S.GenerateResult, errors: [422] },
   { path: "/stages/{id}/complete", method: "post", summary: "Guarded stage completion / progression", tag: "stages", response: S.CompleteResult, errors: [422] },
   { path: "/stages/{id}/standings", method: "get", summary: "Standings snapshot", tag: "stages", query: { pool_id: { schema: { type: "string", format: "uuid" } } } },
+  // Scheduling console (doc 12 §4, PROMPT-17)
+  { path: "/divisions/{id}/schedule-settings", method: "get", summary: "Get scheduling settings (defaults when unset)", tag: "scheduling", response: S.ScheduleSettings },
+  { path: "/divisions/{id}/schedule-settings", method: "put", summary: "Upsert scheduling settings (constraint fields are Pro)", tag: "scheduling", request: S.PutScheduleSettings, response: S.ScheduleSettings, errors: [402] },
+  { path: "/stages/{id}/schedule/auto", method: "post", summary: "Run the pure calendar pass — propose only, nothing persisted", tag: "scheduling", request: S.AutoScheduleRequest, response: S.AutoScheduleResult },
+  { path: "/stages/{id}/schedule/apply", method: "post", summary: "Persist an assignment set; blocking conflicts → 409", tag: "scheduling", request: S.ApplyScheduleRequest, response: S.ApplyScheduleResult, errors: [402, 409, 422] },
+  { path: "/divisions/{id}/schedule/validate", method: "post", summary: "Full board conflict report (doc 12 §2 taxonomy)", tag: "scheduling", response: S.ValidateScheduleResult },
+  { path: "/divisions/{id}/publish-schedule", method: "post", summary: "Publish the timetable (division → scheduled)", tag: "scheduling", response: S.PublishScheduleResult, errors: [422] },
+  { path: "/divisions/{id}/start", method: "post", summary: "Start the tournament (quick-start generates fixtures)", tag: "scheduling", response: S.StartDivisionResult, errors: [422] },
   // Fixtures & scoring
   { path: "/fixtures/{id}", method: "get", summary: "Get a fixture", tag: "fixtures", response: S.Fixture },
-  { path: "/fixtures/{id}", method: "patch", summary: "Schedule, venue, officials", tag: "fixtures", request: S.PatchFixture, response: S.Fixture },
+  { path: "/fixtures/{id}", method: "patch", summary: "Schedule move, venue, officials, pin/lock — blocking conflicts → 409", tag: "fixtures", request: S.PatchFixture, response: S.Fixture, errors: [402, 409, 422] },
   { path: "/fixtures/{id}/lineups/{entrantId}", method: "get", summary: "Get a side's lineup", tag: "fixtures" },
   { path: "/fixtures/{id}/lineups/{entrantId}", method: "put", summary: "Replace a side's lineup", tag: "fixtures", request: S.PutLineup, errors: [422] },
   { path: "/fixtures/{id}/events", method: "post", summary: "Append a score event (THE scoring endpoint)", tag: "scoring", request: S.AppendEventRequest, response: S.AppendEventResponse, status: 201, errors: [409, 422, 429] },

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -18,7 +18,8 @@ export const Slug = z
 
 export const Visibility = z.enum(["private", "unlisted", "public"]);
 export const CompetitionStatus = z.enum(["draft", "published", "live", "completed", "archived"]);
-export const DivisionStatus = z.enum(["setup", "active", "completed"]);
+// Doc 12 §1: 'scheduled' = timetable published, scoring not yet open.
+export const DivisionStatus = z.enum(["setup", "scheduled", "active", "completed"]);
 export const StageKind = z.enum(["league", "group", "swiss", "knockout", "double_elim", "stepladder"]);
 export const EntrantKind = z.enum(["team", "individual", "pair"]);
 export const EntrantStatus = z.enum(["registered", "confirmed", "withdrawn", "disqualified"]);
@@ -245,6 +246,8 @@ export const PatchFixture = z
     venue: z.string().max(200).nullable(),
     court_label: z.string().max(100).nullable(),
     officials: z.array(z.record(z.string(), z.unknown())),
+    /** Pin/lock (doc 12 §2): locked assignments survive re-running auto. */
+    schedule_locked: z.boolean(),
   })
   .partial()
   .refine((p) => Object.keys(p).length > 0, "empty patch");
@@ -265,6 +268,8 @@ export const Fixture = z.object({
   officials: z.array(z.unknown()),
   status: z.enum(["scheduled", "in_play", "decided", "finalized", "abandoned", "forfeited", "cancelled"]),
   outcome: z.unknown().nullable(),
+  schedule_source: z.enum(["none", "auto", "manual"]),
+  schedule_locked: z.boolean(),
   created_at: z.string(),
 });
 
@@ -362,4 +367,123 @@ export const CompleteResult = z.object({
   events: z.array(z.record(z.string(), z.unknown())),
   /** Set when completion resolved the next stage's qualification spec. */
   qualified: z.object({ stage_id: Uuid, entrants: z.array(Uuid) }).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Scheduling console (doc 12, PROMPT-17)
+// ---------------------------------------------------------------------------
+
+const IsoDateTime = z.iso.datetime({ offset: true });
+
+/** Doc 12 §3 schedule_settings.config — the calendar pass inputs (05 §2.6). */
+export const ScheduleConfig = z.object({
+  startAt: IsoDateTime.nullish(),
+  matchMinutes: z.number().int().min(1).max(24 * 60).default(30),
+  gapMinutes: z.number().int().min(0).max(24 * 60).default(0),
+  courts: z.array(z.string().min(1).max(100)).min(1).max(50).default(["Court 1"]),
+  perEntrantMinRest: z.number().int().min(0).max(24 * 60).default(0),
+  blackouts: z
+    .array(z.object({ court: z.string().max(100).optional(), from: IsoDateTime, to: IsoDateTime }))
+    .max(200)
+    .default([]),
+  sessionWindows: z
+    .array(z.object({ from: IsoDateTime, to: IsoDateTime }))
+    .max(200)
+    .default([]),
+  /** Quick-start rolling times (doc 12 §1.A): round r starts at startAt + (r−1)·roundMinutes. */
+  roundMinutes: z.number().int().min(1).max(24 * 60).nullish(),
+});
+export type ScheduleConfig = z.infer<typeof ScheduleConfig>;
+
+export const PutScheduleSettings = z.object({
+  config: ScheduleConfig,
+  /** Venue-local timezone (doc 12 §6 — DST boundaries in sessionWindows). */
+  tz: z.string().min(1).max(64).default("UTC"),
+});
+export type PutScheduleSettings = z.infer<typeof PutScheduleSettings>;
+
+export const ScheduleSettings = z.object({
+  division_id: Uuid,
+  config: ScheduleConfig,
+  tz: z.string(),
+  updated_at: z.string(),
+});
+
+/** Doc 12 §2 conflict taxonomy. `blocking` = conflict.court, or warn.order on
+ *  a direct feed; blocked writes are rejected, warnings persist as badges. */
+export const ScheduleConflict = z.object({
+  fixture_id: Uuid,
+  code: z.enum([
+    "conflict.court",
+    "warn.rest",
+    "warn.person_overlap",
+    "warn.order",
+    "warn.blackout",
+    "warn.no_slot",
+  ]),
+  blocking: z.boolean(),
+  detail: z.string().optional(),
+});
+export type ScheduleConflict = z.infer<typeof ScheduleConflict>;
+
+export const ScheduleAssignment = z.object({
+  fixture_id: Uuid,
+  scheduled_at: z.string(),
+  ends_at: z.string(),
+  court_label: z.string(),
+});
+export type ScheduleAssignment = z.infer<typeof ScheduleAssignment>;
+
+/** POST /stages/{id}/schedule/auto — propose only, nothing persisted (doc 12 §4). */
+export const AutoScheduleRequest = z.object({
+  /** true (default) = re-flow unlocked fixtures only, locked ones are fixed
+   *  obstacles ("re-flow remaining", doc 12 §2); false = fresh full pass. */
+  only_unlocked: z.boolean().default(true),
+});
+export type AutoScheduleRequest = z.infer<typeof AutoScheduleRequest>;
+
+export const AutoScheduleResult = z.object({
+  assignments: z.array(ScheduleAssignment),
+  conflicts: z.array(ScheduleConflict),
+});
+
+/** POST /stages/{id}/schedule/apply — persist an assignment set. */
+export const ApplyScheduleRequest = z.object({
+  assignments: z
+    .array(
+      z.object({
+        fixture_id: Uuid,
+        scheduled_at: IsoDateTime,
+        court_label: z.string().min(1).max(100),
+        venue: z.string().max(200).nullish(),
+        schedule_locked: z.boolean().optional(),
+      }),
+    )
+    .min(1)
+    .max(500),
+  source: z.enum(["auto", "manual"]).default("auto"),
+});
+export type ApplyScheduleRequest = z.infer<typeof ApplyScheduleRequest>;
+
+export const ApplyScheduleResult = z.object({
+  applied: z.number().int(),
+  conflicts: z.array(ScheduleConflict),
+});
+
+export const ValidateScheduleResult = z.object({
+  conflicts: z.array(ScheduleConflict),
+});
+
+export const PublishScheduleResult = z.object({
+  division_id: Uuid,
+  status: DivisionStatus,
+  published: z.boolean(),
+});
+
+export const StartDivisionResult = z.object({
+  division_id: Uuid,
+  status: DivisionStatus,
+  started: z.boolean(),
+  /** Fixtures generated by quick-start (0 when they already existed). */
+  generated: z.number().int(),
 });

--- a/apps/web/src/server/engine-db/competition.ts
+++ b/apps/web/src/server/engine-db/competition.ts
@@ -204,8 +204,9 @@ export async function recomputeStandings(
 }
 
 // Append a division_event under the division lock, assigning a gapless per-
-// division seq (doc 07 note 3). Returns the new seq.
-async function appendDivisionEvent(
+// division seq (doc 07 note 3). Returns the new seq. Callers that treat the
+// event as the division watermark also bump divisions.seq (doc 07).
+export async function appendDivisionEvent(
   tx: Tx,
   divisionId: string,
   type: string,

--- a/apps/web/src/server/engine-db/index.ts
+++ b/apps/web/src/server/engine-db/index.ts
@@ -7,6 +7,7 @@ export { rebuildState, verifyStateConsistency, type ConsistencyReport } from "./
 export {
   recomputeStandings,
   completeStageIfReady,
+  appendDivisionEvent,
   type CompleteResult,
 } from "./competition";
 export { resolveModule } from "./registry";

--- a/apps/web/src/server/usecases/__tests__/entitlements-v2.test.ts
+++ b/apps/web/src/server/usecases/__tests__/entitlements-v2.test.ts
@@ -16,6 +16,7 @@ import { createCompetition, patchCompetition, listCompetitions, getCompetition }
 import { createDivision } from "../divisions";
 import { createEntrants } from "../entrants";
 import { createStages, generateStageFixtures } from "../stages";
+import { startDivision } from "../schedule";
 import { scoreEvent } from "../scoring";
 import { createApiKey } from "../api-keys";
 
@@ -94,6 +95,8 @@ async function makeFixture(auth: AuthCtx, competitionId: string, sport: string, 
     seq: 1, kind: "league", name: "L", config: {},
   } as never);
   const { fixtures } = await generateStageFixtures(auth, stage.id);
+  // Scoring opens only after start (doc 12 §1, PROMPT-17).
+  await startDivision(auth, division.id);
   return { division, entrants, fixtureId: fixtures[0].id };
 }
 

--- a/apps/web/src/server/usecases/__tests__/integration.test.ts
+++ b/apps/web/src/server/usecases/__tests__/integration.test.ts
@@ -11,6 +11,7 @@ import { createCompetition, deleteCompetition } from "../competitions";
 import { createDivision } from "../divisions";
 import { createEntrants } from "../entrants";
 import { createStages, generateStageFixtures, completeStage, getStandings } from "../stages";
+import { startDivision } from "../schedule";
 import { scoreEvent } from "../scoring";
 import { createApiKey } from "../api-keys";
 import { publicStandings } from "../public";
@@ -109,6 +110,13 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     expect(again.created).toBe(0);
     expect(again.existing).toBe(6);
 
+    // Scoring opens only after the explicit start (doc 12 §1, PROMPT-17).
+    await expect(decide(auth, first.fixtures[0].id, 2, 0)).rejects.toSatisfy((err: unknown) =>
+      EngineError.is(err, "WRONG_PHASE"),
+    );
+    const started = await startDivision(auth, division.id);
+    expect(started.status).toBe("active");
+
     // Decide every fixture (home wins) → standings + guarded completion.
     for (const fixture of first.fixtures) {
       await decide(auth, fixture.id, 2, 0);
@@ -140,6 +148,7 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     ]);
     const [stage] = await createStages(auth, division.id, { seq: 1, kind: "league", name: "L", config: {} });
     const { fixtures } = await generateStageFixtures(auth, stage.id);
+    await startDivision(auth, division.id);
     const fixtureId = fixtures[0].id;
 
     const started = await scoreEvent(auth, fixtureId, {
@@ -198,6 +207,7 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     ]);
     const [stage] = await createStages(auth, division.id, { seq: 1, kind: "knockout", name: "KO", config: {} });
     const generated = await generateStageFixtures(auth, stage.id);
+    await startDivision(auth, division.id);
 
     const semis = generated.fixtures.filter((f) => f.round_no === 1);
     const final = generated.fixtures.find((f) => f.round_no === 2);
@@ -270,6 +280,7 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     const seedOf = new Map(entrants.map((e) => [e.id, e.seed]));
     expect([...aMembers].map((id) => seedOf.get(id as string)).sort()).toEqual([1, 4, 5, 8]);
 
+    await startDivision(auth, division.id);
     // Decide everything (home wins), complete → KO gets seeded.
     for (const fixture of generated.fixtures) await decide(auth, fixture.id, 1, 0);
     const completion = await completeStage(auth, groups.id);
@@ -337,6 +348,7 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     ]);
     const [stage] = await createStages(auth, division.id, { seq: 1, kind: "league", name: "L", config: {} });
     const { fixtures } = await generateStageFixtures(auth, stage.id);
+    await startDivision(auth, division.id);
     await decide(auth, fixtures[0].id, 1, 0);
     await expect(deleteCompetition(auth, competition.id)).rejects.toMatchObject({ status: 409 });
   });

--- a/apps/web/src/server/usecases/__tests__/schedule.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule.test.ts
@@ -1,0 +1,401 @@
+// PROMPT-17 acceptance E2E (doc 12): 8-team group+KO division — auto-schedule
+// across 2 courts with a rest constraint, drag into a court clash (blocked),
+// into a rest violation (warned, allowed), lock two cards, re-flow, publish,
+// start, score round 1, rain-reschedule remaining. Plus the Community gates
+// (doc 12 §5): constraints/board are Pro, quick-start unaffected.
+// Real Postgres required; skipped without DATABASE_URL (CI runs them).
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { EngineError } from "@seazn/engine/core";
+import { sql } from "@/lib/db";
+import { PaymentRequiredError } from "@/lib/errors";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages, generateStageFixtures } from "../stages";
+import {
+  putScheduleSettings,
+  getScheduleSettings,
+  autoSchedule,
+  applySchedule,
+  moveFixture,
+  validateSchedule,
+  publishSchedule,
+  startDivision,
+} from "../schedule";
+import { patchFixture } from "../fixtures";
+import { scoreEvent } from "../scoring";
+import { publicSchedule } from "../public";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const DIVISION_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+const T0 = "2026-08-01T09:00:00.000Z";
+const MIN = 60_000;
+const at = (minutes: number) => new Date(Date.parse(T0) + minutes * MIN).toISOString();
+
+async function seedOrg(plan: "community" | "pro"): Promise<{ auth: AuthCtx; orgSlug: string }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Org " + suffix}, ${"org-" + suffix})
+    returning id`;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(DIVISION_CONFIG)}, true)
+    on conflict do nothing`;
+  if (plan === "pro") {
+    for (const feature of ["scheduling.constraints", "scheduling.board", "scheduling.multi_division"]) {
+      await sql`
+        insert into org_entitlement_overrides (org_id, feature_key, bool_value)
+        values (${orgId}, ${feature}, true)
+        on conflict (org_id, feature_key) do update set bool_value = true`;
+    }
+  }
+  return {
+    auth: { orgId, via: "session", userId: null, role: "owner", keyId: null },
+    orgSlug: "org-" + suffix,
+  };
+}
+
+async function decide(auth: AuthCtx, fixtureId: string, homeScore: number, awayScore: number) {
+  await scoreEvent(auth, fixtureId, { expected_seq: 0, type: "core.start", payload: {} });
+  return scoreEvent(auth, fixtureId, {
+    expected_seq: 1,
+    type: "generic.result",
+    payload: { p1Score: homeScore, p2Score: awayScore },
+  });
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("scheduling console (doc 12, PROMPT-17)", () => {
+  it("drives the full plan-first lifecycle on an 8-team group+KO division", async () => {
+    const { auth, orgSlug } = await seedOrg("pro");
+    const competition = await createCompetition(auth, {
+      name: "Weekend Carnival",
+      visibility: "public",
+      branding: {},
+    });
+    const division = await createDivision(auth, competition.id, {
+      name: "Open",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+      eligibility: [],
+    });
+    await createEntrants(
+      auth,
+      division.id,
+      Array.from({ length: 8 }, (_, i) => ({
+        kind: "individual" as const,
+        display_name: `E${i + 1}`,
+        seed: i + 1,
+        members: [],
+      })),
+    );
+    const [groups] = await createStages(auth, division.id, [
+      { seq: 1, kind: "group", name: "Groups", config: { pools: { count: 2 } } },
+      {
+        seq: 2, kind: "knockout", name: "KO", config: {},
+        qualification: { take: [
+          { pool: "A", rank: 1 }, { pool: "B", rank: 2 },
+          { pool: "B", rank: 1 }, { pool: "A", rank: 2 },
+        ] },
+      },
+    ]);
+
+    // Settings: 2 courts + rest constraint (Pro — the override allows it).
+    const settings = await putScheduleSettings(auth, division.id, {
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        courts: ["Court 1", "Court 2"],
+        perEntrantMinRest: 30,
+        blackouts: [],
+        sessionWindows: [],
+      },
+      tz: "UTC",
+    });
+    expect(settings.config.courts).toHaveLength(2);
+    const roundTrip = await getScheduleSettings(auth, division.id);
+    expect(roundTrip.config.perEntrantMinRest).toBe(30);
+
+    // Generate the group stage (2 pools × 6 fixtures) and auto-schedule it.
+    const generated = await generateStageFixtures(auth, groups.id);
+    expect(generated.created).toBe(12);
+
+    const proposal = await autoSchedule(auth, groups.id, false);
+    expect(proposal.assignments).toHaveLength(12);
+    expect(proposal.conflicts.filter((c) => c.blocking)).toHaveLength(0);
+    // Both courts in use; per-entrant rest ≥ 30 min in the proposal.
+    expect(new Set(proposal.assignments.map((a) => a.court_label))).toEqual(
+      new Set(["Court 1", "Court 2"]),
+    );
+
+    // Propose-only: nothing persisted until apply (doc 12 §4).
+    const [{ n: persisted }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from fixtures
+      where stage_id = ${groups.id} and scheduled_at is not null`;
+    expect(persisted).toBe(0);
+
+    const applied = await applySchedule(auth, groups.id, {
+      assignments: proposal.assignments.map((a) => ({
+        fixture_id: a.fixture_id,
+        scheduled_at: a.scheduled_at,
+        court_label: a.court_label,
+      })),
+      source: "auto",
+    });
+    expect(applied.applied).toBe(12);
+
+    const board = await sql<
+      { id: string; scheduled_at: Date; court_label: string; home_entrant_id: string; away_entrant_id: string; schedule_source: string }[]
+    >`
+      select id, scheduled_at, court_label, home_entrant_id, away_entrant_id, schedule_source
+      from fixtures where stage_id = ${groups.id} order by scheduled_at, court_label`;
+    expect(board.every((f) => f.schedule_source === "auto")).toBe(true);
+
+    // Rest constraint honoured in the persisted board.
+    const byEntrant = new Map<string, number[]>();
+    for (const f of board) {
+      for (const e of [f.home_entrant_id, f.away_entrant_id]) {
+        (byEntrant.get(e) ?? byEntrant.set(e, []).get(e)!).push(f.scheduled_at.getTime());
+      }
+    }
+    for (const times of byEntrant.values()) {
+      times.sort((a, b) => a - b);
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i]! - times[i - 1]!).toBeGreaterThanOrEqual((30 + 30) * MIN);
+      }
+    }
+
+    // Drag into a court clash → BLOCKED (conflict.court, doc 12 §2), nothing moves.
+    const [f1, f2] = [board[0]!, board.find((f) => f.id !== board[0]!.id)!];
+    await expect(
+      moveFixture(auth, f2.id, {
+        scheduled_at: f1.scheduled_at.toISOString(),
+        court_label: f1.court_label,
+      }),
+    ).rejects.toSatisfy((err: unknown) => EngineError.is(err, "SCHEDULE_CONFLICT"));
+    const [f2After] = await sql<{ scheduled_at: Date; court_label: string }[]>`
+      select scheduled_at, court_label from fixtures where id = ${f2.id}`;
+    expect(f2After.scheduled_at.getTime()).toBe(f2.scheduled_at.getTime());
+    expect(f2After.court_label).toBe(f2.court_label);
+
+    // Drag into a rest violation → warned but ALLOWED. Park two fixtures that
+    // share an entrant back-to-back on different courts, far from the rest.
+    const shared = board.find(
+      (f) =>
+        f.id !== f1.id &&
+        (f.home_entrant_id === f1.home_entrant_id || f.away_entrant_id === f1.home_entrant_id ||
+         f.home_entrant_id === f1.away_entrant_id || f.away_entrant_id === f1.away_entrant_id),
+    )!;
+    await moveFixture(auth, f1.id, { scheduled_at: at(600), court_label: "Court 1" });
+    await moveFixture(auth, shared.id, { scheduled_at: at(630), court_label: "Court 2" });
+    const report = await validateSchedule(auth, division.id);
+    const restWarnings = report.conflicts.filter((c) => c.code === "warn.rest");
+    expect(restWarnings.length).toBeGreaterThan(0);
+    expect(restWarnings.every((c) => !c.blocking)).toBe(true);
+    // The single move is audited (doc 12 §2: schedule_edited {fixture, from, to}).
+    const [{ n: edits }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from division_events
+      where division_id = ${division.id} and type = 'schedule_edited'`;
+    expect(edits).toBeGreaterThanOrEqual(2);
+
+    // Lock two cards, re-flow the rest: pins survive byte-identically.
+    const pinA = board[2]!;
+    const pinB = board[3]!;
+    await patchFixture(auth, pinA.id, { schedule_locked: true });
+    await patchFixture(auth, pinB.id, { schedule_locked: true });
+    const reflow = await autoSchedule(auth, groups.id, true);
+    const pinnedOut = new Map(reflow.assignments.map((a) => [a.fixture_id, a]));
+    expect(pinnedOut.get(pinA.id)?.scheduled_at).toBe(pinA.scheduled_at.toISOString());
+    expect(pinnedOut.get(pinA.id)?.court_label).toBe(pinA.court_label);
+    expect(pinnedOut.get(pinB.id)?.scheduled_at).toBe(pinB.scheduled_at.toISOString());
+    await applySchedule(auth, groups.id, {
+      assignments: reflow.assignments.map((a) => ({
+        fixture_id: a.fixture_id,
+        scheduled_at: a.scheduled_at,
+        court_label: a.court_label,
+      })),
+      source: "auto",
+    });
+
+    // Publish-gating (PROMPT-17 item 7): while the division is in setup the
+    // public schedule shows no timetable; publish lights it up.
+    const before = (await publicSchedule(orgSlug, competition.slug, division.slug)) as {
+      fixtures: { scheduled_at: string | null }[];
+    };
+    expect(before.fixtures.every((f) => f.scheduled_at === null)).toBe(true);
+
+    const published = await publishSchedule(auth, division.id);
+    expect(published.status).toBe("scheduled");
+    const after = (await publicSchedule(orgSlug, competition.slug, division.slug)) as {
+      fixtures: { scheduled_at: string | null }[];
+    };
+    expect(after.fixtures.some((f) => f.scheduled_at !== null)).toBe(true);
+
+    // Scoring is still closed between publish and start (doc 12 §1).
+    await expect(decide(auth, board[4]!.id, 1, 0)).rejects.toSatisfy((err: unknown) =>
+      EngineError.is(err, "WRONG_PHASE"),
+    );
+    const startOut = await startDivision(auth, division.id);
+    expect(startOut).toMatchObject({ status: "active", started: true, generated: 0 });
+
+    // Score round 1.
+    const round1 = await sql<{ id: string }[]>`
+      select id from fixtures where stage_id = ${groups.id} and round_no = 1`;
+    for (const f of round1) await decide(auth, f.id, 2, 0);
+
+    // Rain! Reschedule the remaining fixtures only; decided ones are immutable.
+    const remaining = await sql<{ id: string }[]>`
+      select id from fixtures where stage_id = ${groups.id} and status = 'scheduled'
+      order by scheduled_at, id`;
+    expect(remaining.length).toBeGreaterThan(0);
+    const rain = await applySchedule(auth, groups.id, {
+      assignments: remaining.map((f, i) => ({
+        fixture_id: f.id,
+        scheduled_at: at(24 * 60 + i * 35),
+        court_label: "Court 1",
+      })),
+      source: "auto",
+    });
+    expect(rain.applied).toBe(remaining.length);
+    await expect(
+      moveFixture(auth, round1[0]!.id, { scheduled_at: at(24 * 60), court_label: "Court 2" }),
+    ).rejects.toMatchObject({ status: 422 });
+    await expect(
+      applySchedule(auth, groups.id, {
+        assignments: [{ fixture_id: round1[0]!.id, scheduled_at: at(25 * 60), court_label: "Court 2" }],
+        source: "auto",
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    // The structural ledger recorded the whole story.
+    const events = await sql<{ type: string }[]>`
+      select type from division_events where division_id = ${division.id} order by seq`;
+    const types = new Set(events.map((e) => e.type));
+    for (const expected of ["schedule_applied", "schedule_edited", "schedule_published", "division_started"]) {
+      expect(types).toContain(expected);
+    }
+  });
+
+  it("Community org: constraints/board are 402-gated, quick-start unaffected", async () => {
+    const { auth } = await seedOrg("community");
+    const competition = await createCompetition(auth, { name: "Club Night", visibility: "private", branding: {} });
+    const division = await createDivision(auth, competition.id, {
+      name: "Open", sport_key: "generic", variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false }, eligibility: [],
+    });
+    await createEntrants(auth, division.id, [
+      { kind: "individual", display_name: "A", seed: 1, members: [] },
+      { kind: "individual", display_name: "B", seed: 2, members: [] },
+      { kind: "individual", display_name: "C", seed: 3, members: [] },
+      { kind: "individual", display_name: "D", seed: 4, members: [] },
+    ]);
+    const [stage] = await createStages(auth, division.id, { seq: 1, kind: "league", name: "L", config: {} });
+
+    // Constraint solver fields → 402 scheduling.constraints (doc 12 §5).
+    await expect(
+      putScheduleSettings(auth, division.id, {
+        config: {
+          startAt: T0, matchMinutes: 30, gapMinutes: 0,
+          courts: ["C1", "C2"], // multi-court is the constraint solver
+          perEntrantMinRest: 0, blackouts: [], sessionWindows: [],
+        },
+        tz: "UTC",
+      }),
+    ).rejects.toMatchObject({ featureKey: "scheduling.constraints" });
+
+    // Basic single-court settings + basic auto are Community features.
+    await putScheduleSettings(auth, division.id, {
+      config: {
+        startAt: T0, matchMinutes: 30, gapMinutes: 0,
+        courts: ["C1"], perEntrantMinRest: 0, blackouts: [], sessionWindows: [],
+      },
+      tz: "UTC",
+    });
+    const { fixtures } = await generateStageFixtures(auth, stage.id);
+    const proposal = await autoSchedule(auth, stage.id, false);
+    expect(proposal.assignments).toHaveLength(6);
+    await applySchedule(auth, stage.id, {
+      assignments: proposal.assignments.map((a) => ({
+        fixture_id: a.fixture_id, scheduled_at: a.scheduled_at, court_label: a.court_label,
+      })),
+      source: "auto",
+    });
+
+    // Board editing (pins, manual assignment sets) is Pro (view-only board).
+    await expect(
+      patchFixture(auth, fixtures[0]!.id, { schedule_locked: true }),
+    ).rejects.toBeInstanceOf(PaymentRequiredError);
+    await expect(
+      applySchedule(auth, stage.id, {
+        assignments: [{ fixture_id: fixtures[0]!.id, scheduled_at: at(600), court_label: "C1" }],
+        source: "manual",
+      }),
+    ).rejects.toMatchObject({ featureKey: "scheduling.board" });
+
+    // Quick-start unaffected: start opens scoring immediately.
+    const started = await startDivision(auth, division.id);
+    expect(started.status).toBe("active");
+    const out = await decide(auth, fixtures[0]!.id, 2, 1);
+    expect(out.status).toBe("decided");
+  });
+
+  it("quick-start generates fixtures and slots rolling round times (doc 12 §1.A)", async () => {
+    const { auth } = await seedOrg("community");
+    const competition = await createCompetition(auth, { name: "Rolling", visibility: "private", branding: {} });
+    const division = await createDivision(auth, competition.id, {
+      name: "Open", sport_key: "generic", variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false }, eligibility: [],
+    });
+    await createEntrants(auth, division.id, [
+      { kind: "individual", display_name: "A", seed: 1, members: [] },
+      { kind: "individual", display_name: "B", seed: 2, members: [] },
+      { kind: "individual", display_name: "C", seed: 3, members: [] },
+      { kind: "individual", display_name: "D", seed: 4, members: [] },
+    ]);
+    await createStages(auth, division.id, { seq: 1, kind: "league", name: "L", config: {} });
+    await putScheduleSettings(auth, division.id, {
+      config: {
+        startAt: T0, matchMinutes: 25, gapMinutes: 0,
+        courts: ["C1"], perEntrantMinRest: 0, blackouts: [], sessionWindows: [],
+        roundMinutes: 60,
+      },
+      tz: "UTC",
+    });
+
+    // One click: generate → sequence-slot → active (no fixtures existed).
+    const started = await startDivision(auth, division.id);
+    expect(started.started).toBe(true);
+    expect(started.generated).toBe(6);
+
+    const rows = await sql<{ round_no: number; scheduled_at: Date | null }[]>`
+      select round_no, scheduled_at from fixtures f
+      join stages s on s.id = f.stage_id
+      where s.division_id = ${division.id} order by round_no`;
+    // Rolling: round r starts at startAt + (r−1)·roundMinutes.
+    for (const r of rows) {
+      expect(r.scheduled_at?.toISOString()).toBe(at((r.round_no - 1) * 60));
+    }
+  });
+});

--- a/apps/web/src/server/usecases/fixtures.ts
+++ b/apps/web/src/server/usecases/fixtures.ts
@@ -7,6 +7,7 @@ import { HttpError } from "@/lib/errors";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { PatchFixture, PutLineup } from "@/server/api-v1/schemas";
 import { FIXTURE_COLS, type FixtureRow } from "./stages";
+import { moveFixture } from "./schedule";
 
 export async function getFixture(auth: AuthCtx, id: string): Promise<FixtureRow> {
   return withTenant(auth.orgId, async (tx) => {
@@ -30,15 +31,20 @@ export async function listDivisionFixtures(auth: AuthCtx, divisionId: string): P
 }
 
 export async function patchFixture(auth: AuthCtx, id: string, patch: PatchFixture): Promise<FixtureRow> {
+  // Schedule-touching fields go through the scheduling console's move path
+  // (doc 12 §4): conflict validation (court clashes / direct-feed order
+  // violations block), schedule_edited ledger event, board realtime refresh.
+  const { officials, ...move } = patch;
+  if (Object.keys(move).length > 0) {
+    await moveFixture(auth, id, move);
+  }
   return withTenant(auth.orgId, async (tx) => {
-    const cols = Object.keys(patch);
-    const values = {
-      ...patch,
-      ...(patch.officials ? { officials: tx.json(patch.officials as never) } : {}),
-    };
+    if (officials) {
+      await tx`
+        update fixtures set officials = ${tx.json(officials as never)} where id = ${id}`;
+    }
     const [row] = await tx<FixtureRow[]>`
-      update fixtures set ${tx(values as never, ...(cols as never[]))}
-      where id = ${id} returning ${tx(FIXTURE_COLS)}`;
+      select ${tx(FIXTURE_COLS)} from fixtures where id = ${id}`;
     if (!row) throw new HttpError(404, "fixture not found");
     return row;
   });

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -1,0 +1,740 @@
+import "server-only";
+// Scheduling console use-cases (doc 12, PROMPT-17): schedule-settings PUT,
+// the pure auto pass (propose only), transactional apply, single-fixture move,
+// full-board validation, publish, and the division start action. The engine
+// stays pure — this module converts DB rows ↔ engine inputs (epoch ms) and
+// owns every persist.
+import type postgres from "postgres";
+import { withTenant } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { requireFeature } from "@/lib/entitlements";
+import { cacheDelPattern } from "@/lib/cache";
+import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
+import { publishDivisionUpdate } from "@/lib/realtime";
+import { EngineError } from "@seazn/engine/core";
+import {
+  slotFixtures,
+  validateAssignments,
+  type Assignment,
+  type Conflict,
+  type OrderDependency,
+  type SchedulableFixture,
+  type SlotConfig,
+} from "@seazn/engine/scheduling";
+import { appendDivisionEvent } from "@/server/engine-db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import {
+  ScheduleConfig,
+  type ApplyScheduleRequest,
+  type PutScheduleSettings,
+  type ScheduleConflict,
+} from "@/server/api-v1/schemas";
+import { assertCompetitionNotFrozen } from "./entitlement-freeze";
+import { generateStageFixtures } from "./stages";
+
+type Tx = postgres.TransactionSql;
+
+const MS_PER_MIN = 60_000;
+const ms = (v: string | Date): number => new Date(v).getTime();
+const iso = (t: number): string => new Date(t).toISOString();
+
+// Every schedule write invalidates both public cache layers (the same pattern
+// as scoring, doc 09 §3 / doc 12 §2) and refreshes any open boards.
+function afterScheduleWrite(
+  divisionId: string,
+  competitionId: string,
+  reason: "schedule" | "publish" | "start",
+): void {
+  fireDivisionRevalidate(divisionId, competitionId);
+  void cacheDelPattern(`pub:v1:div:${divisionId}:*`);
+  void publishDivisionUpdate(divisionId, reason);
+}
+
+// A fixture the auto pass / board may still move; everything else on the
+// timetable is a fixed obstacle (doc 12 §6: decided fixtures are immutable —
+// rain-rescheduling touches remaining fixtures only).
+const MOVABLE_STATUS = "scheduled";
+// Statuses that still occupy a court (cancelled/abandoned ones do not).
+const OCCUPYING = ["scheduled", "in_play", "decided", "finalized", "forfeited"];
+
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+export interface ScheduleSettingsOut {
+  division_id: string;
+  config: ScheduleConfig;
+  tz: string;
+  updated_at: string;
+}
+
+/** Does a config use the Pro constraint solver (doc 12 §5)? Community keeps
+ *  quick-start + basic auto: one court, no rest/blackout/session constraints. */
+function usesConstraints(config: ScheduleConfig): boolean {
+  return (
+    config.perEntrantMinRest > 0 ||
+    config.blackouts.length > 0 ||
+    config.sessionWindows.length > 0 ||
+    config.courts.length > 1
+  );
+}
+
+export async function putScheduleSettings(
+  auth: AuthCtx,
+  divisionId: string,
+  input: PutScheduleSettings,
+): Promise<ScheduleSettingsOut> {
+  if (usesConstraints(input.config)) {
+    await requireFeature(auth.orgId, "scheduling.constraints");
+  }
+  return withTenant(auth.orgId, async (tx) => {
+    const [division] = await tx<{ competition_id: string }[]>`
+      select competition_id from divisions where id = ${divisionId}`;
+    if (!division) throw new HttpError(404, "division not found");
+    await assertCompetitionNotFrozen(auth.orgId, division.competition_id, tx);
+    const [row] = await tx<{ division_id: string; config: unknown; tz: string; updated_at: string }[]>`
+      insert into schedule_settings (division_id, config, tz, updated_at)
+      values (${divisionId}, ${tx.json(input.config as never)}, ${input.tz}, now())
+      on conflict (division_id) do update
+        set config = excluded.config, tz = excluded.tz, updated_at = now()
+      returning division_id, config, tz, updated_at`;
+    return { ...row, config: ScheduleConfig.parse(row.config) };
+  });
+}
+
+export async function getScheduleSettings(
+  auth: AuthCtx,
+  divisionId: string,
+): Promise<ScheduleSettingsOut> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [division] = await tx`select 1 from divisions where id = ${divisionId}`;
+    if (!division) throw new HttpError(404, "division not found");
+    return loadSettings(tx, divisionId);
+  });
+}
+
+// Settings row or the parsed defaults — the board and quick-start work
+// without an explicit PUT (single court, no constraints).
+async function loadSettings(tx: Tx, divisionId: string): Promise<ScheduleSettingsOut> {
+  const [row] = await tx<{ division_id: string; config: unknown; tz: string; updated_at: string }[]>`
+    select division_id, config, tz, updated_at from schedule_settings
+    where division_id = ${divisionId}`;
+  if (row) return { ...row, config: ScheduleConfig.parse(row.config) };
+  return {
+    division_id: divisionId,
+    config: ScheduleConfig.parse({}),
+    tz: "UTC",
+    updated_at: new Date(0).toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Engine input assembly
+// ---------------------------------------------------------------------------
+
+interface FixtureLite {
+  id: string;
+  stage_id: string;
+  division_id: string;
+  round_no: number;
+  home_entrant_id: string | null;
+  away_entrant_id: string | null;
+  scheduled_at: string | Date | null;
+  court_label: string | null;
+  status: string;
+  schedule_locked: boolean;
+  winner_to_fixture: string | null;
+  loser_to_fixture: string | null;
+}
+
+const FIXTURE_LITE_COLS = [
+  "id", "stage_id", "division_id", "round_no", "home_entrant_id", "away_entrant_id",
+  "scheduled_at", "court_label", "status", "schedule_locked",
+  "winner_to_fixture", "loser_to_fixture",
+] as const;
+
+async function divisionFixtures(tx: Tx, divisionId: string): Promise<FixtureLite[]> {
+  return tx<FixtureLite[]>`
+    select ${tx(FIXTURE_LITE_COLS)} from fixtures
+    where division_id = ${divisionId} and status in ${tx(OCCUPYING)}
+    order by round_no, seq_in_round, id`;
+}
+
+// person ids per entrant, for cross-division overlap warnings (doc 06 §4.3).
+async function peopleByEntrant(tx: Tx, entrantIds: string[]): Promise<Map<string, string[]>> {
+  const map = new Map<string, string[]>();
+  if (entrantIds.length === 0) return map;
+  const rows = await tx<{ entrant_id: string; person_id: string }[]>`
+    select entrant_id, person_id from entrant_members where entrant_id in ${tx(entrantIds)}`;
+  for (const r of rows) {
+    (map.get(r.entrant_id) ?? map.set(r.entrant_id, []).get(r.entrant_id)!).push(r.person_id);
+  }
+  return map;
+}
+
+function peopleOf(f: FixtureLite, people: Map<string, string[]>): string[] {
+  return [
+    ...(f.home_entrant_id ? (people.get(f.home_entrant_id) ?? []) : []),
+    ...(f.away_entrant_id ? (people.get(f.away_entrant_id) ?? []) : []),
+  ];
+}
+
+function toAssignment(f: FixtureLite, matchMinutes: number, people: Map<string, string[]>): Assignment {
+  const start = ms(f.scheduled_at as string | Date);
+  return {
+    fixtureId: f.id,
+    court: f.court_label ?? "",
+    startAt: start,
+    endAt: start + matchMinutes * MS_PER_MIN,
+    entrants: [f.home_entrant_id, f.away_entrant_id].filter((e): e is string => e !== null),
+    people: peopleOf(f, people),
+  };
+}
+
+// Direct-feed dependencies (doc 12 §2 warn.order): the source fixture's
+// winner/loser feeds the target, so the target must not start earlier.
+function feedDependencies(fixtures: readonly FixtureLite[]): OrderDependency[] {
+  const ids = new Set(fixtures.map((f) => f.id));
+  const deps: OrderDependency[] = [];
+  for (const f of fixtures) {
+    for (const target of [f.winner_to_fixture, f.loser_to_fixture]) {
+      if (target !== null && ids.has(target)) {
+        deps.push({ fixtureId: target, dependsOn: f.id, direct: true });
+      }
+    }
+  }
+  return deps;
+}
+
+// Sibling divisions' timetables (doc 06 §4.3): fixed court occupancy for the
+// pass, and the source of cross-division person-overlap warnings. Durations
+// use each sibling's own matchMinutes when it has settings.
+async function siblingAssignments(
+  tx: Tx,
+  divisionId: string,
+  competitionId: string,
+  fallbackMatchMinutes: number,
+): Promise<Assignment[]> {
+  const rows = await tx<FixtureLite[]>`
+    select ${tx(FIXTURE_LITE_COLS)} from fixtures
+    where division_id in (select id from divisions
+                          where competition_id = ${competitionId} and id <> ${divisionId})
+      and scheduled_at is not null and court_label is not null
+      and status in ${tx(OCCUPYING)}`;
+  if (rows.length === 0) return [];
+  const settings = await tx<{ division_id: string; config: unknown }[]>`
+    select division_id, config from schedule_settings
+    where division_id in ${tx([...new Set(rows.map((r) => r.division_id))])}`;
+  const minutes = new Map(
+    settings.map((s) => [s.division_id, ScheduleConfig.parse(s.config).matchMinutes]),
+  );
+  const entrantIds = [
+    ...new Set(rows.flatMap((r) => [r.home_entrant_id, r.away_entrant_id])),
+  ].filter((e): e is string => e !== null);
+  const people = await peopleByEntrant(tx, entrantIds);
+  return rows.map((r) =>
+    toAssignment(r, minutes.get(r.division_id) ?? fallbackMatchMinutes, people),
+  );
+}
+
+function toSlotConfig(settings: ScheduleSettingsOut, now: number): SlotConfig {
+  const c = settings.config;
+  return {
+    startAt: c.startAt ? ms(c.startAt) : now,
+    matchMinutes: c.matchMinutes,
+    gapMinutes: c.gapMinutes,
+    courts: [...c.courts],
+    perEntrantMinRest: c.perEntrantMinRest,
+    blackouts: c.blackouts.map((b) => ({
+      ...(b.court !== undefined ? { court: b.court } : {}),
+      from: ms(b.from),
+      to: ms(b.to),
+    })),
+    sessionWindows: c.sessionWindows.map((w) => ({ from: ms(w.from), to: ms(w.to) })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Conflict taxonomy (doc 12 §2) — engine reasons → API codes
+// ---------------------------------------------------------------------------
+
+const REASON_CODE: Record<Conflict["reason"], ScheduleConflict["code"]> = {
+  court: "conflict.court",
+  rest: "warn.rest",
+  person_overlap: "warn.person_overlap",
+  order: "warn.order",
+  blackout: "warn.blackout",
+  no_slot: "warn.no_slot",
+};
+
+function mapConflicts(conflicts: readonly Conflict[]): ScheduleConflict[] {
+  return conflicts.map((c) => ({
+    fixture_id: c.fixtureId,
+    code: REASON_CODE[c.reason],
+    // conflict.court blocks (physically impossible); warn.order blocks for
+    // direct feeds; everything else is a badge (doc 12 §2).
+    blocking: c.reason === "court" || (c.reason === "order" && c.direct === true),
+    ...(c.detail !== undefined ? { detail: c.detail } : {}),
+  }));
+}
+
+function assertNoBlocking(conflicts: ScheduleConflict[]): void {
+  const blocking = conflicts.filter((c) => c.blocking);
+  if (blocking.length > 0) {
+    throw new EngineError("SCHEDULE_CONFLICT", "schedule change hits a blocking conflict", {
+      conflicts: blocking,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auto pass (propose only — doc 12 §4: nothing persisted)
+// ---------------------------------------------------------------------------
+
+export interface AutoScheduleOut {
+  assignments: { fixture_id: string; scheduled_at: string; ends_at: string; court_label: string }[];
+  conflicts: ScheduleConflict[];
+}
+
+export async function autoSchedule(
+  auth: AuthCtx,
+  stageId: string,
+  onlyUnlocked: boolean,
+): Promise<AutoScheduleOut> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [stage] = await tx<{ division_id: string; competition_id: string }[]>`
+      select s.division_id, d.competition_id
+      from stages s join divisions d on d.id = s.division_id
+      where s.id = ${stageId}`;
+    if (!stage) throw new HttpError(404, "stage not found");
+
+    const settings = await loadSettings(tx, stage.division_id);
+    const all = await divisionFixtures(tx, stage.division_id);
+    const entrantIds = [
+      ...new Set(all.flatMap((f) => [f.home_entrant_id, f.away_entrant_id])),
+    ].filter((e): e is string => e !== null);
+    const people = await peopleByEntrant(tx, entrantIds);
+
+    // Movable: this stage's undecided fixtures. Fixed obstacles: everything
+    // already on the timetable elsewhere in the division (other stages,
+    // decided fixtures) plus sibling divisions.
+    const movable = all.filter((f) => f.stage_id === stageId && f.status === MOVABLE_STATUS);
+    const obstacles = all
+      .filter((f) => !movable.includes(f))
+      .filter((f) => f.scheduled_at !== null && f.court_label !== null)
+      .map((f) => toAssignment(f, settings.config.matchMinutes, people));
+    const siblings = await siblingAssignments(
+      tx,
+      stage.division_id,
+      stage.competition_id,
+      settings.config.matchMinutes,
+    );
+
+    const schedulable: SchedulableFixture[] = movable.map((f) => ({
+      id: f.id,
+      roundNo: f.round_no,
+      ...(f.home_entrant_id !== null ? { home: f.home_entrant_id } : {}),
+      ...(f.away_entrant_id !== null ? { away: f.away_entrant_id } : {}),
+      people: peopleOf(f, people),
+      // Re-flow remaining (doc 12 §2): pinned cards are fixed obstacles.
+      ...(onlyUnlocked && f.schedule_locked && f.scheduled_at !== null && f.court_label !== null
+        ? { locked: { court: f.court_label, startAt: ms(f.scheduled_at) } }
+        : {}),
+    }));
+
+    const result = slotFixtures({
+      fixtures: schedulable,
+      config: toSlotConfig(settings, roundToMinute(Date.now())),
+      existing: [...obstacles, ...siblings],
+    });
+    return {
+      assignments: result.assignments.map((a) => ({
+        fixture_id: a.fixtureId,
+        scheduled_at: iso(a.startAt),
+        ends_at: iso(a.endAt),
+        court_label: a.court,
+      })),
+      conflicts: mapConflicts(result.conflicts),
+    };
+  });
+}
+
+const roundToMinute = (t: number): number => Math.ceil(t / MS_PER_MIN) * MS_PER_MIN;
+
+// ---------------------------------------------------------------------------
+// Apply (transactional persist — doc 12 §4)
+// ---------------------------------------------------------------------------
+
+export interface ApplyScheduleOut {
+  applied: number;
+  conflicts: ScheduleConflict[];
+}
+
+export async function applySchedule(
+  auth: AuthCtx,
+  stageId: string,
+  input: ApplyScheduleRequest,
+): Promise<ApplyScheduleOut> {
+  // Manual assignment sets and pin changes are board editing — Pro (doc 12 §5;
+  // Community keeps the basic auto flow).
+  if (input.source === "manual" || input.assignments.some((a) => a.schedule_locked !== undefined)) {
+    await requireFeature(auth.orgId, "scheduling.board");
+  }
+  const out = await withTenant(auth.orgId, async (tx) => {
+    const [stage] = await tx<{ division_id: string; competition_id: string }[]>`
+      select s.division_id, d.competition_id
+      from stages s join divisions d on d.id = s.division_id
+      where s.id = ${stageId}`;
+    if (!stage) throw new HttpError(404, "stage not found");
+    await tx`select pg_advisory_xact_lock(hashtext(${"division:" + stage.division_id}))`;
+    await assertCompetitionNotFrozen(auth.orgId, stage.competition_id, tx);
+
+    const settings = await loadSettings(tx, stage.division_id);
+    const all = await divisionFixtures(tx, stage.division_id);
+    const byId = new Map(all.map((f) => [f.id, f]));
+    for (const a of input.assignments) {
+      const f = byId.get(a.fixture_id);
+      if (!f || f.stage_id !== stageId) {
+        throw new HttpError(422, `fixture ${a.fixture_id} is not part of this stage`);
+      }
+      if (f.status !== MOVABLE_STATUS) {
+        throw new HttpError(422, `fixture ${a.fixture_id} is ${f.status} — decided fixtures are immutable`);
+      }
+    }
+
+    const entrantIds = [
+      ...new Set(all.flatMap((f) => [f.home_entrant_id, f.away_entrant_id])),
+    ].filter((e): e is string => e !== null);
+    const people = await peopleByEntrant(tx, entrantIds);
+
+    const proposed: Assignment[] = input.assignments.map((a) => {
+      const f = byId.get(a.fixture_id) as FixtureLite;
+      const start = ms(a.scheduled_at);
+      return {
+        fixtureId: a.fixture_id,
+        court: a.court_label,
+        startAt: start,
+        endAt: start + settings.config.matchMinutes * MS_PER_MIN,
+        entrants: [f.home_entrant_id, f.away_entrant_id].filter((e): e is string => e !== null),
+        people: peopleOf(f, people),
+      };
+    });
+    const listed = new Set(input.assignments.map((a) => a.fixture_id));
+    const untouched = all
+      .filter((f) => !listed.has(f.id) && f.scheduled_at !== null && f.court_label !== null)
+      .map((f) => toAssignment(f, settings.config.matchMinutes, people));
+    const siblings = await siblingAssignments(
+      tx,
+      stage.division_id,
+      stage.competition_id,
+      settings.config.matchMinutes,
+    );
+
+    const conflicts = mapConflicts(
+      validateAssignments(
+        proposed,
+        toSlotConfig(settings, 0),
+        [...untouched, ...siblings],
+        feedDependencies(all),
+      ),
+    );
+    assertNoBlocking(conflicts);
+
+    const moves: { fixture: string; from: unknown; to: unknown }[] = [];
+    for (const a of input.assignments) {
+      const f = byId.get(a.fixture_id) as FixtureLite;
+      await tx`
+        update fixtures set
+          scheduled_at = ${a.scheduled_at},
+          court_label = ${a.court_label},
+          venue = coalesce(${a.venue ?? null}, venue),
+          schedule_source = ${input.source},
+          schedule_locked = ${a.schedule_locked ?? f.schedule_locked}
+        where id = ${a.fixture_id}`;
+      moves.push({
+        fixture: a.fixture_id,
+        from: {
+          at: f.scheduled_at !== null ? iso(ms(f.scheduled_at)) : null,
+          court: f.court_label,
+        },
+        to: { at: a.scheduled_at, court: a.court_label },
+      });
+    }
+    // One auditable ledger entry per apply (doc 12 §2 family: schedule_edited/…).
+    const seq = await appendDivisionEvent(tx, stage.division_id, "schedule_applied", {
+      stageId,
+      source: input.source,
+      moves,
+    });
+    await tx`update divisions set seq = ${seq} where id = ${stage.division_id}`;
+    return { divisionId: stage.division_id, competitionId: stage.competition_id, applied: input.assignments.length, conflicts };
+  });
+  afterScheduleWrite(out.divisionId, out.competitionId, "schedule");
+  return { applied: out.applied, conflicts: out.conflicts };
+}
+
+// ---------------------------------------------------------------------------
+// Single move (fixture PATCH, doc 12 §4) — used by the drag-and-drop board
+// ---------------------------------------------------------------------------
+
+export interface MoveInput {
+  scheduled_at?: string | null;
+  court_label?: string | null;
+  venue?: string | null;
+  schedule_locked?: boolean;
+}
+
+/**
+ * Schedule-aware single-fixture move: blocks on conflict.court / direct
+ * warn.order (409 with the conflicts), otherwise persists and appends
+ * `schedule_edited {fixture, from, to}` (doc 12 §2).
+ */
+export async function moveFixture(
+  auth: AuthCtx,
+  fixtureId: string,
+  patch: MoveInput,
+): Promise<void> {
+  if (patch.schedule_locked !== undefined) {
+    await requireFeature(auth.orgId, "scheduling.board");
+  }
+  const out = await withTenant(auth.orgId, async (tx) => {
+    const [fixture] = await tx<
+      (FixtureLite & { competition_id: string })[]
+    >`
+      select f.id, f.stage_id, f.division_id, f.round_no, f.home_entrant_id,
+             f.away_entrant_id, f.scheduled_at, f.court_label, f.status,
+             f.schedule_locked, f.winner_to_fixture, f.loser_to_fixture,
+             d.competition_id
+      from fixtures f join divisions d on d.id = f.division_id
+      where f.id = ${fixtureId}`;
+    if (!fixture) throw new HttpError(404, "fixture not found");
+    await tx`select pg_advisory_xact_lock(hashtext(${"division:" + fixture.division_id}))`;
+    await assertCompetitionNotFrozen(auth.orgId, fixture.competition_id, tx);
+
+    const movesTimetable = patch.scheduled_at !== undefined || patch.court_label !== undefined;
+    if (movesTimetable && fixture.status !== MOVABLE_STATUS) {
+      throw new HttpError(422, `fixture is ${fixture.status} — decided fixtures are immutable`);
+    }
+
+    const settings = await loadSettings(tx, fixture.division_id);
+    const nextAt = patch.scheduled_at !== undefined ? patch.scheduled_at : (fixture.scheduled_at !== null ? iso(ms(fixture.scheduled_at)) : null);
+    const nextCourt = patch.court_label !== undefined ? patch.court_label : fixture.court_label;
+
+    let conflicts: ScheduleConflict[] = [];
+    if (movesTimetable && nextAt !== null && nextCourt !== null) {
+      const all = await divisionFixtures(tx, fixture.division_id);
+      const entrantIds = [
+        ...new Set(all.flatMap((f) => [f.home_entrant_id, f.away_entrant_id])),
+      ].filter((e): e is string => e !== null);
+      const people = await peopleByEntrant(tx, entrantIds);
+      const start = ms(nextAt);
+      const proposed: Assignment = {
+        fixtureId: fixture.id,
+        court: nextCourt,
+        startAt: start,
+        endAt: start + settings.config.matchMinutes * MS_PER_MIN,
+        entrants: [fixture.home_entrant_id, fixture.away_entrant_id].filter(
+          (e): e is string => e !== null,
+        ),
+        people: peopleOf(fixture, people),
+      };
+      const others = all
+        .filter((f) => f.id !== fixture.id && f.scheduled_at !== null && f.court_label !== null)
+        .map((f) => toAssignment(f, settings.config.matchMinutes, people));
+      const siblings = await siblingAssignments(
+        tx,
+        fixture.division_id,
+        fixture.competition_id,
+        settings.config.matchMinutes,
+      );
+      conflicts = mapConflicts(
+        validateAssignments(
+          [proposed],
+          toSlotConfig(settings, 0),
+          [...others, ...siblings],
+          feedDependencies(all),
+        ),
+      );
+      assertNoBlocking(conflicts);
+    }
+
+    const values: Record<string, unknown> = {};
+    if (patch.scheduled_at !== undefined) values.scheduled_at = patch.scheduled_at;
+    if (patch.court_label !== undefined) values.court_label = patch.court_label;
+    if (patch.venue !== undefined) values.venue = patch.venue;
+    if (patch.schedule_locked !== undefined) values.schedule_locked = patch.schedule_locked;
+    if (movesTimetable) values.schedule_source = "manual";
+    if (Object.keys(values).length > 0) {
+      await tx`
+        update fixtures set ${tx(values as never, ...(Object.keys(values) as never[]))}
+        where id = ${fixture.id}`;
+    }
+
+    if (movesTimetable || patch.schedule_locked !== undefined) {
+      const seq = await appendDivisionEvent(tx, fixture.division_id, "schedule_edited", {
+        fixture: fixture.id,
+        from: {
+          at: fixture.scheduled_at !== null ? iso(ms(fixture.scheduled_at)) : null,
+          court: fixture.court_label,
+          locked: fixture.schedule_locked,
+        },
+        to: {
+          at: nextAt,
+          court: nextCourt,
+          locked: patch.schedule_locked ?? fixture.schedule_locked,
+        },
+      });
+      await tx`update divisions set seq = ${seq} where id = ${fixture.division_id}`;
+    }
+    return { divisionId: fixture.division_id, competitionId: fixture.competition_id };
+  });
+  afterScheduleWrite(out.divisionId, out.competitionId, "schedule");
+}
+
+// ---------------------------------------------------------------------------
+// Validate (full board report — doc 12 §4)
+// ---------------------------------------------------------------------------
+
+export async function validateSchedule(
+  auth: AuthCtx,
+  divisionId: string,
+): Promise<{ conflicts: ScheduleConflict[] }> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [division] = await tx<{ competition_id: string }[]>`
+      select competition_id from divisions where id = ${divisionId}`;
+    if (!division) throw new HttpError(404, "division not found");
+    const settings = await loadSettings(tx, divisionId);
+    const all = await divisionFixtures(tx, divisionId);
+    const entrantIds = [
+      ...new Set(all.flatMap((f) => [f.home_entrant_id, f.away_entrant_id])),
+    ].filter((e): e is string => e !== null);
+    const people = await peopleByEntrant(tx, entrantIds);
+    const assignments = all
+      .filter((f) => f.scheduled_at !== null && f.court_label !== null)
+      .map((f) => toAssignment(f, settings.config.matchMinutes, people));
+    const siblings = await siblingAssignments(
+      tx,
+      divisionId,
+      division.competition_id,
+      settings.config.matchMinutes,
+    );
+    return {
+      conflicts: mapConflicts(
+        validateAssignments(assignments, toSlotConfig(settings, 0), siblings, feedDependencies(all)),
+      ),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Publish & start (doc 12 §1 state machine)
+// ---------------------------------------------------------------------------
+
+export interface PublishScheduleOut {
+  division_id: string;
+  status: string;
+  published: boolean;
+}
+
+export async function publishSchedule(auth: AuthCtx, divisionId: string): Promise<PublishScheduleOut> {
+  const out = await withTenant(auth.orgId, async (tx) => {
+    const [division] = await tx<{ status: string; competition_id: string }[]>`
+      select status, competition_id from divisions where id = ${divisionId}`;
+    if (!division) throw new HttpError(404, "division not found");
+    await tx`select pg_advisory_xact_lock(hashtext(${"division:" + divisionId}))`;
+    await assertCompetitionNotFrozen(auth.orgId, division.competition_id, tx);
+    if (division.status === "completed") {
+      throw new HttpError(422, "a completed division cannot publish a schedule");
+    }
+    const status = division.status === "setup" ? "scheduled" : division.status;
+    if (status !== division.status) {
+      await tx`update divisions set status = ${status} where id = ${divisionId}`;
+    }
+    const [{ n }] = await tx<{ n: number }[]>`
+      select count(*)::int as n from fixtures
+      where division_id = ${divisionId} and scheduled_at is not null`;
+    const seq = await appendDivisionEvent(tx, divisionId, "schedule_published", {
+      fixturesScheduled: n,
+    });
+    await tx`update divisions set seq = ${seq} where id = ${divisionId}`;
+    return { competitionId: division.competition_id, status };
+  });
+  afterScheduleWrite(divisionId, out.competitionId, "publish");
+  return { division_id: divisionId, status: out.status, published: true };
+}
+
+export interface StartDivisionOut {
+  division_id: string;
+  status: string;
+  started: boolean;
+  generated: number;
+}
+
+/**
+ * The "start tournament" action (doc 12 §1 — both modes end here). Quick-start
+ * from setup generates the first stage's fixtures when none exist and, when
+ * `roundMinutes` is configured, slots rolling times (round r at startAt +
+ * (r−1)·roundMinutes). Scoring opens only after this (division_started).
+ */
+export async function startDivision(auth: AuthCtx, divisionId: string): Promise<StartDivisionOut> {
+  const pre = await withTenant(auth.orgId, async (tx) => {
+    const [division] = await tx<{ status: string; competition_id: string }[]>`
+      select status, competition_id from divisions where id = ${divisionId}`;
+    if (!division) throw new HttpError(404, "division not found");
+    await assertCompetitionNotFrozen(auth.orgId, division.competition_id, tx);
+    if (division.status === "completed") throw new HttpError(422, "division is completed");
+    const [firstStage] = await tx<{ id: string; n: number }[]>`
+      select s.id, (select count(*)::int from fixtures f where f.stage_id = s.id) as n
+      from stages s where s.division_id = ${divisionId}
+      order by s.seq limit 1`;
+    if (!firstStage) throw new HttpError(422, "division has no stages to start");
+    return { ...division, firstStage };
+  });
+  if (pre.status === "active") {
+    return { division_id: divisionId, status: "active", started: false, generated: 0 };
+  }
+
+  // Quick-start: generate outside the status transaction (the generator takes
+  // its own division lock).
+  let generated = 0;
+  if (pre.firstStage.n === 0) {
+    const outcome = await generateStageFixtures(auth, pre.firstStage.id);
+    generated = outcome.created;
+  }
+
+  const out = await withTenant(auth.orgId, async (tx) => {
+    await tx`select pg_advisory_xact_lock(hashtext(${"division:" + divisionId}))`;
+    const [division] = await tx<{ status: string }[]>`
+      select status from divisions where id = ${divisionId}`;
+    if (!division || division.status === "active") return { started: false };
+
+    // Rolling quick-start times (doc 12 §1.A) — only for a straight
+    // setup→active start; a published timetable is left untouched.
+    const settings = await loadSettings(tx, divisionId);
+    if (division.status === "setup" && settings.config.roundMinutes) {
+      const startAt = settings.config.startAt
+        ? ms(settings.config.startAt)
+        : roundToMinute(Date.now());
+      const step = settings.config.roundMinutes * MS_PER_MIN;
+      const rounds = await tx<{ round_no: number }[]>`
+        select distinct round_no from fixtures
+        where stage_id = ${pre.firstStage.id} and scheduled_at is null
+        order by round_no`;
+      for (const [i, r] of rounds.entries()) {
+        await tx`
+          update fixtures set scheduled_at = ${iso(startAt + i * step)}, schedule_source = 'auto'
+          where stage_id = ${pre.firstStage.id} and round_no = ${r.round_no}
+            and scheduled_at is null`;
+      }
+    }
+
+    await tx`update divisions set status = 'active' where id = ${divisionId}`;
+    const seq = await appendDivisionEvent(tx, divisionId, "division_started", {
+      from: division.status,
+    });
+    await tx`update divisions set seq = ${seq} where id = ${divisionId}`;
+    return { started: true };
+  });
+  afterScheduleWrite(divisionId, pre.competition_id, "start");
+  return { division_id: divisionId, status: "active", started: out.started, generated };
+}

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -8,6 +8,7 @@ import { withTenant } from "@/lib/db";
 import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
 import { rateLimit } from "@/lib/rate-limit";
 import { requireFeature } from "@/lib/entitlements";
+import { EngineError } from "@seazn/engine/core";
 import { appendEvent, resolveModule } from "@/server/engine-db";
 import { recomputeStandings } from "@/server/engine-db";
 import { publishFixtureUpdate } from "@/lib/realtime";
@@ -97,9 +98,16 @@ async function assertEntitledToScore(
 ): Promise<void> {
   const ctx = await withTenant(auth.orgId, async (tx) => {
     const [row] = await tx<
-      { sport_key: string; module_version: string; config: unknown; competition_id: string }[]
+      {
+        sport_key: string;
+        module_version: string;
+        config: unknown;
+        competition_id: string;
+        division_status: string;
+      }[]
     >`
-      select d.sport_key, d.module_version, d.config, d.competition_id
+      select d.sport_key, d.module_version, d.config, d.competition_id,
+             d.status as division_status
       from fixtures f join divisions d on d.id = f.division_id
       where f.id = ${fixtureId}`;
     if (!row) return null;
@@ -107,6 +115,14 @@ async function assertEntitledToScore(
     return row;
   });
   if (!ctx) return;
+
+  // Doc 12 §1: scoring opens only after the explicit start action
+  // (division_started). A published-but-unstarted timetable stays read-only.
+  if (ctx.division_status === "setup" || ctx.division_status === "scheduled") {
+    throw new EngineError("WRONG_PHASE", "division has not started — scoring is closed", {
+      divisionStatus: ctx.division_status,
+    });
+  }
 
   const sportModule = resolveModule(ctx.sport_key, ctx.module_version);
   const feature = requiredFeatureForEvent(sportModule, input.type);

--- a/apps/web/src/server/usecases/stages.ts
+++ b/apps/web/src/server/usecases/stages.ts
@@ -51,7 +51,7 @@ const STAGE_COLS = ["id", "division_id", "seq", "kind", "name", "config", "quali
 export const FIXTURE_COLS = [
   "id", "stage_id", "division_id", "pool_id", "round_no", "seq_in_round",
   "home_entrant_id", "away_entrant_id", "scheduled_at", "venue", "court_label",
-  "officials", "status", "outcome", "created_at",
+  "officials", "status", "outcome", "schedule_source", "schedule_locked", "created_at",
 ] as const;
 
 export interface FixtureRow {
@@ -69,6 +69,8 @@ export interface FixtureRow {
   officials: unknown[];
   status: string;
   outcome: unknown;
+  schedule_source: "none" | "auto" | "manual";
+  schedule_locked: boolean;
   created_at: string;
 }
 

--- a/engine/12-scheduling-ux.md
+++ b/engine/12-scheduling-ux.md
@@ -78,11 +78,17 @@ create table schedule_settings (          -- per division (or competition-level 
 from groups) schedule with TBD entrants — cards render feed labels; rest/overlap warnings
 recompute automatically when entrants resolve.
 
+Publish-gating (PROMPT-17): `divisions.status` gains the `scheduled` state (§1
+machine), and `public_fixtures_v` nulls `scheduled_at/venue/court_label` while a
+division is still in `setup` — so the public schedule tab, `/api/v1/public/...
+/schedule` and the `.ics` feed reflect the published timetable only, from the
+same view. Quick-start divisions jump straight to `active`, unaffected.
+
 ## 4. Engine/API surface (extends doc 08 §3)
 
 ```
-PUT   /api/v1/divisions/{id}/schedule-settings
-POST  /api/v1/stages/{id}/schedule/auto        # run/re-run pure pass; body {onlyUnlocked: true}
+GET/PUT /api/v1/divisions/{id}/schedule-settings
+POST  /api/v1/stages/{id}/schedule/auto        # run/re-run pure pass; body {only_unlocked: true}
                                                # → {assignments, conflicts[]}; nothing persisted
 POST  /api/v1/stages/{id}/schedule/apply       # persist an assignment set (from auto or editor)
 PATCH /api/v1/fixtures/{id}                    # single move: {scheduled_at, court_label, schedule_locked}
@@ -92,6 +98,21 @@ POST  /api/v1/divisions/{id}/start             # the "start tournament" action (
 ```
 Auto pass runs `@seazn/engine` `scheduling/calendar.ts` — the engine stays pure; persist
 is a separate step (propose → review → apply, same pattern as fixture generation).
+
+PROMPT-17 implementation notes (deviations from the sketches above):
+- Body field is `only_unlocked` (house snake_case JSON), not `onlyUnlocked`.
+- Blocking writes (conflict.court, direct-feed warn.order) are rejected with
+  `409 SCHEDULE_CONFLICT` carrying the conflict list; warnings ride along in
+  200 responses and render as badges.
+- A bulk apply appends ONE `schedule_applied {source, moves[]}` division event
+  (each move still records `{fixture, from, to}`); single PATCH moves append
+  `schedule_edited {fixture, from, to}` as specified.
+- Session-window violations are reported under the `warn.blackout` code with
+  detail "outside session windows" — the complement of the windows is treated
+  as blackout time, keeping the §2 taxonomy closed.
+- `warn.order` is emitted for direct winner/loser feeds (which block);
+  non-direct (transitive) order warnings are a later refinement.
+- `schedule_settings` also carries `tz` (§6 DST note) and `updated_at`.
 
 ## 5. Entitlements (extends doc 10)
 

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -1775,6 +1775,7 @@
                             "type": "string",
                             "enum": [
                               "setup",
+                              "scheduled",
                               "active",
                               "completed"
                             ]
@@ -2104,6 +2105,7 @@
                           "type": "string",
                           "enum": [
                             "setup",
+                            "scheduled",
                             "active",
                             "completed"
                           ]
@@ -2451,6 +2453,7 @@
                           "type": "string",
                           "enum": [
                             "setup",
+                            "scheduled",
                             "active",
                             "completed"
                           ]
@@ -2681,6 +2684,7 @@
                     "type": "string",
                     "enum": [
                       "setup",
+                      "scheduled",
                       "active",
                       "completed"
                     ]
@@ -2757,6 +2761,7 @@
                           "type": "string",
                           "enum": [
                             "setup",
+                            "scheduled",
                             "active",
                             "completed"
                           ]
@@ -7321,6 +7326,17 @@
                                   }
                                 ]
                               },
+                              "schedule_source": {
+                                "type": "string",
+                                "enum": [
+                                  "none",
+                                  "auto",
+                                  "manual"
+                                ]
+                              },
+                              "schedule_locked": {
+                                "type": "boolean"
+                              },
                               "created_at": {
                                 "type": "string"
                               }
@@ -7340,6 +7356,8 @@
                               "officials",
                               "status",
                               "outcome",
+                              "schedule_source",
+                              "schedule_locked",
                               "created_at"
                             ],
                             "additionalProperties": false
@@ -8019,6 +8037,2324 @@
         ]
       }
     },
+    "/api/v1/divisions/{id}/schedule-settings": {
+      "get": {
+        "summary": "Get scheduling settings (defaults when unset)",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "division_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "startAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "matchMinutes": {
+                              "default": 30,
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 1440
+                            },
+                            "gapMinutes": {
+                              "default": 0,
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 1440
+                            },
+                            "courts": {
+                              "default": [
+                                "Court 1"
+                              ],
+                              "minItems": 1,
+                              "maxItems": 50,
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 100
+                              }
+                            },
+                            "perEntrantMinRest": {
+                              "default": 0,
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 1440
+                            },
+                            "blackouts": {
+                              "default": [],
+                              "maxItems": 200,
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "court": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "from": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  },
+                                  "to": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  }
+                                },
+                                "required": [
+                                  "from",
+                                  "to"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "sessionWindows": {
+                              "default": [],
+                              "maxItems": 200,
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "from": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  },
+                                  "to": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  }
+                                },
+                                "required": [
+                                  "from",
+                                  "to"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "roundMinutes": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 1440
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "matchMinutes",
+                            "gapMinutes",
+                            "courts",
+                            "perEntrantMinRest",
+                            "blackouts",
+                            "sessionWindows"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "tz": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "division_id",
+                        "config",
+                        "tz",
+                        "updated_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "put": {
+        "summary": "Upsert scheduling settings (constraint fields are Pro)",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "properties": {
+                      "startAt": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date-time",
+                            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "matchMinutes": {
+                        "default": 30,
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 1440
+                      },
+                      "gapMinutes": {
+                        "default": 0,
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1440
+                      },
+                      "courts": {
+                        "default": [
+                          "Court 1"
+                        ],
+                        "minItems": 1,
+                        "maxItems": 50,
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 100
+                        }
+                      },
+                      "perEntrantMinRest": {
+                        "default": 0,
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 1440
+                      },
+                      "blackouts": {
+                        "default": [],
+                        "maxItems": 200,
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "court": {
+                              "type": "string",
+                              "maxLength": 100
+                            },
+                            "from": {
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            },
+                            "to": {
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            }
+                          },
+                          "required": [
+                            "from",
+                            "to"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "sessionWindows": {
+                        "default": [],
+                        "maxItems": 200,
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "from": {
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            },
+                            "to": {
+                              "type": "string",
+                              "format": "date-time",
+                              "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                            }
+                          },
+                          "required": [
+                            "from",
+                            "to"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "roundMinutes": {
+                        "anyOf": [
+                          {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 1440
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      }
+                    },
+                    "required": [
+                      "matchMinutes",
+                      "gapMinutes",
+                      "courts",
+                      "perEntrantMinRest",
+                      "blackouts",
+                      "sessionWindows"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "tz": {
+                    "default": "UTC",
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64
+                  }
+                },
+                "required": [
+                  "config",
+                  "tz"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "division_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "config": {
+                          "type": "object",
+                          "properties": {
+                            "startAt": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time",
+                                  "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "matchMinutes": {
+                              "default": 30,
+                              "type": "integer",
+                              "minimum": 1,
+                              "maximum": 1440
+                            },
+                            "gapMinutes": {
+                              "default": 0,
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 1440
+                            },
+                            "courts": {
+                              "default": [
+                                "Court 1"
+                              ],
+                              "minItems": 1,
+                              "maxItems": 50,
+                              "type": "array",
+                              "items": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 100
+                              }
+                            },
+                            "perEntrantMinRest": {
+                              "default": 0,
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 1440
+                            },
+                            "blackouts": {
+                              "default": [],
+                              "maxItems": 200,
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "court": {
+                                    "type": "string",
+                                    "maxLength": 100
+                                  },
+                                  "from": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  },
+                                  "to": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  }
+                                },
+                                "required": [
+                                  "from",
+                                  "to"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "sessionWindows": {
+                              "default": [],
+                              "maxItems": 200,
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "from": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  },
+                                  "to": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                                  }
+                                },
+                                "required": [
+                                  "from",
+                                  "to"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "roundMinutes": {
+                              "anyOf": [
+                                {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 1440
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "matchMinutes",
+                            "gapMinutes",
+                            "courts",
+                            "perEntrantMinRest",
+                            "blackouts",
+                            "sessionWindows"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "tz": {
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "division_id",
+                        "config",
+                        "tz",
+                        "updated_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Plan upgrade required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stages/{id}/schedule/auto": {
+      "post": {
+        "summary": "Run the pure calendar pass — propose only, nothing persisted",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "only_unlocked": {
+                    "default": true,
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "only_unlocked"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "assignments": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fixture_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "scheduled_at": {
+                                "type": "string"
+                              },
+                              "ends_at": {
+                                "type": "string"
+                              },
+                              "court_label": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fixture_id",
+                              "scheduled_at",
+                              "ends_at",
+                              "court_label"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "conflicts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fixture_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "code": {
+                                "type": "string",
+                                "enum": [
+                                  "conflict.court",
+                                  "warn.rest",
+                                  "warn.person_overlap",
+                                  "warn.order",
+                                  "warn.blackout",
+                                  "warn.no_slot"
+                                ]
+                              },
+                              "blocking": {
+                                "type": "boolean"
+                              },
+                              "detail": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fixture_id",
+                              "code",
+                              "blocking"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "assignments",
+                        "conflicts"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stages/{id}/schedule/apply": {
+      "post": {
+        "summary": "Persist an assignment set; blocking conflicts → 409",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "assignments": {
+                    "minItems": 1,
+                    "maxItems": 500,
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fixture_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "scheduled_at": {
+                          "type": "string",
+                          "format": "date-time",
+                          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+                        },
+                        "court_label": {
+                          "type": "string",
+                          "minLength": 1,
+                          "maxLength": 100
+                        },
+                        "venue": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "maxLength": 200
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "schedule_locked": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "fixture_id",
+                        "scheduled_at",
+                        "court_label"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "source": {
+                    "default": "auto",
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "manual"
+                    ]
+                  }
+                },
+                "required": [
+                  "assignments",
+                  "source"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "applied": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "conflicts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fixture_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "code": {
+                                "type": "string",
+                                "enum": [
+                                  "conflict.court",
+                                  "warn.rest",
+                                  "warn.person_overlap",
+                                  "warn.order",
+                                  "warn.blackout",
+                                  "warn.no_slot"
+                                ]
+                              },
+                              "blocking": {
+                                "type": "boolean"
+                              },
+                              "detail": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fixture_id",
+                              "code",
+                              "blocking"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "applied",
+                        "conflicts"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Plan upgrade required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/divisions/{id}/schedule/validate": {
+      "post": {
+        "summary": "Full board conflict report (doc 12 §2 taxonomy)",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "conflicts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fixture_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "code": {
+                                "type": "string",
+                                "enum": [
+                                  "conflict.court",
+                                  "warn.rest",
+                                  "warn.person_overlap",
+                                  "warn.order",
+                                  "warn.blackout",
+                                  "warn.no_slot"
+                                ]
+                              },
+                              "blocking": {
+                                "type": "boolean"
+                              },
+                              "detail": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "fixture_id",
+                              "code",
+                              "blocking"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "conflicts"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/divisions/{id}/publish-schedule": {
+      "post": {
+        "summary": "Publish the timetable (division → scheduled)",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "division_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "setup",
+                            "scheduled",
+                            "active",
+                            "completed"
+                          ]
+                        },
+                        "published": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "division_id",
+                        "status",
+                        "published"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/divisions/{id}/start": {
+      "post": {
+        "summary": "Start the tournament (quick-start generates fixtures)",
+        "tags": [
+          "scheduling"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "division_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "setup",
+                            "scheduled",
+                            "active",
+                            "completed"
+                          ]
+                        },
+                        "started": {
+                          "type": "boolean"
+                        },
+                        "generated": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        }
+                      },
+                      "required": [
+                        "division_id",
+                        "status",
+                        "started",
+                        "generated"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/api/v1/fixtures/{id}": {
       "get": {
         "summary": "Get a fixture",
@@ -8170,6 +10506,17 @@
                             }
                           ]
                         },
+                        "schedule_source": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "auto",
+                            "manual"
+                          ]
+                        },
+                        "schedule_locked": {
+                          "type": "boolean"
+                        },
                         "created_at": {
                           "type": "string"
                         }
@@ -8189,6 +10536,8 @@
                         "officials",
                         "status",
                         "outcome",
+                        "schedule_source",
+                        "schedule_locked",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8345,7 +10694,7 @@
         ]
       },
       "patch": {
-        "summary": "Schedule, venue, officials",
+        "summary": "Schedule move, venue, officials, pin/lock — blocking conflicts → 409",
         "tags": [
           "fixtures"
         ],
@@ -8410,6 +10759,9 @@
                       },
                       "additionalProperties": {}
                     }
+                  },
+                  "schedule_locked": {
+                    "type": "boolean"
                   }
                 },
                 "additionalProperties": false
@@ -8551,6 +10903,17 @@
                             }
                           ]
                         },
+                        "schedule_source": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "auto",
+                            "manual"
+                          ]
+                        },
+                        "schedule_locked": {
+                          "type": "boolean"
+                        },
                         "created_at": {
                           "type": "string"
                         }
@@ -8570,6 +10933,8 @@
                         "officials",
                         "status",
                         "outcome",
+                        "schedule_source",
+                        "schedule_locked",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8671,8 +11036,140 @@
               }
             }
           },
+          "402": {
+            "description": "Plan upgrade required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/engine/src/core/errors.test.ts
+++ b/packages/engine/src/core/errors.test.ts
@@ -36,6 +36,8 @@ describe("EngineError", () => {
       "CONFIG_INVALID",
       "SEQ_CONFLICT",
       "STAGE_NOT_READY",
+      // PROMPT-17 scheduling console (doc 12 §2 blocking conflicts)
+      "SCHEDULE_CONFLICT",
       "ELIGIBILITY",
       // PROMPT-03 registry additions
       "MODULE_NOT_FOUND",

--- a/packages/engine/src/core/errors.ts
+++ b/packages/engine/src/core/errors.ts
@@ -12,6 +12,9 @@ export const EngineErrorCode = z.enum([
   "CONFIG_INVALID",
   "SEQ_CONFLICT",
   "STAGE_NOT_READY",
+  // PROMPT-17 — a schedule write hit a blocking conflict (doc 12 §2:
+  // conflict.court, or warn.order on a direct feed). data.conflicts lists them.
+  "SCHEDULE_CONFLICT",
   "ELIGIBILITY",
   // PROMPT-03 — registry resolution (spec 03 §3 registry & versioning).
   "MODULE_NOT_FOUND",

--- a/packages/engine/src/scheduling/calendar.test.ts
+++ b/packages/engine/src/scheduling/calendar.test.ts
@@ -119,6 +119,42 @@ describe("slotFixtures — greedy placement (spec 05 §2.6)", () => {
   });
 });
 
+describe("slotFixtures — session windows (doc 12 §2, PROMPT-17)", () => {
+  it("schedules only inside session windows", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "f1", roundNo: 1, home: "A", away: "B" },
+      { id: "f2", roundNo: 1, home: "C", away: "D" },
+      { id: "f3", roundNo: 2, home: "A", away: "C" },
+    ];
+    const windows = [
+      { from: 10 * MIN, to: 45 * MIN }, // fits exactly one 30-min match
+      { from: 120 * MIN, to: 300 * MIN },
+    ];
+    const { assignments, conflicts } = slotFixtures({
+      fixtures,
+      config: baseConfig({ sessionWindows: windows }),
+    });
+    expect(conflicts).toHaveLength(0);
+    for (const a of assignments) {
+      expect(windows.some((w) => a.startAt >= w.from && a.endAt <= w.to)).toBe(true);
+    }
+  });
+
+  it("reports a locked slot outside every session window as a blackout", () => {
+    const fixtures: SchedulableFixture[] = [
+      { id: "pin", roundNo: 1, home: "A", away: "B", locked: { court: "C1", startAt: 50 * MIN } },
+    ];
+    const { assignments, conflicts } = slotFixtures({
+      fixtures,
+      config: baseConfig({ sessionWindows: [{ from: 0, to: 45 * MIN }] }),
+    });
+    expect(assignments).toHaveLength(1); // pin honoured, not moved
+    expect(conflicts).toEqual([
+      expect.objectContaining({ fixtureId: "pin", reason: "blackout" }),
+    ]);
+  });
+});
+
 describe("validateAssignments — board conflict report (doc 12 §2/§4)", () => {
   it("flags a court double-booking", () => {
     const a: Assignment[] = [
@@ -145,6 +181,66 @@ describe("validateAssignments — board conflict report (doc 12 §2/§4)", () =>
     ];
     const conflicts = validateAssignments(a, { perEntrantMinRest: 60, gapMinutes: 0 });
     expect(conflicts.some((c) => c.reason === "rest")).toBe(true);
+  });
+
+  it("flags an assignment outside every session window", () => {
+    const a: Assignment[] = [
+      { fixtureId: "x", court: "C1", startAt: 50 * MIN, endAt: 80 * MIN, entrants: ["A"], people: [] },
+    ];
+    const conflicts = validateAssignments(a, {
+      perEntrantMinRest: 0,
+      gapMinutes: 0,
+      sessionWindows: [{ from: 0, to: 45 * MIN }],
+    });
+    expect(conflicts).toEqual([
+      expect.objectContaining({ fixtureId: "x", reason: "blackout", detail: "outside session windows" }),
+    ]);
+  });
+
+  it("flags a fixture scheduled before its feeder ends; direct feeds are marked", () => {
+    const a: Assignment[] = [
+      { fixtureId: "semi", court: "C1", startAt: 60 * MIN, endAt: 90 * MIN, entrants: [], people: [] },
+      { fixtureId: "final", court: "C2", startAt: 0, endAt: 30 * MIN, entrants: [], people: [] },
+    ];
+    const conflicts = validateAssignments(a, { perEntrantMinRest: 0, gapMinutes: 0 }, [], [
+      { fixtureId: "final", dependsOn: "semi", direct: true },
+    ]);
+    expect(conflicts).toEqual([
+      expect.objectContaining({ fixtureId: "final", reason: "order", direct: true }),
+    ]);
+  });
+
+  it("order check ignores dependencies whose feeder is not on the board", () => {
+    const a: Assignment[] = [
+      { fixtureId: "final", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: [], people: [] },
+    ];
+    const conflicts = validateAssignments(a, { perEntrantMinRest: 0, gapMinutes: 0 }, [], [
+      { fixtureId: "final", dependsOn: "semi", direct: true },
+    ]);
+    expect(conflicts).toHaveLength(0);
+  });
+
+  it("finds every seeded conflict class in one report (PROMPT-17 acceptance)", () => {
+    // One board seeding all five classes: court, rest, blackout (window +
+    // session), person_overlap, order.
+    const a: Assignment[] = [
+      { fixtureId: "c1", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: ["A"], people: [] },
+      { fixtureId: "c2", court: "C1", startAt: 10 * MIN, endAt: 40 * MIN, entrants: ["B"], people: [] }, // court clash
+      { fixtureId: "r1", court: "C2", startAt: 35 * MIN, endAt: 65 * MIN, entrants: ["A"], people: [] }, // A rest < 60
+      { fixtureId: "b1", court: "C3", startAt: 200 * MIN, endAt: 230 * MIN, entrants: ["C"], people: [] }, // blackout
+      { fixtureId: "p1", court: "C4", startAt: 0, endAt: 30 * MIN, entrants: ["D"], people: ["kid"] },
+      { fixtureId: "p2", court: "C5", startAt: 0, endAt: 30 * MIN, entrants: ["E"], people: ["kid"] }, // person overlap
+      { fixtureId: "o1", court: "C6", startAt: 500 * MIN, endAt: 530 * MIN, entrants: [], people: [] },
+      { fixtureId: "o2", court: "C7", startAt: 400 * MIN, endAt: 430 * MIN, entrants: [], people: [] }, // before feeder o1
+    ];
+    const conflicts = validateAssignments(
+      a,
+      { perEntrantMinRest: 60, gapMinutes: 0, blackouts: [{ from: 195 * MIN, to: 240 * MIN }] },
+      [],
+      [{ fixtureId: "o2", dependsOn: "o1", direct: true }],
+    );
+    const reasons = new Set(conflicts.map((c) => c.reason));
+    expect(reasons).toEqual(new Set(["court", "rest", "blackout", "person_overlap", "order"]));
   });
 });
 
@@ -231,6 +327,57 @@ describe("slotFixtures — invariants (spec 05 §6)", () => {
         const assigned = new Set(assignments.map((a) => a.fixtureId));
         const noSlot = new Set(conflicts.filter((c) => c.reason === "no_slot").map((c) => c.fixtureId));
         for (const f of fixtures) expect(assigned.has(f.id) || noSlot.has(f.id)).toBe(true);
+      }),
+    );
+  });
+
+  it("re-run with all outputs locked = zero moves (PROMPT-17 acceptance)", () => {
+    fc.assert(
+      fc.property(fixtureArb, fc.integer({ min: 1, max: 3 }), (raw, courtCount) => {
+        const fixtures = dedupeIds(raw).filter((f) => f.home !== f.away);
+        const courts = Array.from({ length: courtCount }, (_, i) => `C${i}`);
+        const cfg = baseConfig({ courts, perEntrantMinRest: 30 });
+        const first = slotFixtures({ fixtures, config: cfg });
+        const bySlot = new Map(first.assignments.map((a) => [a.fixtureId, a]));
+        // Lock every placed fixture at its own output slot and re-run.
+        const locked = fixtures
+          .filter((f) => bySlot.has(f.id))
+          .map((f) => {
+            const a = bySlot.get(f.id) as Assignment;
+            return { ...f, locked: { court: a.court, startAt: a.startAt } };
+          });
+        const second = slotFixtures({ fixtures: locked, config: cfg });
+        const secondBySlot = new Map(second.assignments.map((a) => [a.fixtureId, a]));
+        expect(secondBySlot.size).toBe(bySlot.size);
+        for (const [id, a] of bySlot) {
+          const b = secondBySlot.get(id) as Assignment;
+          expect({ court: b.court, startAt: b.startAt, endAt: b.endAt }).toEqual({
+            court: a.court,
+            startAt: a.startAt,
+            endAt: a.endAt,
+          });
+        }
+        // A mutually consistent board re-locked must not report court clashes.
+        expect(second.conflicts.filter((c) => c.reason === "court")).toHaveLength(0);
+      }),
+    );
+  });
+
+  it("every assignment sits fully inside a session window when windows are set", () => {
+    fc.assert(
+      fc.property(fixtureArb, (raw) => {
+        const fixtures = dedupeIds(raw);
+        const windows = [
+          { from: 0, to: 90 * MIN },
+          { from: 240 * MIN, to: 480 * MIN },
+        ];
+        const { assignments } = slotFixtures({
+          fixtures,
+          config: baseConfig({ courts: ["C0", "C1"], sessionWindows: windows }),
+        });
+        for (const a of assignments) {
+          expect(windows.some((w) => a.startAt >= w.from && a.endAt <= w.to)).toBe(true);
+        }
       }),
     );
   });

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -15,6 +15,13 @@ export interface Blackout {
   to: number; // exclusive
 }
 
+// A playable window (doc 12 §2): matches must sit fully inside one. The
+// complement of the union of windows behaves as a global blackout.
+export interface SessionWindow {
+  from: number;
+  to: number; // exclusive
+}
+
 export interface SlotConfig {
   startAt: number; // earliest slot (injected)
   matchMinutes: number;
@@ -22,6 +29,7 @@ export interface SlotConfig {
   courts: string[]; // court/venue labels, tried in order
   perEntrantMinRest: number; // minutes an entrant must rest between its matches
   blackouts?: readonly Blackout[];
+  sessionWindows?: readonly SessionWindow[]; // when set, matches only inside these
   horizonMinutes?: number; // how far past startAt to search before reporting no_slot
 }
 
@@ -47,13 +55,24 @@ export type ConflictReason =
   | "no_slot" // no court/time within the horizon satisfies the hard constraints
   | "court" // two matches share a court+time (blocks — physically impossible)
   | "rest" // an entrant is below perEntrantMinRest (warn)
-  | "blackout" // inside a blackout window (warn)
-  | "person_overlap"; // a person plays in two overlapping matches (warn — doc 06 §4.3)
+  | "blackout" // inside a blackout window / outside every session window (warn)
+  | "person_overlap" // a person plays in two overlapping matches (warn — doc 06 §4.3)
+  | "order"; // scheduled before a fixture that feeds it (doc 12 §2; blocks when direct)
 
 export interface Conflict {
   fixtureId: string;
   reason: ConflictReason;
   detail?: string;
+  /** `order` only: true when the dependency is a direct feed (blocks, doc 12 §2). */
+  direct?: boolean;
+}
+
+/** Bracket dependency for order validation: `fixtureId` must not start before
+ *  `dependsOn` ends. `direct` = winner/loser feed (blocks); otherwise warns. */
+export interface OrderDependency {
+  fixtureId: string;
+  dependsOn: string;
+  direct?: boolean;
 }
 
 export interface SlotInput {
@@ -69,6 +88,43 @@ export interface SlotResult {
 
 const entrantsOf = (f: SchedulableFixture): EntrantId[] =>
   [f.home, f.away].filter((e): e is EntrantId => e !== undefined);
+
+// Session windows reduce to blackouts: the complement of their union over
+// [lo, hi] is unplayable time. Keeps every downstream check (slotting,
+// validation, candidate scan) window-aware without a second interval system.
+function sessionGaps(
+  windows: readonly SessionWindow[],
+  lo: number,
+  hi: number,
+): Blackout[] {
+  const merged = [...windows]
+    .sort((a, b) => a.from - b.from)
+    .reduce<SessionWindow[]>((acc, w) => {
+      const last = acc[acc.length - 1];
+      if (last && w.from <= last.to) last.to = Math.max(last.to, w.to);
+      else acc.push({ ...w });
+      return acc;
+    }, []);
+  const gaps: Blackout[] = [];
+  let cursor = lo;
+  for (const w of merged) {
+    if (w.from > cursor) gaps.push({ from: cursor, to: w.from });
+    cursor = Math.max(cursor, w.to);
+  }
+  if (cursor < hi) gaps.push({ from: cursor, to: hi });
+  return gaps;
+}
+
+// Effective blackout list: configured blackouts plus session-window complement.
+function effectiveBlackouts(
+  config: Pick<SlotConfig, "blackouts" | "sessionWindows">,
+  lo: number,
+  hi: number,
+): readonly Blackout[] {
+  const blackouts = config.blackouts ?? [];
+  if (!config.sessionWindows || config.sessionWindows.length === 0) return blackouts;
+  return [...blackouts, ...sessionGaps(config.sessionWindows, lo, hi)];
+}
 
 const overlaps = (aStart: number, aEnd: number, bStart: number, bEnd: number): boolean =>
   aStart < bEnd && bStart < aEnd;
@@ -130,7 +186,14 @@ export function slotFixtures(input: SlotInput): SlotResult {
   const gapMs = config.gapMinutes * MS_PER_MIN;
   const restMs = config.perEntrantMinRest * MS_PER_MIN;
   const horizon = config.startAt + (config.horizonMinutes ?? 365 * 24 * 60) * MS_PER_MIN;
-  const blackouts = config.blackouts ?? [];
+  // Session-gap range must span every time the pass can touch, including
+  // pinned slots outside [startAt, horizon].
+  const pinned = input.fixtures
+    .map((f) => f.locked?.startAt)
+    .filter((t): t is number => t !== undefined);
+  const lo = Math.min(config.startAt, ...pinned) - durMs;
+  const hi = Math.max(horizon, ...pinned.map((t) => t + durMs)) + durMs;
+  const blackouts = effectiveBlackouts(config, lo, hi);
 
   const bookings: Assignment[] = [...(input.existing ?? [])]; // court occupancy (incl. siblings)
   const placed: Assignment[] = [];
@@ -210,18 +273,23 @@ export function slotFixtures(input: SlotInput): SlotResult {
 }
 
 // Full conflict report over a fixed board (the drag-and-drop validate pass, doc
-// 12 §2/§4): court double-bookings (block), rest and blackout violations, and
-// per-person overlaps (warn). Pure — the same inputs always give the same report.
+// 12 §2/§4): court double-bookings (block), rest / blackout / session-window
+// violations, per-person overlaps, and feed-order violations against the given
+// bracket dependencies (block when direct). Pure — the same inputs always give
+// the same report.
 export function validateAssignments(
   assignments: readonly Assignment[],
-  config: Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts">,
+  config: Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts" | "sessionWindows">,
   existing: readonly Assignment[] = [],
+  dependencies: readonly OrderDependency[] = [],
 ): Conflict[] {
   const restMs = config.perEntrantMinRest * MS_PER_MIN;
   const gapMs = config.gapMinutes * MS_PER_MIN;
   const blackouts = config.blackouts ?? [];
+  const windows = config.sessionWindows ?? [];
   const conflicts: Conflict[] = [];
   const board = [...existing, ...assignments];
+  const byId = new Map(board.map((a) => [a.fixtureId, a]));
 
   for (const a of assignments) {
     // Court clash / blackout — check against everything else on the board.
@@ -235,6 +303,10 @@ export function validateAssignments(
         conflicts.push({ fixtureId: a.fixtureId, reason: "blackout", detail: "inside a blackout window" });
         break;
       }
+    }
+    // Session windows: the match must sit fully inside one (doc 12 §2).
+    if (windows.length > 0 && !windows.some((w) => a.startAt >= w.from && a.endAt <= w.to)) {
+      conflicts.push({ fixtureId: a.fixtureId, reason: "blackout", detail: "outside session windows" });
     }
     // Rest & person overlap — against other matches sharing an entrant/person.
     for (const other of board) {
@@ -256,6 +328,24 @@ export function validateAssignments(
           conflicts.push({ fixtureId: a.fixtureId, reason: "person_overlap", detail: `person ${p} overlap` });
         }
       }
+    }
+  }
+
+  // Feed order (doc 12 §2 warn.order): a fixture may not start before a
+  // fixture that feeds it has finished. Direct feeds block; the API layer maps
+  // `direct` to blocking. Dependencies whose source is not on the board are
+  // fine — an unscheduled feeder constrains nothing yet.
+  for (const dep of dependencies) {
+    const target = byId.get(dep.fixtureId);
+    const source = byId.get(dep.dependsOn);
+    if (!target || !source) continue;
+    if (target.startAt < source.endAt) {
+      conflicts.push({
+        fixtureId: dep.fixtureId,
+        reason: "order",
+        detail: `starts before feeder ${dep.dependsOn} ends`,
+        direct: dep.direct === true,
+      });
     }
   }
   return conflicts;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -300,8 +300,19 @@ async function v1Suite(admin: Session, orgId: string, orgSlug: string): Promise<
   check("v1 generate is idempotent", v1data<{ created: number; existing: number }>(gen2).created === 0);
   const fixtures = v1data<{ fixtures: { id: string }[] }>(gen1).fixtures;
 
-  // Scoring: append, optimistic-concurrency 409 (parallel scorers), void.
+  // Scheduling console (doc 12, PROMPT-17): scoring is closed until the
+  // explicit start; auto pass proposes without persisting; start opens scoring.
   const fx = fixtures[0].id;
+  const early = await v1(admin, `/api/v1/fixtures/${fx}/events`, "POST", {
+    expected_seq: 0, type: "core.start", payload: {},
+  });
+  check("v1 scoring before start → 422 WRONG_PHASE", early.status === 422 && early.json.error?.code === "WRONG_PHASE");
+  const auto = await v1(admin, `/api/v1/stages/${stageId}/schedule/auto`, "POST", {});
+  check("v1 schedule/auto proposes all fixtures", v1data<{ assignments: unknown[] }>(auto).assignments.length === 6);
+  const startRes = await v1(admin, `/api/v1/divisions/${divId}/start`, "POST");
+  check("v1 division start → active", v1data<{ status: string }>(startRes).status === "active");
+
+  // Scoring: append, optimistic-concurrency 409 (parallel scorers), void.
   const started = await v1(admin, `/api/v1/fixtures/${fx}/events`, "POST", {
     expected_seq: 0, type: "core.start", payload: {},
   });

--- a/supabase/migrations/014_scheduling.sql
+++ b/supabase/migrations/014_scheduling.sql
@@ -1,0 +1,77 @@
+-- =============================================================================
+-- Migration 014: Scheduling console (PROMPT-17, doc 12 §3).
+--
+-- Adds the schedule provenance columns to fixtures, the per-division
+-- schedule_settings table, the 'scheduled' division state (doc 12 §1 state
+-- machine) and the scheduling entitlement seeds (doc 12 §5).
+--
+-- Ordering note: on a FRESH bootstrap apply-db runs migrations BEFORE
+-- schema_v2.sql, so the v2 tables do not exist yet — every v2-touching block
+-- is guarded and no-ops; schema_v2.sql (idempotent) then creates the same
+-- shape. On a LIVE environment the v2 tables exist and this applies the delta.
+-- =============================================================================
+
+-- fixtures.schedule_source / schedule_locked (doc 12 §3; manual = pinned).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'fixtures') THEN
+    ALTER TABLE fixtures ADD COLUMN IF NOT EXISTS schedule_source text NOT NULL DEFAULT 'none';
+    ALTER TABLE fixtures ADD COLUMN IF NOT EXISTS schedule_locked boolean NOT NULL DEFAULT false;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fixtures_schedule_source_check') THEN
+      ALTER TABLE fixtures ADD CONSTRAINT fixtures_schedule_source_check
+        CHECK (schedule_source IN ('none','auto','manual'));
+    END IF;
+  END IF;
+END $$;
+
+-- Division state machine gains 'scheduled' (doc 12 §1:
+-- setup → schedule→publish → scheduled → start → active).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'divisions') THEN
+    ALTER TABLE divisions DROP CONSTRAINT IF EXISTS divisions_status_check;
+    ALTER TABLE divisions ADD CONSTRAINT divisions_status_check
+      CHECK (status IN ('setup','scheduled','active','completed'));
+  END IF;
+END $$;
+
+-- Per-division scheduling settings (doc 12 §3). config carries startAt,
+-- matchMinutes, gapMinutes, courts[], perEntrantMinRest, blackouts[],
+-- sessionWindows[]; tz is the venue-local zone (doc 12 §6 — DST boundaries).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'divisions') THEN
+    CREATE TABLE IF NOT EXISTS schedule_settings (
+      division_id uuid PRIMARY KEY REFERENCES divisions(id) ON DELETE CASCADE,
+      org_id      uuid NOT NULL,
+      config      jsonb NOT NULL DEFAULT '{}',
+      tz          text NOT NULL DEFAULT 'UTC',
+      updated_at  timestamptz NOT NULL DEFAULT now()
+    );
+
+    -- House pattern (migration 010 / schema_v2): denormalized org_id filled by
+    -- the generic parent trigger + direct RLS policy.
+    DROP TRIGGER IF EXISTS trg_set_org ON schedule_settings;
+    CREATE TRIGGER trg_set_org BEFORE INSERT ON schedule_settings
+      FOR EACH ROW EXECUTE FUNCTION set_org_from_parent('divisions', 'division_id');
+
+    ALTER TABLE schedule_settings ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE schedule_settings FORCE  ROW LEVEL SECURITY;
+    DROP POLICY IF EXISTS schedule_settings_tenant ON schedule_settings;
+    CREATE POLICY schedule_settings_tenant ON schedule_settings FOR ALL TO app_user
+      USING (org_id = current_org_id()) WITH CHECK (org_id = current_org_id());
+    GRANT SELECT, INSERT, UPDATE, DELETE ON schedule_settings TO app_user;
+  END IF;
+END $$;
+
+-- Entitlements (doc 12 §5). scheduling.constraints already seeded by 012;
+-- scheduling.board (drag-and-drop editing; Community = view-only) and the
+-- competition-wide multi-division board are new.
+INSERT INTO plan_entitlements (plan_key, feature_key, bool_value, int_value) VALUES
+  ('community', 'scheduling.board',          false, null),
+  ('pro',       'scheduling.board',          true,  null),
+  ('business',  'scheduling.board',          true,  null),
+  ('community', 'scheduling.multi_division', false, null),
+  ('pro',       'scheduling.multi_division', true,  null),
+  ('business',  'scheduling.multi_division', true,  null)
+ON CONFLICT (plan_key, feature_key) DO NOTHING;

--- a/supabase/schema_v2.sql
+++ b/supabase/schema_v2.sql
@@ -131,11 +131,24 @@ create table if not exists divisions (
   module_version text not null,                -- PINNED engine module version
   eligibility    jsonb not null default '[]',
   tiebreakers    jsonb,                         -- override cascade; null = sport default
-  status         text not null default 'setup' check (status in ('setup','active','completed')),
+  status         text not null default 'setup' check (status in ('setup','scheduled','active','completed')),
   seq            int not null default 0,        -- division_events watermark
   created_at     timestamptz not null default now(),
   unique (competition_id, slug)
 );
+-- Doc 12 §1 state machine: 'scheduled' (published timetable, not yet started)
+-- sits between setup and active. Re-assert on DBs created before PROMPT-17.
+do $$ begin
+  if exists (
+    select 1 from pg_constraint c
+    where c.conname = 'divisions_status_check'
+      and pg_get_constraintdef(c.oid) not like '%scheduled%'
+  ) then
+    alter table divisions drop constraint divisions_status_check;
+    alter table divisions add constraint divisions_status_check
+      check (status in ('setup','scheduled','active','completed'));
+  end if;
+end $$;
 
 create table if not exists stages (
   id            uuid primary key default gen_random_uuid(),
@@ -220,6 +233,18 @@ alter table fixtures add column if not exists ext_key text;
 create unique index if not exists fixtures_stage_ext_key_idx
   on fixtures(stage_id, ext_key) where ext_key is not null;
 
+-- Scheduling provenance (doc 12 §3, PROMPT-17): where the assignment came
+-- from ('manual' = hand-placed/pinned) and whether it is locked against
+-- re-running the auto pass.
+alter table fixtures add column if not exists schedule_source text not null default 'none';
+alter table fixtures add column if not exists schedule_locked boolean not null default false;
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'fixtures_schedule_source_check') then
+    alter table fixtures add constraint fixtures_schedule_source_check
+      check (schedule_source in ('none','auto','manual'));
+  end if;
+end $$;
+
 create index if not exists fixtures_stage_idx    on fixtures(stage_id, round_no, seq_in_round);
 create index if not exists fixtures_division_idx on fixtures(division_id, scheduled_at);
 -- DEVIATION: doc 07 sketched one statement with two table refs — illegal.
@@ -281,6 +306,17 @@ create table if not exists standings_snapshots (
   pool_scope           uuid generated always as
                        (coalesce(pool_id, '00000000-0000-0000-0000-000000000000'::uuid)) stored,
   primary key (stage_id, pool_scope)
+);
+
+-- Per-division scheduling settings (doc 12 §3, PROMPT-17). config carries
+-- startAt, matchMinutes, gapMinutes, courts[], perEntrantMinRest, blackouts[],
+-- sessionWindows[]; tz is the venue-local zone (doc 12 §6 — DST boundaries).
+create table if not exists schedule_settings (
+  division_id uuid primary key references divisions(id) on delete cascade,
+  org_id      uuid not null,
+  config      jsonb not null default '{}',
+  tz          text not null default 'UTC',
+  updated_at  timestamptz not null default now()
 );
 
 create table if not exists division_events (    -- structural ledger, hash-chained per division
@@ -362,7 +398,8 @@ declare
     array['match_states',       'fixtures',     'fixture_id'],
     array['standings_snapshots','stages',       'stage_id'],
     array['division_events',    'divisions',    'division_id'],
-    array['player_profiles',    'persons',      'person_id']
+    array['player_profiles',    'persons',      'person_id'],
+    array['schedule_settings',  'divisions',    'division_id']
   ];
 begin
   foreach spec slice 1 in array specs loop
@@ -468,7 +505,7 @@ begin
     'sport_variants','persons','player_profiles','teams','competitions',
     'divisions','stages','pools','entrants','entrant_members','fixtures',
     'lineups','score_events','match_states','standings_snapshots',
-    'division_events','api_keys'
+    'division_events','api_keys','schedule_settings'
   ] loop
     execute format('alter table %I enable row level security', tbl);
     execute format('alter table %I force  row level security', tbl);
@@ -496,7 +533,8 @@ begin
   foreach tbl in array array[
     'persons','player_profiles','teams','competitions','divisions','stages',
     'pools','entrants','entrant_members','fixtures','lineups','score_events',
-    'match_states','standings_snapshots','division_events','api_keys'
+    'match_states','standings_snapshots','division_events','api_keys',
+    'schedule_settings'
   ] loop
     execute format('drop policy if exists %I on %I', tbl || '_tenant', tbl);
     execute format(
@@ -570,9 +608,18 @@ create or replace view public_divisions_v as
 
 -- `summary` (render-agnostic score lines from the fold cache) rides along for
 -- the live public fixture endpoint — it never contains person data.
+-- Timetable fields are PUBLISH-GATED (doc 12 §1/PROMPT-17): while a division
+-- is still in setup (plan-first draft, timetable not yet published) the
+-- public read model nulls scheduled_at/venue/court_label, so the schedule tab
+-- and .ics show nothing an organiser has not published. publish-schedule
+-- moves the division to 'scheduled' (quick-start moves straight to 'active'),
+-- which lights the fields up.
 create or replace view public_fixtures_v as
   select f.id, f.division_id, f.stage_id, f.pool_id, f.round_no, f.seq_in_round,
-         f.home_entrant_id, f.away_entrant_id, f.scheduled_at, f.venue, f.court_label,
+         f.home_entrant_id, f.away_entrant_id,
+         case when d.status = 'setup' then null else f.scheduled_at end as scheduled_at,
+         case when d.status = 'setup' then null else f.venue end        as venue,
+         case when d.status = 'setup' then null else f.court_label end as court_label,
          f.status, f.outcome, f.created_at,
          m.summary, m.last_seq
   from fixtures f
@@ -677,4 +724,16 @@ grant select on public_competitions_v, public_divisions_v, public_fixtures_v,
 insert into plan_entitlements (plan_key, feature_key, bool_value, int_value) values
   ('community', 'dashboard.public.max', null, 1),
   ('pro',       'dashboard.public.max', null, null)
+on conflict (plan_key, feature_key) do nothing;
+
+-- Doc 12 §5 scheduling matrix (PROMPT-17; scheduling.constraints seeded by
+-- 012): board editing is Pro (Community renders it view-only), the
+-- competition-wide multi-division board is Pro.
+insert into plan_entitlements (plan_key, feature_key, bool_value, int_value) values
+  ('community', 'scheduling.board',          false, null),
+  ('pro',       'scheduling.board',          true,  null),
+  ('business',  'scheduling.board',          true,  null),
+  ('community', 'scheduling.multi_division', false, null),
+  ('pro',       'scheduling.multi_division', true,  null),
+  ('business',  'scheduling.multi_division', true,  null)
 on conflict (plan_key, feature_key) do nothing;


### PR DESCRIPTION
Implements `engine/prompts/PROMPT-17-scheduling-console.md` per `engine/12-scheduling-ux.md` (normative), 05 §2.6 and 08 §3.

## Engine (pure)
- `scheduling/calendar.ts`: `sessionWindows` (complement of the windows treated as blackout time), order-dependency validation (`warn.order`; direct feeds block), `SCHEDULE_CONFLICT` error code.
- Property tests: **re-run with all outputs locked = zero moves**, session containment, validator finds every seeded conflict class.

## Schema (doc 12 §3)
- Migration `014_scheduling.sql` (guarded for fresh-bootstrap ordering) + idempotent `schema_v2.sql` delta.
- `fixtures.schedule_source/schedule_locked`; `schedule_settings` table with RLS + org_id trigger (house pattern, `check:rls` covered); `divisions.status` gains `scheduled` (doc 12 §1 state machine).
- `public_fixtures_v` publish-gates `scheduled_at/venue/court_label` while a division is in `setup` — public schedule tab, public API and `.ics` reflect the published timetable only, from one view. Quick-start unaffected.

## API (doc 12 §4)
- `GET/PUT /divisions/{id}/schedule-settings` (constraint fields 402-gate on `scheduling.constraints`)
- `POST /stages/{id}/schedule/auto` — propose only, nothing persisted; `only_unlocked` re-flows around pins
- `POST /stages/{id}/schedule/apply` — transactional persist + `schedule_applied` division event
- `PATCH /fixtures/{id}` — single move/pin through the validated move path + `schedule_edited {fixture, from, to}`
- `POST /divisions/{id}/schedule/validate`, `publish-schedule`, `start`
- Conflict taxonomy exactly doc 12 §2: `conflict.court` and direct-feed `warn.order` block (`409 SCHEDULE_CONFLICT` with the conflict list); others warn.
- Scoring endpoints reject events before `division_started` (WRONG_PHASE).

## UI
- Division page: the two launch actions — **Start tournament** (quick-start: generate → sequence-slot incl. rolling `roundMinutes` times → active) and **Schedule** (plan-first board).
- Drag-and-drop board: courts × time grid (day/week), TBD feed labels ("Winner of R1 #2"), optimistic drag + debounced re-validate, violation badges, 🔒 pin/lock, re-flow remaining, bulk shift/swap, realtime refresh on `division:{id}`, keyboard-accessible move panel (a11y).
- Competition-wide multi-division board with division colours (Pro).

## Entitlements (doc 12 §5)
- Seeded `scheduling.board` (Community = view-only) and `scheduling.multi_division`; enforced server-side, UpgradeGate copy added.

## Tests
- E2E acceptance: 8-team group+KO — auto-schedule across 2 courts with rest constraint, drag into court clash (blocked), into rest violation (warned, allowed), lock two cards, re-flow (pins survive byte-identically), publish (public visibility flips), start, score round 1, rain-reschedule remaining; decided fixtures immutable.
- Community org: constraints/board 402-gated; quick-start + basic single-court auto unaffected.
- Verified locally against a real Postgres 17: schema apply, `check:rls`, full server suite (one pre-existing `verifyStateConsistency` parallel-worker flake fails on baseline too — untouched).

## Docs
- `engine/12-scheduling-ux.md` updated with implementation notes (`only_unlocked` field name, bulk `schedule_applied` event, session violations under `warn.blackout`, non-direct order warnings deferred) — docs and code do not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)