### PR TITLE
CD: Flyway migrate before staging deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,16 @@ jobs:
         run: cat dev-server.log || true
 
   # -------------------------------------------------------------------------
-  # Deploy to the staging Fly app. Only on push to main, and only once both
-  # gates above are green. PRs never deploy.
+  # CD (staging): Flyway migrate against the staging database, THEN deploy the
+  # app to Fly. Only on push to main, and only once every gate above is green;
+  # PRs never deploy. Migration-before-deploy means every migration must be
+  # backward compatible with the app version still running (expand/contract) —
+  # if the migrate step fails, the old app keeps running untouched.
+  #
+  # Requires the STAGING_DATABASE_URL secret (Supabase SESSION pooler, port
+  # 5432 — Flyway's JDBC driver doesn't get along with the transaction
+  # pooler's statement handling on 6543). One-time setup on a pre-Flyway
+  # database: run the "Baseline staging DB" workflow (db-baseline.yml).
   # -------------------------------------------------------------------------
   deploy-staging:
     name: Deploy (staging)
@@ -168,6 +176,26 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5 # scripts/flyway.sh parses DATABASE_URL with node
+        with:
+          node-version: 22
+
+      - name: Cache Flyway CLI
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/seazn-flyway
+          key: flyway-cli-10.22.0-linux-x64
+
+      - name: Pending migrations
+        run: bash scripts/flyway.sh info
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+
+      - name: Migrate staging database (Flyway)
+        run: bash scripts/flyway.sh migrate
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy -c fly.stg.toml --remote-only
         env:

--- a/.github/workflows/db-baseline.yml
+++ b/.github/workflows/db-baseline.yml
@@ -1,0 +1,36 @@
+name: Baseline staging DB
+
+# One-time (per database): mark a PRE-FLYWAY database as already containing
+# every migration up to db/flyway.toml's baselineVersion (V240), so the CD
+# pipeline's `flyway migrate` runs incrementally from there. Safe to re-run —
+# Flyway refuses to baseline a database that already has a history table.
+# Manual trigger only; requires the STAGING_DATABASE_URL secret.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  baseline:
+    name: flyway baseline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - name: Cache Flyway CLI
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/seazn-flyway
+          key: flyway-cli-10.22.0-linux-x64
+
+      - name: Baseline (marks V240 as applied; no SQL is executed)
+        run: bash scripts/flyway.sh baseline
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+
+      - name: Migration history
+        run: bash scripts/flyway.sh info
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}


### PR DESCRIPTION
## Summary
- `deploy-staging` (push to main, after all gates) now runs `flyway info` + `flyway migrate` against the staging database before `flyctl deploy` — migrations land first, and a failed migration aborts the deploy leaving the running app untouched. Migrations must stay backward compatible with the running version (expand/contract), noted in the workflow.
- New manual workflow **Baseline staging DB** (`db-baseline.yml`, workflow_dispatch): one-time `flyway baseline` for pre-Flyway databases — marks V240 applied without executing SQL; Flyway refuses to re-baseline, so it's safe.

## Setup required (repo secret)
`STAGING_DATABASE_URL` — the staging Supabase **session pooler** URL (port 5432, not the 6543 transaction pooler; Flyway's JDBC driver + PgBouncer transaction mode don't mix). Then run the Baseline workflow once.

## Test plan
- [x] YAML lint on both workflows
- [ ] After secret + baseline: next push to main migrates then deploys (first run should show "no pending migrations" and deploy as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)