### PR TITLE
Product tour, plan badges, slideshows & organiser UX polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+scripts/.seed-demo-state.json

--- a/apps/web/public/entrants-sample.csv
+++ b/apps/web/public/entrants-sample.csv
@@ -1,0 +1,5 @@
+name,dob,gender,seed,team,squad_number
+A. Sharma,2011-04-02,m,1,Riverside U16,7
+B. Khan,2010-11-19,m,,Riverside U16,10
+C. Patel,2011-01-25,f,2,Lakeside U16,9
+D. Nguyen,2010-08-14,f,,Lakeside U16,4

--- a/apps/web/src/app/api/tour/route.ts
+++ b/apps/web/src/app/api/tour/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+import { markTourDone, resetTour } from "@/lib/activation";
+
+export async function POST() {
+  const user = await getCurrentUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  await markTourDone(user.id);
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE() {
+  const user = await getCurrentUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  await resetTour(user.id);
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/api/v1/orgs/[id]/api-keys/route.ts
+++ b/apps/web/src/app/api/v1/orgs/[id]/api-keys/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: Request, { params }: Ctx) {
   });
 }
 
-/** Mint a key: the sk_live_ secret appears in this response only (doc 08 §2). */
+/** Mint a key: the sc_ secret appears in this response only (doc 08 §2). */
 export async function POST(req: Request, { params }: Ctx) {
   return v1(async () => {
     const { id } = await params;

--- a/apps/web/src/app/competitions/[id]/page.tsx
+++ b/apps/web/src/app/competitions/[id]/page.tsx
@@ -1,12 +1,11 @@
 export const dynamic = "force-dynamic";
-// Competition overview: settings + division list (PROMPT-15 task 1).
+// Competition overview: division list; settings live on their own page.
 import Link from "next/link";
+import { Settings } from "lucide-react";
 import { Nav } from "@/components/nav";
 import { requireResourcePageAuth } from "@/server/page-auth";
 import { getCompetition } from "@/server/usecases/competitions";
 import { listDivisions } from "@/server/usecases/divisions";
-import { CompetitionSettings } from "@/components/v2/competition-settings";
-import { hasFeature } from "@/lib/entitlements";
 import { sql } from "@/lib/db";
 
 export default async function CompetitionPage({
@@ -16,11 +15,10 @@ export default async function CompetitionPage({
 }) {
   const { id } = await params;
   const { auth, org, canEdit } = await requireResourcePageAuth("competition", id);
-  const [competition, divisions, [orgRow], discoveryBranding] = await Promise.all([
+  const [competition, divisions, [orgRow]] = await Promise.all([
     getCompetition(auth, id),
     listDivisions(auth, id),
     sql<{ slug: string }[]>`select slug from organizations where id = ${auth.orgId}`,
-    hasFeature(auth.orgId, "discovery.branding"),
   ]);
   const publicPath =
     competition.visibility !== "private" && orgRow
@@ -43,17 +41,32 @@ export default async function CompetitionPage({
               {competition.name}
             </h1>
           </div>
-          <Link href={`/competitions/${competition.id}/schedule`} className="btn btn-ghost">
-            Schedule board
-          </Link>
-          {publicPath && (
-            <Link href={publicPath} className="btn btn-ghost" target="_blank">
-              View public page ↗
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              href={`/competitions/${competition.id}/slideshow`}
+              target="_blank"
+              className="btn btn-ghost"
+            >
+              Slideshow ↗
             </Link>
-          )}
+            <Link href={`/competitions/${competition.id}/schedule`} className="btn btn-ghost">
+              Schedule board
+            </Link>
+            {publicPath && (
+              <Link href={publicPath} className="btn btn-ghost" target="_blank">
+                View public page ↗
+              </Link>
+            )}
+            <Link
+              href={`/competitions/${competition.id}/settings`}
+              className="btn btn-ghost flex items-center gap-1.5"
+            >
+              <Settings className="h-4 w-4" strokeWidth={1.75} />
+              Settings
+            </Link>
+          </div>
         </div>
 
-        <div className="grid gap-6 lg:grid-cols-[1fr_340px]">
           <section>
             <div className="mb-3 flex items-center justify-between">
               <h2 className="text-sm font-semibold text-slate-700">Divisions</h2>
@@ -94,27 +107,6 @@ export default async function CompetitionPage({
               </ul>
             )}
           </section>
-
-          <aside>
-            <CompetitionSettings
-              competition={{
-                id: competition.id,
-                name: competition.name,
-                slug: competition.slug,
-                description: competition.description,
-                starts_on: competition.starts_on,
-                ends_on: competition.ends_on,
-                visibility: competition.visibility,
-                status: competition.status,
-                frozen: competition.frozen ?? false,
-                discoverable: competition.discoverable,
-                discovery: (competition.discovery ?? {}) as Record<string, string | null>,
-              }}
-              canEdit={canEdit}
-              discoveryBranding={discoveryBranding}
-            />
-          </aside>
-        </div>
       </main>
     </>
   );

--- a/apps/web/src/app/competitions/[id]/settings/page.tsx
+++ b/apps/web/src/app/competitions/[id]/settings/page.tsx
@@ -1,0 +1,60 @@
+export const dynamic = "force-dynamic";
+// Competition settings — moved off the overview into its own page.
+import Link from "next/link";
+import { Nav } from "@/components/nav";
+import { requireResourcePageAuth } from "@/server/page-auth";
+import { getCompetition } from "@/server/usecases/competitions";
+import { CompetitionSettings } from "@/components/v2/competition-settings";
+import { hasFeature } from "@/lib/entitlements";
+
+export default async function CompetitionSettingsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { auth, org, canEdit } = await requireResourcePageAuth("competition", id);
+  const [competition, discoveryBranding] = await Promise.all([
+    getCompetition(auth, id),
+    hasFeature(auth.orgId, "discovery.branding"),
+  ]);
+
+  return (
+    <>
+      <Nav />
+      <main className="mx-auto max-w-2xl px-4 py-8">
+        <div className="mb-6">
+          <p className="text-xs text-slate-400">
+            <Link href="/dashboard" className="hover:text-purple-600">
+              Competitions
+            </Link>{" "}
+            / {org.name} /{" "}
+            <Link href={`/competitions/${competition.id}`} className="hover:text-purple-600">
+              {competition.name}
+            </Link>
+          </p>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight text-slate-900">
+            Settings — {competition.name}
+          </h1>
+        </div>
+        <CompetitionSettings
+          competition={{
+            id: competition.id,
+            name: competition.name,
+            slug: competition.slug,
+            description: competition.description,
+            starts_on: competition.starts_on,
+            ends_on: competition.ends_on,
+            visibility: competition.visibility,
+            status: competition.status,
+            frozen: competition.frozen ?? false,
+            discoverable: competition.discoverable,
+            discovery: (competition.discovery ?? {}) as Record<string, string | null>,
+          }}
+          canEdit={canEdit}
+          discoveryBranding={discoveryBranding}
+        />
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/app/competitions/[id]/slideshow/page.tsx
+++ b/apps/web/src/app/competitions/[id]/slideshow/page.tsx
@@ -5,6 +5,7 @@ import { requireResourcePageAuth } from "@/server/page-auth";
 import { getCompetition } from "@/server/usecases/competitions";
 import { listDivisions } from "@/server/usecases/divisions";
 import { buildDivisionSlides, type Slide } from "@/server/slideshow-data";
+import { hasFeature } from "@/lib/entitlements";
 import { Slideshow } from "@/components/v2/slideshow";
 
 export default async function CompetitionSlideshowPage({
@@ -30,12 +31,15 @@ export default async function CompetitionSlideshowPage({
   for (const d of ordered) {
     slides.push(...(await buildDivisionSlides(auth, d.id, d.name)));
   }
+  const realtime = await hasFeature(auth.orgId, "realtime");
 
   return (
     <Slideshow
       title={competition.name}
       slides={slides}
       backHref={`/competitions/${id}`}
+      divisionIds={ordered.map((d) => d.id)}
+      realtime={realtime}
     />
   );
 }

--- a/apps/web/src/app/competitions/[id]/slideshow/page.tsx
+++ b/apps/web/src/app/competitions/[id]/slideshow/page.tsx
@@ -1,0 +1,41 @@
+export const dynamic = "force-dynamic";
+// Competition-wide noticeboard slideshow — rotates through every division
+// that has something to show (active divisions first).
+import { requireResourcePageAuth } from "@/server/page-auth";
+import { getCompetition } from "@/server/usecases/competitions";
+import { listDivisions } from "@/server/usecases/divisions";
+import { buildDivisionSlides, type Slide } from "@/server/slideshow-data";
+import { Slideshow } from "@/components/v2/slideshow";
+
+export default async function CompetitionSlideshowPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { auth } = await requireResourcePageAuth("competition", id);
+  const [competition, divisions] = await Promise.all([
+    getCompetition(auth, id),
+    listDivisions(auth, id),
+  ]);
+
+  // Active divisions lead; the rest follow so a finished division's final
+  // table still cycles through.
+  const ordered = [...divisions].sort(
+    (a, b) => Number(b.status === "active") - Number(a.status === "active"),
+  );
+  // Sequential on purpose: parallel decks × parallel queries inside each deck
+  // can exhaust the small pg pool through the Supabase pooler.
+  const slides: Slide[] = [];
+  for (const d of ordered) {
+    slides.push(...(await buildDivisionSlides(auth, d.id, d.name)));
+  }
+
+  return (
+    <Slideshow
+      title={competition.name}
+      slides={slides}
+      backHref={`/competitions/${id}`}
+    />
+  );
+}

--- a/apps/web/src/app/competitions/new/page.tsx
+++ b/apps/web/src/app/competitions/new/page.tsx
@@ -11,7 +11,7 @@ export default async function NewCompetitionPage() {
   return (
     <>
       <Nav />
-      <main className="mx-auto max-w-2xl px-4 py-8">
+      <main className="mx-auto max-w-2xl px-4 py-8" data-tour="competition-wizard">
         <h1 className="mb-6 text-xl font-semibold tracking-tight text-slate-900">
           New competition
         </h1>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -49,7 +49,7 @@ export default async function DashboardPage() {
               People
             </Link>
             {canEdit && (
-              <Link href="/competitions/new" className="btn btn-primary">
+              <Link href="/competitions/new" data-tour="new-competition" className="btn btn-primary">
                 + New Competition
               </Link>
             )}

--- a/apps/web/src/app/divisions/[id]/page.tsx
+++ b/apps/web/src/app/divisions/[id]/page.tsx
@@ -103,6 +103,9 @@ export default async function DivisionPage({
             </span>
             {frozen && <span className="badge bg-sky-100 text-sky-700">read-only</span>}
             <div className="flex-1" />
+            <Link href={`/divisions/${id}/slideshow`} target="_blank" className="btn btn-ghost">
+              Slideshow ↗
+            </Link>
             <Link href={`/divisions/${id}/registrations`} className="btn btn-ghost">
               Registrations
             </Link>

--- a/apps/web/src/app/divisions/[id]/page.tsx
+++ b/apps/web/src/app/divisions/[id]/page.tsx
@@ -149,6 +149,7 @@ export default async function DivisionPage({
 
         {tab === "fixtures" && (
           <StagesPanel
+            divisionId={id}
             stages={stages}
             fixtures={fixtures}
             entrantNames={entrantNames}

--- a/apps/web/src/app/divisions/[id]/registrations/page.tsx
+++ b/apps/web/src/app/divisions/[id]/registrations/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { requireResourcePageAuth } from "@/server/page-auth";
+import { hasFeature } from "@/lib/entitlements";
 import { getDivision } from "@/server/usecases/divisions";
 import { getCompetition } from "@/server/usecases/competitions";
 import { RegistrationsPanel } from "@/components/v2/registrations-panel";
@@ -16,6 +17,7 @@ export default async function DivisionRegistrationsPage({
   const { auth, canEdit } = await requireResourcePageAuth("division", id);
   const division = await getDivision(auth, id);
   const competition = await getCompetition(auth, division.competition_id);
+  const paidAllowed = await hasFeature(auth.orgId, "registration.paid");
 
   return (
     <>
@@ -43,6 +45,7 @@ export default async function DivisionRegistrationsPage({
           orgId={auth.orgId}
           divisionId={id}
           canEdit={canEdit && !(competition.frozen ?? false)}
+          paidAllowed={paidAllowed}
         />
       </main>
     </>

--- a/apps/web/src/app/divisions/[id]/slideshow/page.tsx
+++ b/apps/web/src/app/divisions/[id]/slideshow/page.tsx
@@ -1,0 +1,27 @@
+export const dynamic = "force-dynamic";
+// Per-division noticeboard slideshow — standings, live fixtures, results.
+import { requireResourcePageAuth } from "@/server/page-auth";
+import { getDivision } from "@/server/usecases/divisions";
+import { getCompetition } from "@/server/usecases/competitions";
+import { buildDivisionSlides } from "@/server/slideshow-data";
+import { Slideshow } from "@/components/v2/slideshow";
+
+export default async function DivisionSlideshowPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { auth } = await requireResourcePageAuth("division", id);
+  const division = await getDivision(auth, id);
+  const competition = await getCompetition(auth, division.competition_id);
+  const slides = await buildDivisionSlides(auth, id, division.name);
+
+  return (
+    <Slideshow
+      title={`${competition.name} · ${division.name}`}
+      slides={slides}
+      backHref={`/divisions/${id}`}
+    />
+  );
+}

--- a/apps/web/src/app/divisions/[id]/slideshow/page.tsx
+++ b/apps/web/src/app/divisions/[id]/slideshow/page.tsx
@@ -4,6 +4,7 @@ import { requireResourcePageAuth } from "@/server/page-auth";
 import { getDivision } from "@/server/usecases/divisions";
 import { getCompetition } from "@/server/usecases/competitions";
 import { buildDivisionSlides } from "@/server/slideshow-data";
+import { hasFeature } from "@/lib/entitlements";
 import { Slideshow } from "@/components/v2/slideshow";
 
 export default async function DivisionSlideshowPage({
@@ -15,13 +16,18 @@ export default async function DivisionSlideshowPage({
   const { auth } = await requireResourcePageAuth("division", id);
   const division = await getDivision(auth, id);
   const competition = await getCompetition(auth, division.competition_id);
-  const slides = await buildDivisionSlides(auth, id, division.name);
+  const [slides, realtime] = await Promise.all([
+    buildDivisionSlides(auth, id, division.name),
+    hasFeature(auth.orgId, "realtime"),
+  ]);
 
   return (
     <Slideshow
       title={`${competition.name} · ${division.name}`}
       slides={slides}
       backHref={`/divisions/${id}`}
+      divisionIds={[id]}
+      realtime={realtime}
     />
   );
 }

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import {
   Building2, Users, CreditCard, UserCircle,
   Pencil, Image as ImageIcon, ArrowLeftRight, Zap, BarChart2,
-  TrendingUp, User, Mail, Download, ShieldOff, KeyRound,
+  TrendingUp, User, Mail, Download, ShieldOff, KeyRound, Compass,
   type LucideIcon,
 } from "lucide-react";
 import { getActiveOrgId, getCurrentUser, getUserOrgs, requireOrgRole } from "@/lib/auth";
@@ -25,6 +25,8 @@ import {
   DeleteAccountButton,
 } from "@/components/account-actions";
 import { ApiKeysPanel } from "@/components/api-keys";
+import { TourReplayButton } from "@/components/tour-replay";
+import { PlanBadge } from "@/components/plan-badge";
 
 function SectionHeader({ icon: Icon, children, action }: {
   icon: LucideIcon;
@@ -276,7 +278,7 @@ export default async function SettingsPage({
                 </div>
 
                 {canEdit && (
-                  <div className="mt-5 border-t border-slate-100 pt-5">
+                  <div className="mt-5 border-t border-slate-100 pt-5" data-tour="org-rename">
                     <SubSection icon={Pencil} label="Rename" />
                     <OrgRename orgId={active.id} initialName={active.name} />
                   </div>
@@ -295,10 +297,11 @@ export default async function SettingsPage({
                         }
                       />
                     ) : (
-                      <p className="text-sm text-slate-400">
+                      <p className="flex items-center gap-2 text-sm text-slate-400">
+                        <PlanBadge feature="branding" />
                         Org logo requires{" "}
                         <Link href="/settings?tab=billing" className="text-purple-600 underline">
-                          Pro plan ✦
+                          an upgrade
                         </Link>
                       </p>
                     )}
@@ -309,6 +312,13 @@ export default async function SettingsPage({
                   <SubSection icon={ArrowLeftRight} label="Switch organisation" />
                   <OrgSwitcher orgs={orgs} activeId={active.id} />
                 </div>
+
+                {canEdit && (
+                  <div className="mt-5 border-t border-slate-100 pt-5">
+                    <SubSection icon={Compass} label="Product tour" />
+                    <TourReplayButton />
+                  </div>
+                )}
               </section>
             )}
 
@@ -417,10 +427,11 @@ export default async function SettingsPage({
                 ) : hasApiAccess ? (
                   <ApiKeysPanel orgId={active.id} canWriteScope={hasApiWrite} />
                 ) : (
-                  <p className="text-sm text-slate-400">
+                  <p className="flex items-center gap-2 text-sm text-slate-400">
+                    <PlanBadge feature="api.access" />
                     Platform API keys require{" "}
                     <Link href="/settings?tab=billing" className="text-purple-600 underline">
-                      Pro plan ✦
+                      an upgrade
                     </Link>
                   </p>
                 )}

--- a/apps/web/src/components/api-keys.tsx
+++ b/apps/web/src/components/api-keys.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Copy, Check, KeyRound } from "lucide-react";
+import { PlanBadge } from "@/components/plan-badge";
 
 interface ApiKeyRow {
   id: string;
@@ -37,7 +38,7 @@ function fmt(iso: string | null): string {
   });
 }
 
-/** Manage the org's platform API keys (Pro). The sk_live_ secret is shown
+/** Manage the org's platform API keys (Pro). The sc_ secret is shown
  *  exactly once, right after minting — it can never be retrieved again. */
 export function ApiKeysPanel({
   orgId,
@@ -175,7 +176,10 @@ export function ApiKeysPanel({
           />
           Allow writes
           {!canWriteScope && (
-            <span className="text-xs text-slate-400">(read-only on Pro — writes need Business)</span>
+            <>
+              <PlanBadge feature="api.write" />
+              <span className="text-xs text-slate-400">(read-only on Pro)</span>
+            </>
           )}
         </label>
       </div>
@@ -186,7 +190,7 @@ export function ApiKeysPanel({
       ) : active.length === 0 ? (
         <p className="text-sm text-slate-400">
           No API keys yet. Create one to call the platform API with{" "}
-          <code className="font-mono text-xs">Authorization: Bearer sk_live_…</code>
+          <code className="font-mono text-xs">Authorization: Bearer sc_…</code>
         </p>
       ) : (
         <ul className="divide-y divide-slate-100">

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
 import { LayoutDashboard, Settings, Users } from "lucide-react";
 import { getActiveOrgId, getCurrentUser, getUserOrgs } from "@/lib/auth";
+import { needsTour } from "@/lib/activation";
+import { EDITOR_ROLES } from "@/lib/types";
 import { LogoutButton } from "@/components/logout-button";
+import { ProductTour } from "@/components/product-tour";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 
@@ -14,7 +17,12 @@ function orgLogoUrl(org: { logo_storage_path: string | null; logo_url: string | 
 
 export async function Nav() {
   const user = await getCurrentUser();
-  let activeOrg: { name: string; logo_storage_path: string | null; logo_url: string | null } | null = null;
+  let activeOrg: {
+    name: string;
+    role: string;
+    logo_storage_path: string | null;
+    logo_url: string | null;
+  } | null = null;
   if (user) {
     const orgs = await getUserOrgs(user.id);
     if (orgs.length > 0) {
@@ -23,6 +31,10 @@ export async function Nav() {
     }
   }
   const logoUrl = activeOrg ? orgLogoUrl(activeOrg) : null;
+  // Tour targets editor flows (rename org, create competition) — viewers skip it.
+  const canTour =
+    !!user && !!activeOrg && (EDITOR_ROLES as readonly string[]).includes(activeOrg.role);
+  const tourPending = canTour && (await needsTour(user!.id));
 
   return (
     <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
@@ -39,7 +51,10 @@ export async function Nav() {
           )}
         </Link>
         {user && activeOrg && (
-          <span className="hidden items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 sm:flex">
+          <span
+            data-tour="org-chip"
+            className="hidden items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-600 sm:flex"
+          >
             <span className="h-1.5 w-1.5 rounded-full bg-purple-500" />
             {activeOrg.name}
           </span>
@@ -83,6 +98,7 @@ export async function Nav() {
           <Link href="/login" className="btn btn-primary">Sign in</Link>
         )}
       </div>
+      {canTour && <ProductTour autoStart={tourPending} />}
     </header>
   );
 }

--- a/apps/web/src/components/plan-badge.tsx
+++ b/apps/web/src/components/plan-badge.tsx
@@ -1,0 +1,24 @@
+// Tiny plan pill shown on any gated button/panel so users see the required
+// tier before they click (doc 10 §3). Server- and client-safe (no hooks).
+import { featurePlan, type PaidPlan } from "@/lib/feature-copy";
+
+const STYLE: Record<PaidPlan, string> = {
+  pro: "bg-purple-100 text-purple-700",
+  business: "bg-indigo-100 text-indigo-700",
+};
+
+const LABEL: Record<PaidPlan, string> = {
+  pro: "Pro ✦",
+  business: "Business ◆",
+};
+
+export function PlanBadge({ plan, feature }: { plan?: PaidPlan; feature?: string }) {
+  const p = plan ?? featurePlan(feature ?? "");
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${STYLE[p]}`}
+    >
+      {LABEL[p]}
+    </span>
+  );
+}

--- a/apps/web/src/components/product-tour.tsx
+++ b/apps/web/src/components/product-tour.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { usePathname, useRouter } from "next/navigation";
+
+interface TourStep {
+  id: string;
+  /** Route this step lives on — advancing across routes navigates there. */
+  path: string;
+  /** Matches an element's data-tour attribute; null renders a centered card. */
+  target: string | null;
+  title: string;
+  body: string;
+}
+
+const STEPS: TourStep[] = [
+  {
+    id: "welcome",
+    path: "/dashboard",
+    target: null,
+    title: "Welcome to Seazn Club 👋",
+    body: "A quick tour of the essentials — your organisation, settings and creating your first competition. Takes under a minute.",
+  },
+  {
+    id: "org-chip",
+    path: "/dashboard",
+    target: "org-chip",
+    title: "Your organisation",
+    body: "Everything you create lives under this organisation. Next, let's see where you can rename it.",
+  },
+  {
+    id: "org-rename",
+    path: "/settings",
+    target: "org-rename",
+    title: "Rename your organisation",
+    body: "Type a new name here and save. The tabs on the left also cover your team, plan and API keys.",
+  },
+  {
+    id: "new-competition",
+    path: "/dashboard",
+    target: "new-competition",
+    title: "Create a competition",
+    body: "A competition holds one or more divisions — each with its own sport, entrants and format. Let's start one.",
+  },
+  {
+    id: "wizard",
+    path: "/competitions/new",
+    target: "competition-wizard",
+    title: "Your first competition",
+    body: "Follow the wizard: name it, add a division, pick a sport and format. Replay this tour anytime from Settings → Organisation.",
+  },
+];
+
+export const TOUR_STORAGE_KEY = "seazn.tour.step";
+const PADDING = 8;
+const TOOLTIP_WIDTH = 320;
+
+type Rect = { top: number; left: number; width: number; height: number };
+
+function measure(target: string): Rect | null {
+  const el = document.querySelector(`[data-tour="${target}"]`);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  if (r.width === 0 && r.height === 0) return null;
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+export function ProductTour({ autoStart }: { autoStart: boolean }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const [step, setStep] = useState<number | null>(null);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  // Resume a tour in progress (after cross-page navigation) or auto-start on
+  // the dashboard for users who haven't completed it yet.
+  useEffect(() => {
+    const stored = sessionStorage.getItem(TOUR_STORAGE_KEY);
+    if (stored !== null) {
+      const i = Number(stored);
+      if (Number.isInteger(i) && STEPS[i]?.path === pathname) {
+        setStep(i);
+      } else if (!Number.isInteger(i) || !STEPS[i]) {
+        sessionStorage.removeItem(TOUR_STORAGE_KEY);
+      }
+      // Path mismatch: keep the key — the navigation we triggered may still
+      // be in flight; the component on the destination page resumes it.
+      return;
+    }
+    if (autoStart && pathname === "/dashboard") {
+      sessionStorage.setItem(TOUR_STORAGE_KEY, "0");
+      setStep(0);
+    }
+  }, [autoStart, pathname]);
+
+  const finish = useCallback((markDone: boolean) => {
+    sessionStorage.removeItem(TOUR_STORAGE_KEY);
+    setStep(null);
+    if (markDone) fetch("/api/tour", { method: "POST" }).catch(() => {});
+  }, []);
+
+  const goTo = useCallback(
+    (i: number) => {
+      if (i >= STEPS.length) {
+        finish(true);
+        return;
+      }
+      if (i < 0) return;
+      sessionStorage.setItem(TOUR_STORAGE_KEY, String(i));
+      if (STEPS[i].path !== pathname) {
+        setStep(null); // hide until the destination page's tour resumes
+        router.push(STEPS[i].path);
+      } else {
+        setStep(i);
+      }
+    },
+    [pathname, router, finish],
+  );
+
+  // Track the highlighted element's position; poll briefly in case it renders
+  // after navigation, then follow resize/scroll.
+  useEffect(() => {
+    if (step === null) return;
+    const target = STEPS[step].target;
+    if (!target) {
+      setRect(null);
+      return;
+    }
+    let cancelled = false;
+    let attempts = 0;
+    let scrolled = false;
+
+    const update = () => {
+      if (cancelled) return;
+      const r = measure(target);
+      if (r) {
+        if (!scrolled) {
+          scrolled = true;
+          document
+            .querySelector(`[data-tour="${target}"]`)
+            ?.scrollIntoView({ block: "center", behavior: "instant" as ScrollBehavior });
+          setRect(measure(target));
+        } else {
+          setRect(r);
+        }
+      } else if (attempts++ < 20) {
+        setTimeout(update, 50);
+      } else {
+        setRect(null); // target missing (e.g. hidden on mobile) — centered card
+      }
+    };
+    update();
+
+    const follow = () => {
+      if (!cancelled && scrolled) setRect(measure(target));
+    };
+    window.addEventListener("resize", follow);
+    window.addEventListener("scroll", follow, true);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("resize", follow);
+      window.removeEventListener("scroll", follow, true);
+    };
+  }, [step]);
+
+  // Escape skips the tour.
+  useEffect(() => {
+    if (step === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") finish(true);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [step, finish]);
+
+  if (!mounted || step === null) return null;
+  const s = STEPS[step];
+  const isLast = step === STEPS.length - 1;
+
+  // Tooltip placement: below the target when there's room, otherwise above;
+  // centered card when there's no target.
+  let tooltipStyle: React.CSSProperties;
+  if (rect) {
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const left = Math.min(Math.max(rect.left, 16), Math.max(vw - TOOLTIP_WIDTH - 16, 16));
+    const below = rect.top + rect.height + PADDING + 220 < vh;
+    tooltipStyle = below
+      ? { top: rect.top + rect.height + PADDING + 8, left }
+      : { bottom: vh - rect.top + PADDING + 8, left };
+  } else {
+    tooltipStyle = { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true" aria-label="Product tour">
+      {/* Dim layer — spotlight cut-out around the target via box-shadow */}
+      {rect ? (
+        <div
+          className="pointer-events-none fixed rounded-xl ring-2 ring-purple-400 transition-all duration-300"
+          style={{
+            top: rect.top - PADDING,
+            left: rect.left - PADDING,
+            width: rect.width + PADDING * 2,
+            height: rect.height + PADDING * 2,
+            boxShadow: "0 0 0 9999px rgba(15, 23, 42, 0.55)",
+          }}
+        />
+      ) : (
+        <div className="fixed inset-0 bg-slate-900/55" />
+      )}
+
+      {/* Tooltip */}
+      <div
+        className="fixed rounded-xl border border-slate-200 bg-white p-5 shadow-xl"
+        style={{ width: TOOLTIP_WIDTH, ...tooltipStyle }}
+      >
+        <h3 className="text-sm font-semibold text-slate-800">{s.title}</h3>
+        <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{s.body}</p>
+
+        <div className="mt-4 flex items-center gap-1.5">
+          {STEPS.map((_, i) => (
+            <span
+              key={i}
+              className={`h-1.5 rounded-full transition-all ${
+                i === step ? "w-4 bg-purple-500" : "w-1.5 bg-slate-200"
+              }`}
+            />
+          ))}
+        </div>
+
+        <div className="mt-4 flex items-center justify-between gap-2">
+          <button
+            type="button"
+            onClick={() => finish(true)}
+            className="text-xs text-slate-400 hover:text-slate-600"
+          >
+            Skip tour
+          </button>
+          <div className="flex items-center gap-2">
+            {step > 0 && (
+              <button type="button" onClick={() => goTo(step - 1)} className="btn btn-ghost text-xs">
+                Back
+              </button>
+            )}
+            <button type="button" onClick={() => goTo(step + 1)} className="btn btn-primary text-xs">
+              {isLast ? "Finish" : "Next"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/tour-replay.tsx
+++ b/apps/web/src/components/tour-replay.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { TOUR_STORAGE_KEY } from "@/components/product-tour";
+
+export function TourReplayButton() {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function replay() {
+    setBusy(true);
+    try {
+      await fetch("/api/tour", { method: "DELETE" });
+      sessionStorage.removeItem(TOUR_STORAGE_KEY);
+      router.push("/dashboard");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <p className="text-sm text-slate-500">
+        Walk through the basics again — organisation, settings and creating a competition.
+      </p>
+      <button type="button" onClick={replay} disabled={busy} className="btn btn-ghost shrink-0 text-xs">
+        {busy ? "Starting…" : "Replay tour"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/upgrade-gate.tsx
+++ b/apps/web/src/components/upgrade-gate.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { featureReason } from "@/lib/feature-copy";
+import { PlanBadge } from "@/components/plan-badge";
 
 interface Props {
   /** Entitlement feature key, e.g. "scoring.ball_by_ball" (doc 10 §1). */
@@ -33,6 +34,7 @@ export function UpgradeGate({ feature, href = "/settings/billing", compact = fal
         className="inline-flex items-center gap-1.5 rounded-full bg-purple-50 px-3 py-1 text-xs font-medium text-purple-700 hover:bg-purple-100"
       >
         <LockIcon />
+        <PlanBadge feature={feature} />
         {reason} <span className="font-semibold underline">Upgrade →</span>
       </Link>
     );
@@ -45,6 +47,7 @@ export function UpgradeGate({ feature, href = "/settings/billing", compact = fal
     >
       <p className="flex items-center gap-2 font-medium">
         <LockIcon />
+        <PlanBadge feature={feature} />
         {reason}
       </p>
       <p className="mt-2">

--- a/apps/web/src/components/v2/division-builder.tsx
+++ b/apps/web/src/components/v2/division-builder.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-// Division builder (PROMPT-15 task 1): sport → variant → eligibility template
-// → stage graph. Creates the division, then its stages, then lands on the
-// division console. Config overrides are validated server-side by the pinned
-// module's configSchema — invalid JSON never reaches the DB.
+// Division builder (PROMPT-15 task 1): sport → variant → match rules →
+// eligibility template → stage graph. Creates the division, then its stages,
+// then lands on the division console. Match-rule fields build the config
+// override object, validated server-side by the pinned module's configSchema.
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
@@ -69,6 +69,15 @@ const STAGE_TEMPLATES: {
     ],
   },
   {
+    key: "group_stepladder",
+    label: "Group + Stepladder",
+    help: "Round robin, then a stepladder final — lowest seed climbs.",
+    build: (q) => [
+      { kind: "league", name: "League", config: { legs: 1 }, qualification: null },
+      { kind: "stepladder", name: "Stepladder finals", config: {}, qualification: { topN: q } },
+    ],
+  },
+  {
     key: "swiss",
     label: "Swiss",
     help: "Score-group pairings, fixed rounds.",
@@ -98,6 +107,126 @@ const GENDERS = [
   { key: "x", label: "Mixed / other" },
 ];
 
+// ---------------------------------------------------------------------------
+// Match rules — curated per-sport fields that build the config override
+// object (previously a raw-JSON textarea). Blank = keep the variant default;
+// the pinned module's configSchema still validates server-side.
+// ---------------------------------------------------------------------------
+
+interface RuleField {
+  key: string;
+  label: string;
+  help?: string;
+  /** number input, or a Default/On/Off select for booleans, or an option list. */
+  kind: "number" | "bool" | "select";
+  min?: number;
+  max?: number;
+  options?: { value: string; label: string }[];
+  /** Maps the entered value onto the override object (top-level key). */
+  build: (value: string) => Record<string, unknown>;
+}
+
+const SETBASED_RULES: RuleField[] = [
+  {
+    key: "bestOf",
+    label: "Best of (sets)",
+    kind: "select",
+    options: [1, 3, 5, 7].map((n) => ({ value: String(n), label: `Best of ${n}` })),
+    build: (v) => ({ bestOf: Number(v) }),
+  },
+  {
+    key: "setTo",
+    label: "Points to win a set",
+    kind: "number",
+    min: 1,
+    max: 100,
+    build: (v) => ({ setTo: Number(v) }),
+  },
+  {
+    key: "finalSetTo",
+    label: "Points in the deciding set",
+    kind: "number",
+    min: 1,
+    max: 100,
+    build: (v) => ({ finalSetTo: Number(v) }),
+  },
+];
+
+const SPORT_RULES: Record<string, RuleField[]> = {
+  football: [
+    {
+      key: "halfMinutes",
+      label: "Half length (minutes)",
+      kind: "number",
+      min: 5,
+      max: 60,
+      build: (v) => ({ halfMinutes: Number(v) }),
+    },
+    {
+      key: "extraTime",
+      label: "Extra time",
+      help: "Knockout fixtures only.",
+      kind: "bool",
+      build: (v) => ({ extraTime: { enabled: v === "on", halfMinutes: 15 } }),
+    },
+    {
+      key: "shootout",
+      label: "Penalty shootout",
+      help: "Knockout fixtures only.",
+      kind: "bool",
+      build: (v) => ({ shootout: v === "on" }),
+    },
+  ],
+  cricket: [
+    {
+      key: "overs",
+      label: "Overs per innings",
+      kind: "number",
+      min: 1,
+      max: 100,
+      build: (v) => ({ ballsPerInnings: Number(v) * 6 }),
+    },
+    {
+      key: "maxOversPerBowler",
+      label: "Max overs per bowler",
+      kind: "number",
+      min: 1,
+      max: 50,
+      build: (v) => ({ maxOversPerBowler: Number(v) }),
+    },
+    {
+      key: "superOver",
+      label: "Super over on a tie",
+      help: "Knockout fixtures only.",
+      kind: "bool",
+      build: (v) => ({ superOver: v === "on" }),
+    },
+    {
+      key: "dls",
+      label: "DLS revised targets",
+      help: "Pro feature — a manual umpire target works on every plan.",
+      kind: "bool",
+      build: (v) => ({ dls: { enabled: v === "on", edition: "standard" } }),
+    },
+  ],
+  volleyball: SETBASED_RULES,
+  badminton: SETBASED_RULES,
+  tabletennis: SETBASED_RULES,
+  boardgame: [
+    {
+      key: "variant",
+      label: "Clock family",
+      kind: "select",
+      options: [
+        { value: "classical", label: "Classical" },
+        { value: "rapid", label: "Rapid" },
+        { value: "blitz", label: "Blitz" },
+      ],
+      build: (v) => ({ variant: v }),
+    },
+  ],
+};
+
 export function DivisionBuilder({
   competitionId,
   sports,
@@ -110,8 +239,8 @@ export function DivisionBuilder({
   const [sportKey, setSportKey] = useState(sports[0]?.key ?? "");
   const sport = useMemo(() => sports.find((s) => s.key === sportKey), [sports, sportKey]);
   const [variantKey, setVariantKey] = useState(sport?.variants[0]?.key ?? "");
-  const [overridesText, setOverridesText] = useState("");
-  const [showAdvanced, setShowAdvanced] = useState(false);
+  // Match-rule values keyed by RuleField.key; "" = keep the variant default.
+  const [ruleValues, setRuleValues] = useState<Record<string, string>>({});
 
   // Eligibility template (doc 06 §2): age cutoff + gender + note.
   const [maxAge, setMaxAge] = useState("");
@@ -134,6 +263,7 @@ export function DivisionBuilder({
     setSportKey(key);
     const next = sports.find((s) => s.key === key);
     setVariantKey(next?.variants[0]?.key ?? "");
+    setRuleValues({}); // rules are sport-specific
   }
 
   function buildEligibility(): Record<string, unknown>[] {
@@ -170,14 +300,12 @@ export function DivisionBuilder({
     setError(null);
     setPaywallFeature(null);
 
+    // Only rules the user actually set become overrides; the rest stay on
+    // the variant's defaults.
     let overrides: Record<string, unknown> = {};
-    if (overridesText.trim()) {
-      try {
-        overrides = JSON.parse(overridesText) as Record<string, unknown>;
-      } catch {
-        setError("Config overrides must be valid JSON.");
-        return;
-      }
+    for (const field of SPORT_RULES[sportKey] ?? []) {
+      const value = ruleValues[field.key];
+      if (value) overrides = { ...overrides, ...field.build(value) };
     }
 
     setBusy(true);
@@ -212,7 +340,8 @@ export function DivisionBuilder({
   }
 
   const templateInfo = STAGE_TEMPLATES.find((t) => t.key === template);
-  const hasSecondStage = template === "league_ko" || template === "groups_ko";
+  const hasSecondStage =
+    template === "league_ko" || template === "groups_ko" || template === "group_stepladder";
 
   return (
     <form onSubmit={submit} className="space-y-6">
@@ -257,24 +386,60 @@ export function DivisionBuilder({
             </select>
           </label>
         </div>
-        <button
-          type="button"
-          onClick={() => setShowAdvanced(!showAdvanced)}
-          className="text-xs font-medium text-purple-600 hover:underline"
-        >
-          {showAdvanced ? "Hide" : "Show"} advanced config overrides
-        </button>
-        {showAdvanced && (
-          <label className="block">
-            <span className="label">Config overrides (JSON, merged over the variant)</span>
-            <textarea
-              rows={4}
-              value={overridesText}
-              onChange={(e) => setOverridesText(e.target.value)}
-              placeholder='{"maxOversPerBowler": 4}'
-              className="textarea font-mono text-xs"
-            />
-          </label>
+        {(SPORT_RULES[sportKey] ?? []).length > 0 && (
+          <div className="border-t border-slate-100 pt-4">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Match rules
+            </h3>
+            <p className="mt-0.5 text-xs text-slate-400">
+              Leave a field on its default to use the variant&apos;s standard rules.
+            </p>
+            <div className="mt-3 grid gap-4 sm:grid-cols-3">
+              {(SPORT_RULES[sportKey] ?? []).map((field) => (
+                <label key={field.key} className="block">
+                  <span className="label">{field.label}</span>
+                  {field.kind === "number" ? (
+                    <input
+                      type="number"
+                      min={field.min}
+                      max={field.max}
+                      value={ruleValues[field.key] ?? ""}
+                      onChange={(e) =>
+                        setRuleValues({ ...ruleValues, [field.key]: e.target.value })
+                      }
+                      placeholder="Default"
+                      className="input"
+                    />
+                  ) : (
+                    <select
+                      value={ruleValues[field.key] ?? ""}
+                      onChange={(e) =>
+                        setRuleValues({ ...ruleValues, [field.key]: e.target.value })
+                      }
+                      className="select"
+                    >
+                      <option value="">Default</option>
+                      {field.kind === "bool" ? (
+                        <>
+                          <option value="on">On</option>
+                          <option value="off">Off</option>
+                        </>
+                      ) : (
+                        (field.options ?? []).map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))
+                      )}
+                    </select>
+                  )}
+                  {field.help && (
+                    <span className="mt-0.5 block text-[11px] text-slate-400">{field.help}</span>
+                  )}
+                </label>
+              ))}
+            </div>
+          </div>
         )}
       </section>
 
@@ -378,7 +543,15 @@ export function DivisionBuilder({
                 type="radio"
                 name="template"
                 checked={template === t.key}
-                onChange={() => setTemplate(t.key)}
+                onChange={() => {
+                  setTemplate(t.key);
+                  // Keep the qualifier valid for the template's option list.
+                  if (t.key === "group_stepladder" && ![3, 4, 5, 6].includes(qualified)) {
+                    setQualified(4);
+                  } else if (t.key !== "group_stepladder" && ![2, 4, 8, 16].includes(qualified)) {
+                    setQualified(4);
+                  }
+                }}
                 className="sr-only"
               />
               <span className="block font-medium">{t.label}</span>
@@ -387,7 +560,10 @@ export function DivisionBuilder({
           ))}
         </div>
         <div className="grid gap-4 sm:grid-cols-3">
-          {(template === "league" || template === "league_ko" || template === "groups_ko") && (
+          {(template === "league" ||
+            template === "league_ko" ||
+            template === "groups_ko" ||
+            template === "group_stepladder") && (
             <label className="block">
               <span className="label">Legs</span>
               <select
@@ -434,7 +610,7 @@ export function DivisionBuilder({
                 onChange={(e) => setQualified(Number(e.target.value))}
                 className="select"
               >
-                {[2, 4, 8, 16].map((n) => (
+                {(template === "group_stepladder" ? [3, 4, 5, 6] : [2, 4, 8, 16]).map((n) => (
                   <option key={n} value={n}>
                     Top {n}
                   </option>

--- a/apps/web/src/components/v2/entrants-panel.tsx
+++ b/apps/web/src/components/v2/entrants-panel.tsx
@@ -2,7 +2,7 @@
 
 // Entrant & roster management (PROMPT-15 task 1): persons picker, CSV import,
 // position/role assignment from the module catalog, withdraw/seed.
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
@@ -120,22 +120,21 @@ export function EntrantsPanel({
       )}
 
       {canEdit && (
-        <div className="grid gap-4 lg:grid-cols-2">
-          <AddEntrantForm
-            persons={persons}
-            busy={busy}
-            onSubmit={(payload) =>
-              run(() =>
-                apiV1(`/api/v1/divisions/${divisionId}/entrants`, {
-                  method: "POST",
-                  json: payload,
-                }),
-              )
-            }
-          />
-          <CsvImport
-            busy={busy}
-            onImport={async (rows) =>
+        <AddEntrantForm
+          persons={persons}
+          busy={busy}
+          onSubmit={(payload) =>
+            run(() =>
+              apiV1(`/api/v1/divisions/${divisionId}/entrants`, {
+                method: "POST",
+                json: payload,
+              }),
+            )
+          }
+          importControls={
+            <CsvImport
+              busy={busy}
+              onImport={async (rows) =>
               run(async () => {
                 // Create missing persons first (matched by exact name against
                 // the directory), then register entrants in one bulk call.
@@ -204,8 +203,9 @@ export function EntrantsPanel({
                 }
               })
             }
-          />
-        </div>
+            />
+          }
+        />
       )}
 
       {paywallFeature && <UpgradeGate feature={paywallFeature} />}
@@ -279,10 +279,13 @@ function AddEntrantForm({
   persons,
   busy,
   onSubmit,
+  importControls,
 }: {
   persons: Person[];
   busy: boolean;
   onSubmit: (payload: Record<string, unknown>) => void;
+  /** Inline CSV-import controls rendered in the footer row. */
+  importControls?: React.ReactNode;
 }) {
   const [name, setName] = useState("");
   const [kind, setKind] = useState("individual");
@@ -386,9 +389,12 @@ function AddEntrantForm({
         )}
       </div>
 
-      <button type="submit" disabled={busy || !name.trim()} className="btn btn-primary">
-        {busy ? "Saving…" : "Add entrant"}
-      </button>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button type="submit" disabled={busy || !name.trim()} className="btn btn-primary">
+          {busy ? "Saving…" : "Add entrant"}
+        </button>
+        {importControls}
+      </div>
     </form>
   );
 }
@@ -449,42 +455,47 @@ function CsvImport({
   busy: boolean;
   onImport: (rows: CsvRow[]) => void;
 }) {
-  const [text, setText] = useState("");
-  const rows = useMemo(() => parseCsv(text), [text]);
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-picking the same file
+    if (!file) return;
+    const rows = parseCsv(await file.text());
+    if (rows.length === 0) {
+      setError("No entrants found in that file — check it matches the sample format.");
+      return;
+    }
+    setError(null);
+    onImport(rows);
+  }
 
   return (
-    <div className="card space-y-3 p-4">
-      <h3 className="text-sm font-semibold text-slate-700">CSV import</h3>
-      <p className="text-xs text-slate-400">
-        Columns: <span className="font-mono">name</span> (required),{" "}
-        <span className="font-mono">dob</span>, <span className="font-mono">gender</span>,{" "}
-        <span className="font-mono">seed</span>, <span className="font-mono">team</span>,{" "}
-        <span className="font-mono">squad_number</span>. A <span className="font-mono">team</span>{" "}
-        column groups people into team entrants; otherwise each row is an individual.
-      </p>
-      <textarea
-        rows={5}
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder={"name,dob,team\nA. Sharma,2011-04-02,Riverside U16\nB. Khan,2010-11-19,Riverside U16"}
-        className="textarea font-mono text-xs"
+    <div className="flex flex-wrap items-center gap-3">
+      <input
+        ref={fileRef}
+        type="file"
+        accept=".csv,text/csv"
+        onChange={onFile}
+        className="hidden"
       />
-      <div className="flex items-center justify-between">
-        <span className="text-xs text-slate-400">
-          {rows.length > 0 ? `${rows.length} row(s) parsed` : "Paste CSV above"}
-        </span>
-        <button
-          type="button"
-          disabled={busy || rows.length === 0}
-          onClick={() => {
-            onImport(rows);
-            setText("");
-          }}
-          className="btn btn-ghost"
-        >
-          {busy ? "Importing…" : "Import"}
-        </button>
-      </div>
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => fileRef.current?.click()}
+        className="btn btn-ghost"
+      >
+        {busy ? "Importing…" : "Import CSV"}
+      </button>
+      <a
+        href="/entrants-sample.csv"
+        download
+        className="text-xs text-purple-600 underline hover:text-purple-800"
+      >
+        Sample CSV
+      </a>
+      {error && <span className="text-xs text-red-600">{error}</span>}
     </div>
   );
 }

--- a/apps/web/src/components/v2/fixture-console.tsx
+++ b/apps/web/src/components/v2/fixture-console.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { describeEvent, EVENT_TONE_STYLE } from "@/lib/event-copy";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { LineupEditor } from "@/components/v2/lineup-editor";
 import { GenericPad } from "@/components/v2/pads/generic-pad";
@@ -169,6 +170,9 @@ export function FixtureConsole({
   const started = live.status !== "scheduled";
 
   const sides = { home, away };
+  const entrantNames: Record<string, string> = {};
+  if (home) entrantNames[home.id] = home.name;
+  if (away) entrantNames[away.id] = away.name;
   const lastVoidable = [...events]
     .reverse()
     .find((e) => e.type !== "core.void" && !events.some((v) => v.voids_event_id === e.id));
@@ -301,7 +305,7 @@ export function FixtureConsole({
       <section className="card overflow-hidden">
         <header className="border-b border-slate-100 px-4 py-3">
           <h2 className="text-sm font-semibold text-slate-700">
-            Event log <span className="font-normal text-slate-400">({events.length})</span>
+            Activity <span className="font-normal text-slate-400">({events.length})</span>
           </h2>
         </header>
         {events.length === 0 ? (
@@ -310,16 +314,20 @@ export function FixtureConsole({
           <ul className="max-h-96 divide-y divide-slate-50 overflow-y-auto">
             {[...events].reverse().map((e) => {
               const voided = events.some((v) => v.voids_event_id === e.id);
+              const desc = describeEvent(e.type, e.payload, entrantNames);
               return (
                 <li
                   key={e.id}
+                  title={`${e.type} ${JSON.stringify(e.payload)}`}
                   className={`flex items-center gap-3 px-4 py-2 text-xs ${voided ? "line-through opacity-40" : ""}`}
                 >
-                  <span className="w-8 shrink-0 font-mono text-slate-400">#{e.seq}</span>
-                  <span className="w-44 shrink-0 font-medium text-slate-700">{e.type}</span>
-                  <span className="min-w-0 flex-1 truncate font-mono text-slate-400">
-                    {e.type === "core.void" ? "" : JSON.stringify(e.payload)}
+                  <span className="w-8 shrink-0 font-mono text-slate-300">#{e.seq}</span>
+                  <span
+                    className={`badge w-24 shrink-0 justify-center capitalize ${EVENT_TONE_STYLE[desc.tone]}`}
+                  >
+                    {desc.label}
                   </span>
+                  <span className="min-w-0 flex-1 truncate text-slate-700">{desc.text}</span>
                   <span className="shrink-0 text-slate-400">
                     {new Date(e.recorded_at).toLocaleTimeString()}
                   </span>

--- a/apps/web/src/components/v2/registrations-panel.tsx
+++ b/apps/web/src/components/v2/registrations-panel.tsx
@@ -7,6 +7,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
+import { PlanBadge } from "@/components/plan-badge";
 
 interface FormField {
   key: string;
@@ -68,10 +69,13 @@ export function RegistrationsPanel({
   orgId,
   divisionId,
   canEdit,
+  paidAllowed = true,
 }: {
   orgId: string;
   divisionId: string;
   canEdit: boolean;
+  /** registration.paid entitlement — false shows the plan badge on the fee field. */
+  paidAllowed?: boolean;
 }) {
   const [settings, setSettings] = useState<Settings | null>(null);
   const [regs, setRegs] = useState<Registration[]>([]);
@@ -227,7 +231,10 @@ export function RegistrationsPanel({
 
           <div className="grid grid-cols-2 gap-2">
             <label className="block text-xs text-slate-500">
-              Entry fee (cents; 0 = free)
+              <span className="flex items-center gap-1.5">
+                Entry fee (cents; 0 = free)
+                {!paidAllowed && <PlanBadge feature="registration.paid" />}
+              </span>
               <input
                 type="number"
                 min={0}

--- a/apps/web/src/components/v2/slideshow.tsx
+++ b/apps/web/src/components/v2/slideshow.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+// Full-screen noticeboard slideshow: rotates slides every 9 s, silently
+// re-fetches server data every 45 s (router.refresh), Escape returns to the
+// console. Dark, large-type, made for a TV across the hall.
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Slide } from "@/server/slideshow-data";
+
+const SLIDE_MS = 9000;
+const REFRESH_MS = 45000;
+
+const STATUS_LABEL: Record<string, string> = {
+  scheduled: "Scheduled",
+  in_play: "In play",
+  decided: "Final",
+  finalized: "Final",
+  forfeited: "Forfeit",
+  abandoned: "Abandoned",
+  cancelled: "Cancelled",
+};
+
+export function Slideshow({
+  title,
+  slides,
+  backHref,
+}: {
+  title: string;
+  slides: Slide[];
+  backHref: string;
+}) {
+  const router = useRouter();
+  const [index, setIndex] = useState(0);
+  const [clock, setClock] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (slides.length < 2) return;
+    const t = setInterval(() => setIndex((i) => (i + 1) % slides.length), SLIDE_MS);
+    return () => clearInterval(t);
+  }, [slides.length]);
+
+  useEffect(() => {
+    const t = setInterval(() => router.refresh(), REFRESH_MS);
+    return () => clearInterval(t);
+  }, [router]);
+
+  useEffect(() => {
+    const tick = () =>
+      setClock(new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }));
+    tick();
+    const t = setInterval(tick, 10_000);
+    return () => clearInterval(t);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") router.push(backHref);
+      if (e.key === "ArrowRight") setIndex((i) => (i + 1) % Math.max(slides.length, 1));
+      if (e.key === "ArrowLeft")
+        setIndex((i) => (i - 1 + Math.max(slides.length, 1)) % Math.max(slides.length, 1));
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [router, backHref, slides.length]);
+
+  const slide = slides[Math.min(index, Math.max(slides.length - 1, 0))];
+
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      {/* Header */}
+      <header className="flex items-center justify-between px-10 py-6">
+        <h1 className="truncate text-2xl font-bold tracking-tight">{title}</h1>
+        <div className="flex items-center gap-4 text-slate-400">
+          {clock && <span className="text-2xl font-medium tabular-nums">{clock}</span>}
+        </div>
+      </header>
+
+      {/* Slide */}
+      <main className="flex flex-1 flex-col justify-center px-10 pb-10">
+        {!slide ? (
+          <p className="text-center text-2xl text-slate-500">
+            Nothing to show yet — generate fixtures to get started.
+          </p>
+        ) : (
+          <div>
+            <p className="mb-1 text-lg font-semibold uppercase tracking-widest text-purple-400">
+              {slide.division}
+            </p>
+            <h2 className="mb-6 text-4xl font-bold">
+              {slide.kind === "standings" ? slide.caption : slide.title}
+            </h2>
+
+            {slide.kind === "standings" ? (
+              <table className="w-full max-w-4xl text-xl">
+                <thead>
+                  <tr className="text-left text-base uppercase tracking-wider text-slate-500">
+                    <th className="w-12 pb-2">#</th>
+                    <th className="pb-2">Entrant</th>
+                    <th className="w-14 pb-2 text-right">P</th>
+                    <th className="w-14 pb-2 text-right">W</th>
+                    <th className="w-14 pb-2 text-right">D</th>
+                    <th className="w-14 pb-2 text-right">L</th>
+                    <th className="w-20 pb-2 text-right">Pts</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {slide.rows.slice(0, 10).map((r) => (
+                    <tr key={r.rank + r.name} className="border-t border-slate-800">
+                      <td className="py-2.5 text-slate-500">{r.rank}</td>
+                      <td className="py-2.5 font-medium">{r.name}</td>
+                      <td className="py-2.5 text-right text-slate-300">{r.played}</td>
+                      <td className="py-2.5 text-right text-slate-300">{r.won}</td>
+                      <td className="py-2.5 text-right text-slate-300">{r.drawn}</td>
+                      <td className="py-2.5 text-right text-slate-300">{r.lost}</td>
+                      <td className="py-2.5 text-right text-2xl font-bold text-purple-300">
+                        {r.points}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <ul className="max-w-4xl space-y-3 text-2xl">
+                {slide.items.map((f, i) => (
+                  <li
+                    key={i}
+                    className="flex items-center justify-between gap-6 rounded-xl bg-slate-900 px-6 py-4"
+                  >
+                    <span className="min-w-0 flex-1 truncate text-right">{f.home}</span>
+                    <span className="shrink-0 font-bold text-purple-300">
+                      {f.line ?? "vs"}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{f.away}</span>
+                    <span
+                      className={`shrink-0 rounded-full px-3 py-1 text-sm font-medium ${
+                        f.status === "in_play"
+                          ? "bg-amber-400/20 text-amber-300"
+                          : "bg-slate-800 text-slate-400"
+                      }`}
+                    >
+                      {STATUS_LABEL[f.status] ?? f.status}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </main>
+
+      {/* Progress dots */}
+      {slides.length > 1 && (
+        <footer className="flex items-center justify-center gap-2 pb-6">
+          {slides.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              aria-label={`Slide ${i + 1}`}
+              onClick={() => setIndex(i)}
+              className={`h-2 rounded-full transition-all ${
+                i === index ? "w-6 bg-purple-400" : "w-2 bg-slate-700"
+              }`}
+            />
+          ))}
+        </footer>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/v2/slideshow.tsx
+++ b/apps/web/src/components/v2/slideshow.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-// Full-screen noticeboard slideshow: rotates slides every 9 s, silently
-// re-fetches server data every 45 s (router.refresh), Escape returns to the
-// console. Dark, large-type, made for a TV across the hall.
-import { useEffect, useState } from "react";
+// Full-screen noticeboard slideshow: rotates slides every 9 s. Data refresh
+// is entitlement-split (doc 09 §4 pattern, same as live-score): Pro orgs
+// subscribe to `division:{id}` realtime broadcasts and refresh on push;
+// everyone else (and any subscription failure) falls back to 45 s polling.
+// Escape returns to the console. Dark, large-type, made for a TV.
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Slide } from "@/server/slideshow-data";
 
 const SLIDE_MS = 9000;
-const REFRESH_MS = 45000;
+const POLL_MS = 45_000;
+const SUBSCRIBED_POLL_MS = 5 * 60_000; // safety net once push is live
 
 const STATUS_LABEL: Record<string, string> = {
   scheduled: "Scheduled",
@@ -24,14 +27,21 @@ export function Slideshow({
   title,
   slides,
   backHref,
+  divisionIds = [],
+  realtime = false,
 }: {
   title: string;
   slides: Slide[];
   backHref: string;
+  /** Divisions on show — realtime subscription topics. */
+  divisionIds?: string[];
+  /** Org `realtime` entitlement, resolved server-side. */
+  realtime?: boolean;
 }) {
   const router = useRouter();
   const [index, setIndex] = useState(0);
   const [clock, setClock] = useState<string | null>(null);
+  const [subscribed, setSubscribed] = useState(false);
 
   useEffect(() => {
     if (slides.length < 2) return;
@@ -39,10 +49,59 @@ export function Slideshow({
     return () => clearInterval(t);
   }, [slides.length]);
 
+  // Realtime push (Pro): refresh on any division's score/schedule broadcast.
+  // Any failure leaves `subscribed` false and the poll below takes over.
+  // Keyed on the joined ids — router.refresh() hands us a fresh array each
+  // time and identity-keying would tear down the sockets on every refresh.
+  const divisionKey = divisionIds.join(",");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    const t = setInterval(() => router.refresh(), REFRESH_MS);
+    const ids = divisionKey ? divisionKey.split(",") : [];
+    if (!realtime || ids.length === 0) return;
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL) return;
+    let cancelled = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const channels: any[] = [];
+    const onPush = () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => router.refresh(), 1000);
+    };
+    (async () => {
+      try {
+        const { supabaseBrowser } = await import("@/lib/supabase-browser");
+        const sb = supabaseBrowser();
+        for (const id of ids) {
+          if (cancelled) return;
+          channels.push(
+            sb
+              .channel(`division:${id}`)
+              .on("broadcast", { event: "state_changed" }, onPush)
+              .on("broadcast", { event: "schedule_changed" }, onPush)
+              .subscribe((status: string) => {
+                if (!cancelled && status === "SUBSCRIBED") setSubscribed(true);
+              }),
+          );
+        }
+      } catch {
+        // env missing / websocket refused → polling
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      setSubscribed(false);
+      for (const ch of channels) void ch.unsubscribe?.();
+    };
+  }, [realtime, divisionKey, router]);
+
+  // Polling — primary refresh on Community, slow safety net once push is live.
+  useEffect(() => {
+    const t = setInterval(
+      () => router.refresh(),
+      subscribed ? SUBSCRIBED_POLL_MS : POLL_MS,
+    );
     return () => clearInterval(t);
-  }, [router]);
+  }, [router, subscribed]);
 
   useEffect(() => {
     const tick = () =>

--- a/apps/web/src/components/v2/stages-panel.tsx
+++ b/apps/web/src/components/v2/stages-panel.tsx
@@ -34,6 +34,7 @@ interface FixtureRow {
 }
 
 interface Props {
+  divisionId: string;
   stages: StageRow[];
   fixtures: FixtureRow[];
   entrantNames: Record<string, string>;
@@ -50,7 +51,7 @@ const FIXTURE_STATUS_STYLE: Record<string, string> = {
   cancelled: "bg-slate-100 text-slate-400",
 };
 
-export function StagesPanel({ stages, fixtures, entrantNames, canEdit }: Props) {
+export function StagesPanel({ divisionId, stages, fixtures, entrantNames, canEdit }: Props) {
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [paywallFeature, setPaywallFeature] = useState<string | null>(null);
@@ -74,14 +75,17 @@ export function StagesPanel({ stages, fixtures, entrantNames, canEdit }: Props) 
             : "Nothing new to generate — fixtures are up to date.",
         );
       } else {
-        const out = await apiV1<{ completed: boolean }>(
-          `/api/v1/stages/${stageId}/complete`,
-          { method: "POST", json: {} },
-        );
+        const out = await apiV1<{
+          completed: boolean;
+          qualified?: { entrants: string[] };
+          next_stage_fixtures?: number;
+        }>(`/api/v1/stages/${stageId}/complete`, { method: "POST", json: {} });
         setNotice(
-          out.completed
-            ? "Stage completed — next stage seeded from the final table."
-            : "Stage is not ready to complete (undecided fixtures remain).",
+          !out.completed
+            ? "Stage is not ready to complete (undecided fixtures remain)."
+            : out.next_stage_fixtures !== undefined
+              ? `Stage completed — top ${out.qualified?.entrants.length ?? ""} advance; ${out.next_stage_fixtures} fixture(s) generated for the next stage.`
+              : "Stage completed.",
         );
       }
       router.refresh();
@@ -181,7 +185,131 @@ export function StagesPanel({ stages, fixtures, entrantNames, canEdit }: Props) 
           </section>
         );
       })}
+
+      {canEdit && (
+        <AddStageForm
+          divisionId={divisionId}
+          nextSeq={Math.max(0, ...stages.map((s) => s.seq)) + 1}
+          onDone={(msg) => {
+            setNotice(msg);
+            router.refresh();
+          }}
+          onError={setError}
+        />
+      )}
     </div>
+  );
+}
+
+// Follow-up stage (e.g. finals after a league). Qualification resolves from
+// the previous stage's final table; if that stage is already complete the
+// server seeds + generates on the spot.
+const ADD_KINDS = [
+  { key: "knockout", label: "Knockout" },
+  { key: "stepladder", label: "Stepladder" },
+  { key: "double_elim", label: "Double elimination" },
+] as const;
+
+function AddStageForm({
+  divisionId,
+  nextSeq,
+  onDone,
+  onError,
+}: {
+  divisionId: string;
+  nextSeq: number;
+  onDone: (msg: string) => void;
+  onError: (msg: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("Finals");
+  const [kind, setKind] = useState<string>("knockout");
+  const [topN, setTopN] = useState(4);
+  const [busy, setBusy] = useState(false);
+
+  async function add() {
+    setBusy(true);
+    onError("");
+    try {
+      const stage = await apiV1<{ id: string }>(`/api/v1/divisions/${divisionId}/stages`, {
+        method: "POST",
+        json: {
+          seq: nextSeq,
+          kind,
+          name: name.trim() || "Finals",
+          config: {},
+          qualification: { topN },
+        },
+      });
+      try {
+        const gen = await apiV1<{ created: number }>(`/api/v1/stages/${stage.id}/generate`, {
+          method: "POST",
+          json: {},
+        });
+        onDone(`Stage added — ${gen.created} fixture(s) generated for the top ${topN}.`);
+      } catch (err) {
+        // Previous stage not complete yet — the stage exists; completion will
+        // seed + generate it.
+        if (err instanceof ApiV1Error && err.code === "STAGE_NOT_READY") {
+          onDone("Stage added — fixtures will generate when the previous stage completes.");
+        } else {
+          throw err;
+        }
+      }
+      setOpen(false);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button type="button" onClick={() => setOpen(true)} className="btn btn-ghost text-xs">
+        + Add stage
+      </button>
+    );
+  }
+
+  return (
+    <section className="card flex flex-wrap items-end gap-3 p-4">
+      <label className="block">
+        <span className="label">Stage name</span>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={200}
+          className="input w-40"
+        />
+      </label>
+      <label className="block">
+        <span className="label">Format</span>
+        <select value={kind} onChange={(e) => setKind(e.target.value)} className="select">
+          {ADD_KINDS.map((k) => (
+            <option key={k.key} value={k.key}>
+              {k.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="block">
+        <span className="label">Qualify from table</span>
+        <select value={topN} onChange={(e) => setTopN(Number(e.target.value))} className="select">
+          {[2, 3, 4, 6, 8].map((n) => (
+            <option key={n} value={n}>
+              Top {n}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button type="button" disabled={busy} onClick={add} className="btn btn-primary text-xs">
+        {busy ? "Adding…" : "Add stage"}
+      </button>
+      <button type="button" onClick={() => setOpen(false)} className="btn btn-ghost text-xs">
+        Cancel
+      </button>
+    </section>
   );
 }
 

--- a/apps/web/src/lib/activation.ts
+++ b/apps/web/src/lib/activation.ts
@@ -42,3 +42,25 @@ export async function needsOnboarding(userId: string): Promise<boolean> {
     from users where id = ${userId}`;
   return !row?.done;
 }
+
+/** Mark the product tour complete (or skipped) for this user. */
+export async function markTourDone(userId: string): Promise<void> {
+  await sql`
+    update users set product_tour_completed_at = now()
+    where id = ${userId} and product_tour_completed_at is null`;
+}
+
+/** Reset the tour so it auto-starts again on the dashboard (settings replay). */
+export async function resetTour(userId: string): Promise<void> {
+  await sql`
+    update users set product_tour_completed_at = null
+    where id = ${userId}`;
+}
+
+/** True if user has not yet completed the product tour. */
+export async function needsTour(userId: string): Promise<boolean> {
+  const [row] = await sql<{ done: boolean }[]>`
+    select product_tour_completed_at is not null as done
+    from users where id = ${userId}`;
+  return !row?.done;
+}

--- a/apps/web/src/lib/event-copy.ts
+++ b/apps/web/src/lib/event-copy.ts
@@ -1,0 +1,170 @@
+// Human copy for score-ledger events (doc 09 §2): the fixture console's
+// activity feed renders these instead of raw `type {json}` rows. Isomorphic —
+// no server imports. Unknown event types fall back to a prettified label so
+// new sports degrade gracefully.
+
+export interface EventDescription {
+  /** Short badge text, e.g. "Goal", "Set", "Undo". */
+  label: string;
+  /** Human sentence, e.g. "Riverside FC — 21' (penalty)". */
+  text: string;
+  /** Badge tint bucket. */
+  tone: "start" | "score" | "card" | "period" | "admin" | "void" | "note";
+}
+
+type Payload = Record<string, unknown>;
+
+const PERIOD_LABEL: Record<string, string> = {
+  HT: "Half-time",
+  FT: "Full-time",
+  ET_H1: "Extra time — first half",
+  ET_HT: "Extra time — half-time",
+  ET_H2: "Extra time — second half",
+  ET_FT: "End of extra time",
+};
+
+function name(names: Record<string, string>, id: unknown): string {
+  return typeof id === "string" ? (names[id] ?? "Unknown") : "Unknown";
+}
+
+function minute(p: Payload): string {
+  return typeof p.minute === "number" ? ` — ${p.minute}'` : "";
+}
+
+/** "volleyball.set.summary" → "Set summary" */
+function prettify(type: string): string {
+  const tail = type.split(".").slice(1).join(" ").replace(/_/g, " ").trim() || type;
+  return tail.charAt(0).toUpperCase() + tail.slice(1);
+}
+
+/** Compact human rendering of an unknown payload: skip ids/uuids, keep scalars. */
+function scalars(p: Payload): string {
+  const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}/i;
+  return Object.entries(p)
+    .filter(([, v]) => ["number", "string", "boolean"].includes(typeof v))
+    .filter(([, v]) => !(typeof v === "string" && UUID.test(v)))
+    .map(([k, v]) => `${k.replace(/_/g, " ")}: ${v}`)
+    .join(", ");
+}
+
+export function describeEvent(
+  type: string,
+  rawPayload: unknown,
+  names: Record<string, string>,
+): EventDescription {
+  const p = (rawPayload ?? {}) as Payload;
+
+  switch (type) {
+    // ── core ──
+    case "core.start":
+      return { label: "Started", text: "Match started", tone: "start" };
+    case "core.note":
+      return { label: "Note", text: String(p.text ?? ""), tone: "note" };
+    case "core.void":
+      return { label: "Undo", text: "Previous entry voided", tone: "void" };
+    case "core.forfeit":
+      return {
+        label: "Forfeit",
+        text: `${name(names, p.by)} forfeited${p.reason ? ` — ${p.reason}` : ""}`,
+        tone: "admin",
+      };
+    case "core.abandon":
+      return {
+        label: "Abandoned",
+        text: `Match abandoned${p.reason ? ` — ${p.reason}` : ""}`,
+        tone: "admin",
+      };
+    case "core.award":
+      return { label: "Awarded", text: `Awarded to ${name(names, p.to)}`, tone: "admin" };
+
+    // ── football ──
+    case "football.goal": {
+      const extras = [p.ownGoal && "own goal", p.penalty && "penalty"].filter(Boolean).join(", ");
+      return {
+        label: p.ownGoal ? "Own goal" : "Goal",
+        text: `${name(names, p.by)}${minute(p)}${extras && !p.ownGoal ? ` (${extras})` : ""}`,
+        tone: "score",
+      };
+    }
+    case "football.card":
+      return {
+        label: `${String(p.color ?? "card").replace("_", " ")}`,
+        text: `${name(names, p.by)}${minute(p)}`,
+        tone: "card",
+      };
+    case "football.period":
+      return {
+        label: "Period",
+        text: PERIOD_LABEL[String(p.phase)] ?? String(p.phase ?? "period"),
+        tone: "period",
+      };
+    case "football.shootout.kick":
+      return {
+        label: "Shootout",
+        text: `${name(names, p.by)} ${p.scored ? "scored" : "missed"}`,
+        tone: "score",
+      };
+    case "football.substitution":
+      return { label: "Substitution", text: name(names, p.by), tone: "note" };
+
+    // ── cricket ──
+    case "cricket.innings.summary":
+      return { label: "Innings", text: scalars(p), tone: "score" };
+    case "cricket.interruption":
+      return {
+        label: "Interruption",
+        text: scalars(p) || String(p.kind ?? "interruption"),
+        tone: "admin",
+      };
+    case "cricket.superover":
+      return { label: "Super over", text: scalars(p), tone: "score" };
+
+    // ── boardgame / generic ──
+    case "boardgame.result":
+      return {
+        label: "Result",
+        text:
+          p.winner != null
+            ? `${name(names, p.winner)} wins${p.method ? ` by ${p.method}` : ""}`
+            : "Draw",
+        tone: "score",
+      };
+    case "generic.result": {
+      const hasScores = p.p1Score != null || p.p2Score != null;
+      return {
+        label: "Result",
+        text: hasScores ? `${p.p1Score ?? 0} – ${p.p2Score ?? 0}` : p.isDraw ? "Draw" : "Recorded",
+        tone: "score",
+      };
+    }
+  }
+
+  // Set-based coarse summaries: volleyball.set.summary, badminton.game.summary,
+  // tabletennis.game.summary — all carry {home, away, partial?}.
+  if (/\.(set|game)\.summary$/.test(type)) {
+    const unit = type.includes(".set.") ? "Set" : "Game";
+    return {
+      label: p.partial ? `${unit} (live)` : unit,
+      text: `${p.home ?? 0} – ${p.away ?? 0}${p.partial ? " in progress" : ""}`,
+      tone: "score",
+    };
+  }
+  if (/\.rally$/.test(type)) {
+    return { label: "Rally", text: `Point ${name(names, p.wonBy)}`, tone: "score" };
+  }
+  if (/\.ball$/.test(type)) {
+    return { label: "Ball", text: scalars(p), tone: "score" };
+  }
+
+  return { label: prettify(type), text: scalars(p), tone: "note" };
+}
+
+export const EVENT_TONE_STYLE: Record<EventDescription["tone"], string> = {
+  start: "bg-sky-100 text-sky-700",
+  score: "bg-emerald-100 text-emerald-700",
+  card: "bg-amber-100 text-amber-700",
+  period: "bg-purple-100 text-purple-700",
+  admin: "bg-red-50 text-red-600",
+  void: "bg-amber-100 text-amber-700",
+  note: "bg-slate-100 text-slate-600",
+};

--- a/apps/web/src/lib/feature-copy.ts
+++ b/apps/web/src/lib/feature-copy.ts
@@ -51,3 +51,15 @@ const FEATURE_REASONS: Record<string, string> = {
 export function featureReason(featureKey: string): string {
   return FEATURE_REASONS[featureKey] ?? "This feature needs a plan upgrade.";
 }
+
+// Cheapest plan that unlocks each feature (mirrors the plan_entitlements
+// seeds, V112 + V240). Everything not listed here unlocks on Pro — only the
+// Business-tier exceptions need rows.
+const BUSINESS_FEATURES = new Set(["api.write", "webhooks", "scorers.max"]);
+
+export type PaidPlan = "pro" | "business";
+
+/** Cheapest plan that unlocks a feature key. Never throws. */
+export function featurePlan(featureKey: string): PaidPlan {
+  return BUSINESS_FEATURES.has(featureKey) ? "business" : "pro";
+}

--- a/apps/web/src/lib/realtime.ts
+++ b/apps/web/src/lib/realtime.ts
@@ -40,13 +40,15 @@ export async function publishFixtureUpdate(
 }
 
 /**
- * Broadcast a schedule_changed event on `division:{id}` after a schedule
- * write (doc 12 §2/§6 — two organisers on one board see each other's moves,
- * last-write-wins per fixture). Fire-and-forget, never throws.
+ * Broadcast on `division:{id}`: schedule_changed after a schedule write
+ * (doc 12 §2/§6 — two organisers on one board see each other's moves),
+ * state_changed after a scoring write (reason "score") so division-wide
+ * listeners like the slideshow refresh without one channel per fixture.
+ * Fire-and-forget, never throws.
  */
 export async function publishDivisionUpdate(
   divisionId: string,
-  reason: "schedule" | "publish" | "start",
+  reason: "schedule" | "publish" | "start" | "score",
 ): Promise<void> {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -63,7 +65,7 @@ export async function publishDivisionUpdate(
         messages: [
           {
             topic: `division:${divisionId}`,
-            event: "schedule_changed",
+            event: reason === "score" ? "state_changed" : "schedule_changed",
             payload: { v: Date.now(), reason, at: new Date().toISOString() },
           },
         ],

--- a/apps/web/src/server/api-v1/auth.ts
+++ b/apps/web/src/server/api-v1/auth.ts
@@ -1,6 +1,6 @@
 import "server-only";
 // /api/v1 authentication (doc 08 §2): session cookie (our UI) or API key
-// (Pro integrations — `Authorization: Bearer sk_live_…`). Both resolve to the
+// (Pro integrations — `Authorization: Bearer sc_…`). Both resolve to the
 // same AuthCtx so use-cases don't care which door the caller came through.
 import { createHash, randomBytes } from "node:crypto";
 import { sql } from "@/lib/db";
@@ -25,7 +25,10 @@ export interface AuthCtx {
   deviceLinkId?: string;
 }
 
-const KEY_PREFIX = "sk_live_";
+const KEY_PREFIX = "sc_";
+// Keys minted before the sc_ rename; still accepted (hash lookup is
+// prefix-agnostic), just no longer minted.
+const LEGACY_KEY_PREFIX = "sk_live_";
 const DEVICE_LINK_PREFIX = "dl_";
 
 export function hashApiKey(secret: string): string {
@@ -66,7 +69,7 @@ function bearerToken(req: Request): string | null {
   const header = req.headers.get("authorization");
   if (!header?.startsWith("Bearer ")) return null;
   const token = header.slice("Bearer ".length).trim();
-  return token.startsWith(KEY_PREFIX) ? token : null;
+  return token.startsWith(KEY_PREFIX) || token.startsWith(LEGACY_KEY_PREFIX) ? token : null;
 }
 
 function deviceLinkToken(req: Request): string | null {
@@ -86,7 +89,7 @@ function rejectDeviceLink(req: Request): void {
 }
 
 /**
- * Authenticate a request against an org: API key when a Bearer sk_live_ token
+ * Authenticate a request against an org: API key when a Bearer sc_ token
  * is present, else the session cookie. `write` needs an editor role
  * (owner/admin) or a write-scoped key; `read` an org-wide read role (doc 13
  * §2: scorers get NO org-wide access — their door is requireFixtureActor).

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -253,7 +253,7 @@ export function buildOpenApiDocument(): Record<string, unknown> {
         apiKey: {
           type: "http",
           scheme: "bearer",
-          description: "Pro API key: `Authorization: Bearer sk_live_…` (entitlement api.access)",
+          description: "Pro API key: `Authorization: Bearer sc_…` (entitlement api.access)",
         },
         deviceLink: {
           type: "http",

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -367,7 +367,7 @@ export const ApiKey = z.object({
 });
 
 export const CreatedApiKey = ApiKey.extend({
-  /** The sk_live_ secret — returned exactly once, at creation. */
+  /** The sc_ secret — returned exactly once, at creation. */
   secret: z.string(),
 });
 

--- a/apps/web/src/server/slideshow-data.ts
+++ b/apps/web/src/server/slideshow-data.ts
@@ -1,0 +1,123 @@
+import "server-only";
+// Slide builder for the noticeboard slideshow (v1 parity — the marketing page
+// promises "Print & slideshow"). One slide deck per division; the competition
+// slideshow concatenates the decks of every division with anything to show.
+import { withTenant } from "@/lib/db";
+import { listStages, getStandings } from "@/server/usecases/stages";
+import { listDivisionFixtures } from "@/server/usecases/fixtures";
+import { listEntrants } from "@/server/usecases/entrants";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+const TABLE_KINDS = new Set(["league", "group", "swiss"]);
+
+export interface StandingsSlideRow {
+  rank: number;
+  name: string;
+  played: number;
+  won: number;
+  drawn: number;
+  lost: number;
+  points: number;
+}
+
+export interface FixtureSlideItem {
+  home: string;
+  away: string;
+  /** Display-ready score headline from match_states, e.g. "2 – 1" or "21-15, 21-18". */
+  line: string | null;
+  status: string;
+  round: number;
+}
+
+export type Slide =
+  | { kind: "standings"; division: string; caption: string; rows: StandingsSlideRow[] }
+  | { kind: "fixtures"; division: string; title: string; items: FixtureSlideItem[] };
+
+export async function buildDivisionSlides(
+  auth: AuthCtx,
+  divisionId: string,
+  divisionName: string,
+): Promise<Slide[]> {
+  const [stages, fixtures, entrants] = await Promise.all([
+    listStages(auth, divisionId),
+    listDivisionFixtures(auth, divisionId),
+    listEntrants(auth, divisionId),
+  ]);
+  const names = Object.fromEntries(entrants.map((e) => [e.id, e.display_name]));
+  const slides: Slide[] = [];
+
+  // ── Standings — one slide per table stage (per pool when pooled) ──
+  for (const stage of stages.filter((s) => TABLE_KINDS.has(s.kind))) {
+    const pools = await withTenant(auth.orgId, (tx) =>
+      tx<{ id: string; name: string }[]>`
+        select id, name from pools where stage_id = ${stage.id} order by key`,
+    );
+    const tables =
+      pools.length > 0
+        ? await Promise.all(
+            pools.map(async (p) => ({
+              caption: `${stage.name} — ${p.name}`,
+              snap: await getStandings(auth, stage.id, p.id),
+            })),
+          )
+        : [{ caption: stage.name, snap: await getStandings(auth, stage.id) }];
+    for (const { caption, snap } of tables) {
+      const rows = (snap.rows as {
+        entrantId: string;
+        played: number;
+        won: number;
+        drawn: number;
+        lost: number;
+        points: number;
+        rank?: number;
+      }[]).map((r, i) => ({
+        rank: r.rank ?? i + 1,
+        name: names[r.entrantId] ?? "—",
+        played: r.played,
+        won: r.won,
+        drawn: r.drawn,
+        lost: r.lost,
+        points: r.points,
+      }));
+      if (rows.length > 0) {
+        slides.push({ kind: "standings", division: divisionName, caption, rows });
+      }
+    }
+  }
+
+  // ── Fixtures — score headlines come from match_states.summary ──
+  const ids = fixtures.map((f) => f.id);
+  const summaries =
+    ids.length === 0
+      ? []
+      : await withTenant(auth.orgId, (tx) =>
+          tx<{ fixture_id: string; summary: { headline?: string } | null }[]>`
+            select fixture_id, summary from match_states
+            where fixture_id = any(${ids})`,
+        );
+  const lineOf = new Map(summaries.map((s) => [s.fixture_id, s.summary?.headline ?? null]));
+
+  const item = (f: (typeof fixtures)[number]): FixtureSlideItem => ({
+    home: names[f.home_entrant_id ?? ""] ?? "TBD",
+    away: names[f.away_entrant_id ?? ""] ?? "TBD",
+    line: lineOf.get(f.id) ?? null,
+    status: f.status,
+    round: f.round_no,
+  });
+
+  const live = fixtures.filter((f) => f.status === "in_play").map(item);
+  const results = fixtures
+    .filter((f) => ["decided", "finalized", "forfeited"].includes(f.status))
+    .slice(-8)
+    .map(item);
+  const upcoming = fixtures.filter((f) => f.status === "scheduled").slice(0, 8).map(item);
+
+  if (live.length > 0)
+    slides.push({ kind: "fixtures", division: divisionName, title: "In play", items: live });
+  if (results.length > 0)
+    slides.push({ kind: "fixtures", division: divisionName, title: "Latest results", items: results });
+  if (upcoming.length > 0)
+    slides.push({ kind: "fixtures", division: divisionName, title: "Coming up", items: upcoming });
+
+  return slides;
+}

--- a/apps/web/src/server/usecases/__tests__/integration.test.ts
+++ b/apps/web/src/server/usecases/__tests__/integration.test.ts
@@ -281,19 +281,29 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     expect([...aMembers].map((id) => seedOf.get(id as string)).sort()).toEqual([1, 4, 5, 8]);
 
     await startDivision(auth, division.id);
+    // Generating the KO before the group stage completes must refuse — it
+    // would otherwise bracket every division entrant, not the qualifiers.
+    await expect(generateStageFixtures(auth, knockout.id)).rejects.toMatchObject({
+      code: "STAGE_NOT_READY",
+    });
     // Decide everything (home wins), complete → KO gets seeded.
     for (const fixture of generated.fixtures) await decide(auth, fixture.id, 1, 0);
     const completion = await completeStage(auth, groups.id);
     expect(completion.completed).toBe(true);
     expect(completion.qualified?.stage_id).toBe(knockout.id);
     expect(completion.qualified?.entrants).toHaveLength(4);
-    // Re-complete is idempotent: same seeded list, no duplicate seeding.
+    // Completion auto-generates the seeded stage: 2 semis + final.
+    expect(completion.next_stage_fixtures).toBe(3);
+    // Re-complete is idempotent: same seeded list, no duplicate fixtures.
     const again = await completeStage(auth, groups.id);
     expect(again.qualified?.entrants).toEqual(completion.qualified?.entrants);
+    expect(again.next_stage_fixtures).toBe(0);
 
-    // KO generates from the qualified order (its order IS the seeding).
+    // Explicit re-generate is a no-op; fixtures came from the qualified order
+    // (its order IS the seeding).
     const ko = await generateStageFixtures(auth, knockout.id);
-    expect(ko.created).toBe(3); // 2 semis + final
+    expect(ko.created).toBe(0);
+    expect(ko.fixtures).toHaveLength(3);
     const semis = ko.fixtures.filter((f) => f.round_no === 1);
     const q = completion.qualified!.entrants;
     const pairs = semis.map((f) => new Set([f.home_entrant_id, f.away_entrant_id]));

--- a/apps/web/src/server/usecases/__tests__/integration.test.ts
+++ b/apps/web/src/server/usecases/__tests__/integration.test.ts
@@ -310,7 +310,7 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
     expect(final.away_entrant_id).not.toBeNull();
   });
 
-  it("API keys are 402-gated on api.access and mint sk_live_ secrets once", async () => {
+  it("API keys are 402-gated on api.access and mint sc_ secrets once", async () => {
     const { auth } = await seedOrg();
     // Community default: no api.access → 402.
     await expect(createApiKey(auth, { name: "ci", scopes: ["read"] })).rejects.toBeInstanceOf(
@@ -330,10 +330,10 @@ describe.skipIf(!HAS_DB)("/api/v1 service layer", () => {
       values (${auth.orgId}, 'api.write', true)
       on conflict (org_id, feature_key) do update set bool_value = true`;
     const key = await createApiKey(auth, { name: "ci", scopes: ["read", "write"] });
-    expect(key.secret.startsWith("sk_live_")).toBe(true);
+    expect(key.secret.startsWith("sc_")).toBe(true);
     const [stored] = await sql<{ key_hash: string }[]>`
       select key_hash from api_keys where id = ${key.id}`;
-    expect(stored.key_hash).not.toContain(key.secret.slice(8)); // only the hash at rest
+    expect(stored.key_hash).not.toContain(key.secret.slice(3)); // only the hash at rest
   });
 
   it("refuses to delete a competition with recorded play", async () => {

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -4,7 +4,7 @@ import "server-only";
 // per-fixture rate limiting, bracket slot progression, standings recompute,
 // realtime publish and public-cache invalidation. undo = core.void through the
 // same door.
-import { withTenant } from "@/lib/db";
+import { sql, withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
 import { rateLimit } from "@/lib/rate-limit";
@@ -12,7 +12,7 @@ import { requireFeature } from "@/lib/entitlements";
 import { EngineError } from "@seazn/engine/core";
 import { appendEvent, resolveModule } from "@/server/engine-db";
 import { recomputeStandings } from "@/server/engine-db";
-import { publishFixtureUpdate } from "@/lib/realtime";
+import { publishDivisionUpdate, publishFixtureUpdate } from "@/lib/realtime";
 import {
   fireDivisionRevalidate,
   fireDiscoveryRevalidate,
@@ -90,6 +90,11 @@ export async function scoreEvent(
   const movesDiscovery =
     result.outcome !== null || input.type === "core.void" || input.type === "core.start";
   void publishFixtureUpdate(fixtureId, "event");
+  // Division-wide state_changed so multi-fixture listeners (slideshow) get
+  // one channel per division instead of one per fixture.
+  void sql<{ division_id: string }[]>`select division_id from fixtures where id = ${fixtureId}`
+    .then(([row]) => row && publishDivisionUpdate(row.division_id, "score"))
+    .catch(() => null);
   void invalidatePublicCache(auth.orgId, fixtureId, movesDiscovery);
   return out;
 }

--- a/apps/web/src/server/usecases/stages.ts
+++ b/apps/web/src/server/usecases/stages.ts
@@ -343,6 +343,33 @@ async function fireStageRevalidate(orgId: string, stageId: string): Promise<void
 }
 
 export async function generateStageFixtures(auth: AuthCtx, stageId: string): Promise<GenerateOutcome> {
+  // A qualification stage must draw from the previous stage's final table
+  // (config.qualified), never from the whole entrant list. If it isn't seeded
+  // yet: seed it now when the previous stage is complete (stage added after
+  // the fact), otherwise refuse — generating early would bracket everyone.
+  {
+    const pre = await withTenant(auth.orgId, async (tx) => {
+      const [stage] = await tx<StageRow[]>`
+        select ${tx(STAGE_COLS)} from stages where id = ${stageId}`;
+      if (!stage) throw new HttpError(404, "stage not found");
+      if (!stage.qualification || Array.isArray(stage.config.qualified)) return null;
+      const [prev] = await tx<{ id: string; status: string }[]>`
+        select id, status from stages
+        where division_id = ${stage.division_id} and seq < ${stage.seq}
+        order by seq desc limit 1`;
+      return prev ?? null;
+    });
+    if (pre) {
+      if (pre.status !== "complete") {
+        throw new EngineError(
+          "STAGE_NOT_READY",
+          "this stage draws its entrants from the previous stage's final table — complete the previous stage first",
+          { stageId, previousStageId: pre.id },
+        );
+      }
+      await seedNextStage(auth, pre.id);
+    }
+  }
   const outcome = await withTenant(auth.orgId, async (tx) => {
     const [stage] = await tx<StageRow[]>`
       select ${tx(STAGE_COLS)} from stages where id = ${stageId}`;
@@ -496,14 +523,18 @@ export interface SeededStage {
 export interface CompleteStageResult extends CompleteResult {
   /** Set when completion resolved the next stage's qualification spec. */
   qualified?: SeededStage;
+  /** Fixtures auto-generated for the seeded next stage. */
+  next_stage_fixtures?: number;
 }
 
 /**
  * Guarded progression (doc 08 §3): no-op unless the completion predicate
  * holds. On completion, if the next stage declares a qualification spec
  * (doc 05 §3), resolve it against this stage's ranked tables into an ordered
- * seed list, snapshotted as the next stage's `config.qualified` — which its
- * /generate then consumes. Idempotent: an already-seeded stage is not re-seeded.
+ * seed list, snapshotted as the next stage's `config.qualified` — and then
+ * generate that stage's fixtures so the bracket appears immediately (the
+ * organiser shouldn't have to know a second Generate click is needed).
+ * Idempotent: an already-seeded stage is not re-seeded.
  */
 export async function completeStage(auth: AuthCtx, stageId: string): Promise<CompleteStageResult> {
   await withTenant(auth.orgId, async (tx) => {
@@ -514,7 +545,15 @@ export async function completeStage(auth: AuthCtx, stageId: string): Promise<Com
   if (!result.completed) return result;
   const qualified = await seedNextStage(auth, stageId);
   void fireStageRevalidate(auth.orgId, stageId);
-  return qualified ? { ...result, qualified } : result;
+  if (!qualified) return result;
+  // Best-effort: completion stands even if generation trips (e.g. paywall).
+  let generated: number | undefined;
+  try {
+    generated = (await generateStageFixtures(auth, qualified.stage_id)).created;
+  } catch {
+    generated = undefined;
+  }
+  return { ...result, qualified, ...(generated !== undefined ? { next_stage_fixtures: generated } : {}) };
 }
 
 // Resolve the next pending stage's qualification against the completed stage's

--- a/db/migration/deltas/V241__product_tour.sql
+++ b/db/migration/deltas/V241__product_tour.sql
@@ -1,0 +1,8 @@
+-- =============================================================================
+-- Migration 241: product tour
+-- =============================================================================
+
+-- Track when a user completes (or skips) the in-app product tour.
+-- Null = tour will auto-start on the dashboard; settings can reset it to
+-- replay the tour.
+alter table users add column if not exists product_tour_completed_at timestamptz;

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -61,7 +61,7 @@
       "apiKey": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Pro API key: `Authorization: Bearer sk_live_…` (entitlement api.access)"
+        "description": "Pro API key: `Authorization: Bearer sc_…` (entitlement api.access)"
       },
       "deviceLink": {
         "type": "http",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:coverage": "npm run test:coverage --workspace apps/web",
     "test:smoke": "node --experimental-strip-types scripts/smoke.ts",
     "test:smoke:sports": "node --experimental-strip-types scripts/smoke-sports.ts",
+    "seed:demo:setup": "node --env-file=apps/web/.env.local --experimental-strip-types scripts/seed-demo.ts --phase=setup",
+    "seed:demo": "node --env-file=apps/web/.env.local --experimental-strip-types scripts/seed-demo.ts --phase=seed",
     "sim": "npm run sim --workspace packages/engine",
     "sim:replay": "npm run sim:replay --workspace packages/engine --",
     "engine:boundary": "node --experimental-strip-types scripts/engine-boundary.ts",

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -4,14 +4,15 @@
 // entrant counts, and results played so standings/fixtures/brackets populate.
 //
 // Usage (dev server must be running on SEED_BASE, default localhost:3000):
-//   node --env-file=apps/web/.env.local --experimental-strip-types scripts/seed-demo.ts --phase=setup
-//   node --env-file=apps/web/.env.local --experimental-strip-types scripts/seed-demo.ts --phase=seed
+//   npm run seed:demo:setup -- --account=pro         (or --account=community)
+//   npm run seed:demo -- --account=pro
 //
-// --phase=setup signs up a fresh smoke account (writes .seed-demo-state.json,
-// gitignored) and — when DATABASE_URL is set — grants the org the entitlement
-// overrides the plan needs (5 active competitions, many divisions, double
-// elim). --phase=seed is resume-safe: rerunning skips competitions/divisions
-// that already exist, so tweak PLAN below and rerun to add more.
+// Two account flavours: --account=pro gets a real pro subscription row (set
+// via DATABASE_URL) and the full 5-competition plan; --account=community
+// stays inside the free caps (2 competitions × 1 division) and shows the
+// gated/paywalled experience. Accounts land in .seed-demo-state.json
+// (gitignored). --phase=seed is resume-safe: rerunning skips competitions/
+// divisions that already exist, so tweak the PLANs below and rerun.
 import { writeFileSync, readFileSync } from "node:fs";
 
 const BASE = process.env.SEED_BASE ?? "http://localhost:3000";
@@ -176,7 +177,8 @@ interface DivPlan {
 }
 const GENERIC_CFG = { resultMode: "score", allowDraws: false, points: { w: 3, d: 1, l: 0 }, progressScore: false };
 
-const PLAN: { name: string; divisions: DivPlan[] }[] = [
+// Pro account: the full spread — every format, mixed kinds, 5 competitions.
+const PLAN_PRO: { name: string; divisions: DivPlan[] }[] = [
   { name: "Spring Football League", divisions: [
     { name: "Premier Division", sport: "football", variant: "11-a-side", kind: "team", n: 6 + rnd(3), template: "league", ratio: 1 },
     { name: "U16 Cup", sport: "football", variant: "youth", kind: "team", n: 8, template: "league_ko", q: 4, ratio: 1 },
@@ -205,20 +207,49 @@ const PLAN: { name: string; divisions: DivPlan[] }[] = [
   ]},
 ];
 
+// Community account: stays INSIDE the free caps (2 active competitions,
+// 1 division each, ≤16 entrants, ≤2 stages, no double elim) — shows the real
+// free experience including the Pro badges on gated controls.
+const PLAN_COMMUNITY: { name: string; divisions: DivPlan[] }[] = [
+  { name: "Friday Night Football", divisions: [
+    { name: "League", sport: "football", variant: "small-sided", kind: "team", n: 6, template: "league", ratio: 0.7 },
+  ]},
+  { name: "Office Table Tennis", divisions: [
+    { name: "Singles Championship", sport: "tabletennis", variant: "bo5", kind: "individual", n: 8, template: "league_ko", q: 4, ratio: 1 },
+  ]},
+];
+
+function loadState(): Record<string, { email: string }> {
+  try {
+    return JSON.parse(readFileSync(STATE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
 async function main() {
   const phase = process.argv.find((a) => a.startsWith("--phase="))?.split("=")[1] ?? "seed";
+  const account = (process.argv.find((a) => a.startsWith("--account="))?.split("=")[1] ?? "pro") as
+    | "community"
+    | "pro";
+  const PLAN = account === "community" ? PLAN_COMMUNITY : PLAN_PRO;
 
   if (phase === "setup") {
-    const email = `smoke-demo-${1000 + rnd(9000)}@example.com`;
+    const email = `smoke-${account}-${1000 + rnd(9000)}@example.com`;
     const reg = await call("/api/auth/signup", "POST", { email, password: PASSWORD });
     await call("/api/auth/verify-email", "POST", { token: reg.verify_token });
     await call("/api/onboarding/complete", "POST");
     await call("/api/tour", "POST");
-    writeFileSync(STATE, JSON.stringify({ email }));
-    console.log(`account: ${email} / ${PASSWORD}`);
+    writeFileSync(STATE, JSON.stringify({ ...loadState(), [account]: { email } }));
+    console.log(`${account} account: ${email} / ${PASSWORD}`);
 
-    // The plan exceeds Community caps — grant overrides when we can reach the DB.
-    if (process.env.DATABASE_URL) {
+    // Pro account gets a real pro subscription row — entitlements resolve from
+    // plan_entitlements exactly like a paying org (no piecemeal overrides).
+    if (account === "pro") {
+      if (!process.env.DATABASE_URL) {
+        console.log("DATABASE_URL not set — set the org's subscription to 'pro' manually before seeding");
+        return;
+      }
       const { default: postgres } = await import("postgres");
       const sql = postgres(process.env.DATABASE_URL, {
         ssl: /localhost|127\.0\.0\.1/.test(process.env.DATABASE_URL) ? false : "require",
@@ -229,23 +260,18 @@ async function main() {
         with org as (
           select m.org_id from org_members m join users u on u.id = m.user_id
           where u.email = ${email} limit 1)
-        insert into org_entitlement_overrides (org_id, feature_key, bool_value, int_value)
-        select org_id, k, b, i from org, (values
-          ('competitions.max_active', null::boolean, 99),
-          ('divisions.per_competition.max', null::boolean, 99),
-          ('formats.double_elim', true, null::int)
-        ) as v(k, b, i)
-        on conflict (org_id, feature_key) do update
-          set bool_value = excluded.bool_value, int_value = excluded.int_value`;
+        insert into subscriptions (org_id, plan_key, status)
+        select org_id, 'pro', 'active' from org
+        on conflict (org_id) do update set plan_key = 'pro', status = 'active'`;
       await sql.end();
-      console.log("entitlement overrides applied");
-    } else {
-      console.log("DATABASE_URL not set — apply entitlement overrides manually before seeding");
+      console.log("subscription set to pro/active");
     }
     return;
   }
 
-  const { email } = JSON.parse(readFileSync(STATE, "utf8"));
+  const state = loadState();
+  const email = state[account]?.email;
+  if (!email) throw new Error(`no ${account} account in ${STATE} — run --phase=setup --account=${account} first`);
   await call("/api/auth/login", "POST", { email, password: PASSWORD });
 
   for (const comp of PLAN) {

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -1,0 +1,320 @@
+// Rich demo seeder: 5 competitions, ≥3 divisions each, every stage format
+// (league, league+finals, groups+KO, swiss, knockout, double elim,
+// group+stepladder), mixed entrant kinds (individual/team/pair), random
+// entrant counts, and results played so standings/fixtures/brackets populate.
+//
+// Usage (dev server must be running on SEED_BASE, default localhost:3000):
+//   node --env-file=apps/web/.env.local --experimental-strip-types scripts/seed-demo.ts --phase=setup
+//   node --env-file=apps/web/.env.local --experimental-strip-types scripts/seed-demo.ts --phase=seed
+//
+// --phase=setup signs up a fresh smoke account (writes .seed-demo-state.json,
+// gitignored) and — when DATABASE_URL is set — grants the org the entitlement
+// overrides the plan needs (5 active competitions, many divisions, double
+// elim). --phase=seed is resume-safe: rerunning skips competitions/divisions
+// that already exist, so tweak PLAN below and rerun to add more.
+import { writeFileSync, readFileSync } from "node:fs";
+
+const BASE = process.env.SEED_BASE ?? "http://localhost:3000";
+const STATE = new URL("./.seed-demo-state.json", import.meta.url).pathname;
+const PASSWORD = process.env.SEED_PASSWORD ?? "smokepass123";
+
+const jar = new Map<string, string>();
+const cookieHeader = () => [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+async function call(path: string, method = "GET", body?: unknown) {
+  const res = await fetch(BASE + path, {
+    method,
+    headers: { "content-type": "application/json", ...(jar.size ? { cookie: cookieHeader() } : {}) },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  for (const sc of res.headers.getSetCookie?.() ?? []) {
+    const [pair] = sc.split(";");
+    const eq = pair.indexOf("=");
+    if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1));
+  }
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.ok === false)
+    throw new Error(`${method} ${path} → ${res.status} ${JSON.stringify(json.error ?? json).slice(0, 300)}`);
+  return json.data ?? json;
+}
+
+const rnd = (n: number) => Math.floor(Math.random() * n);
+const coin = () => Math.random() < 0.5;
+
+// ── name pools ──────────────────────────────────────────────────────────────
+const FIRST = ["Aarav","Meera","Ishaan","Priya","Rohan","Anaya","Kabir","Diya","Vihaan","Sara","Arjun","Nisha","Ravi","Tara","Dev","Lila"];
+const LAST = ["Sharma","Patel","Khan","Nguyen","Iyer","Fernandes","Das","Reddy","Mehta","Bose","Kapoor","Joshi","Rao","Menon","Gill","Nair"];
+const CLUBS = ["Riverside","Lakeside","Northfield","Summit","Harbour","Valley","Meadow","Crestwood","Oakwood","Brookfield","Hillcrest","Seaview"];
+let nameCursor = 0;
+const person = () => `${FIRST[nameCursor % 16]} ${LAST[(nameCursor++ * 7 + 3) % 16]}`;
+
+function entrantsFor(kind: "individual" | "team" | "pair", n: number) {
+  if (kind === "team")
+    return CLUBS.slice(0, n).map((c, i) => ({ kind, display_name: `${c} ${coin() ? "FC" : "CC"}`, seed: i + 1 }));
+  if (kind === "pair")
+    return Array.from({ length: n }, (_, i) => ({
+      kind, display_name: `${person().split(" ")[0]} / ${person().split(" ")[0]}`, seed: i + 1,
+    }));
+  return Array.from({ length: n }, (_, i) => ({ kind, display_name: person(), seed: i + 1 }));
+}
+
+// ── stage templates (mirror division-builder) ───────────────────────────────
+type StageSpec = { kind: string; name: string; config: Record<string, unknown>; qualification: Record<string, unknown> | null };
+const TEMPLATES: Record<string, (q: number) => StageSpec[]> = {
+  league: () => [{ kind: "league", name: "League", config: { legs: 1 }, qualification: null }],
+  league_ko: (q) => [
+    { kind: "league", name: "League", config: { legs: 1 }, qualification: null },
+    { kind: "knockout", name: "Finals", config: {}, qualification: { topN: q } },
+  ],
+  groups_ko: (q) => [
+    { kind: "group", name: "Group stage", config: { legs: 1, pools: { count: 2 } }, qualification: null },
+    { kind: "knockout", name: "Knockout", config: {},
+      qualification: { take: Array.from({ length: q }, (_, i) => ({ pool: i % 2 === 0 ? "A" : "B", rank: Math.floor(i / 2) + 1 })) } },
+  ],
+  swiss: () => [{ kind: "swiss", name: "Swiss", config: { rounds: 5 }, qualification: null }],
+  knockout: () => [{ kind: "knockout", name: "Knockout", config: {}, qualification: null }],
+  double_elim: () => [{ kind: "double_elim", name: "Double elimination", config: {}, qualification: null }],
+  group_stepladder: (q) => [
+    { kind: "league", name: "League", config: { legs: 1 }, qualification: null },
+    { kind: "stepladder", name: "Stepladder finals", config: {}, qualification: { topN: q } },
+  ],
+};
+
+// ── per-sport result events (winner side chosen by us) ─────────────────────
+type Ev = { type: string; payload: unknown };
+function resultEvents(sport: string, variant: string, fx: { home: string; away: string }, homeWins: boolean): Ev[] {
+  const w = homeWins ? fx.home : fx.away;
+  const l = homeWins ? fx.away : fx.home;
+  const events: Ev[] = [{ type: "core.start", payload: {} }];
+  switch (sport) {
+    case "football": {
+      const wg = 1 + rnd(4), lg = rnd(wg);
+      for (let i = 0; i < wg; i++) events.push({ type: "football.goal", payload: { by: w, minute: 5 + rnd(85) } });
+      for (let i = 0; i < lg; i++) events.push({ type: "football.goal", payload: { by: l, minute: 5 + rnd(85) } });
+      events.push({ type: "football.period", payload: { phase: "HT" } });
+      events.push({ type: "football.period", payload: { phase: "FT" } });
+      return events;
+    }
+    case "cricket": {
+      // Innings quota per variant: t20 120 balls, hundred 100, odi 300.
+      const quota = variant === "hundred" ? 100 : variant === "odi" ? 300 : 120;
+      const first = 100 + rnd(80);
+      // home bats first (no toss): homeWins ⇒ chase falls short.
+      const chase = homeWins ? first - (5 + rnd(40)) : first + 1 + rnd(20);
+      events.push({ type: "cricket.innings.summary", payload: { runs: first, wickets: 3 + rnd(7), legalBalls: quota } });
+      events.push({ type: "cricket.innings.summary", payload: { runs: Math.max(chase, 10), wickets: homeWins ? 10 : 3 + rnd(6), legalBalls: Math.max(quota - rnd(30), 30) } });
+      return events;
+    }
+    case "boardgame":
+      events.push({ type: "boardgame.result", payload: { winner: w, method: coin() ? "checkmate" : "resign" } });
+      return events;
+    case "generic":
+      events.push({ type: "generic.result", payload: homeWins ? { p1Score: 2 + rnd(3), p2Score: rnd(2) } : { p1Score: rnd(2), p2Score: 2 + rnd(3) } });
+      return events;
+    default: {
+      // Set-based — targets depend on sport AND variant; straight sets keep us
+      // clear of deciding-set target differences (e.g. beach final set to 15).
+      const params: Record<string, { setTo: number; need: number }> = {
+        "volleyball:indoor": { setTo: 25, need: 3 },
+        "volleyball:beach": { setTo: 21, need: 2 },
+        "badminton:bwf": { setTo: 21, need: 2 },
+        "badminton:short": { setTo: 11, need: 2 },
+        "tabletennis:bo5": { setTo: 11, need: 3 },
+        "tabletennis:bo7": { setTo: 11, need: 4 },
+        "tabletennis:hardbat-21": { setTo: 21, need: 3 },
+      };
+      const { setTo, need } = params[`${sport}:${variant}`] ?? { setTo: 21, need: 2 };
+      const evType =
+        sport === "volleyball" ? "volleyball.set.summary" : `${sport}.game.summary`;
+      for (let i = 0; i < need; i++) {
+        const losing = Math.max(0, setTo - 2 - rnd(setTo - 2));
+        events.push({
+          type: evType,
+          payload: homeWins ? { home: setTo, away: losing } : { home: losing, away: setTo },
+        });
+      }
+      return events;
+    }
+  }
+}
+
+async function decideFixture(fixtureId: string, sport: string, variant: string, fx: { home: string; away: string }) {
+  let seq = 0;
+  for (const ev of resultEvents(sport, variant, fx, coin())) {
+    const r = await call(`/api/v1/fixtures/${fixtureId}/events`, "POST", { expected_seq: seq, type: ev.type, payload: ev.payload });
+    seq = r.seq;
+  }
+}
+
+interface GenFx { id: string; round_no?: number; home_entrant_id: string | null; away_entrant_id: string | null }
+
+/** Decide fixtures round by round, refetching feeds (brackets fill as rounds decide). */
+async function playStage(stageId: string, sport: string, variant: string, ratio: number) {
+  const gen = await call(`/api/v1/stages/${stageId}/generate`, "POST");
+  let fixtures: GenFx[] = gen.fixtures;
+  const total = fixtures.length;
+  const target = Math.ceil(total * ratio);
+  let played = 0;
+  const rounds = [...new Set(fixtures.map((f) => f.round_no ?? 0))].sort((a, b) => a - b);
+  for (const round of rounds) {
+    for (const f of fixtures.filter((x) => (x.round_no ?? 0) === round)) {
+      if (played >= target) return { total, played };
+      const cur = (await call(`/api/v1/fixtures/${f.id}`)) as GenFx & { status: string };
+      if (!cur.home_entrant_id || !cur.away_entrant_id) continue; // unresolved feed / bye
+      if (cur.status !== "scheduled") continue; // bye already awarded
+      await decideFixture(f.id, sport, variant, { home: cur.home_entrant_id, away: cur.away_entrant_id });
+      played++;
+    }
+  }
+  return { total, played };
+}
+
+// ── competition plan ────────────────────────────────────────────────────────
+interface DivPlan {
+  name: string; sport: string; variant: string; kind: "individual" | "team" | "pair";
+  n: number; template: keyof typeof TEMPLATES; q?: number; ratio: number;
+  config?: Record<string, unknown>;
+}
+const GENERIC_CFG = { resultMode: "score", allowDraws: false, points: { w: 3, d: 1, l: 0 }, progressScore: false };
+
+const PLAN: { name: string; divisions: DivPlan[] }[] = [
+  { name: "Spring Football League", divisions: [
+    { name: "Premier Division", sport: "football", variant: "11-a-side", kind: "team", n: 6 + rnd(3), template: "league", ratio: 1 },
+    { name: "U16 Cup", sport: "football", variant: "youth", kind: "team", n: 8, template: "league_ko", q: 4, ratio: 1 },
+    { name: "Sunday 5s", sport: "football", variant: "small-sided", kind: "team", n: 5 + rnd(3), template: "league", ratio: 0.5 },
+  ]},
+  { name: "Racquet Masters", divisions: [
+    { name: "Badminton Singles", sport: "badminton", variant: "bwf", kind: "individual", n: 7 + rnd(4), template: "league", ratio: 0.7 },
+    { name: "TT Doubles", sport: "tabletennis", variant: "bo5", kind: "pair", n: 8, template: "groups_ko", q: 4, ratio: 1 },
+    { name: "Badminton Juniors", sport: "badminton", variant: "short", kind: "individual", n: 8, template: "knockout", ratio: 1 },
+  ]},
+  { name: "Chess Open 2026", divisions: [
+    { name: "Open Swiss", sport: "boardgame", variant: "classical", kind: "individual", n: 10 + rnd(3), template: "swiss", ratio: 0.6 },
+    { name: "Blitz Knockout", sport: "boardgame", variant: "blitz", kind: "individual", n: 8, template: "knockout", ratio: 0.8 },
+    { name: "Rapid League", sport: "boardgame", variant: "rapid", kind: "individual", n: 5 + rnd(3), template: "league", ratio: 1 },
+  ]},
+  { name: "Cricket Cup", divisions: [
+    { name: "T20 Groups", sport: "cricket", variant: "t20", kind: "team", n: 8, template: "groups_ko", q: 4, ratio: 1 },
+    { name: "Village League", sport: "cricket", variant: "t20", kind: "team", n: 5, template: "league", ratio: 0.8 },
+    { name: "Hundred Bash", sport: "cricket", variant: "hundred", kind: "team", n: 6, template: "league", ratio: 0.4 },
+  ]},
+  { name: "Community Games", divisions: [
+    { name: "Carrom Ladder", sport: "generic", variant: "score", kind: "individual", n: 6, template: "group_stepladder", q: 4, ratio: 1, config: GENERIC_CFG },
+    { name: "Darts Double Elim", sport: "generic", variant: "score", kind: "individual", n: 8, template: "double_elim", ratio: 0.7, config: GENERIC_CFG },
+    { name: "Volleyball League", sport: "volleyball", variant: "indoor", kind: "team", n: 6, template: "league_ko", q: 4, ratio: 1 },
+    { name: "Beach Pairs", sport: "volleyball", variant: "beach", kind: "pair", n: 5 + rnd(3), template: "league", ratio: 0.6 },
+  ]},
+];
+
+async function main() {
+  const phase = process.argv.find((a) => a.startsWith("--phase="))?.split("=")[1] ?? "seed";
+
+  if (phase === "setup") {
+    const email = `smoke-demo-${1000 + rnd(9000)}@example.com`;
+    const reg = await call("/api/auth/signup", "POST", { email, password: PASSWORD });
+    await call("/api/auth/verify-email", "POST", { token: reg.verify_token });
+    await call("/api/onboarding/complete", "POST");
+    await call("/api/tour", "POST");
+    writeFileSync(STATE, JSON.stringify({ email }));
+    console.log(`account: ${email} / ${PASSWORD}`);
+
+    // The plan exceeds Community caps — grant overrides when we can reach the DB.
+    if (process.env.DATABASE_URL) {
+      const { default: postgres } = await import("postgres");
+      const sql = postgres(process.env.DATABASE_URL, {
+        ssl: /localhost|127\.0\.0\.1/.test(process.env.DATABASE_URL) ? false : "require",
+        max: 1,
+        prepare: !process.env.DATABASE_URL.includes(":6543"),
+      });
+      await sql`
+        with org as (
+          select m.org_id from org_members m join users u on u.id = m.user_id
+          where u.email = ${email} limit 1)
+        insert into org_entitlement_overrides (org_id, feature_key, bool_value, int_value)
+        select org_id, k, b, i from org, (values
+          ('competitions.max_active', null::boolean, 99),
+          ('divisions.per_competition.max', null::boolean, 99),
+          ('formats.double_elim', true, null::int)
+        ) as v(k, b, i)
+        on conflict (org_id, feature_key) do update
+          set bool_value = excluded.bool_value, int_value = excluded.int_value`;
+      await sql.end();
+      console.log("entitlement overrides applied");
+    } else {
+      console.log("DATABASE_URL not set — apply entitlement overrides manually before seeding");
+    }
+    return;
+  }
+
+  const { email } = JSON.parse(readFileSync(STATE, "utf8"));
+  await call("/api/auth/login", "POST", { email, password: PASSWORD });
+
+  for (const comp of PLAN) {
+    // Resume-safe: on a slug conflict reuse the existing competition and skip
+    // any division that already exists.
+    let c: { id: string };
+    try {
+      c = await call("/api/v1/competitions", "POST", { name: comp.name });
+    } catch (e) {
+      if (!String(e).includes("already in use")) throw e;
+      const list = await call("/api/v1/competitions?limit=100");
+      c = (list.items ?? list).find((x: { name: string }) => x.name === comp.name);
+      console.log(`${comp.name}: exists, resuming`);
+    }
+    const existingRes = await call(`/api/v1/competitions/${c.id}/divisions`);
+    const existingArr: { name: string }[] = Array.isArray(existingRes)
+      ? existingRes
+      : (existingRes.items ?? []);
+    const existingNames = new Set(existingArr.map((x) => x.name));
+    for (const d of comp.divisions) {
+      if (existingNames.has(d.name)) {
+        console.log(`${comp.name} / ${d.name}: exists, skipped`);
+        continue;
+      }
+      const div = await call(`/api/v1/competitions/${c.id}/divisions`, "POST", {
+        name: d.name, sport_key: d.sport, variant_key: d.variant,
+        ...(d.config ? { config: d.config } : {}),
+      });
+      await call(`/api/v1/divisions/${div.id}/entrants`, "POST", entrantsFor(d.kind, d.n));
+      const specs = TEMPLATES[d.template](d.q ?? 4).map((s, i) => ({ ...s, seq: i + 1 }));
+      const created = await call(`/api/v1/divisions/${div.id}/stages`, "POST", specs);
+      const stages: { id: string; kind: string; seq: number }[] = Array.isArray(created) ? created : [created];
+      stages.sort((a, b) => a.seq - b.seq);
+
+      const first = await (async () => {
+        const gen = await playStageAfterStart(div.id, stages[0].id, d.sport, d.variant, d.ratio);
+        return gen;
+      })();
+      let note = `${first.played}/${first.total}`;
+      // Second stage only when the first fully decided.
+      if (stages[1] && first.played === first.total) {
+        const second = await playStage(stages[1].id, d.sport, d.variant, 0.6 + Math.random() * 0.4);
+        note += ` + ${stages[1].kind} ${second.played}/${second.total}`;
+      }
+      console.log(`${comp.name} / ${d.name} (${d.sport}, ${d.kind}×${d.n}, ${d.template}): ${note}`);
+    }
+  }
+  console.log("done");
+}
+
+async function playStageAfterStart(divId: string, stageId: string, sport: string, variant: string, ratio: number) {
+  const gen = await call(`/api/v1/stages/${stageId}/generate`, "POST");
+  await call(`/api/v1/divisions/${divId}/start`, "POST");
+  let fixtures: GenFx[] = gen.fixtures;
+  const total = fixtures.length;
+  const target = Math.ceil(total * ratio);
+  let played = 0;
+  const rounds = [...new Set(fixtures.map((f) => f.round_no ?? 0))].sort((a, b) => a - b);
+  for (const round of rounds) {
+    for (const f of fixtures.filter((x) => (x.round_no ?? 0) === round)) {
+      if (played >= target) return { total, played };
+      const cur = (await call(`/api/v1/fixtures/${f.id}`)) as GenFx & { status: string };
+      if (!cur.home_entrant_id || !cur.away_entrant_id) continue;
+      if (cur.status !== "scheduled") continue;
+      await decideFixture(f.id, sport, variant, { home: cur.home_entrant_id, away: cur.away_entrant_id });
+      played++;
+    }
+  }
+  return { total, played };
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -311,8 +311,12 @@ async function main() {
         return gen;
       })();
       let note = `${first.played}/${first.total}`;
-      // Second stage only when the first fully decided.
+      // Second stage only when the first fully decided. Completing stage 1
+      // FIRST is what resolves qualification (topN/take) into the next
+      // stage's config.qualified — generating without it would bracket every
+      // division entrant instead of the qualifiers.
       if (stages[1] && first.played === first.total) {
+        await call(`/api/v1/stages/${stages[0].id}/complete`, "POST");
         const second = await playStage(stages[1].id, d.sport, d.variant, 0.6 + Math.random() * 0.4);
         note += ` + ${stages[1].kind} ${second.played}/${second.total}`;
       }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -376,7 +376,7 @@ async function v1Suite(admin: Session, orgId: string, orgSlug: string): Promise<
              on conflict (org_id, feature_key) do update set bool_value = true`;
     const minted = await v1(admin, `/api/v1/orgs/${orgId}/api-keys`, "POST", { name: "ci", scopes: ["read"] });
     const secret = v1data<{ id: string; secret: string }>(minted).secret;
-    check("v1 API key minted once (sk_live_)", minted.status === 201 && secret.startsWith("sk_live_"));
+    check("v1 API key minted once (sc_)", minted.status === 201 && secret.startsWith("sc_"));
 
     const keyed = await v1(newSession(), "/api/v1/competitions", "GET", undefined, {
       Authorization: `Bearer ${secret}`,


### PR DESCRIPTION
## What's in here

**Onboarding & upgrade moments**
- **Product tour** — 5-step cross-page spotlight tour (dashboard → org name → settings rename → back → new competition → wizard) auto-starts on an editor's first dashboard visit; skip/Esc marks it done; replay from Settings → Organisation. New `users.product_tour_completed_at` (migration **V241**), `POST/DELETE /api/tour`.
- **Plan badges** — every gated button/panel now shows the tier that unlocks it (`Pro ✦` / `Business ◆`): inside `UpgradeGate` (all 13 touchpoints), settings logo/API copy, API-keys write-scope checkbox, registration entry-fee field. `featurePlan()` in `feature-copy.ts` mirrors the plan_entitlements seeds.

**Organiser UX**
- **Slideshows** (v1-parity feature lost in the v2 cutover; marketing still advertises it): `/competitions/[id]/slideshow` rotates every division's standings / live fixtures / results; `/divisions/[id]/slideshow` for a single division. Dark full-screen TV layout, 9s per slide, silent 45s data refresh, arrows/Esc; opens in a new tab from both consoles.
- **Fixture activity feed** — raw `football.goal {json}` ledger rows replaced with human copy (`event-copy.ts`): tone-coloured badges + sentences per sport; unknown events degrade to a prettified label; raw payload on hover.
- **Competition settings page** — moved off the overview sidebar to `/competitions/[id]/settings`; overview gets a Settings button and a full-width division list.
- **Division builder** — raw JSON config-overrides textarea replaced by per-sport "Match rules" fields (football halves/extra time/shootout, cricket overs/bowler cap/super over/DLS, set-based best-of/points, chess clock); added **Group + Stepladder** template (engine/API/public bracket already supported it).
- **Entrants CSV import** — one Import button (file picker) + downloadable sample CSV, inline in the Add entrant card.

**Platform**
- **API keys mint `sc_…` secrets** instead of `sk_live_…` (confusable with Stripe live keys). Legacy `sk_live_` bearers still authenticate — lookup is hash-based. OpenAPI regenerated, smoke + integration tests updated.
- **`scripts/seed-demo.ts`** (`npm run seed:demo:setup` / `seed:demo`) — resume-safe demo seeder: 5 competitions, every stage format, mixed individual/team/pair entrants, results played so standings/brackets populate; applies the needed entitlement overrides when `DATABASE_URL` is set.

## Testing
- 155/155 vitest (incl. DB-backed suites on a fresh V001→V241 Flyway chain)
- Typecheck + lint clean
- Live-verified against dev: tour overlay in headless Chrome, badges/settings/slideshow/builder/CSV flows driven end-to-end via API + rendered HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)