### PR TITLE
Players directory, club & player photos, teams/squad UI

### DIFF
--- a/apps/web/e2e/directory-labels.spec.ts
+++ b/apps/web/e2e/directory-labels.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+// Rename regression: the People directory is now "Players" (labels + routes),
+// and both the club-badge and player-photo upload controls live inline in their
+// respective add forms.
+test("directory reads 'Players' and exposes inline image pickers", async ({ page }) => {
+  // /people is a back-compat redirect onto the Players tab.
+  await page.goto("/people");
+  await expect(page).toHaveURL(/\/directory\?tab=players/);
+  await expect(page.getByRole("link", { name: "Players" })).toBeVisible();
+
+  // Add-player form carries a photo picker and a "Add player" button.
+  await expect(page.getByRole("button", { name: "Add player" })).toBeVisible();
+  await expect(page.getByLabel("Player photo")).toBeVisible();
+  await expect(page.getByRole("checkbox", { name: "consents to public photo" })).toBeVisible();
+
+  // /players resolves to the same tab.
+  await page.goto("/players");
+  await expect(page).toHaveURL(/\/directory\?tab=players/);
+
+  // Clubs tab: the add-club form carries an inline badge picker.
+  await page.goto("/directory?tab=clubs");
+  await expect(page.getByLabel("Club badge")).toBeVisible();
+});

--- a/apps/web/e2e/enroll.spec.ts
+++ b/apps/web/e2e/enroll.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import { TAG, apiJson } from "./helpers";
+
+// Unified Add-Entrant: enroll an EXISTING team into a division from the UI
+// (the "Existing team" mode), instead of re-running the CSV import.
+test("enroll an existing team into a division via the UI", async ({ page }) => {
+  // Seed a team by importing it (no Division column → directory only, no entry).
+  const csv = `Club,Team,Player\nRiverside ${TAG},Riverside U12 ${TAG},Ada ${TAG}`;
+  const up = await page.request.post("/api/v1/imports", {
+    multipart: { file: { name: "p.csv", mimeType: "text/csv", buffer: Buffer.from(csv) } },
+  });
+  const importId = ((await up.json()) as { data: { importId: string } }).data.importId;
+  await page.request.post(`/api/v1/imports/${importId}/commit`, { data: {} });
+
+  // A competition + division to enroll into.
+  const comp = (await apiJson<{ id: string }>(page.request, "/api/v1/competitions", "POST", {
+    name: `Enroll ${TAG}`,
+    visibility: "public",
+  })).data!;
+  const div = (await apiJson<{ id: string }>(
+    page.request,
+    `/api/v1/competitions/${comp.id}/divisions`,
+    "POST",
+    {
+      name: "Open",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { resultMode: "score", allowDraws: true, points: { w: 3, d: 1, l: 0 }, progressScore: false },
+      eligibility: [],
+    },
+  )).data!;
+
+  await page.goto(`/divisions/${div.id}?tab=entrants`);
+  await page.getByRole("button", { name: "Existing team" }).click();
+  await page.getByRole("textbox", { name: "Search teams" }).fill(`Riverside U12 ${TAG}`);
+  await page.getByText(`Riverside U12 ${TAG}`, { exact: true }).first().click();
+  await page.getByRole("button", { name: /Enroll team/ }).click();
+
+  // The team now appears as an entrant in the division table.
+  await expect(page.getByRole("cell", { name: `Riverside U12 ${TAG}` })).toBeVisible();
+});

--- a/apps/web/e2e/team-squad.spec.ts
+++ b/apps/web/e2e/team-squad.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { TAG, apiJson } from "./helpers";
+
+// Add a team directly under a club and manage its persistent squad, all in the
+// Directory → Clubs detail (no spreadsheet import). Names are namespaced so this
+// spec never collides with others sharing the per-run org.
+test("add a team to a club and manage its squad", async ({ page }) => {
+  const clubName = `Harbour ${TAG}`;
+  const teamName = `Squad ${TAG}`;
+  const playerName = `Squaddie ${TAG}`;
+
+  const club = (await apiJson<{ id: string }>(page.request, "/api/v1/clubs", "POST", {
+    name: clubName,
+  })).data!;
+  void club;
+  await apiJson(page.request, "/api/v1/persons", "POST", {
+    full_name: playerName,
+    consent: {},
+    dob: null,
+    gender: null,
+    external_ref: null,
+  });
+
+  await page.goto("/directory?tab=clubs");
+  // Per-row badge control is present for each club in the table.
+  await expect(page.getByLabel(`Badge for ${clubName}`)).toBeAttached();
+  await page.getByRole("button", { name: clubName }).first().click();
+
+  // Add a team under the club.
+  await page.getByPlaceholder("Riverside U12").fill(teamName);
+  await page.getByRole("button", { name: "Add team" }).click();
+  const teamToggle = page.getByRole("button", { name: new RegExp(teamName) });
+  await expect(teamToggle).toBeVisible();
+  // Collapsed by default; the leading-chevron accordion drives aria-expanded.
+  await expect(teamToggle).toHaveAttribute("aria-expanded", "false");
+
+  // Expand its squad, add a player, save.
+  await teamToggle.click();
+  await expect(teamToggle).toHaveAttribute("aria-expanded", "true");
+  await page.getByRole("button", { name: `+ ${playerName}` }).click();
+  await page.getByRole("button", { name: /Save squad/ }).click();
+
+  // Persisted: reopening the panel still shows the player in the squad.
+  await page.reload();
+  await page.getByRole("button", { name: clubName }).first().click();
+  await page.getByRole("button", { name: new RegExp(teamName) }).click();
+  await expect(page.getByText(playerName)).toBeVisible();
+});

--- a/apps/web/e2e/team-squad.spec.ts
+++ b/apps/web/e2e/team-squad.spec.ts
@@ -34,9 +34,12 @@ test("add a team to a club and manage its squad", async ({ page }) => {
   // Collapsed by default; the leading-chevron accordion drives aria-expanded.
   await expect(teamToggle).toHaveAttribute("aria-expanded", "false");
 
-  // Expand its squad, add a player, save.
+  // Expand its squad, add a player, save. The picker is a search that shows
+  // only the first few matches, so filter to our player first (the shared CI
+  // DB holds far more than fit unfiltered).
   await teamToggle.click();
   await expect(teamToggle).toHaveAttribute("aria-expanded", "true");
+  await page.getByPlaceholder("Find player…").fill(playerName);
   await page.getByRole("button", { name: `+ ${playerName}` }).click();
   await page.getByRole("button", { name: /Save squad/ }).click();
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -13,11 +13,20 @@ const securityHeaders = [
     key: "Strict-Transport-Security",
     value: "max-age=31536000; includeSubDomains",
   },
+  // Isolate the browsing context: a window we open (or that opens us) can't
+  // reach back through window.opener. OAuth here is redirect-based, so this is
+  // safe. (CSP is deliberately omitted — it needs a nonce + Sentry/Supabase
+  // allowlist and is tracked as a separate, tested change.)
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "X-Permitted-Cross-Domain-Policies", value: "none" },
+  { key: "X-DNS-Prefetch-Control", value: "off" },
 ];
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  // Don't advertise the framework (removes the `X-Powered-By: Next.js` header).
+  poweredByHeader: false,
   // Monorepo: trace from the workspace root so hoisted node_modules land in
   // .next/standalone (Next docs: config/output caveats).
   outputFileTracingRoot: path.join(import.meta.dirname, "../.."),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,8 @@
     "@anthropic-ai/sdk": "^0.110.0",
     "@seazn/engine": "*",
     "@sentry/nextjs": "^10.62.0",
+    "@stripe/react-stripe-js": "^6.7.0",
+    "@stripe/stripe-js": "^9.9.0",
     "@supabase/supabase-js": "^2.110.0",
     "bcryptjs": "^3.0.3",
     "exceljs": "^4.4.0",

--- a/apps/web/src/app/api/billing/checkout/route.ts
+++ b/apps/web/src/app/api/billing/checkout/route.ts
@@ -5,7 +5,11 @@ import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
 import { baseUrl } from "@/lib/oauth";
 import { checkoutSchema } from "@/lib/types";
+import { buildEmbeddedCheckoutParams } from "@/lib/billing";
 
+/** POST /api/billing/checkout — start an EMBEDDED Stripe Checkout session and
+ *  return its client_secret; the billing page mounts <EmbeddedCheckout> with it
+ *  (in-page, no redirect until completion). */
 export async function POST(req: Request) {
   return handler(async () => {
     const orgId = await getActiveOrgId();
@@ -29,36 +33,17 @@ export async function POST(req: Request) {
     // Reuse existing Stripe customer if we already have one
     const [sub] = await sql<{ stripe_customer_id: string | null }[]>`
       select stripe_customer_id from subscriptions where org_id = ${orgId}`;
-    const existingCustomerId = sub?.stripe_customer_id ?? undefined;
 
-    const stripe = getStripe();
-    const base = baseUrl(req);
+    const session = await getStripe().checkout.sessions.create(
+      buildEmbeddedCheckoutParams({
+        priceId: plan.price_id,
+        orgId,
+        returnUrl: `${baseUrl(req)}/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+        customerId: sub?.stripe_customer_id ?? undefined,
+        customerEmail: user.email,
+      }),
+    );
 
-    const session = await stripe.checkout.sessions.create({
-      mode: "subscription",
-      ...(existingCustomerId
-        ? { customer: existingCustomerId }
-        : { customer_email: user.email }),
-      metadata: { org_id: orgId },
-      // Honour the "no card required" trial: don't ask for a payment method up
-      // front. If none is added by the time the trial ends, cancel rather than
-      // silently attempting to bill a card we never collected.
-      payment_method_collection: "if_required",
-      subscription_data: {
-        trial_period_days: 14,
-        trial_settings: {
-          end_behavior: { missing_payment_method: "cancel" },
-        },
-        metadata: { org_id: orgId },
-      },
-      line_items: [{ price: plan.price_id, quantity: 1 }],
-      success_url: `${base}/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
-      cancel_url: `${base}/settings/billing`,
-      allow_promotion_codes: true,
-      tax_id_collection: { enabled: true },
-      automatic_tax: { enabled: true },
-    });
-
-    return { url: session.url };
+    return { client_secret: session.client_secret };
   });
 }

--- a/apps/web/src/app/api/billing/downgrade/route.ts
+++ b/apps/web/src/app/api/billing/downgrade/route.ts
@@ -1,0 +1,16 @@
+import { getActiveOrgId, requireOrgRole } from "@/lib/auth";
+import { handler } from "@/lib/http";
+import { HttpError } from "@/lib/errors";
+import { downgradeToCommunity } from "@/lib/billing";
+
+/** POST /api/billing/downgrade — self-serve downgrade to Community for a
+ *  non-Stripe (comped) org. Stripe-billed orgs must use the portal. Owner only. */
+export async function POST() {
+  return handler(async () => {
+    const orgId = await getActiveOrgId();
+    if (!orgId) throw new HttpError(400, "No active organization");
+    await requireOrgRole(orgId, ["owner"]);
+    await downgradeToCommunity(orgId);
+    return { plan_key: "community" };
+  });
+}

--- a/apps/web/src/app/api/v1/clubs/[id]/teams/route.ts
+++ b/apps/web/src/app/api/v1/clubs/[id]/teams/route.ts
@@ -1,0 +1,16 @@
+import { v1, reply, parseBody } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { CreateTeam } from "@/server/api-v1/schemas";
+import { createTeam } from "@/server/usecases/teams";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** POST /api/v1/clubs/{id}/teams — create a team under a club (Pro). */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const body = await parseBody(req, CreateTeam);
+    const auth = await requireResourceAuth(req, "club", id, "write");
+    return reply(201, await createTeam(auth, id, body));
+  });
+}

--- a/apps/web/src/app/api/v1/divisions/[id]/entrants/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/entrants/route.ts
@@ -12,8 +12,10 @@ export async function GET(req: Request, { params }: Ctx) {
   return v1(async () => {
     const { id } = await params;
     const auth = await requireResourceAuth(req, "division", id, "read");
-    const clubId = new URL(req.url).searchParams.get("club_id") ?? undefined;
-    return listEntrants(auth, id, clubId);
+    const query = new URL(req.url).searchParams;
+    const clubId = query.get("club_id") ?? undefined;
+    const teamId = query.get("team_id") ?? undefined;
+    return listEntrants(auth, id, { clubId, teamId });
   });
 }
 

--- a/apps/web/src/app/api/v1/divisions/[id]/roster/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/roster/route.ts
@@ -1,0 +1,15 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { divisionRoster } from "@/server/usecases/entrants";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** GET /api/v1/divisions/{id}/roster — every (person → team entrant)
+ *  membership in the division, for the same-division double-roster warning. */
+export async function GET(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "read");
+    return divisionRoster(auth, id);
+  });
+}

--- a/apps/web/src/app/api/v1/persons/[id]/photo/route.ts
+++ b/apps/web/src/app/api/v1/persons/[id]/photo/route.ts
@@ -1,0 +1,22 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { HttpError } from "@/lib/errors";
+import { setPersonPhoto } from "@/server/usecases/persons";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** POST /api/v1/persons/[id]/photo — multipart single 'file' upload; sets the
+ *  player's photo_path. Display is still gated by the public_photo consent. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "person", id, "write");
+    const form = await req.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) throw new HttpError(400, "multipart 'file' entry required");
+    return setPersonPhoto(auth, id, {
+      contentType: file.type,
+      bytes: Buffer.from(await file.arrayBuffer()),
+    });
+  });
+}

--- a/apps/web/src/app/api/v1/teams/[id]/squad/route.ts
+++ b/apps/web/src/app/api/v1/teams/[id]/squad/route.ts
@@ -1,0 +1,25 @@
+import { v1, parseBody } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { SetTeamSquad } from "@/server/api-v1/schemas";
+import { getTeamSquad, setTeamSquad } from "@/server/usecases/teams";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** GET /api/v1/teams/{id}/squad — the team's persistent squad. */
+export async function GET(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "team", id, "read");
+    return getTeamSquad(auth, id);
+  });
+}
+
+/** PUT /api/v1/teams/{id}/squad — full-replace the squad (Pro). */
+export async function PUT(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const body = await parseBody(req, SetTeamSquad);
+    const auth = await requireResourceAuth(req, "team", id, "write");
+    return setTeamSquad(auth, id, body.members);
+  });
+}

--- a/apps/web/src/app/api/v1/teams/route.ts
+++ b/apps/web/src/app/api/v1/teams/route.ts
@@ -1,0 +1,12 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireAuth } from "@/server/api-v1/auth";
+import { listTeams } from "@/server/usecases/teams";
+
+/** GET /api/v1/teams — org teams with resolved club badge and the most-recent
+ *  entrant id, for the enroll-an-existing-team picker. Ungated read. */
+export async function GET(req: Request) {
+  return v1(async () => {
+    const auth = await requireAuth(req, "read");
+    return listTeams(auth);
+  });
+}

--- a/apps/web/src/app/directory/page.tsx
+++ b/apps/web/src/app/directory/page.tsx
@@ -11,7 +11,7 @@ import { listClubs } from "@/server/usecases/clubs";
 import { PersonsPanel } from "@/components/v2/persons-panel";
 import { ClubsPanel } from "@/components/v2/clubs-panel";
 
-const TABS = ["people", "clubs"] as const;
+const TABS = ["players", "clubs"] as const;
 type Tab = (typeof TABS)[number];
 
 export default async function DirectoryPage({
@@ -20,7 +20,7 @@ export default async function DirectoryPage({
   searchParams: Promise<{ tab?: string }>;
 }) {
   const { tab: rawTab } = await searchParams;
-  const tab: Tab = (TABS as readonly string[]).includes(rawTab ?? "") ? (rawTab as Tab) : "people";
+  const tab: Tab = (TABS as readonly string[]).includes(rawTab ?? "") ? (rawTab as Tab) : "players";
   await requirePageAuth();
 
   return (
@@ -30,7 +30,7 @@ export default async function DirectoryPage({
         <div className="mb-6">
           <h1 className="text-xl font-semibold tracking-tight text-slate-900">Directory</h1>
           <p className="mt-1 text-sm text-slate-500">
-            Your organisation&apos;s people and clubs — reused across every competition.
+            Your organisation&apos;s players and clubs — reused across every competition.
           </p>
         </div>
 
@@ -50,19 +50,20 @@ export default async function DirectoryPage({
           ))}
         </nav>
 
-        {tab === "people" ? <PeopleTab /> : <ClubsTab />}
+        {tab === "players" ? <PlayersTab /> : <ClubsTab />}
       </main>
     </>
   );
 }
 
-async function PeopleTab() {
+async function PlayersTab() {
   const { auth, canEdit } = await requirePageAuth();
   const { items } = await listPersons(auth, { cursor: null, limit: 200 });
+  const storageBase = `${process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""}/storage/v1/object/public/assets`;
   return (
     <div className="space-y-4">
       <p className="text-sm text-slate-500">
-        People rostered into entrants across competitions. Date of birth is used only for
+        Players rostered into entrants across competitions. Date of birth is used only for
         eligibility and is never shown publicly; names appear on public pages only with consent.
       </p>
       <PersonsPanel
@@ -73,7 +74,9 @@ async function PeopleTab() {
           gender: p.gender,
           consent: p.consent as { public_name?: boolean; public_photo?: boolean },
           external_ref: p.external_ref,
+          photo_path: p.photo_path,
         }))}
+        storageBase={storageBase}
         canEdit={canEdit}
       />
     </div>

--- a/apps/web/src/app/import/page.tsx
+++ b/apps/web/src/app/import/page.tsx
@@ -20,7 +20,7 @@ export default async function ImportPage() {
           <p className="mt-1 text-sm text-slate-500">
             Bring clubs, teams and players in from one spreadsheet. Nothing is written
             until you commit the previewed plan. Divisions must{" "}
-            <Link href="/competitions" className="underline">
+            <Link href="/dashboard" className="underline">
               exist first
             </Link>{" "}
             — a Division column places each team as an entrant.

--- a/apps/web/src/app/people/page.tsx
+++ b/apps/web/src/app/people/page.tsx
@@ -1,6 +1,6 @@
-// People merged into the unified Directory (People + Clubs tabs).
+// Back-compat: /people now lives as the Players tab of the unified Directory.
 import { redirect } from "next/navigation";
 
 export default function PeoplePage() {
-  redirect("/directory?tab=people");
+  redirect("/directory?tab=players");
 }

--- a/apps/web/src/app/players/page.tsx
+++ b/apps/web/src/app/players/page.tsx
@@ -1,0 +1,6 @@
+// Players tab of the unified Directory (Players + Clubs).
+import { redirect } from "next/navigation";
+
+export default function PlayersPage() {
+  redirect("/directory?tab=players");
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: ["/", "/pricing", "/use-cases/", "/legal/"],
-        disallow: ["/dashboard", "/admin", "/api/", "/settings", "/competitions/", "/divisions/", "/fixtures/", "/directory", "/people", "/clubs", "/orgs/"],
+        disallow: ["/dashboard", "/admin", "/api/", "/settings", "/competitions/", "/divisions/", "/fixtures/", "/directory", "/players", "/people", "/clubs", "/orgs/"],
       },
     ],
     sitemap: "https://seazn.club/sitemap.xml",

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -6,7 +6,7 @@ import { sql } from "@/lib/db";
 import { reconcileCheckout } from "@/lib/billing";
 import { Nav } from "@/components/nav";
 import { BillingBanner } from "@/components/billing-banner";
-import { UpgradeButton, ManageBillingButton } from "@/components/billing-actions";
+import { UpgradeButton, ManageBillingButton, DowngradeButton } from "@/components/billing-actions";
 import { ORG_ROLES, type Subscription } from "@/lib/types";
 import { getLimit } from "@/lib/entitlements";
 
@@ -61,6 +61,9 @@ export default async function BillingPage({
   const status = sub?.status ?? "active";
   const isPro = planKey === "pro";
   const hasStripeCustomer = !!sub?.stripe_customer_id;
+  // A comped/dev-granted Pro org has no Stripe subscription — it can't use the
+  // portal, so offer an in-app downgrade instead.
+  const hasStripeSubscription = !!sub?.stripe_subscription_id;
 
   // v2 usage vs plan quotas (doc 10 §1) — v1 seasons/tournaments died at the
   // PROMPT-15 cutover; overrides are honoured via getLimit.
@@ -137,6 +140,7 @@ export default async function BillingPage({
             </div>
 
             {isOwner && isPro && hasStripeCustomer && <ManageBillingButton />}
+            {isOwner && isPro && !hasStripeSubscription && <DowngradeButton />}
           </div>
         </section>
 

--- a/apps/web/src/components/billing-actions.tsx
+++ b/apps/web/src/components/billing-actions.tsx
@@ -1,7 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { loadStripe } from "@stripe/stripe-js";
+import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js";
 
+// Load Stripe.js once for the whole app (publishable key is public).
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "");
+
+/** In-page upgrade via Stripe Embedded Checkout — reveals the checkout inline
+ *  (no redirect out) and only returns to the billing page on completion. */
 export function UpgradeButton({
   interval,
   label,
@@ -9,20 +16,71 @@ export function UpgradeButton({
   interval: "monthly" | "annual";
   label: string;
 }) {
-  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function go() {
-    setLoading(true);
-    setError(null);
+  const fetchClientSecret = useCallback(async () => {
     const res = await fetch("/api/billing/checkout", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ plan_key: "pro", interval }),
     });
     const data = await res.json();
-    if (data.ok && data.data?.url) {
-      window.location.href = data.data.url;
+    if (!data.ok || !data.data?.client_secret) {
+      throw new Error(data.error ?? "Checkout is unavailable right now.");
+    }
+    return data.data.client_secret as string;
+  }, [interval]);
+
+  if (open) {
+    return (
+      <div className="mt-2">
+        <EmbeddedCheckoutProvider stripe={stripePromise} options={{ fetchClientSecret }}>
+          <EmbeddedCheckout />
+        </EmbeddedCheckoutProvider>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="mt-3 text-xs text-slate-500 hover:underline"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          setError(null);
+          setOpen(true);
+        }}
+        className="btn btn-primary"
+      >
+        {label}
+      </button>
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+export function DowngradeButton() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function go() {
+    if (!confirm("Downgrade to Community? Pro features become unavailable immediately.")) return;
+    setLoading(true);
+    setError(null);
+    const res = await fetch("/api/billing/downgrade", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    const data = await res.json();
+    if (data.ok) {
+      window.location.reload();
     } else {
       setError(data.error ?? "Something went wrong");
       setLoading(false);
@@ -31,8 +89,8 @@ export function UpgradeButton({
 
   return (
     <div>
-      <button onClick={go} disabled={loading} className="btn btn-primary disabled:opacity-60">
-        {loading ? "Redirecting…" : label}
+      <button onClick={go} disabled={loading} className="btn btn-ghost disabled:opacity-60">
+        {loading ? "Downgrading…" : "Downgrade to Community"}
       </button>
       {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
     </div>

--- a/apps/web/src/components/v2/clubs-panel.tsx
+++ b/apps/web/src/components/v2/clubs-panel.tsx
@@ -2,10 +2,23 @@
 
 // Clubs directory (Jul3/01 §2, §5, §8): club CRUD, teams-across-divisions
 // detail, and the bulk logo grid (drag-drop, per-club re-map, assign-remaining).
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
+
+interface PersonLite {
+  id: string;
+  full_name: string;
+}
+interface SquadMember {
+  person_id: string;
+  full_name: string;
+  squad_number: number | null;
+  default_position_key: string | null;
+  is_captain: boolean;
+  roles: string[];
+}
 
 export interface ClubListRow {
   id: string;
@@ -46,7 +59,34 @@ export function ClubsPanel({
   const [busy, setBusy] = useState(false);
   const [name, setName] = useState("");
   const [shortName, setShortName] = useState("");
+  const [logo, setLogo] = useState<File | null>(null);
+  const logoInput = useRef<HTMLInputElement>(null);
   const [detail, setDetail] = useState<ClubDetail | null>(null);
+  // Persons directory for the squad picker (loaded once; org rosters are small).
+  const [persons, setPersons] = useState<PersonLite[]>([]);
+
+  useEffect(() => {
+    if (!canEdit) return;
+    (async () => {
+      const all: PersonLite[] = [];
+      let cursor: string | null = null;
+      for (let i = 0; i < 20; i++) {
+        const url: string = cursor
+          ? `/api/v1/persons?limit=100&cursor=${encodeURIComponent(cursor)}`
+          : "/api/v1/persons?limit=100";
+        const page: { items: PersonLite[]; nextCursor: string | null } = await apiV1(url);
+        all.push(...page.items);
+        if (!page.nextCursor) break;
+        cursor = page.nextCursor;
+      }
+      setPersons(all);
+    })().catch(() => setPersons([]));
+  }, [canEdit]);
+
+  const reloadDetail = (clubId: string) =>
+    apiV1<ClubDetail>(`/api/v1/clubs/${clubId}`)
+      .then(setDetail)
+      .catch((err) => setError(err instanceof Error ? err.message : "Failed"));
 
   async function run(fn: () => Promise<unknown>) {
     setError(null);
@@ -66,24 +106,56 @@ export function ClubsPanel({
     }
   }
 
+  // Per-row badge (single file mapped to the club) — same endpoint as the bulk
+  // grid, so imported/existing clubs can be re-badged one at a time.
+  const uploadBadge = (clubId: string, file: File) =>
+    run(async () => {
+      const form = new FormData();
+      form.append("files", file);
+      form.append("mapping", JSON.stringify({ [file.name]: clubId }));
+      const res = await fetch("/api/v1/clubs/logos", { method: "POST", body: form });
+      if (!res.ok) {
+        const p = (await res.json().catch(() => ({}))) as {
+          error?: { message?: string; feature_key?: string };
+        };
+        if (res.status === 402) {
+          setPaywallFeature(String(p.error?.feature_key ?? ""));
+          return;
+        }
+        throw new Error(p.error?.message ?? "Badge upload failed");
+      }
+    });
+
   return (
     <div className="space-y-5">
       {canEdit && (
         <form
-          className="card flex flex-wrap items-end gap-3 p-4"
+          className="card grid grid-cols-1 gap-3 p-4 sm:flex sm:flex-wrap sm:items-end"
           onSubmit={(e) => {
             e.preventDefault();
             if (!name.trim()) return;
             void run(async () => {
-              await apiV1("/api/v1/clubs", {
+              const club = await apiV1<ClubListRow>("/api/v1/clubs", {
                 method: "POST",
                 json: {
                   name: name.trim(),
                   ...(shortName.trim() ? { short_name: shortName.trim() } : {}),
                 },
               });
+              if (logo) {
+                const form = new FormData();
+                form.append("files", logo);
+                form.append("mapping", JSON.stringify({ [logo.name]: club.id }));
+                const res = await fetch("/api/v1/clubs/logos", { method: "POST", body: form });
+                if (!res.ok) {
+                  const p = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+                  throw new Error(p.error?.message ?? "Badge upload failed");
+                }
+              }
               setName("");
               setShortName("");
+              setLogo(null);
+              if (logoInput.current) logoInput.current.value = "";
             });
           }}
         >
@@ -93,9 +165,20 @@ export function ClubsPanel({
           </label>
           <label className="flex flex-col gap-1 text-sm text-slate-600">
             Short name
-            <input className="input w-28" value={shortName} onChange={(e) => setShortName(e.target.value)} />
+            <input className="input w-full sm:w-28" value={shortName} onChange={(e) => setShortName(e.target.value)} />
           </label>
-          <button type="submit" className="btn btn-primary" disabled={busy}>
+          <label className="flex flex-col gap-1 text-sm text-slate-600">
+            Badge
+            <input
+              ref={logoInput}
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/svg+xml"
+              aria-label="Club badge"
+              className="w-full text-sm text-slate-600 file:mr-2 file:rounded-md file:border-0 file:bg-slate-900 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-white hover:file:bg-slate-700"
+              onChange={(e) => setLogo(e.target.files?.[0] ?? null)}
+            />
+          </label>
+          <button type="submit" className="btn btn-primary w-full sm:w-auto" disabled={busy}>
             Add club
           </button>
         </form>
@@ -141,16 +224,7 @@ export function ClubsPanel({
                 </td>
                 <td className="px-4 py-2 text-sm text-slate-500">{c.short_name ?? "—"}</td>
                 <td className="px-4 py-2">
-                  {c.logo_path ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={`${storageBase}/${c.logo_path}`}
-                      alt={`${c.name} badge`}
-                      className="h-8 w-8 rounded object-contain"
-                    />
-                  ) : (
-                    <span className="text-sm text-slate-400">—</span>
-                  )}
+                  <BadgeCell club={c} storageBase={storageBase} canEdit={canEdit} busy={busy} onUpload={uploadBadge} />
                 </td>
                 {canEdit && (
                   <td className="px-4 py-2 text-right">
@@ -186,20 +260,355 @@ export function ClubsPanel({
           {detail.teams.length === 0 ? (
             <p className="text-sm text-slate-500">No teams belong to this club yet.</p>
           ) : (
-            <ul className="space-y-1 text-sm text-slate-700">
+            <ul className="space-y-2 text-sm text-slate-700">
               {detail.teams.map((t) => (
-                <li key={t.id} className="flex flex-wrap items-center gap-2">
-                  <span className="font-medium">{t.name}</span>
-                  {t.entries.map((e) => (
-                    <span key={e.division_id} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
-                      {e.division_name}
-                    </span>
-                  ))}
-                </li>
+                <TeamDetailRow
+                  key={t.id}
+                  team={t}
+                  persons={persons}
+                  canEdit={canEdit}
+                  onError={setError}
+                  onPaywall={setPaywallFeature}
+                />
               ))}
             </ul>
           )}
+
+          {canEdit && (
+            <AddTeamForm
+              clubId={detail.id}
+              onError={setError}
+              onPaywall={setPaywallFeature}
+              onDone={() => reloadDetail(detail.id)}
+            />
+          )}
         </section>
+      )}
+    </div>
+  );
+}
+
+// Badge cell in the clubs table: shows the badge (or a dash) plus, for editors,
+// a set/change control that uploads a single file for this club.
+function BadgeCell({
+  club,
+  storageBase,
+  canEdit,
+  busy,
+  onUpload,
+}: {
+  club: ClubListRow;
+  storageBase: string;
+  canEdit: boolean;
+  busy: boolean;
+  onUpload: (clubId: string, file: File) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <div className="flex items-center gap-2">
+      {club.logo_path ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={`${storageBase}/${club.logo_path}`}
+          alt={`${club.name} badge`}
+          className="h-8 w-8 rounded object-contain"
+        />
+      ) : (
+        <span className="text-sm text-slate-400">—</span>
+      )}
+      {canEdit && (
+        <>
+          <button
+            type="button"
+            className="text-xs text-purple-600 hover:underline"
+            disabled={busy}
+            onClick={() => inputRef.current?.click()}
+          >
+            {club.logo_path ? "change" : "set"}
+          </button>
+          <input
+            ref={inputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/svg+xml"
+            aria-label={`Badge for ${club.name}`}
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) onUpload(club.id, f);
+              e.target.value = "";
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+}
+
+// Add a team directly under a club (Pro clubs.hierarchy).
+function AddTeamForm({
+  clubId,
+  onError,
+  onPaywall,
+  onDone,
+}: {
+  clubId: string;
+  onError: (msg: string) => void;
+  onPaywall: (feature: string) => void;
+  onDone: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [shortName, setShortName] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <form
+      className="grid grid-cols-1 gap-2 border-t border-slate-200 pt-3 sm:flex sm:flex-wrap sm:items-end"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        setBusy(true);
+        onError("");
+        void apiV1(`/api/v1/clubs/${clubId}/teams`, {
+          method: "POST",
+          json: { name: name.trim(), ...(shortName.trim() ? { short_name: shortName.trim() } : {}) },
+        })
+          .then(() => {
+            setName("");
+            setShortName("");
+            onDone();
+          })
+          .catch((err) => {
+            if (err instanceof ApiV1Error && err.code === "PAYMENT_REQUIRED")
+              onPaywall(String(err.extra.feature_key ?? ""));
+            else onError(err instanceof Error ? err.message : "Failed");
+          })
+          .finally(() => setBusy(false));
+      }}
+    >
+      <label className="flex flex-col gap-1 text-xs text-slate-600">
+        Team name
+        <input className="input" value={name} onChange={(e) => setName(e.target.value)} placeholder="Riverside U12" />
+      </label>
+      <label className="flex flex-col gap-1 text-xs text-slate-600">
+        Short
+        <input className="input w-full sm:w-24" value={shortName} onChange={(e) => setShortName(e.target.value)} />
+      </label>
+      <button type="submit" className="btn btn-primary w-full text-sm sm:w-auto" disabled={busy || !name.trim()}>
+        Add team
+      </button>
+    </form>
+  );
+}
+
+// One team in the club detail: its division entries + an expandable squad editor.
+function TeamDetailRow({
+  team,
+  persons,
+  canEdit,
+  onError,
+  onPaywall,
+}: {
+  team: { id: string; name: string; entries: { division_id: string; division_name: string }[] };
+  persons: PersonLite[];
+  canEdit: boolean;
+  onError: (msg: string) => void;
+  onPaywall: (feature: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [squad, setSquad] = useState<SquadMember[] | null>(null);
+
+  async function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && squad === null) {
+      try {
+        const res = await apiV1<{ members: SquadMember[] }>(`/api/v1/teams/${team.id}/squad`);
+        setSquad(res.members);
+      } catch {
+        setSquad([]);
+      }
+    }
+  }
+
+  return (
+    <li className="rounded-md border border-slate-100">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        className="flex w-full flex-wrap items-center gap-2 p-2 text-left hover:text-purple-700"
+      >
+        <span
+          aria-hidden
+          className={`inline-block text-[10px] leading-none text-slate-400 transition-transform ${open ? "rotate-90" : ""}`}
+        >
+          ▸
+        </span>
+        <span className="font-medium text-slate-800">{team.name}</span>
+        {team.entries.map((e) => (
+          <span key={e.division_id} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+            {e.division_name}
+          </span>
+        ))}
+      </button>
+      {open && (
+        <div className="px-2 pb-2 pl-6">
+          {squad === null ? (
+            <p className="text-xs text-slate-400">Loading squad…</p>
+          ) : (
+            <TeamSquadEditor
+              teamId={team.id}
+              initial={squad}
+              persons={persons}
+              canEdit={canEdit}
+              onSaved={setSquad}
+              onError={onError}
+              onPaywall={onPaywall}
+            />
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+// The persistent squad editor: add/remove people, squad number, captain. Saved
+// members auto-seed an entrant roster whenever the team is enrolled.
+function TeamSquadEditor({
+  teamId,
+  initial,
+  persons,
+  canEdit,
+  onSaved,
+  onError,
+  onPaywall,
+}: {
+  teamId: string;
+  initial: SquadMember[];
+  persons: PersonLite[];
+  canEdit: boolean;
+  onSaved: (members: SquadMember[]) => void;
+  onError: (msg: string) => void;
+  onPaywall: (feature: string) => void;
+}) {
+  const [members, setMembers] = useState<SquadMember[]>(initial);
+  const [filter, setFilter] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const memberIds = new Set(members.map((m) => m.person_id));
+  const candidates = persons
+    .filter((p) => !memberIds.has(p.id))
+    .filter((p) => !filter || p.full_name.toLowerCase().includes(filter.toLowerCase()))
+    .slice(0, 6);
+
+  function update(i: number, patch: Partial<SquadMember>) {
+    setMembers((prev) => prev.map((m, j) => (j === i ? { ...m, ...patch } : m)));
+    setDirty(true);
+  }
+
+  function save() {
+    setBusy(true);
+    onError("");
+    void apiV1<{ members: SquadMember[] }>(`/api/v1/teams/${teamId}/squad`, {
+      method: "PUT",
+      json: {
+        members: members.map((m) => ({
+          person_id: m.person_id,
+          squad_number: m.squad_number,
+          default_position_key: m.default_position_key,
+          is_captain: m.is_captain,
+          roles: m.roles,
+        })),
+      },
+    })
+      .then((res) => {
+        setMembers(res.members);
+        onSaved(res.members);
+        setDirty(false);
+      })
+      .catch((err) => {
+        if (err instanceof ApiV1Error && err.code === "PAYMENT_REQUIRED")
+          onPaywall(String(err.extra.feature_key ?? ""));
+        else onError(err instanceof Error ? err.message : "Failed");
+      })
+      .finally(() => setBusy(false));
+  }
+
+  return (
+    <div className="space-y-2 rounded-md bg-slate-50 p-2 text-xs">
+      {members.length === 0 && <p className="text-slate-400">No players in this squad yet.</p>}
+      {members.map((m, i) => (
+        <div key={m.person_id} className="flex flex-wrap items-center gap-2">
+          <span className="w-40 truncate font-medium text-slate-700">{m.full_name}</span>
+          <input
+            type="number"
+            min={0}
+            placeholder="No."
+            disabled={!canEdit}
+            value={m.squad_number ?? ""}
+            onChange={(e) => update(i, { squad_number: e.target.value ? Number(e.target.value) : null })}
+            className="input w-16 px-2 py-1"
+            aria-label={`Squad number for ${m.full_name}`}
+          />
+          <label className="flex items-center gap-1 text-slate-500">
+            <input
+              type="checkbox"
+              disabled={!canEdit}
+              checked={m.is_captain}
+              onChange={(e) =>
+                setMembers((prev) =>
+                  prev.map((mm, j) => ({ ...mm, is_captain: j === i ? e.target.checked : false })),
+                )
+              }
+            />
+            captain
+          </label>
+          {canEdit && (
+            <button
+              type="button"
+              className="text-red-600 hover:underline"
+              onClick={() => {
+                setMembers((prev) => prev.filter((_, j) => j !== i));
+                setDirty(true);
+              }}
+            >
+              remove
+            </button>
+          )}
+        </div>
+      ))}
+
+      {canEdit && (
+        <div className="flex flex-wrap items-center gap-2 border-t border-slate-200 pt-2">
+          <input
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Find player…"
+            className="input w-40 px-2 py-1"
+          />
+          {candidates.map((p) => (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => {
+                setMembers((prev) => [
+                  ...prev,
+                  { person_id: p.id, full_name: p.full_name, squad_number: null, default_position_key: null, is_captain: false, roles: [] },
+                ]);
+                setDirty(true);
+              }}
+              className="rounded-full border border-slate-200 px-2 py-0.5 text-slate-500 hover:border-purple-300"
+            >
+              + {p.full_name}
+            </button>
+          ))}
+          {persons.length === 0 && <span className="text-slate-400">No players yet — add them under Players.</span>}
+          <div className="flex-1" />
+          <button type="button" className="btn btn-primary px-3 py-1" disabled={busy || !dirty} onClick={save}>
+            {busy ? "Saving…" : "Save squad"}
+          </button>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/components/v2/entrants-panel.tsx
+++ b/apps/web/src/components/v2/entrants-panel.tsx
@@ -18,9 +18,19 @@ interface RoleSpec {
 interface EntrantRow {
   id: string;
   kind: string;
+  team_id: string | null;
   display_name: string;
   seed: number | null;
   status: string;
+}
+interface TeamOption {
+  id: string;
+  name: string;
+  short_name: string | null;
+  club_name: string | null;
+  club_short_name: string | null;
+  logo_path: string | null;
+  latest_entrant_id: string | null;
 }
 interface Member {
   person_id: string;
@@ -35,6 +45,11 @@ interface Person {
   full_name: string;
   dob: string | null;
   gender: string | null;
+}
+interface DivisionRosterRow {
+  person_id: string;
+  entrant_id: string;
+  entrant_name: string;
 }
 
 interface Props {
@@ -81,13 +96,47 @@ export function EntrantsPanel({
   const [clubs, setClubs] = useState<{ id: string; name: string }[]>([]);
   const [clubFilter, setClubFilter] = useState("");
   const [clubEntrantIds, setClubEntrantIds] = useState<Set<string> | null>(null);
+  // Existing-team enrollment (unified Add Entrant): the org's teams, for the
+  // picker. Empty for orgs that never imported — the form then shows only the
+  // "new entrant" mode, exactly as before.
+  const [teams, setTeams] = useState<TeamOption[]>([]);
+  // Division-wide (person → team entrant) map, for the same-division
+  // double-roster warning (advisory: a person on two teams here is flagged,
+  // not blocked).
+  const [rosterIndex, setRosterIndex] = useState<DivisionRosterRow[]>([]);
+  // Bumped after every mutation to force a roster-map refetch.
+  const [rosterBump, setRosterBump] = useState(0);
 
   useEffect(() => {
     loadAllPersons().then(setPersons).catch(() => setPersons([]));
     apiV1<{ id: string; name: string }[]>("/api/v1/clubs")
       .then(setClubs)
       .catch(() => setClubs([]));
+    apiV1<TeamOption[]>("/api/v1/teams")
+      .then(setTeams)
+      .catch(() => setTeams([]));
   }, []);
+
+  const enteredTeamIds = useMemo(
+    () => new Set(entrants.map((e) => e.team_id).filter((id): id is string => id != null)),
+    [entrants],
+  );
+
+  // Refetch the roster map whenever the entrant set changes OR any mutation
+  // runs (rosterBump) — a member added/removed on one team must clear/raise the
+  // warning on the others, and entrant ids alone don't capture roster edits.
+  const entrantSig = entrants.map((e) => `${e.id}:${e.status}`).join(",");
+  useEffect(() => {
+    apiV1<DivisionRosterRow[]>(`/api/v1/divisions/${divisionId}/roster`)
+      .then(setRosterIndex)
+      .catch(() => setRosterIndex([]));
+  }, [divisionId, entrantSig, rosterBump]);
+
+  const otherTeamsFor = useCallback(
+    (personId: string, exceptEntrantId: string) =>
+      rosterIndex.filter((r) => r.person_id === personId && r.entrant_id !== exceptEntrantId),
+    [rosterIndex],
+  );
 
   useEffect(() => {
     if (!clubFilter) return; // cleared in the select's onChange
@@ -110,15 +159,18 @@ export function EntrantsPanel({
     }
   }, []);
 
-  async function run(fn: () => Promise<unknown>) {
+  async function run<T>(fn: () => Promise<T>): Promise<T | undefined> {
     setError(null);
     setPaywallFeature(null);
     setBusy(true);
     try {
-      await fn();
+      const result = await fn();
       router.refresh();
+      setRosterBump((n) => n + 1); // re-pull the division roster map
+      return result;
     } catch (err) {
       fail(err);
+      return undefined;
     } finally {
       setBusy(false);
     }
@@ -143,13 +195,15 @@ export function EntrantsPanel({
       {canEdit && (
         <AddEntrantForm
           persons={persons}
+          teams={teams}
+          enteredTeamIds={enteredTeamIds}
           busy={busy}
           onSubmit={(payload) =>
             run(() =>
-              apiV1(`/api/v1/divisions/${divisionId}/entrants`, {
-                method: "POST",
-                json: payload,
-              }),
+              apiV1<{ roster_keys_dropped?: number }>(
+                `/api/v1/divisions/${divisionId}/entrants`,
+                { method: "POST", json: payload },
+              ),
             )
           }
           importControls={
@@ -282,6 +336,7 @@ export function EntrantsPanel({
                 persons={persons}
                 positionGroups={positionGroups}
                 roles={roles}
+                otherTeamsFor={otherTeamsFor}
                 onPatch={(patch) =>
                   run(() =>
                     apiV1(`/api/v1/entrants/${e.id}`, { method: "PATCH", json: patch }),
@@ -316,17 +371,220 @@ function eligibilityLabel(rule: Record<string, unknown>): string {
 // Add one entrant
 // ---------------------------------------------------------------------------
 
+const STORAGE_BASE = `${process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""}/storage/v1/object/public/assets`;
+
 function AddEntrantForm({
   persons,
+  teams,
+  enteredTeamIds,
   busy,
   onSubmit,
   importControls,
 }: {
   persons: Person[];
+  teams: TeamOption[];
+  enteredTeamIds: Set<string>;
   busy: boolean;
-  onSubmit: (payload: Record<string, unknown>) => void;
+  onSubmit: (
+    payload: Record<string, unknown>,
+  ) => Promise<{ roster_keys_dropped?: number } | undefined>;
   /** Inline CSV-import controls rendered in the footer row. */
   importControls?: React.ReactNode;
+}) {
+  // "Existing team" mode is only meaningful once the org has teams (they are
+  // created by import). Mirror the club-filter visibility rule: no teams → the
+  // form is exactly the old "new entrant" flow, so free orgs see no change.
+  const hasTeams = teams.length > 0;
+  const [mode, setMode] = useState<"existing" | "new">("new");
+  const [touched, setTouched] = useState(false);
+  // Teams load after first paint; default to "existing" once they arrive, but
+  // never override a mode the organiser explicitly picked.
+  useEffect(() => {
+    if (!touched) setMode(hasTeams ? "existing" : "new");
+  }, [hasTeams, touched]);
+
+  return (
+    <form className="card space-y-3 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-700">Add entrant</h3>
+        {hasTeams && (
+          <div className="inline-flex rounded-lg border border-slate-200 p-0.5 text-xs">
+            {(["existing", "new"] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => {
+                  setTouched(true);
+                  setMode(m);
+                }}
+                className={`rounded-md px-2.5 py-1 font-medium transition ${
+                  mode === m ? "bg-purple-600 text-white" : "text-slate-500 hover:text-slate-800"
+                }`}
+              >
+                {m === "existing" ? "Existing team" : "New entrant"}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {mode === "existing" ? (
+        <ExistingTeamFields
+          teams={teams}
+          enteredTeamIds={enteredTeamIds}
+          busy={busy}
+          onSubmit={onSubmit}
+        />
+      ) : (
+        <NewEntrantFields persons={persons} busy={busy} onSubmit={onSubmit} />
+      )}
+
+      <div className="flex flex-wrap items-center justify-end gap-3">{importControls}</div>
+    </form>
+  );
+}
+
+/** Mode A: enroll a team that already exists (season rollover, league + cup). */
+function ExistingTeamFields({
+  teams,
+  enteredTeamIds,
+  busy,
+  onSubmit,
+}: {
+  teams: TeamOption[];
+  enteredTeamIds: Set<string>;
+  busy: boolean;
+  onSubmit: (
+    payload: Record<string, unknown>,
+  ) => Promise<{ roster_keys_dropped?: number } | undefined>;
+}) {
+  const [filter, setFilter] = useState("");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [copyRoster, setCopyRoster] = useState(true);
+  const [note, setNote] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    const rows = q
+      ? teams.filter(
+          (t) =>
+            t.name.toLowerCase().includes(q) ||
+            (t.club_name ?? "").toLowerCase().includes(q),
+        )
+      : teams;
+    return rows.slice(0, 12);
+  }, [teams, filter]);
+
+  const selected = teams.find((t) => t.id === selectedId) ?? null;
+  const canCopy = Boolean(selected?.latest_entrant_id);
+
+  async function submit() {
+    if (!selected) return;
+    setNote(null);
+    const res = await onSubmit({
+      kind: "team",
+      team_id: selected.id,
+      // display_name is intentionally omitted — the server snapshots it from
+      // the team so a later rename never rewrites historical standings.
+      ...(copyRoster && selected.latest_entrant_id
+        ? { copy_roster_from_entrant_id: selected.latest_entrant_id }
+        : {}),
+    });
+    if (res === undefined) return; // failed — panel shows the error (incl. 409)
+    setSelectedId(null);
+    setFilter("");
+    if (res.roster_keys_dropped)
+      setNote(
+        `Enrolled. ${res.roster_keys_dropped} position/role setting${
+          res.roster_keys_dropped > 1 ? "s" : ""
+        } didn't carry over to this sport.`,
+      );
+  }
+
+  return (
+    <div className="space-y-3">
+      <input
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="input"
+        placeholder="Search teams…"
+        aria-label="Search teams"
+      />
+      <div className="flex flex-wrap gap-1.5">
+        {teams.length === 0 && (
+          <span className="text-xs text-slate-400">No teams yet — import some first.</span>
+        )}
+        {filtered.map((t) => {
+          const entered = enteredTeamIds.has(t.id);
+          const isSelected = t.id === selectedId;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              disabled={entered}
+              onClick={() => setSelectedId(isSelected ? null : t.id)}
+              className={`flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition ${
+                entered
+                  ? "cursor-not-allowed border-slate-200 text-slate-300"
+                  : isSelected
+                    ? "border-purple-500 bg-purple-50 text-purple-700"
+                    : "border-slate-200 text-slate-600 hover:border-purple-200"
+              }`}
+              title={t.club_name ?? undefined}
+            >
+              {t.logo_path && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={`${STORAGE_BASE}/${t.logo_path}`}
+                  alt=""
+                  className="h-4 w-4 rounded object-contain"
+                />
+              )}
+              <span>{t.name}</span>
+              {t.club_short_name && (
+                <span className="text-[10px] text-slate-400">{t.club_short_name}</span>
+              )}
+              {entered && <span className="text-[10px] text-slate-400">· Already entered</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <label className="flex items-center gap-2 text-xs text-slate-600">
+        <input
+          type="checkbox"
+          checked={copyRoster && canCopy}
+          disabled={!canCopy}
+          onChange={(e) => setCopyRoster(e.target.checked)}
+        />
+        Copy roster from this team&apos;s most recent entrant
+        {!canCopy && selected && <span className="text-slate-400">(no earlier roster)</span>}
+      </label>
+
+      {note && <p className="text-xs text-emerald-600">{note}</p>}
+
+      <button
+        type="button"
+        onClick={submit}
+        disabled={busy || !selected}
+        className="btn btn-primary"
+      >
+        {busy ? "Enrolling…" : "Enroll team"}
+      </button>
+    </div>
+  );
+}
+
+/** Mode B: the original ad-hoc entrant (scratch pairs, one-offs) — never
+ *  creates a team, kept deliberately as an explicit choice. */
+function NewEntrantFields({
+  persons,
+  busy,
+  onSubmit,
+}: {
+  persons: Person[];
+  busy: boolean;
+  onSubmit: (payload: Record<string, unknown>) => Promise<unknown>;
 }) {
   const [name, setName] = useState("");
   const [kind, setKind] = useState("individual");
@@ -340,9 +598,8 @@ function AddEntrantForm({
     return persons.filter((p) => p.full_name.toLowerCase().includes(q)).slice(0, 8);
   }, [persons, filter]);
 
-  function submit(e: React.FormEvent) {
-    e.preventDefault();
-    onSubmit({
+  async function submit() {
+    await onSubmit({
       kind,
       display_name: name,
       seed: seed ? Number(seed) : null,
@@ -354,13 +611,11 @@ function AddEntrantForm({
   }
 
   return (
-    <form onSubmit={submit} className="card space-y-3 p-4">
-      <h3 className="text-sm font-semibold text-slate-700">Add entrant</h3>
+    <div className="space-y-3">
       <div className="grid grid-cols-2 gap-3">
         <label className="block">
           <span className="label">Name</span>
           <input
-            required
             value={name}
             onChange={(e) => setName(e.target.value)}
             className="input"
@@ -395,7 +650,7 @@ function AddEntrantForm({
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
           className="input"
-          placeholder="Search people…"
+          placeholder="Search players…"
         />
         <div className="mt-2 flex flex-wrap gap-1.5">
           {filtered.map((p) => {
@@ -421,7 +676,7 @@ function AddEntrantForm({
           })}
           {persons.length === 0 && (
             <span className="text-xs text-slate-400">
-              No people yet — add them under People, or import a CSV.
+              No players yet — add them under Players, or import a CSV.
             </span>
           )}
         </div>
@@ -430,13 +685,15 @@ function AddEntrantForm({
         )}
       </div>
 
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <button type="submit" disabled={busy || !name.trim()} className="btn btn-primary">
-          {busy ? "Saving…" : "Add entrant"}
-        </button>
-        {importControls}
-      </div>
-    </form>
+      <button
+        type="button"
+        onClick={submit}
+        disabled={busy || !name.trim()}
+        className="btn btn-primary"
+      >
+        {busy ? "Saving…" : "Add entrant"}
+      </button>
+    </div>
   );
 }
 
@@ -552,6 +809,7 @@ function EntrantTableRow({
   persons,
   positionGroups,
   roles,
+  otherTeamsFor,
   onPatch,
 }: {
   entrant: EntrantRow;
@@ -560,6 +818,7 @@ function EntrantTableRow({
   persons: Person[];
   positionGroups: PositionGroup[];
   roles: RoleSpec[];
+  otherTeamsFor: (personId: string, exceptEntrantId: string) => DivisionRosterRow[];
   onPatch: (patch: Record<string, unknown>) => void;
 }) {
   const [open, setOpen] = useState(false);
@@ -651,6 +910,7 @@ function EntrantTableRow({
                 roles={roles}
                 canEdit={canEdit}
                 busy={busy}
+                conflictsFor={(personId) => otherTeamsFor(personId, entrant.id)}
                 onSave={(next) =>
                   onPatch({
                     members: next.map((m) => ({
@@ -685,6 +945,7 @@ function RosterEditor({
   roles,
   canEdit,
   busy,
+  conflictsFor,
   onSave,
 }: {
   members: Member[];
@@ -693,6 +954,8 @@ function RosterEditor({
   roles: RoleSpec[];
   canEdit: boolean;
   busy: boolean;
+  /** Other team entrants IN THIS DIVISION a person is already on. */
+  conflictsFor: (personId: string) => DivisionRosterRow[];
   onSave: (members: Member[]) => void;
 }) {
   const [members, setMembers] = useState(initial);
@@ -710,14 +973,41 @@ function RosterEditor({
     .filter((p) => !filter || p.full_name.toLowerCase().includes(filter.toLowerCase()))
     .slice(0, 6);
 
+  // Advisory: people also rostered to another team in this division. Not
+  // blocked — the organiser may knowingly double-roster (guest, correction).
+  const conflicts = members
+    .map((m) => ({ name: m.full_name, on: conflictsFor(m.person_id) }))
+    .filter((c) => c.on.length > 0);
+
   return (
     <div className="space-y-3">
+      {conflicts.length > 0 && (
+        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          <span className="font-medium">Also on another team in this division:</span>{" "}
+          {conflicts
+            .map((c) => `${c.name} (${c.on.map((o) => o.entrant_name).join(", ")})`)
+            .join("; ")}
+          . You can still save.
+        </div>
+      )}
       {members.length === 0 && (
-        <p className="text-xs text-slate-400">No people on this roster.</p>
+        <p className="text-xs text-slate-400">No players on this roster.</p>
       )}
       {members.map((m, i) => (
         <div key={m.person_id} className="flex flex-wrap items-center gap-2 text-xs">
-          <span className="w-40 truncate font-medium text-slate-700">{m.full_name}</span>
+          <span className="w-40 truncate font-medium text-slate-700">
+            {m.full_name}
+            {conflictsFor(m.person_id).length > 0 && (
+              <span
+                className="ml-1 text-amber-600"
+                title={`Also on ${conflictsFor(m.person_id)
+                  .map((o) => o.entrant_name)
+                  .join(", ")} in this division`}
+              >
+                ⚠
+              </span>
+            )}
+          </span>
           <input
             type="number"
             min={0}
@@ -764,7 +1054,9 @@ function RosterEditor({
             />
             captain
           </label>
-          {roles.map((r) => (
+          {/* `captain` has its own dedicated checkbox above; don't render it
+              again as a generic role (some sport specs list it in roles). */}
+          {roles.filter((r) => r.key !== "captain").map((r) => (
             <label key={r.key} className="flex items-center gap-1 text-slate-500">
               <input
                 type="checkbox"
@@ -801,32 +1093,45 @@ function RosterEditor({
           <input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            placeholder="Add person…"
+            placeholder="Find player…"
             className="input w-44 px-2 py-1 text-xs"
           />
-          {candidates.map((p) => (
-            <button
-              key={p.id}
-              type="button"
-              onClick={() => {
-                setMembers((prev) => [
-                  ...prev,
-                  {
-                    person_id: p.id,
-                    full_name: p.full_name,
-                    squad_number: null,
-                    default_position_key: null,
-                    is_captain: false,
-                    roles: [],
-                  },
-                ]);
-                setDirty(true);
-              }}
-              className="rounded-full border border-slate-200 px-2 py-0.5 text-xs text-slate-500 hover:border-purple-300"
-            >
-              + {p.full_name}
-            </button>
-          ))}
+          {candidates.map((p) => {
+            const onOther = conflictsFor(p.id);
+            return (
+              <button
+                key={p.id}
+                type="button"
+                title={
+                  onOther.length > 0
+                    ? `Already on ${onOther.map((o) => o.entrant_name).join(", ")} in this division`
+                    : undefined
+                }
+                onClick={() => {
+                  setMembers((prev) => [
+                    ...prev,
+                    {
+                      person_id: p.id,
+                      full_name: p.full_name,
+                      squad_number: null,
+                      default_position_key: null,
+                      is_captain: false,
+                      roles: [],
+                    },
+                  ]);
+                  setDirty(true);
+                }}
+                className={`rounded-full border px-2 py-0.5 text-xs hover:border-purple-300 ${
+                  onOther.length > 0
+                    ? "border-amber-300 text-amber-700"
+                    : "border-slate-200 text-slate-500"
+                }`}
+              >
+                + {p.full_name}
+                {onOther.length > 0 && " ⚠"}
+              </button>
+            );
+          })}
           <div className="flex-1" />
           <button
             type="button"

--- a/apps/web/src/components/v2/officials-panel.tsx
+++ b/apps/web/src/components/v2/officials-panel.tsx
@@ -415,7 +415,15 @@ export function OfficialsPanel({
               <tr key={f.id} className="border-t border-slate-100 align-top">
                 <td className="px-4 py-2 text-sm text-slate-700">{f.label}</td>
                 <td className="px-4 py-2 text-sm text-slate-500">
-                  {f.scheduled_at ? new Date(f.scheduled_at).toLocaleString() : "—"}
+                  {f.scheduled_at
+                    ? new Date(f.scheduled_at).toLocaleString("en-GB", {
+                        weekday: "short",
+                        day: "numeric",
+                        month: "short",
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })
+                    : "—"}
                 </td>
                 <td className="px-4 py-2">
                   {f.officials.length === 0 ? (

--- a/apps/web/src/components/v2/persons-panel.tsx
+++ b/apps/web/src/components/v2/persons-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-// Persons directory: add/edit people, consent toggles, merge duplicates.
-import { useMemo, useState } from "react";
+// Players directory: add/edit players, consent toggles, merge duplicates.
+import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1 } from "@/lib/client-v1";
 
@@ -12,9 +12,18 @@ interface Person {
   gender: string | null;
   consent: { public_name?: boolean; public_photo?: boolean };
   external_ref: string | null;
+  photo_path: string | null;
 }
 
-export function PersonsPanel({ persons, canEdit }: { persons: Person[]; canEdit: boolean }) {
+export function PersonsPanel({
+  persons,
+  storageBase,
+  canEdit,
+}: {
+  persons: Person[];
+  storageBase: string;
+  canEdit: boolean;
+}) {
   const router = useRouter();
   const [filter, setFilter] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -45,8 +54,25 @@ export function PersonsPanel({ persons, canEdit }: { persons: Person[]; canEdit:
       {canEdit && (
         <AddPersonForm
           busy={busy}
-          onSubmit={(payload) =>
-            run(() => apiV1("/api/v1/persons", { method: "POST", json: payload }))
+          onSubmit={(payload, photo) =>
+            run(async () => {
+              const person = await apiV1<Person>("/api/v1/persons", {
+                method: "POST",
+                json: payload,
+              });
+              if (photo) {
+                const form = new FormData();
+                form.append("file", photo);
+                const res = await fetch(`/api/v1/persons/${person.id}/photo`, {
+                  method: "POST",
+                  body: form,
+                });
+                if (!res.ok) {
+                  const p = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+                  throw new Error(p.error?.message ?? "Photo upload failed");
+                }
+              }
+            })
           }
         />
       )}
@@ -56,7 +82,7 @@ export function PersonsPanel({ persons, canEdit }: { persons: Person[]; canEdit:
       )}
       {mergeSource && (
         <p className="rounded-md bg-sky-50 px-3 py-2 text-sm text-sky-700">
-          Merging <strong>{mergeSource.full_name}</strong> into… pick the person to
+          Merging <strong>{mergeSource.full_name}</strong> into… pick the player to
           keep below.{" "}
           <button
             type="button"
@@ -71,7 +97,7 @@ export function PersonsPanel({ persons, canEdit }: { persons: Person[]; canEdit:
       <input
         value={filter}
         onChange={(e) => setFilter(e.target.value)}
-        placeholder="Search people…"
+        placeholder="Search players…"
         className="input max-w-xs"
       />
 
@@ -91,19 +117,38 @@ export function PersonsPanel({ persons, canEdit }: { persons: Person[]; canEdit:
             {filtered.length === 0 && (
               <tr>
                 <td colSpan={canEdit ? 6 : 5} className="px-4 py-6 text-center text-sm text-slate-400">
-                  No people found.
+                  No players found.
                 </td>
               </tr>
             )}
             {filtered.map((p) => (
               <tr key={p.id}>
                 <td className="px-4 py-2 text-sm font-medium text-slate-800">
-                  {p.full_name}
-                  {p.external_ref && (
-                    <span className="ml-2 font-mono text-xs text-slate-400">
-                      {p.external_ref}
+                  <span className="flex items-center gap-2">
+                    {p.photo_path ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={`${storageBase}/${p.photo_path}`}
+                        alt={`${p.full_name} photo`}
+                        className="h-7 w-7 rounded-full object-cover"
+                      />
+                    ) : (
+                      <span
+                        aria-hidden
+                        className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 text-xs text-slate-400"
+                      >
+                        {p.full_name.charAt(0).toUpperCase()}
+                      </span>
+                    )}
+                    <span>
+                      {p.full_name}
+                      {p.external_ref && (
+                        <span className="ml-2 font-mono text-xs text-slate-400">
+                          {p.external_ref}
+                        </span>
+                      )}
                     </span>
-                  )}
+                  </span>
                 </td>
                 <td className="px-4 py-2 text-sm text-slate-500">{p.dob ?? "—"}</td>
                 <td className="px-4 py-2 text-sm text-slate-500">{p.gender ?? "—"}</td>
@@ -175,28 +220,37 @@ function AddPersonForm({
   onSubmit,
 }: {
   busy: boolean;
-  onSubmit: (payload: Record<string, unknown>) => void;
+  onSubmit: (payload: Record<string, unknown>, photo: File | null) => void;
 }) {
   const [name, setName] = useState("");
   const [dob, setDob] = useState("");
   const [gender, setGender] = useState("");
   const [publicName, setPublicName] = useState(false);
+  const [publicPhoto, setPublicPhoto] = useState(false);
+  const [photo, setPhoto] = useState<File | null>(null);
+  const photoInput = useRef<HTMLInputElement>(null);
 
   return (
     <form
-      className="card flex flex-wrap items-end gap-3 p-4"
+      className="card grid w-full grid-cols-1 gap-3 p-4 sm:grid-cols-2"
       onSubmit={(e) => {
         e.preventDefault();
-        onSubmit({
-          full_name: name,
-          dob: dob || null,
-          gender: gender || null,
-          consent: { public_name: publicName, public_photo: false },
-        });
+        onSubmit(
+          {
+            full_name: name,
+            dob: dob || null,
+            gender: gender || null,
+            consent: { public_name: publicName, public_photo: publicPhoto },
+          },
+          photo,
+        );
         setName("");
         setDob("");
         setGender("");
         setPublicName(false);
+        setPublicPhoto(false);
+        setPhoto(null);
+        if (photoInput.current) photoInput.current.value = "";
       }}
     >
       <label className="block">
@@ -205,7 +259,7 @@ function AddPersonForm({
           required
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="input w-56"
+          className="input"
           placeholder="Priya Sharma"
         />
       </label>
@@ -215,23 +269,44 @@ function AddPersonForm({
       </label>
       <label className="block">
         <span className="label">Gender</span>
-        <select value={gender} onChange={(e) => setGender(e.target.value)} className="select w-28">
+        <select value={gender} onChange={(e) => setGender(e.target.value)} className="select">
           <option value="">—</option>
           <option value="m">m</option>
           <option value="f">f</option>
           <option value="x">x</option>
         </select>
       </label>
-      <label className="flex items-center gap-1.5 pb-2.5 text-xs text-slate-500">
+      <label className="block">
+        <span className="label">Photo</span>
+        <input
+          ref={photoInput}
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          aria-label="Player photo"
+          className="block w-full text-sm text-slate-600 file:mr-2 file:rounded-md file:border-0 file:bg-slate-900 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-white hover:file:bg-slate-700"
+          onChange={(e) => setPhoto(e.target.files?.[0] ?? null)}
+        />
+      </label>
+      <label className="flex items-center gap-2 text-sm text-slate-600">
         <input
           type="checkbox"
           checked={publicName}
           onChange={(e) => setPublicName(e.target.checked)}
+          className="h-4 w-4 rounded border-purple-200 accent-purple-600"
         />
         consents to public name
       </label>
-      <button type="submit" disabled={busy || !name.trim()} className="btn btn-primary">
-        {busy ? "Adding…" : "Add person"}
+      <label className="flex items-center gap-2 text-sm text-slate-600">
+        <input
+          type="checkbox"
+          checked={publicPhoto}
+          onChange={(e) => setPublicPhoto(e.target.checked)}
+          className="h-4 w-4 rounded border-purple-200 accent-purple-600"
+        />
+        consents to public photo
+      </label>
+      <button type="submit" disabled={busy || !name.trim()} className="btn btn-primary w-full sm:col-span-2 sm:w-auto sm:justify-self-start">
+        {busy ? "Adding…" : "Add player"}
       </button>
     </form>
   );

--- a/apps/web/src/components/v2/registrations-panel.tsx
+++ b/apps/web/src/components/v2/registrations-panel.tsx
@@ -217,7 +217,7 @@ export function RegistrationsPanel({
               onChange={(e) => set({ entrant_kind: e.target.value as Settings["entrant_kind"] })}
               className="input mt-1 w-full"
             >
-              <option value="individual">Individual (creates a person)</option>
+              <option value="individual">Individual (creates a player)</option>
               <option value="team">Team</option>
               <option value="pair">Pair</option>
             </select>

--- a/apps/web/src/config/__tests__/stripe-plans.test.ts
+++ b/apps/web/src/config/__tests__/stripe-plans.test.ts
@@ -1,0 +1,43 @@
+// Guards the Stripe plan seed that `npm run stripe:sync` applies. A malformed
+// seed silently breaks checkout (the route reads plans.stripe_price_id_*), so
+// pin its shape. No DB, no Stripe — pure structural validation.
+import { describe, expect, it } from "vitest";
+import seed from "../stripe-plans.json";
+
+interface PriceSpec { lookup_key: string; unit_amount: number; interval: string }
+interface PlanSpec {
+  key: string;
+  product: { name: string; description?: string };
+  prices: { monthly: PriceSpec; annual: PriceSpec };
+}
+
+describe("stripe-plans seed", () => {
+  it("declares a valid currency and at least the pro plan", () => {
+    expect(typeof seed.currency).toBe("string");
+    expect(seed.currency).toMatch(/^[a-z]{3}$/);
+    const keys = (seed.plans as PlanSpec[]).map((p) => p.key);
+    expect(keys).toContain("pro");
+  });
+
+  it("gives every plan a product and both monthly + annual prices", () => {
+    for (const plan of seed.plans as PlanSpec[]) {
+      expect(plan.product?.name, `${plan.key} product name`).toBeTruthy();
+      for (const interval of ["monthly", "annual"] as const) {
+        const price = plan.prices[interval];
+        expect(price, `${plan.key}.${interval}`).toBeTruthy();
+        expect(price.lookup_key, `${plan.key}.${interval} lookup_key`).toMatch(/^[a-z0-9_]+$/);
+        expect(price.unit_amount, `${plan.key}.${interval} amount`).toBeGreaterThan(0);
+      }
+      expect(plan.prices.monthly.interval).toBe("month");
+      expect(plan.prices.annual.interval).toBe("year");
+    }
+  });
+
+  it("uses globally-unique lookup_keys (Stripe requires them unique per account)", () => {
+    const lookups = (seed.plans as PlanSpec[]).flatMap((p) => [
+      p.prices.monthly.lookup_key,
+      p.prices.annual.lookup_key,
+    ]);
+    expect(new Set(lookups).size).toBe(lookups.length);
+  });
+});

--- a/apps/web/src/config/stripe-plans.json
+++ b/apps/web/src/config/stripe-plans.json
@@ -1,0 +1,17 @@
+{
+  "$comment": "Stripe product/price seed for paid plans. Idempotent source of truth: `npm run stripe:sync` ensures each product + price exists in the Stripe account of STRIPE_SECRET_KEY (matched by price lookup_key) and writes the resulting price ids into the `plans` table. Re-run after any DB wipe, and against each environment (test/prod) by pointing STRIPE_SECRET_KEY + DATABASE_URL at it. Community is free (no Stripe).",
+  "currency": "usd",
+  "plans": [
+    {
+      "key": "pro",
+      "product": {
+        "name": "Seazn Club Pro",
+        "description": "Unlimited competitions, multi-division, online registration + entry fees, realtime scoreboard, custom branding, CSV/PDF exports."
+      },
+      "prices": {
+        "monthly": { "lookup_key": "seazn_pro_monthly", "unit_amount": 2000, "interval": "month" },
+        "annual": { "lookup_key": "seazn_pro_annual", "unit_amount": 20000, "interval": "year" }
+      }
+    }
+  ]
+}

--- a/apps/web/src/lib/__tests__/billing-checkout.test.ts
+++ b/apps/web/src/lib/__tests__/billing-checkout.test.ts
@@ -1,0 +1,41 @@
+// buildEmbeddedCheckoutParams shapes the Stripe Embedded Checkout session.
+// Pure (no Stripe/DB) — pins the embedded ui_mode, the return_url contract, and
+// the 14-day no-card trial that the checkout route depends on.
+import { describe, expect, it } from "vitest";
+import { buildEmbeddedCheckoutParams } from "@/lib/billing";
+
+const base = {
+  priceId: "price_123",
+  orgId: "org-abc",
+  returnUrl: "https://app.test/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}",
+};
+
+describe("buildEmbeddedCheckoutParams", () => {
+  it("uses embedded ui_mode with a return_url and no hosted urls", () => {
+    const p = buildEmbeddedCheckoutParams({ ...base, customerEmail: "a@b.com" });
+    expect(p.ui_mode).toBe("embedded_page");
+    expect(p.return_url).toBe(base.returnUrl);
+    expect("success_url" in p).toBe(false);
+    expect("cancel_url" in p).toBe(false);
+    expect(p.mode).toBe("subscription");
+    expect(p.line_items).toEqual([{ price: "price_123", quantity: 1 }]);
+    expect(p.metadata).toMatchObject({ org_id: "org-abc" });
+  });
+
+  it("keeps the 14-day no-card trial (cancel if no method by trial end)", () => {
+    const p = buildEmbeddedCheckoutParams({ ...base, customerEmail: "a@b.com" });
+    expect(p.payment_method_collection).toBe("if_required");
+    expect(p.subscription_data?.trial_period_days).toBe(14);
+    expect(p.subscription_data?.trial_settings?.end_behavior?.missing_payment_method).toBe("cancel");
+  });
+
+  it("reuses an existing customer id, else falls back to customer_email", () => {
+    const withCust = buildEmbeddedCheckoutParams({ ...base, customerId: "cus_9" });
+    expect(withCust.customer).toBe("cus_9");
+    expect("customer_email" in withCust).toBe(false);
+
+    const withEmail = buildEmbeddedCheckoutParams({ ...base, customerEmail: "a@b.com" });
+    expect(withEmail.customer_email).toBe("a@b.com");
+    expect("customer" in withEmail).toBe(false);
+  });
+});

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -2,6 +2,64 @@ import "server-only";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+
+/**
+ * Params for an EMBEDDED subscription checkout (rendered in-page via Stripe's
+ * Embedded Checkout, not a redirect). Pure — no Stripe/DB — so it's unit-tested.
+ * Honours the 14-day no-card trial: `payment_method_collection: "if_required"`
+ * + cancel when no card is added by trial end. `ui_mode: "embedded"` requires a
+ * `return_url` (not success/cancel urls); Stripe redirects there on completion,
+ * where the billing page reconciles from the session id.
+ */
+export function buildEmbeddedCheckoutParams(args: {
+  priceId: string;
+  orgId: string;
+  returnUrl: string;
+  customerId?: string;
+  customerEmail?: string;
+}): Stripe.Checkout.SessionCreateParams {
+  return {
+    // stripe-node v22 names the embedded UI mode "embedded_page".
+    ui_mode: "embedded_page",
+    mode: "subscription",
+    ...(args.customerId ? { customer: args.customerId } : { customer_email: args.customerEmail }),
+    metadata: { org_id: args.orgId },
+    payment_method_collection: "if_required",
+    subscription_data: {
+      trial_period_days: 14,
+      trial_settings: { end_behavior: { missing_payment_method: "cancel" } },
+      metadata: { org_id: args.orgId },
+    },
+    line_items: [{ price: args.priceId, quantity: 1 }],
+    return_url: args.returnUrl,
+    allow_promotion_codes: true,
+    tax_id_collection: { enabled: true },
+    automatic_tax: { enabled: true },
+  };
+}
+
+/**
+ * In-app downgrade to Community for orgs WITHOUT a Stripe subscription
+ * (admin-comped / dev-granted Pro). A Stripe-billed org must cancel through the
+ * customer portal instead, so paid state never desyncs. Idempotent.
+ */
+export async function downgradeToCommunity(orgId: string): Promise<void> {
+  const [sub] = await sql<{ stripe_subscription_id: string | null }[]>`
+    select stripe_subscription_id from subscriptions where org_id = ${orgId}`;
+  if (sub?.stripe_subscription_id) {
+    throw new HttpError(
+      400,
+      "This organization is billed through Stripe — cancel via Manage billing.",
+    );
+  }
+  await sql`
+    update subscriptions
+    set plan_key = 'community', status = 'active', cancel_at_period_end = false
+    where org_id = ${orgId}`;
+  await invalidateOrgEntitlements(orgId);
+}
 
 /** Map a Stripe subscription status to our subscription status enum. */
 const STATUS_MAP: Record<string, string> = {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -21,14 +21,17 @@ function cspHeader(nonce: string): { name: string; value: string } {
   const enforce = process.env.CSP_MODE === "enforce";
   const value = [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    // Stripe.js is loaded from js.stripe.com for Embedded Checkout.
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://js.stripe.com${isDev ? " 'unsafe-eval'" : ""}`,
     // Tailwind ships an external stylesheet; 'unsafe-inline' covers the small
     // inline styles Next injects. Styles are low-risk vs script injection.
     `style-src 'self' 'unsafe-inline'`,
     `img-src 'self' blob: data: https:`,
     `font-src 'self' data:`,
-    `connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.ingest.sentry.io https://*.sentry.io`,
-    `frame-src 'self'`,
+    // Stripe: api.stripe.com for tokenization; supabase + sentry as before.
+    `connect-src 'self' https://api.stripe.com https://*.supabase.co wss://*.supabase.co https://*.ingest.sentry.io https://*.sentry.io`,
+    // Embedded Checkout renders inside a Stripe-hosted iframe.
+    `frame-src 'self' https://js.stripe.com https://*.stripe.com https://hooks.stripe.com`,
     `object-src 'none'`,
     `base-uri 'self'`,
     `form-action 'self'`,

--- a/apps/web/src/server/api-v1/__tests__/schemas.test.ts
+++ b/apps/web/src/server/api-v1/__tests__/schemas.test.ts
@@ -1,0 +1,49 @@
+// Schema-level regression tests (no DB) for the entrant/team contract added
+// with the unified Add-Entrant + team-squad work.
+import { describe, expect, it } from "vitest";
+import { CreateEntrant, CreateTeam, SetTeamSquad } from "../schemas";
+
+const UUID = "11111111-1111-4111-8111-111111111111";
+
+describe("CreateEntrant", () => {
+  it("accepts display_name without team_id", () => {
+    expect(CreateEntrant.safeParse({ kind: "individual", display_name: "A" }).success).toBe(true);
+  });
+
+  it("accepts team_id without display_name (server snapshots the name)", () => {
+    expect(CreateEntrant.safeParse({ kind: "team", team_id: UUID }).success).toBe(true);
+  });
+
+  it("rejects when BOTH display_name and team_id are absent", () => {
+    const r = CreateEntrant.safeParse({ kind: "individual" });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts an optional copy_roster_from_entrant_id", () => {
+    const r = CreateEntrant.safeParse({ kind: "team", team_id: UUID, copy_roster_from_entrant_id: UUID });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("CreateTeam", () => {
+  it("requires a name", () => {
+    expect(CreateTeam.safeParse({ name: "Riverside U12" }).success).toBe(true);
+    expect(CreateTeam.safeParse({ name: "" }).success).toBe(false);
+    expect(CreateTeam.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("SetTeamSquad", () => {
+  it("defaults members to an empty array", () => {
+    const r = SetTeamSquad.safeParse({});
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.members).toEqual([]);
+  });
+
+  it("accepts squad members in the entrant-member shape", () => {
+    const r = SetTeamSquad.safeParse({
+      members: [{ person_id: UUID, squad_number: 7, is_captain: true, roles: ["captain"] }],
+    });
+    expect(r.success).toBe(true);
+  });
+});

--- a/apps/web/src/server/api-v1/auth.ts
+++ b/apps/web/src/server/api-v1/auth.ts
@@ -194,6 +194,7 @@ const ORG_TABLES = {
   fixture: "fixtures",
   registration: "registrations",
   club: "clubs",
+  team: "teams",
   import: "imports",
   official: "officials",
 } as const;

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -55,12 +55,14 @@ export const ROUTES: RouteSpec[] = [
   { path: "/divisions/{id}/entrants", method: "post", summary: "Register entrant(s) — object or bulk array", tag: "entrants", request: S.CreateEntrants, response: z.union([S.Entrant, z.array(S.Entrant)]), status: 201, errors: [422] },
   { path: "/entrants/{id}", method: "get", summary: "Get an entrant with members", tag: "entrants", response: S.Entrant },
   { path: "/entrants/{id}", method: "patch", summary: "Withdraw, seed or edit members", tag: "entrants", request: S.PatchEntrant, response: S.Entrant, errors: [422] },
+  { path: "/divisions/{id}/roster", method: "get", summary: "Every (person → team entrant) membership in the division (same-division double-roster warning)", tag: "entrants" },
   // Persons
   { path: "/persons", method: "get", summary: "List persons", tag: "persons", response: pageOf(S.Person), query: PAGE_QUERY },
   { path: "/persons", method: "post", summary: "Create a person", tag: "persons", request: S.CreatePerson, response: S.Person, status: 201 },
   { path: "/persons/{id}", method: "get", summary: "Get a person", tag: "persons", response: S.Person },
   { path: "/persons/{id}", method: "patch", summary: "Update a person", tag: "persons", request: S.PatchPerson, response: S.Person },
   { path: "/persons/{id}/merge", method: "post", summary: "Merge a duplicate person into this one", tag: "persons", request: S.MergePersons, response: S.Person, errors: [422] },
+  { path: "/persons/{id}/photo", method: "post", summary: "Upload a player photo (multipart `file`); public display gated by public_photo consent", tag: "persons", response: S.Person, errors: [400, 404, 415, 502] },
   { path: "/persons/{id}/profiles/{sport}", method: "get", summary: "Get a per-sport profile", tag: "persons" },
   { path: "/persons/{id}/profiles/{sport}", method: "put", summary: "Upsert a per-sport profile", tag: "persons", request: S.PutProfile, errors: [422] },
   // Stages
@@ -130,6 +132,11 @@ export const ROUTES: RouteSpec[] = [
   { path: "/clubs/{id}", method: "get", summary: "Club detail: teams across divisions", tag: "clubs", response: S.ClubDetail },
   { path: "/clubs/{id}", method: "patch", summary: "Update a club", tag: "clubs", request: S.PatchClub, response: S.Club, errors: [402] },
   { path: "/clubs/{id}", method: "delete", summary: "Delete a club (teams survive, badges fall back)", tag: "clubs", errors: [402] },
+  // Teams (Pro clubs.hierarchy) — parent-club teams and their persistent squads.
+  { path: "/clubs/{id}/teams", method: "post", summary: "Add a team under a club (Pro `clubs.hierarchy`)", tag: "clubs", request: S.CreateTeam, status: 201, errors: [402, 404, 409] },
+  { path: "/teams", method: "get", summary: "List teams with their division entries", tag: "clubs" },
+  { path: "/teams/{id}/squad", method: "get", summary: "Get a team's persistent squad", tag: "clubs", errors: [404] },
+  { path: "/teams/{id}/squad", method: "put", summary: "Replace a team's squad (auto-seeds entrant rosters on enrollment)", tag: "clubs", request: S.SetTeamSquad, errors: [402, 404] },
   { path: "/clubs/logos", method: "post", summary: "Bulk logo assign: multipart `files` + `mapping` JSON + `assign_remaining` (Jul3/01 §5; Pro `logos.bulk` for >1 file)", tag: "clubs", response: z.array(S.LogoAssignment), errors: [402, 422] },
   { path: "/imports", method: "post", summary: "Upload a participants spreadsheet (multipart `file`) → dry-run { importId, plan }; writes nothing (Jul3/01 §6)", tag: "clubs", response: S.ImportPreview, status: 201, errors: [402, 413, 422] },
   { path: "/imports/{id}", method: "get", summary: "Re-preview a stored import against current state", tag: "clubs", response: S.ImportPreview },

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -151,17 +151,40 @@ export const EntrantMemberInput = z.object({
   roles: z.array(z.string()).default([]),
 });
 
-export const CreateEntrant = z.object({
-  kind: EntrantKind,
-  display_name: z.string().min(1).max(200),
-  team_id: Uuid.nullish(),
-  seed: z.number().int().min(1).nullish(),
-  members: z.array(EntrantMemberInput).default([]),
-});
+export const CreateEntrant = z
+  .object({
+    kind: EntrantKind,
+    // Optional when enrolling an existing team: the server snapshots the name
+    // from teams.name at creation so a later rename never rewrites history.
+    display_name: z.string().min(1).max(200).optional(),
+    team_id: Uuid.nullish(),
+    seed: z.number().int().min(1).nullish(),
+    members: z.array(EntrantMemberInput).default([]),
+    // Copy the roster from an earlier entrant of the SAME team (season rollover,
+    // league + cup). Resolved server-side in the creation transaction.
+    copy_roster_from_entrant_id: Uuid.nullish(),
+  })
+  .refine((e) => e.display_name != null || e.team_id != null, {
+    message: "display_name is required unless team_id is provided",
+    path: ["display_name"],
+  });
 export type CreateEntrant = z.infer<typeof CreateEntrant>;
 
 /** POST /divisions/{id}/entrants — one entrant or a bulk array (doc 08 §3). */
 export const CreateEntrants = z.union([CreateEntrant, z.array(CreateEntrant).min(1).max(500)]);
+
+/** POST /clubs/{id}/teams — create a team under a club. */
+export const CreateTeam = z.object({
+  name: z.string().min(1).max(200),
+  short_name: z.string().max(60).nullish(),
+});
+export type CreateTeam = z.infer<typeof CreateTeam>;
+
+/** PUT /teams/{id}/squad — full-replace the team's persistent squad. */
+export const SetTeamSquad = z.object({
+  members: z.array(EntrantMemberInput).default([]),
+});
+export type SetTeamSquad = z.infer<typeof SetTeamSquad>;
 
 export const PatchEntrant = z
   .object({

--- a/apps/web/src/server/usecases/__tests__/downgrade.test.ts
+++ b/apps/web/src/server/usecases/__tests__/downgrade.test.ts
@@ -1,0 +1,48 @@
+// In-app downgrade to Community for comped (non-Stripe) orgs. A Stripe-billed
+// org must cancel via the portal, so the downgrade refuses. Real Postgres.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { hasFeature } from "@/lib/entitlements";
+import { downgradeToCommunity } from "@/lib/billing";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function seedProOrg(opts: { stripeSub?: string } = {}): Promise<string> {
+  const s = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Bill " + s}, ${"bill-" + s}) returning id`;
+  await sql`
+    insert into subscriptions (org_id, plan_key, status, stripe_subscription_id)
+    values (${orgId}, 'pro', 'active', ${opts.stripeSub ?? null})
+    on conflict (org_id) do update set plan_key = 'pro', stripe_subscription_id = ${opts.stripeSub ?? null}`;
+  return orgId;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const c = g._sql;
+  g._sql = undefined;
+  await c?.end();
+});
+
+describe.skipIf(!HAS_DB)("downgradeToCommunity", () => {
+  it("downgrades a comped Pro org and revokes Pro entitlements", async () => {
+    const orgId = await seedProOrg();
+    expect(await hasFeature(orgId, "clubs.hierarchy")).toBe(true); // Pro feature on
+
+    await downgradeToCommunity(orgId);
+
+    const [row] = await sql<{ plan_key: string }[]>`select plan_key from subscriptions where org_id = ${orgId}`;
+    expect(row.plan_key).toBe("community");
+    expect(await hasFeature(orgId, "clubs.hierarchy")).toBe(false); // revoked
+  });
+
+  it("refuses when the org is billed through Stripe (must use the portal)", async () => {
+    const orgId = await seedProOrg({ stripeSub: "sub_test_123" });
+    await expect(downgradeToCommunity(orgId)).rejects.toMatchObject({ status: 400 });
+    const [row] = await sql<{ plan_key: string }[]>`select plan_key from subscriptions where org_id = ${orgId}`;
+    expect(row.plan_key).toBe("pro"); // unchanged
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/entrant-enroll.test.ts
+++ b/apps/web/src/server/usecases/__tests__/entrant-enroll.test.ts
@@ -1,0 +1,203 @@
+// Unified "Add Entrant": enrolling an EXISTING club team into a division
+// (season rollover, league + cup) with optional roster copy. Real Postgres
+// required (RLS, triggers, the partial unique index); skipped without
+// DATABASE_URL. Redis intentionally absent — entitlement reads hit the
+// documented fail-open (cache miss → Postgres) path.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { football } from "@seazn/engine/sports/football";
+import { cricket } from "@seazn/engine/sports/cricket";
+import { sql, withTenant } from "@/lib/db";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants, listEntrants, getEntrant, divisionRoster } from "../entrants";
+import { createPerson } from "../persons";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const GENERIC_CONFIG = { resultMode: "score", allowDraws: true, points: { w: 3, d: 1, l: 0 }, progressScore: false };
+
+async function setPlan(orgId: string, plan: "community" | "pro"): Promise<void> {
+  await sql`
+    insert into subscriptions (org_id, plan_key, status)
+    values (${orgId}, ${plan}, 'active')
+    on conflict (org_id) do update set plan_key = ${plan}`;
+  await invalidateOrgEntitlements(orgId);
+}
+
+async function seedOrg(plan: "community" | "pro" = "community"): Promise<{ auth: AuthCtx }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Enr " + suffix}, ${"enr-" + suffix})
+    returning id`;
+  if (plan !== "community") {
+    await sql`
+      insert into subscriptions (org_id, plan_key, status)
+      values (${orgId}, ${plan}, 'active')
+      on conflict (org_id) do update set plan_key = ${plan}`;
+  }
+  await sql`
+    insert into sports (key, name, module_version, position_catalog) values
+      ('generic',  'Generic',  '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })}),
+      ('football', 'Football', ${football.version}, ${sql.json(football.positions as never)}),
+      ('cricket',  'Cricket',  ${cricket.version}, ${sql.json(cricket.positions as never)})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system) values
+      ('generic',  'score',   'Score',   ${sql.json({ resultMode: "score", points: { w: 3, d: 1, l: 0 } })}, true),
+      ('football', 'default', 'Default', ${sql.json({})}, true),
+      ('cricket',  't20',     'T20',     ${sql.json(cricket.variants.t20 as never)}, true)
+    on conflict do nothing`;
+  return { auth: { orgId, via: "session", userId: null, role: "owner", keyId: null } };
+}
+
+/** Teams are normally born in the CSV import; seed one directly (with a parent
+ *  club) so the enroll flow has something to reference. */
+async function seedTeam(
+  auth: AuthCtx,
+  name: string,
+  clubName = "Riverside FC",
+): Promise<{ id: string; name: string }> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [club] = await tx<{ id: string }[]>`
+      insert into clubs (org_id, name) values (${auth.orgId}, ${clubName}) returning id`;
+    const [team] = await tx<{ id: string; name: string }[]>`
+      insert into teams (org_id, name, club_id)
+      values (${auth.orgId}, ${name}, ${club!.id}) returning id, name`;
+    return team!;
+  });
+}
+
+async function makeDivision(auth: AuthCtx, competitionId: string, sport: string) {
+  return createDivision(auth, competitionId, {
+    name: `Div ${randomUUID().slice(0, 6)}`,
+    sport_key: sport,
+    variant_key: sport === "football" ? "default" : sport === "cricket" ? "t20" : "score",
+    config: sport === "generic" ? GENERIC_CONFIG : {},
+    eligibility: [],
+  } as never);
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("enroll an existing team", () => {
+  it("enrolls into a division, snapshotting the name; club filter returns it; 409 on repeat", async () => {
+    // Seed under Pro (division + team creation are Pro), then DOWNGRADE to
+    // community before enrolling — enrolling an existing team is ungated, so an
+    // org that lost Pro keeps working with its imported teams.
+    const { auth } = await seedOrg("pro");
+    const comp = await createCompetition(auth, { name: "Rollover Cup", visibility: "private", branding: {} });
+    const team = await seedTeam(auth, "Riverside U12");
+    const league = await makeDivision(auth, comp.id, "generic");
+    const cup = await makeDivision(auth, comp.id, "generic");
+    await setPlan(auth.orgId, "community");
+
+    // Criterion 1: same team into two divisions → one team, two entrants.
+    const [inLeague] = await createEntrants(auth, league.id, [{ kind: "team", team_id: team.id, members: [] }]);
+    const [inCup] = await createEntrants(auth, cup.id, [{ kind: "team", team_id: team.id, members: [] }]);
+    expect(inLeague!.display_name).toBe("Riverside U12"); // snapshotted from the team
+    expect(inCup!.display_name).toBe("Riverside U12");
+    expect(inLeague!.team_id).toBe(team.id);
+
+    // Club facet returns the team's entrant in each division.
+    const [{ id: clubId }] = await withTenant(auth.orgId, (tx) => tx<{ id: string }[]>`
+      select club_id as id from teams where id = ${team.id}`);
+    const leagueByClub = await listEntrants(auth, league.id, { clubId });
+    expect(leagueByClub.map((e) => e.id)).toContain(inLeague!.id);
+
+    // Criterion 3: enrolling the same team into the same division again → 409.
+    await expect(
+      createEntrants(auth, league.id, [{ kind: "team", team_id: team.id, members: [] }]),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("copies the roster, keeping keys within a sport and dropping invalid ones across sports", async () => {
+    const { auth } = await seedOrg("pro");
+    const comp = await createCompetition(auth, { name: "Copy Cup", visibility: "private", branding: {} });
+    const team = await seedTeam(auth, "Harbour U16");
+
+    const p1 = await createPerson(auth, { full_name: "Ada Keeper", consent: {}, dob: null, gender: null, external_ref: null });
+    const p2 = await createPerson(auth, { full_name: "Bea Back", consent: {}, dob: null, gender: null, external_ref: null });
+
+    // Source: football entrant with a position ("GK") and role ("captain").
+    const foot1 = await makeDivision(auth, comp.id, "football");
+    const [source] = await createEntrants(auth, foot1.id, [{
+      kind: "team", team_id: team.id,
+      members: [
+        { person_id: p1.id, squad_number: 1, is_captain: true, roles: ["captain"], default_position_key: "GK" },
+        { person_id: p2.id, squad_number: 2, is_captain: false, roles: [], default_position_key: "DF" },
+      ],
+    }]);
+
+    // Criterion 2a — same sport: keys carry over, nothing dropped.
+    const foot2 = await makeDivision(auth, comp.id, "football");
+    const [sameSport] = await createEntrants(auth, foot2.id, [
+      { kind: "team", team_id: team.id, copy_roster_from_entrant_id: source!.id, members: [] },
+    ]);
+    expect(sameSport!.roster_keys_dropped ?? 0).toBe(0);
+    const sameMembers = (await getEntrant(auth, sameSport!.id)).members as {
+      person_id: string; default_position_key: string | null; roles: string[]; is_captain: boolean;
+    }[];
+    expect(sameMembers).toHaveLength(2);
+    const keeper = sameMembers.find((m) => m.person_id === p1.id)!;
+    expect(keeper.default_position_key).toBe("GK");
+    expect(keeper.roles).toEqual(["captain"]);
+    expect(keeper.is_captain).toBe(true);
+
+    // Criterion 2b — cross sport: members copy, invalid position dropped, count surfaced.
+    const crick = await makeDivision(auth, comp.id, "cricket");
+    const [crossSport] = await createEntrants(auth, crick.id, [
+      { kind: "team", team_id: team.id, copy_roster_from_entrant_id: source!.id, members: [] },
+    ]);
+    expect(crossSport!.roster_keys_dropped).toBeGreaterThanOrEqual(1); // "GK" not a cricket position
+    const crossMembers = (await getEntrant(auth, crossSport!.id)).members as {
+      person_id: string; default_position_key: string | null;
+    }[];
+    expect(crossMembers).toHaveLength(2); // members kept
+    expect(crossMembers.find((m) => m.person_id === p1.id)!.default_position_key).toBeNull(); // key dropped
+  });
+
+  it("divisionRoster maps every (person → team entrant) for the double-roster warning, org-scoped", async () => {
+    const { auth } = await seedOrg("pro");
+    const other = await seedOrg("pro");
+    const comp = await createCompetition(auth, { name: "Warn Cup", visibility: "private", branding: {} });
+    const div = await makeDivision(auth, comp.id, "generic");
+    const p = await createPerson(auth, { full_name: "Shared", consent: {}, dob: null, gender: null, external_ref: null });
+
+    // Same person on two team entrants in this division.
+    const [red] = await createEntrants(auth, div.id, [
+      { kind: "team", display_name: "Red", members: [{ person_id: p.id, is_captain: false, roles: [] }] },
+    ]);
+    const [blue] = await createEntrants(auth, div.id, [
+      { kind: "team", display_name: "Blue", members: [{ person_id: p.id, is_captain: false, roles: [] }] },
+    ]);
+
+    const roster = await divisionRoster(auth, div.id);
+    const forShared = roster.filter((r) => r.person_id === p.id).map((r) => r.entrant_id).sort();
+    expect(forShared).toEqual([red!.id, blue!.id].sort()); // on both teams → conflict surfaces
+
+    // Another org can't read this division's roster (RLS): empty.
+    expect(await divisionRoster(other.auth, div.id)).toEqual([]);
+  });
+
+  it("leaves the entrant name unchanged after the team is renamed", async () => {
+    const { auth } = await seedOrg("pro");
+    const comp = await createCompetition(auth, { name: "Rename Cup", visibility: "private", branding: {} });
+    const team = await seedTeam(auth, "Old Name U14");
+    const div = await makeDivision(auth, comp.id, "generic");
+    const [entrant] = await createEntrants(auth, div.id, [{ kind: "team", team_id: team.id, members: [] }]);
+
+    await withTenant(auth.orgId, (tx) => tx`update teams set name = ${"New Name U15"} where id = ${team.id}`);
+
+    // Criterion 5: standings read entrants.display_name — the snapshot holds.
+    const after = await getEntrant(auth, entrant!.id);
+    expect(after.display_name).toBe("Old Name U14");
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/person-photo.test.ts
+++ b/apps/web/src/server/usecases/__tests__/person-photo.test.ts
@@ -1,0 +1,21 @@
+// Player photo upload validation. The MIME guard runs before any DB/storage
+// I/O, so this regression test needs no database.
+import { describe, expect, it } from "vitest";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { setPersonPhoto } from "../persons";
+
+const auth: AuthCtx = {
+  orgId: "00000000-0000-0000-0000-000000000000",
+  via: "session",
+  userId: null,
+  role: "owner",
+  keyId: null,
+};
+
+describe("setPersonPhoto", () => {
+  it("rejects unsupported image types with 415 before touching the DB", async () => {
+    await expect(
+      setPersonPhoto(auth, "any-id", { contentType: "text/plain", bytes: Buffer.from("x") }),
+    ).rejects.toMatchObject({ status: 415 });
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/team-squad.test.ts
+++ b/apps/web/src/server/usecases/__tests__/team-squad.test.ts
@@ -1,0 +1,125 @@
+// Persistent team squad: create a team under a club, manage its squad, and have
+// that squad auto-seed an entrant roster on enrollment (filtered per sport).
+// Real Postgres required.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { football } from "@seazn/engine/sports/football";
+import { cricket } from "@seazn/engine/sports/cricket";
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createClub } from "../clubs";
+import { createTeam, setTeamSquad, getTeamSquad } from "../teams";
+import { createPerson } from "../persons";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants, getEntrant } from "../entrants";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const GENERIC = { resultMode: "score", allowDraws: true, points: { w: 3, d: 1, l: 0 }, progressScore: false };
+
+async function seedOrg(plan: "community" | "pro"): Promise<AuthCtx> {
+  const s = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Sq " + s}, ${"sq-" + s}) returning id`;
+  if (plan !== "community") {
+    await sql`insert into subscriptions (org_id, plan_key, status) values (${orgId}, ${plan}, 'active')
+              on conflict (org_id) do update set plan_key = ${plan}`;
+  }
+  await sql`
+    insert into sports (key, name, module_version, position_catalog) values
+      ('generic',  'Generic',  '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })}),
+      ('football', 'Football', ${football.version}, ${sql.json(football.positions as never)}),
+      ('cricket',  'Cricket',  ${cricket.version}, ${sql.json(cricket.positions as never)})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system) values
+      ('generic',  'score',   'Score',   ${sql.json({ resultMode: "score", points: { w: 3, d: 1, l: 0 } })}, true),
+      ('football', 'default', 'Default', ${sql.json({})}, true),
+      ('cricket',  't20',     'T20',     ${sql.json(cricket.variants.t20 as never)}, true)
+    on conflict do nothing`;
+  return { orgId, via: "session", userId: null, role: "owner", keyId: null };
+}
+
+async function makeDivision(auth: AuthCtx, competitionId: string, sport: string) {
+  return createDivision(auth, competitionId, {
+    name: `D ${randomUUID().slice(0, 6)}`,
+    sport_key: sport,
+    variant_key: sport === "football" ? "default" : sport === "cricket" ? "t20" : "score",
+    config: sport === "generic" ? GENERIC : {},
+    eligibility: [],
+  } as never);
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const c = g._sql;
+  g._sql = undefined;
+  await c?.end();
+});
+
+describe.skipIf(!HAS_DB)("team squad", () => {
+  it("gates team creation behind clubs.hierarchy (Pro)", async () => {
+    const pro = await seedOrg("pro");
+    const club = await createClub(pro, { name: "Riverside FC" });
+    const team = await createTeam(pro, club.id, { name: "Riverside U12" });
+    expect(team.name).toBe("Riverside U12");
+    expect(team.club_id).toBe(club.id);
+
+    // A community org cannot create teams (it also can't make the club, so seed
+    // the club under pro then downgrade to prove the team gate specifically).
+    const comm = await seedOrg("community");
+    await expect(createTeam(comm, club.id, { name: "X" })).rejects.toMatchObject({ status: 402 });
+  });
+
+  it("stores and replaces the squad", async () => {
+    const auth = await seedOrg("pro");
+    const club = await createClub(auth, { name: "Harbour FC" });
+    const team = await createTeam(auth, club.id, { name: "Harbour U16" });
+    const p1 = await createPerson(auth, { full_name: "Ada", consent: {}, dob: null, gender: null, external_ref: null });
+    const p2 = await createPerson(auth, { full_name: "Bea", consent: {}, dob: null, gender: null, external_ref: null });
+
+    const saved = await setTeamSquad(auth, team.id, [
+      { person_id: p1.id, squad_number: 7, is_captain: true, roles: [], default_position_key: null },
+      { person_id: p2.id, squad_number: 9, is_captain: false, roles: [], default_position_key: null },
+    ]);
+    expect(saved.members).toHaveLength(2);
+    expect(saved.members.find((m) => m.person_id === p1.id)!.is_captain).toBe(true);
+
+    // Full replace: drop p2.
+    await setTeamSquad(auth, team.id, [
+      { person_id: p1.id, squad_number: 7, is_captain: true, roles: [], default_position_key: null },
+    ]);
+    const after = await getTeamSquad(auth, team.id);
+    expect(after.members.map((m) => m.person_id)).toEqual([p1.id]);
+  });
+
+  it("auto-seeds an entrant roster from the squad on enrollment, filtered per sport", async () => {
+    const auth = await seedOrg("pro");
+    const club = await createClub(auth, { name: "Seed FC" });
+    const team = await createTeam(auth, club.id, { name: "Seed U18" });
+    const p1 = await createPerson(auth, { full_name: "Keeper", consent: {}, dob: null, gender: null, external_ref: null });
+    const p2 = await createPerson(auth, { full_name: "Back", consent: {}, dob: null, gender: null, external_ref: null });
+    await setTeamSquad(auth, team.id, [
+      { person_id: p1.id, squad_number: 1, is_captain: true, roles: ["captain"], default_position_key: "GK" },
+      { person_id: p2.id, squad_number: 2, is_captain: false, roles: [], default_position_key: "DF" },
+    ]);
+
+    const comp = await createCompetition(auth, { name: "Seed Cup", visibility: "private", branding: {} });
+
+    // Football division: squad seeds with its keys intact.
+    const foot = await makeDivision(auth, comp.id, "football");
+    const [inFoot] = await createEntrants(auth, foot.id, [{ kind: "team", team_id: team.id, members: [] }]);
+    const footRoster = (await getEntrant(auth, inFoot!.id)).members as { person_id: string; default_position_key: string | null }[];
+    expect(footRoster).toHaveLength(2); // seeded from squad
+    expect(footRoster.find((m) => m.person_id === p1.id)!.default_position_key).toBe("GK");
+
+    // Cricket division: members seed, GK (not a cricket position) dropped.
+    const crick = await makeDivision(auth, comp.id, "cricket");
+    const [inCrick] = await createEntrants(auth, crick.id, [{ kind: "team", team_id: team.id, members: [] }]);
+    expect(inCrick!.roster_keys_dropped).toBeGreaterThanOrEqual(1);
+    const crickRoster = (await getEntrant(auth, inCrick!.id)).members as { person_id: string; default_position_key: string | null }[];
+    expect(crickRoster).toHaveLength(2);
+    expect(crickRoster.find((m) => m.person_id === p1.id)!.default_position_key).toBeNull();
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/teams.test.ts
+++ b/apps/web/src/server/usecases/__tests__/teams.test.ts
@@ -1,0 +1,52 @@
+// listTeams must be org-scoped: team_display_v is a plain view (no
+// security_invoker) so it bypasses the caller's RLS on `teams` — the usecase
+// filters by org_id explicitly. This guards against a cross-org team leak in
+// the enroll-an-existing-team picker. Real Postgres required.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql, withTenant } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { listTeams } from "../teams";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function seedOrg(): Promise<AuthCtx> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Tm " + suffix}, ${"tm-" + suffix})
+    returning id`;
+  return { orgId, via: "session", userId: null, role: "owner", keyId: null };
+}
+
+async function seedTeam(auth: AuthCtx, name: string): Promise<void> {
+  await withTenant(auth.orgId, async (tx) => {
+    const [club] = await tx<{ id: string }[]>`
+      insert into clubs (org_id, name) values (${auth.orgId}, ${"Club " + name}) returning id`;
+    await tx`insert into teams (org_id, name, club_id) values (${auth.orgId}, ${name}, ${club!.id})`;
+  });
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("listTeams org scoping", () => {
+  it("returns only the caller's org teams, never another org's", async () => {
+    const a = await seedOrg();
+    const b = await seedOrg();
+    await seedTeam(a, "A Team");
+    await seedTeam(b, "B Team");
+
+    const aTeams = await listTeams(a);
+    const bTeams = await listTeams(b);
+
+    expect(aTeams.map((t) => t.name)).toEqual(["A Team"]);
+    expect(bTeams.map((t) => t.name)).toEqual(["B Team"]);
+    // Explicit: A must never see B's team (the leak we fixed).
+    expect(aTeams.some((t) => t.name === "B Team")).toBe(false);
+  });
+});

--- a/apps/web/src/server/usecases/entrants.ts
+++ b/apps/web/src/server/usecases/entrants.ts
@@ -6,6 +6,8 @@ import type postgres from "postgres";
 import { withTenant } from "@/lib/db";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
 import { withinLimit } from "@/lib/entitlements";
+import { resolveModule } from "@/server/engine-db/registry";
+import { loadTeamSquad } from "./teams";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { z } from "zod";
 import type { CreateEntrant, PatchEntrant, EntrantMemberInput } from "@/server/api-v1/schemas";
@@ -13,6 +15,40 @@ import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 
 type Tx = postgres.TransactionSql;
 type MemberInput = z.infer<typeof EntrantMemberInput>;
+
+/** Drop position/role keys the target division's sport doesn't define, keeping
+ *  the member. Returns the cleaned roster plus a count of dropped keys so the
+ *  caller can tell the organiser "N settings didn't carry over". */
+function filterRosterForSport(
+  members: MemberInput[],
+  sportKey: string,
+  moduleVersion: string,
+): { members: MemberInput[]; dropped: number } {
+  const mod = resolveModule(sportKey, moduleVersion);
+  const positions = new Set((mod.positions?.groups ?? []).map((g) => g.key));
+  const roles = new Set((mod.positions?.roles ?? []).map((r) => r.key));
+  let dropped = 0;
+  const cleaned = members.map((m) => {
+    let position = m.default_position_key ?? null;
+    if (position != null && !positions.has(position)) {
+      position = null;
+      dropped += 1;
+    }
+    const src = m.roles ?? [];
+    const keptRoles = src.filter((r) => roles.has(r));
+    dropped += src.length - keptRoles.length;
+    return { ...m, default_position_key: position, roles: keptRoles };
+  });
+  return { members: cleaned, dropped };
+}
+
+/** Load an entrant's roster in the CreateEntrant member shape, for copying. */
+async function loadRosterForCopy(tx: Tx, entrantId: string): Promise<MemberInput[]> {
+  const rows = await tx<MemberInput[]>`
+    select person_id, squad_number, default_position_key, is_captain, roles
+    from entrant_members where entrant_id = ${entrantId}`;
+  return rows;
+}
 
 export interface EntrantRow {
   id: string;
@@ -27,6 +63,12 @@ export interface EntrantRow {
 
 export interface EntrantWithMembers extends EntrantRow {
   members: unknown[];
+}
+
+/** A created entrant, plus (response-only) how many roster keys were dropped
+ *  because the target sport doesn't define them. Not a persisted column. */
+export interface CreatedEntrant extends EntrantRow {
+  roster_keys_dropped?: number;
 }
 
 const COLS = [
@@ -66,29 +108,36 @@ async function withMembers(tx: Tx, entrant: EntrantRow): Promise<EntrantWithMemb
 export async function listEntrants(
   auth: AuthCtx,
   divisionId: string,
-  clubId?: string,
+  filter: { clubId?: string; teamId?: string } = {},
 ): Promise<EntrantRow[]> {
+  const { clubId, teamId } = filter;
   return withTenant(auth.orgId, async (tx) => {
     const [division] = await tx`select 1 from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
     // ?club_id= facet (Jul3/01 §6): a read-side grouping over teams.club_id.
+    // ?team_id= narrows to a single team (used by the enroll-existing flow).
     return tx<EntrantRow[]>`
       select ${tx(COLS)} from entrants
       where division_id = ${divisionId}
       ${clubId ? tx`and team_id in (select id from teams where club_id = ${clubId})` : tx``}
+      ${teamId ? tx`and team_id = ${teamId}` : tx``}
       order by seed nulls last, created_at, id`;
   });
 }
 
-/** Register one entrant or a bulk batch (doc 08 §3 "+ bulk import"). */
+/** Register one entrant or a bulk batch (doc 08 §3 "+ bulk import").
+ *  Enrolling an existing team (team_id set) snapshots the display name from the
+ *  team, enforces one-entry-per-division (409), and can copy a prior roster. */
 export async function createEntrants(
   auth: AuthCtx,
   divisionId: string,
   inputs: CreateEntrant[],
-): Promise<EntrantRow[]> {
+): Promise<CreatedEntrant[]> {
   return withTenant(auth.orgId, async (tx) => {
-    const [division] = await tx<{ status: string; competition_id: string }[]>`
-      select status, competition_id from divisions where id = ${divisionId}`;
+    const [division] = await tx<
+      { status: string; competition_id: string; sport_key: string; module_version: string }[]
+    >`select status, competition_id, sport_key, module_version
+      from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
     await assertCompetitionNotFrozen(auth.orgId, division.competition_id, tx);
 
@@ -99,18 +148,84 @@ export async function createEntrants(
     const quota = await withinLimit(auth.orgId, "entrants.per_division.max", n + inputs.length);
     if (!quota.ok) throw new PaymentRequiredError("entrants.per_division.max");
 
-    const rows: EntrantRow[] = [];
+    const rows: CreatedEntrant[] = [];
     for (const input of inputs) {
-      const [row] = await tx<EntrantRow[]>`
-        insert into entrants (division_id, kind, team_id, display_name, seed)
-        values (${divisionId}, ${input.kind}, ${input.team_id ?? null},
-                ${input.display_name}, ${input.seed ?? null})
-        returning ${tx(COLS)}`;
-      await insertMembers(tx, row.id, input.members);
-      rows.push(row);
+      // Snapshot the name from the team so a later rename never rewrites
+      // historical standings (which read entrants.display_name / snapshots).
+      let displayName = input.display_name ?? null;
+      if (input.team_id) {
+        const [team] = await tx<{ name: string }[]>`
+          select name from teams where id = ${input.team_id}`;
+        if (!team) throw new HttpError(404, "team not found");
+        displayName = team.name;
+      }
+      if (displayName == null) throw new HttpError(422, "display_name is required");
+
+      // Resolve the roster to store, in precedence order: members supplied on
+      // the request → a copied prior entrant → the team's persistent squad.
+      // Copied/seeded rosters are filtered to the target sport.
+      let members = input.members;
+      let dropped = 0;
+      if (input.copy_roster_from_entrant_id) {
+        const [source] = await tx<{ team_id: string | null }[]>`
+          select team_id from entrants where id = ${input.copy_roster_from_entrant_id}`;
+        if (!source) throw new HttpError(404, "roster source entrant not found");
+        if (!input.team_id || source.team_id !== input.team_id) {
+          throw new HttpError(422, "roster source must be an entrant of the same team");
+        }
+        const raw = await loadRosterForCopy(tx, input.copy_roster_from_entrant_id);
+        const filtered = filterRosterForSport(raw, division.sport_key, division.module_version);
+        members = filtered.members;
+        dropped = filtered.dropped;
+      } else if (input.team_id && members.length === 0) {
+        // No explicit roster and no copy source → seed from the team's squad.
+        const squad = await loadTeamSquad(tx, input.team_id);
+        if (squad.length > 0) {
+          const filtered = filterRosterForSport(squad, division.sport_key, division.module_version);
+          members = filtered.members;
+          dropped = filtered.dropped;
+        }
+      }
+
+      let row: EntrantRow;
+      try {
+        [row] = await tx<EntrantRow[]>`
+          insert into entrants (division_id, kind, team_id, display_name, seed)
+          values (${divisionId}, ${input.kind}, ${input.team_id ?? null},
+                  ${displayName}, ${input.seed ?? null})
+          returning ${tx(COLS)}`;
+      } catch (err) {
+        if ((err as { code?: string }).code === "23505") {
+          throw new HttpError(409, "this team is already entered in this division");
+        }
+        throw err;
+      }
+      await insertMembers(tx, row.id, members);
+      rows.push(dropped > 0 ? { ...row, roster_keys_dropped: dropped } : row);
     }
     return rows;
   });
+}
+
+export interface DivisionRosterRow {
+  person_id: string;
+  entrant_id: string;
+  entrant_name: string;
+}
+
+/** Every (person → team entrant) membership in a division. Powers the
+ *  same-division double-roster warning: a person on two teams here is flagged
+ *  (advisory, not blocked). */
+export async function divisionRoster(
+  auth: AuthCtx,
+  divisionId: string,
+): Promise<DivisionRosterRow[]> {
+  return withTenant(auth.orgId, (tx) => tx<DivisionRosterRow[]>`
+    select em.person_id, e.id as entrant_id, e.display_name as entrant_name
+    from entrants e
+    join entrant_members em on em.entrant_id = e.id
+    where e.division_id = ${divisionId}
+      and e.status in ('registered','confirmed')`);
 }
 
 export async function getEntrant(auth: AuthCtx, id: string): Promise<EntrantWithMembers> {

--- a/apps/web/src/server/usecases/persons.ts
+++ b/apps/web/src/server/usecases/persons.ts
@@ -2,8 +2,10 @@ import "server-only";
 // Person use-cases (doc 08 §3): org-wide people registry, per-sport profiles,
 // merge (dedupe). DOB/consent live here and are NEVER exposed publicly — the
 // public read model goes through the consent-filtered views only.
+import { createHash } from "node:crypto";
 import { withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
+import { supabaseAdmin } from "@/lib/supabase-admin";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { page, type ListQuery, type Page } from "@/server/api-v1/http";
 import type { CreatePerson, PatchPerson, PutProfile } from "@/server/api-v1/schemas";
@@ -15,10 +17,20 @@ export interface PersonRow {
   gender: string | null;
   consent: unknown;
   external_ref: string | null;
+  photo_path: string | null;
   created_at: string;
 }
 
-const COLS = ["id", "full_name", "dob", "gender", "consent", "external_ref", "created_at"] as const;
+const COLS = ["id", "full_name", "dob", "gender", "consent", "external_ref", "photo_path", "created_at"] as const;
+
+// Player photos ride the same public 'assets' bucket as club badges; the
+// public_photo consent flag gates display, not upload.
+const PHOTO_BUCKET = "assets";
+const PHOTO_MIME = new Map<string, string>([
+  ["image/png", "png"],
+  ["image/jpeg", "jpg"],
+  ["image/webp", "webp"],
+]);
 
 export async function listPersons(auth: AuthCtx, query: ListQuery): Promise<Page<PersonRow>> {
   return withTenant(auth.orgId, async (tx) => {
@@ -41,6 +53,31 @@ export async function createPerson(auth: AuthCtx, input: CreatePerson): Promise<
               ${tx.json(input.consent as never)}, ${input.external_ref ?? null})
       returning ${tx(COLS)}`;
     return row;
+  });
+}
+
+export interface PhotoFile {
+  contentType: string;
+  bytes: Buffer;
+}
+
+/** Upload a player's photo to storage and record its path (content-hash
+ *  dedupe, mirroring club badges). */
+export async function setPersonPhoto(auth: AuthCtx, id: string, file: PhotoFile): Promise<PersonRow> {
+  const ext = PHOTO_MIME.get(file.contentType);
+  if (!ext) throw new HttpError(415, `unsupported image type '${file.contentType}'`);
+  return withTenant(auth.orgId, async (tx) => {
+    const [person] = await tx<PersonRow[]>`select id from persons where id = ${id}`;
+    if (!person) throw new HttpError(404, "person not found");
+    const hash = createHash("sha256").update(file.bytes).digest("hex").slice(0, 32);
+    const path = `orgs/${auth.orgId}/persons/${hash}.${ext}`;
+    const { error } = await supabaseAdmin()
+      .storage.from(PHOTO_BUCKET)
+      .upload(path, file.bytes, { contentType: file.contentType, upsert: true });
+    if (error) throw new HttpError(502, `photo upload failed: ${error.message}`);
+    const [row] = await tx<PersonRow[]>`
+      update persons set photo_path = ${path} where id = ${id} returning ${tx(COLS)}`;
+    return row!;
   });
 }
 

--- a/apps/web/src/server/usecases/teams.ts
+++ b/apps/web/src/server/usecases/teams.ts
@@ -1,0 +1,137 @@
+import "server-only";
+// Team use-cases. Teams can be created via CSV import (Jul3/01 §6) or directly
+// under a club (createTeam). listTeams exposes them for the "enroll an existing
+// team" flow. Each team carries a persistent squad (team_members) managed in the
+// club directory, used to auto-seed an entrant's roster on enrollment.
+// Reads are ungated; create/edit (Pro club hierarchy) require clubs.hierarchy.
+import type postgres from "postgres";
+import { withTenant } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { requireFeature } from "@/lib/entitlements";
+import type { z } from "zod";
+import type { EntrantMemberInput } from "@/server/api-v1/schemas";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+type Tx = postgres.TransactionSql;
+type MemberInput = z.infer<typeof EntrantMemberInput>;
+
+export interface TeamListRow {
+  id: string;
+  name: string;
+  short_name: string | null;
+  club_id: string | null;
+  club_name: string | null;
+  club_short_name: string | null;
+  logo_path: string | null;
+  /** Most recently created entrant for this team, across all divisions — the
+   *  default roster source when enrolling the team into a new division. */
+  latest_entrant_id: string | null;
+}
+
+export async function listTeams(auth: AuthCtx): Promise<TeamListRow[]> {
+  // team_display_v is a plain (non-security_invoker) view, so it does NOT
+  // inherit the caller's RLS on `teams` — filter by org_id explicitly or it
+  // leaks every org's teams. The entrants subquery reads `entrants` directly,
+  // which IS RLS-scoped under withTenant.
+  return withTenant(auth.orgId, (tx) => tx<TeamListRow[]>`
+    select v.team_id as id, v.name, v.short_name, v.club_id,
+           v.club_name, v.club_short_name, v.logo_path,
+           (select e.id from entrants e
+             where e.team_id = v.team_id
+             order by e.created_at desc, e.id desc
+             limit 1) as latest_entrant_id
+    from team_display_v v
+    where v.org_id = ${auth.orgId}
+    order by v.name, v.team_id`);
+}
+
+export interface TeamRow {
+  id: string;
+  name: string;
+  short_name: string | null;
+  club_id: string | null;
+}
+
+export interface SquadMember {
+  person_id: string;
+  full_name: string;
+  squad_number: number | null;
+  default_position_key: string | null;
+  is_captain: boolean;
+  roles: string[];
+}
+
+/** Create a team under a club. Pro (clubs.hierarchy), mirroring club create. */
+export async function createTeam(
+  auth: AuthCtx,
+  clubId: string,
+  input: { name: string; short_name?: string | null },
+): Promise<TeamRow> {
+  await requireFeature(auth.orgId, "clubs.hierarchy");
+  return withTenant(auth.orgId, async (tx) => {
+    const [club] = await tx`select 1 from clubs where id = ${clubId}`;
+    if (!club) throw new HttpError(404, "club not found");
+    const [team] = await tx<TeamRow[]>`
+      insert into teams (org_id, name, short_name, club_id)
+      values (${auth.orgId}, ${input.name}, ${input.short_name ?? null}, ${clubId})
+      returning id, name, short_name, club_id`;
+    return team!;
+  });
+}
+
+/** Load a team's persistent squad (in the CreateEntrant member shape, minus
+ *  full_name) — used to seed an entrant roster on enrollment. */
+export async function loadTeamSquad(tx: Tx, teamId: string): Promise<MemberInput[]> {
+  return tx<MemberInput[]>`
+    select person_id, squad_number, default_position_key, is_captain, roles
+    from team_members where team_id = ${teamId}`;
+}
+
+export async function getTeamSquad(
+  auth: AuthCtx,
+  teamId: string,
+): Promise<TeamRow & { members: SquadMember[] }> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [team] = await tx<TeamRow[]>`
+      select id, name, short_name, club_id from teams where id = ${teamId}`;
+    if (!team) throw new HttpError(404, "team not found");
+    const members = await tx<SquadMember[]>`
+      select tm.person_id, p.full_name, tm.squad_number, tm.default_position_key,
+             tm.is_captain, tm.roles
+      from team_members tm join persons p on p.id = tm.person_id
+      where tm.team_id = ${teamId}
+      order by tm.squad_number nulls last, p.full_name`;
+    return { ...team, members };
+  });
+}
+
+/** Full-replace a team's squad (like the entrant roster editor). Pro. */
+export async function setTeamSquad(
+  auth: AuthCtx,
+  teamId: string,
+  members: MemberInput[],
+): Promise<TeamRow & { members: SquadMember[] }> {
+  await requireFeature(auth.orgId, "clubs.hierarchy");
+  await withTenant(auth.orgId, async (tx) => {
+    const [team] = await tx`select 1 from teams where id = ${teamId}`;
+    if (!team) throw new HttpError(404, "team not found");
+    const ids = [...new Set(members.map((m) => m.person_id))];
+    if (ids.length > 0) {
+      const visible = await tx<{ id: string }[]>`select id from persons where id in ${tx(ids)}`;
+      if (visible.length !== ids.length) {
+        const seen = new Set(visible.map((r) => r.id));
+        throw new HttpError(422, `unknown person(s): ${ids.filter((id) => !seen.has(id)).join(", ")}`);
+      }
+    }
+    await tx`delete from team_members where team_id = ${teamId}`;
+    for (const m of members) {
+      await tx`
+        insert into team_members (team_id, person_id, squad_number,
+                                  default_position_key, is_captain, roles)
+        values (${teamId}, ${m.person_id}, ${m.squad_number ?? null},
+                ${m.default_position_key ?? null}, ${m.is_captain},
+                ${tx.json(m.roles as never)})`;
+    }
+  });
+  return getTeamSquad(auth, teamId);
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,7 +5,12 @@ export default defineConfig({
   test: {
     environment: "node",
     pool: "threads",
-    isolate: false,
+    // Each DB suite lazily creates a postgres client (cached on globalThis) and
+    // ends it in afterAll. With isolate:false that client + globalThis are shared
+    // across files, so one file's teardown strands another file's in-flight query
+    // (CONNECTION_ENDED). Isolate per file so each owns — and ends — its own
+    // connection; the teardown races vanish.
+    isolate: true,
     // Playwright specs (e2e/) run under `playwright test`, not vitest.
     exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
     // @seazn/engine ships TS source (workspace symlink) — inline it so vitest

--- a/db/migration/deltas/V256__entrant_team_unique.sql
+++ b/db/migration/deltas/V256__entrant_team_unique.sql
@@ -1,0 +1,8 @@
+-- ---------------------------------------------------------------------------
+-- A team may be enrolled into a given division at most once. Individual/pair
+-- entrants (team_id IS NULL) are unconstrained, so the index is partial.
+-- Backs the 409 on duplicate enrollment in the unified "Add Entrant" flow.
+-- ---------------------------------------------------------------------------
+create unique index if not exists entrants_team_division_uq
+  on entrants(team_id, division_id)
+  where team_id is not null;

--- a/db/migration/deltas/V257__team_members.sql
+++ b/db/migration/deltas/V257__team_members.sql
@@ -1,0 +1,31 @@
+-- ---------------------------------------------------------------------------
+-- Persistent team squad. A team's standing roster, independent of any
+-- competition — managed in the club directory and used to auto-seed an
+-- entrant's roster when the team is enrolled into a division. Mirrors
+-- entrant_members so seeding is a straight copy.
+-- ---------------------------------------------------------------------------
+create table if not exists team_members (
+  team_id      uuid not null references teams(id) on delete cascade,
+  person_id    uuid not null references persons(id) on delete cascade,
+  org_id       uuid not null,
+  squad_number int,
+  default_position_key text,
+  is_captain   boolean not null default false,
+  roles        jsonb not null default '[]',
+  primary key (team_id, person_id)
+);
+create index if not exists team_members_team_idx on team_members(team_id);
+
+-- org_id denormalized from the parent team (doc 07 note-3), same trigger the
+-- rest of the v2 tables use.
+drop trigger if exists trg_set_org on team_members;
+create trigger trg_set_org before insert on team_members
+  for each row execute function set_org_from_parent('teams', 'team_id');
+
+-- RLS — migration-010 direct policy (doc 07 conventions).
+alter table team_members enable row level security;
+alter table team_members force  row level security;
+drop policy if exists team_members_tenant on team_members;
+create policy team_members_tenant on team_members for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+grant select, insert, update, delete on team_members to app_user;

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -3679,11 +3679,22 @@
                           ],
                           "additionalProperties": false
                         }
+                      },
+                      "copy_roster_from_entrant_id": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     },
                     "required": [
                       "kind",
-                      "display_name",
                       "members"
                     ],
                     "additionalProperties": false
@@ -3784,11 +3795,22 @@
                             ],
                             "additionalProperties": false
                           }
+                        },
+                        "copy_roster_from_entrant_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         }
                       },
                       "required": [
                         "kind",
-                        "display_name",
                         "members"
                       ],
                       "additionalProperties": false
@@ -4760,6 +4782,192 @@
           },
           "422": {
             "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/divisions/{id}/roster": {
+      "get": {
+        "summary": "Every (person → team entrant) membership in the division (same-division double-roster warning)",
+        "tags": [
+          "entrants"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6251,6 +6459,347 @@
           },
           "422": {
             "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/persons/{id}/photo": {
+      "post": {
+        "summary": "Upload a player photo (multipart `file`); public display gated by public_photo consent",
+        "tags": [
+          "persons"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "full_name": {
+                          "type": "string"
+                        },
+                        "dob": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "gender": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "m",
+                                "f",
+                                "x"
+                              ]
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "consent": {
+                          "type": "object",
+                          "propertyNames": {
+                            "type": "string"
+                          },
+                          "additionalProperties": {}
+                        },
+                        "external_ref": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "created_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "full_name",
+                        "dob",
+                        "gender",
+                        "consent",
+                        "external_ref",
+                        "created_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Error",
             "content": {
               "application/json": {
                 "schema": {
@@ -24278,6 +24827,971 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/clubs/{id}/teams": {
+      "post": {
+        "summary": "Add a team under a club (Pro `clubs.hierarchy`)",
+        "tags": [
+          "clubs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200
+                  },
+                  "short_name": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "maxLength": 60
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Plan upgrade required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/teams": {
+      "get": {
+        "summary": "List teams with their division entries",
+        "tags": [
+          "clubs"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/teams/{id}/squad": {
+      "get": {
+        "summary": "Get a team's persistent squad",
+        "tags": [
+          "clubs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "put": {
+        "summary": "Replace a team's squad (auto-seeds entrant rosters on enrollment)",
+        "tags": [
+          "clubs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "members": {
+                    "default": [],
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "person_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "squad_number": {
+                          "anyOf": [
+                            {
+                              "type": "integer",
+                              "minimum": 0,
+                              "maximum": 9007199254740991
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "default_position_key": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "is_captain": {
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "roles": {
+                          "default": [],
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "person_id",
+                        "is_captain",
+                        "roles"
+                      ],
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "members"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Plan upgrade required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
             "content": {
               "application/json": {
                 "schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@anthropic-ai/sdk": "^0.110.0",
         "@seazn/engine": "*",
         "@sentry/nextjs": "^10.62.0",
+        "@stripe/react-stripe-js": "^6.7.0",
+        "@stripe/stripe-js": "^9.9.0",
         "@supabase/supabase-js": "^2.110.0",
         "bcryptjs": "^3.0.3",
         "exceljs": "^4.4.0",
@@ -2721,6 +2723,29 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.7.0.tgz",
+      "integrity": "sha512-KSWTQHcDlAOlxcOz+uq0pTA/k9G4+IBF/X8mtSFkkBX+nb74buMTIFcCUCHWNhjuPqfD+yJm7NWDan1EaxSyzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=9.5.0 <10.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.9.0.tgz",
+      "integrity": "sha512-Vwqe6Q5cU4i82tPyAv2BpaW/fQSNdOSO4/J8EeDLPp5/oIZiMmdB+Hgh863zFH+rtoxpuWGvD1L7QPh8k1Rdvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.110.0",
@@ -8151,7 +8176,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8593,7 +8617,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9072,7 +9095,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9176,7 +9198,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "db:validate": "bash scripts/flyway.sh validate",
     "db:baseline": "bash scripts/flyway.sh baseline",
     "sync:sports": "node --experimental-strip-types scripts/sync-sports.ts",
+    "stripe:sync": "node --env-file=apps/web/.env.local --experimental-strip-types scripts/stripe-sync.ts",
     "openapi:gen": "node --experimental-strip-types scripts/openapi-gen.ts",
     "check:rls": "node --experimental-strip-types scripts/check-rls.ts"
   }

--- a/scripts/stripe-sync.ts
+++ b/scripts/stripe-sync.ts
@@ -1,0 +1,91 @@
+// Sync Stripe products/prices from apps/web/src/config/stripe-plans.json into
+// Stripe + the `plans` table. Idempotent: a price is matched by its stable
+// `lookup_key`, so re-running never duplicates. Run after db:apply / any wipe,
+// once per environment (test/prod) by pointing the env at it:
+//   node --env-file=apps/web/.env.local --experimental-strip-types scripts/stripe-sync.ts
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import postgres from "postgres";
+import Stripe from "stripe";
+
+interface PriceSpec { lookup_key: string; unit_amount: number; interval: "month" | "year" }
+interface PlanSpec {
+  key: string;
+  product: { name: string; description?: string };
+  prices: { monthly: PriceSpec; annual: PriceSpec };
+}
+interface Seed { currency: string; plans: PlanSpec[] }
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const seedPath = path.join(__dirname, "..", "apps", "web", "src", "config", "stripe-plans.json");
+const seed = JSON.parse(readFileSync(seedPath, "utf8")) as Seed;
+
+const url = process.env.DATABASE_URL;
+const key = process.env.STRIPE_SECRET_KEY;
+if (!url) { console.error("DATABASE_URL is not set."); process.exit(1); }
+if (!key) { console.error("STRIPE_SECRET_KEY is not set."); process.exit(1); }
+console.log(`Stripe mode: ${key.includes("_test_") ? "TEST" : "LIVE"}`);
+
+const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
+const sql = postgres(url, {
+  connection: { search_path: process.env.DB_SCHEMA ?? "seazn_club" },
+  ssl: process.env.DATABASE_SSL === "disable" ? false : isLocal ? false : "require",
+  prepare: !url.includes(":6543"),
+  max: 1,
+});
+const stripe = new Stripe(key);
+
+/** Find a price by lookup_key, else create it (and a product if needed). */
+async function ensurePrice(spec: PriceSpec, plan: PlanSpec, currency: string, productId: string | null): Promise<{ priceId: string; productId: string }> {
+  const found = await stripe.prices.list({ lookup_keys: [spec.lookup_key], limit: 1, expand: ["data.product"] });
+  if (found.data[0]) {
+    const p = found.data[0];
+    const prod = typeof p.product === "string" ? p.product : p.product.id;
+    return { priceId: p.id, productId: prod };
+  }
+  const prod =
+    productId ??
+    (await stripe.products.create({
+      name: plan.product.name,
+      description: plan.product.description,
+      metadata: { seazn_plan: plan.key },
+    })).id;
+  const price = await stripe.prices.create({
+    product: prod,
+    currency,
+    unit_amount: spec.unit_amount,
+    recurring: { interval: spec.interval },
+    lookup_key: spec.lookup_key,
+    transfer_lookup_key: true,
+    metadata: { seazn_plan: plan.key },
+  });
+  return { priceId: price.id, productId: prod };
+}
+
+/** Write resolved price ids onto the plans row (the checkout route reads these). */
+export async function applyPlanPrices(
+  db: postgres.Sql,
+  planKey: string,
+  prices: { monthly: string; annual: string },
+): Promise<void> {
+  await db`
+    update plans
+    set stripe_price_id_monthly = ${prices.monthly},
+        stripe_price_id_annual  = ${prices.annual}
+    where key = ${planKey}`;
+}
+
+try {
+  for (const plan of seed.plans) {
+    let productId: string | null = null;
+    const monthly = await ensurePrice(plan.prices.monthly, plan, seed.currency, productId);
+    productId = monthly.productId;
+    const annual = await ensurePrice(plan.prices.annual, plan, seed.currency, productId);
+    await applyPlanPrices(sql, plan.key, { monthly: monthly.priceId, annual: annual.priceId });
+    console.log(`✓ ${plan.key}: monthly=${monthly.priceId} annual=${annual.priceId}`);
+  }
+  console.log("Stripe sync complete.");
+} finally {
+  await sql.end();
+}


### PR DESCRIPTION
## Summary

This session's UI/feature work (plus pre-existing working-tree WIP that was uncommitted when the branch was cut — see caveat).

### Players directory
- Rename **People → Players** across labels + routes (`/players`, `/directory?tab=players`, `/people` back-compat redirect). API + DB stay `persons`.

### Images
- **Club badges** — inline picker on the create-club form + a per-row **set/change** control in the clubs table. Both reuse the bulk `/clubs/logos` endpoint (single file mapped to the club).
- **Player photos** — new `POST /persons/{id}/photo` (multipart) + `setPersonPhoto` usecase; add-player photo picker; thumbnail (or initial avatar) in the directory table. Public display gated by the new **public_photo** consent checkbox.

### Club → Team → Squad
- Single **leading-chevron accordion** replaces the scattered `▸ squad` text arrows.
- Add forms (club / team / player) stack **1-col on mobile**, grid/inline on `sm+`.
- "Add player" inputs relabelled **"Find player…"** — they search the org directory.

### Infra
- Registered the new + pre-existing **team/squad/roster** routes in the OpenAPI `ROUTES` registry (coverage gate).
- vitest DB suite → **`isolate: true`**, fixing a cross-file connection-teardown flake (`CONNECTION_ENDED`) surfaced by the added DB suites.

## Tests
- web `tsc` + `eslint` clean
- full `vitest` **229 passing**
- e2e `directory-labels` + `team-squad` green (chevron `aria-expanded`, players rename, badge/photo controls)

## ⚠️ Caveat — bundled WIP
Per request, this also bundles pre-existing uncommitted working-tree changes that predate this branch: billing checkout/**downgrade**, `stripe-sync` + `config/stripe-plans`, teams infra (routes/usecase/migrations `V256`/`V257`), and tooling (`package.json`, `proxy.ts`, `auth.ts`, `next.config.js`). I did not author these; they're green under the full suite but review them on their own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)