### PR TITLE
feat(rate-limit): Upstash-only limiter, atomic Lua, real-Redis CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,26 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
+      # Stock Redis speaks the same protocol as Upstash (our client is ioredis
+      # over REDIS_URL, not the Upstash REST SDK), so this exercises the real
+      # rate-limiter path — Lua EVAL, TTL, 429 — end to end in CI.
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     env:
       # Superuser connection so the app can `set role app_user` (RLS). Local =>
       # no SSL. Port 5432 keeps prepared statements on (not the Supabase pooler).
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       DATABASE_SSL: disable
+      # Real Redis for the rate limiter (Upstash-compatible protocol).
+      REDIS_URL: redis://localhost:6379
       # Session signing secret (jose HS256) — CI-only dummy.
       AUTH_SECRET: ci-only-insecure-secret-please-change-in-prod-0123456789
       NEXT_PUBLIC_SUPABASE_URL: ""
@@ -134,6 +148,9 @@ jobs:
 
       - name: Engine-db + service-layer integration tests (real Postgres)
         run: npm test --workspace apps/web -- run src/server
+
+      - name: Rate-limiter integration tests (real Redis)
+        run: npm test --workspace apps/web -- run src/lib/__tests__/rate-limit.redis.test.ts
 
       - name: Start dev server
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,6 @@ jobs:
       # no SSL. Port 5432 keeps prepared statements on (not the Supabase pooler).
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
       DATABASE_SSL: disable
-      # Real Redis for the rate limiter (Upstash-compatible protocol).
-      REDIS_URL: redis://localhost:6379
       # Session signing secret (jose HS256) — CI-only dummy.
       AUTH_SECRET: ci-only-insecure-secret-please-change-in-prod-0123456789
       NEXT_PUBLIC_SUPABASE_URL: ""
@@ -149,8 +147,14 @@ jobs:
       - name: Engine-db + service-layer integration tests (real Postgres)
         run: npm test --workspace apps/web -- run src/server
 
+      # REDIS_URL is scoped to this step only. Setting it job-wide would switch
+      # the entitlement cache (lib/entitlements.ts) on for the src/server suite,
+      # whose tests mutate entitlements via raw SQL without invalidating the
+      # cache — stale reads, false failures. The limiter test is self-contained.
       - name: Rate-limiter integration tests (real Redis)
         run: npm test --workspace apps/web -- run src/lib/__tests__/rate-limit.redis.test.ts
+        env:
+          REDIS_URL: redis://localhost:6379
 
       - name: Start dev server
         run: |

--- a/apps/web/src/lib/__tests__/rate-limit.redis.test.ts
+++ b/apps/web/src/lib/__tests__/rate-limit.redis.test.ts
@@ -1,0 +1,60 @@
+// Integration coverage against a REAL Redis (Upstash-compatible protocol) —
+// proves the parts the mocked unit test can't: the atomic INCR+EXPIRE Lua runs
+// on a live server, the TTL actually expires the window, and rateLimit throws a
+// 429 once the cap is crossed. Skipped when REDIS_URL is unset (local dev); CI
+// provides a redis:7 service container.
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { incrWindow } from "@/lib/cache";
+import { rateLimit } from "@/lib/rate-limit";
+import { HttpError } from "@/lib/errors";
+
+const HAS_REDIS = !!process.env.REDIS_URL;
+
+// Unique per run so parallel/rerun executions never collide on a key.
+const uniq = () => `test:${randomUUID()}`;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe.skipIf(!HAS_REDIS)("rate limiter (real Redis)", () => {
+  // The client uses enableOfflineQueue:false, so a command fired before the
+  // socket is 'ready' rejects → incrWindow returns null. A long-lived server
+  // warms the singleton once; here we warm it explicitly before asserting.
+  beforeAll(async () => {
+    for (let i = 0; i < 50; i++) {
+      if ((await incrWindow(`warmup:${randomUUID()}`, 5)) !== null) return;
+      await sleep(100);
+    }
+    throw new Error("Redis did not become ready");
+  });
+
+  afterAll(async () => {
+    // Release the shared ioredis handle so vitest can exit cleanly.
+    const g = globalThis as unknown as { _redis?: { quit?: () => Promise<unknown> } };
+    await g._redis?.quit?.().catch(() => {});
+  });
+
+  it("incrWindow counts up within a window", async () => {
+    const key = uniq();
+    expect(await incrWindow(key, 60)).toBe(1);
+    expect(await incrWindow(key, 60)).toBe(2);
+    expect(await incrWindow(key, 60)).toBe(3);
+  });
+
+  it("sets a TTL on the first hit so the window self-resets", async () => {
+    const key = uniq();
+    expect(await incrWindow(key, 1)).toBe(1);
+    expect(await incrWindow(key, 1)).toBe(2);
+    // Wait past the 1s window — the key should expire and the counter restart.
+    await sleep(1200);
+    expect(await incrWindow(key, 1)).toBe(1);
+  });
+
+  it("rateLimit passes up to max then throws 429", async () => {
+    const key = uniq();
+    const cfg = { max: 3, windowSeconds: 60 };
+    await expect(rateLimit(key, cfg)).resolves.toBeUndefined(); // 1
+    await expect(rateLimit(key, cfg)).resolves.toBeUndefined(); // 2
+    await expect(rateLimit(key, cfg)).resolves.toBeUndefined(); // 3
+    await expect(rateLimit(key, cfg)).rejects.toBeInstanceOf(HttpError); // 4 → 429
+  });
+});

--- a/apps/web/src/lib/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/__tests__/rate-limit.test.ts
@@ -5,8 +5,11 @@
 // it directly.
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const cacheMock = vi.hoisted(() => ({ incrWindow: vi.fn() }));
-vi.mock("@/lib/cache", () => ({ incrWindow: cacheMock.incrWindow }));
+const cacheMock = vi.hoisted(() => ({ incrWindow: vi.fn(), cacheEnabled: vi.fn(() => true) }));
+vi.mock("@/lib/cache", () => ({
+  incrWindow: cacheMock.incrWindow,
+  cacheEnabled: cacheMock.cacheEnabled,
+}));
 
 import { HttpError } from "@/lib/errors";
 import {
@@ -19,7 +22,11 @@ import {
 
 const CFG = { max: 3, windowSeconds: 60 };
 
-afterEach(() => cacheMock.incrWindow.mockReset());
+afterEach(() => {
+  cacheMock.incrWindow.mockReset();
+  cacheMock.cacheEnabled.mockReset();
+  cacheMock.cacheEnabled.mockReturnValue(true); // Redis configured by default
+});
 
 describe("rateLimit (Upstash-only)", () => {
   it("passes when the count is within the cap", async () => {
@@ -40,7 +47,7 @@ describe("rateLimit (Upstash-only)", () => {
     expect(cacheMock.incrWindow).toHaveBeenCalledWith("rl:login:1.2.3.4", 60);
   });
 
-  describe("when Redis is unavailable (incrWindow → null)", () => {
+  describe("when Redis is configured but unreachable (incrWindow → null)", () => {
     it("fails open by default — allows the request", async () => {
       cacheMock.incrWindow.mockResolvedValue(null);
       await expect(rateLimit("pub:1.2.3.4", CFG)).resolves.toBeUndefined();
@@ -48,9 +55,20 @@ describe("rateLimit (Upstash-only)", () => {
 
     it("fails closed when configured — throws 429", async () => {
       cacheMock.incrWindow.mockResolvedValue(null);
+      cacheMock.cacheEnabled.mockReturnValue(true);
       await expect(
         rateLimit("login:1.2.3.4", { ...CFG, failClosed: true }),
       ).rejects.toBeInstanceOf(HttpError);
+    });
+  });
+
+  describe("when Redis is not configured at all (local dev / e2e)", () => {
+    it("is inert — allows even a failClosed limit so auth flows work", async () => {
+      cacheMock.incrWindow.mockResolvedValue(null);
+      cacheMock.cacheEnabled.mockReturnValue(false);
+      await expect(
+        rateLimit("login:1.2.3.4", { ...CFG, failClosed: true }),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/apps/web/src/lib/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/__tests__/rate-limit.test.ts
@@ -1,0 +1,68 @@
+// Unit coverage for the Upstash-only rate limiter (lib/rate-limit.ts): under
+// the cap passes, over the cap throws 429, and when Redis is unavailable
+// (incrWindow → null) the failClosed policy decides deny-vs-allow. No DB: the
+// Postgres fallback was removed, so incrWindow is the only backend and we mock
+// it directly.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const cacheMock = vi.hoisted(() => ({ incrWindow: vi.fn() }));
+vi.mock("@/lib/cache", () => ({ incrWindow: cacheMock.incrWindow }));
+
+import { HttpError } from "@/lib/errors";
+import {
+  rateLimit,
+  AUTH_LIMIT,
+  EMAIL_LIMIT,
+  WEBHOOK_LIMIT,
+  MUTATION_LIMIT,
+} from "@/lib/rate-limit";
+
+const CFG = { max: 3, windowSeconds: 60 };
+
+afterEach(() => cacheMock.incrWindow.mockReset());
+
+describe("rateLimit (Upstash-only)", () => {
+  it("passes when the count is within the cap", async () => {
+    cacheMock.incrWindow.mockResolvedValue(3);
+    await expect(rateLimit("login:1.2.3.4", CFG)).resolves.toBeUndefined();
+  });
+
+  it("throws 429 once the count exceeds the cap", async () => {
+    cacheMock.incrWindow.mockResolvedValue(4);
+    await expect(rateLimit("login:1.2.3.4", CFG)).rejects.toMatchObject(
+      new HttpError(429, "Too many requests — slow down and try again."),
+    );
+  });
+
+  it("prefixes the key with rl: and forwards the window", async () => {
+    cacheMock.incrWindow.mockResolvedValue(1);
+    await rateLimit("login:1.2.3.4", CFG);
+    expect(cacheMock.incrWindow).toHaveBeenCalledWith("rl:login:1.2.3.4", 60);
+  });
+
+  describe("when Redis is unavailable (incrWindow → null)", () => {
+    it("fails open by default — allows the request", async () => {
+      cacheMock.incrWindow.mockResolvedValue(null);
+      await expect(rateLimit("pub:1.2.3.4", CFG)).resolves.toBeUndefined();
+    });
+
+    it("fails closed when configured — throws 429", async () => {
+      cacheMock.incrWindow.mockResolvedValue(null);
+      await expect(
+        rateLimit("login:1.2.3.4", { ...CFG, failClosed: true }),
+      ).rejects.toBeInstanceOf(HttpError);
+    });
+  });
+
+  describe("preset policies", () => {
+    it("auth + email fail closed (abuse-sensitive)", () => {
+      expect(AUTH_LIMIT.failClosed).toBe(true);
+      expect(EMAIL_LIMIT.failClosed).toBe(true);
+    });
+
+    it("webhook + mutation fail open (availability first)", () => {
+      expect(WEBHOOK_LIMIT.failClosed).toBeUndefined();
+      expect(MUTATION_LIMIT.failClosed).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -79,18 +79,26 @@ export async function cacheDelPattern(pattern: string): Promise<void> {
   }
 }
 
+// INCR + set-TTL-on-first-hit as one atomic server-side step. Done as a single
+// Lua EVAL rather than INCR then EXPIRE so (a) a crash/error can't strand a key
+// with no TTL — which would lock that identifier out forever — and (b) it bills
+// as one Upstash command instead of two on pay-as-you-go.
+const INCR_WINDOW_LUA = `
+local n = redis.call('INCR', KEYS[1])
+if n == 1 then redis.call('EXPIRE', KEYS[1], ARGV[1]) end
+return n`;
+
 /**
  * Fixed-window counter. Returns the new count for `key` within the window, or
- * null if Redis is unavailable (caller should fall back). Sets the TTL on the
- * first increment of a window.
+ * null if Redis is unavailable (caller decides the fallback policy). The TTL is
+ * set atomically on the first increment of a window.
  */
 export async function incrWindow(key: string, windowSeconds: number): Promise<number | null> {
   const c = client();
   if (!c) return null;
   try {
-    const n = await c.incr(key);
-    if (n === 1) await c.expire(key, windowSeconds);
-    return n;
+    const n = await c.eval(INCR_WINDOW_LUA, 1, key, String(windowSeconds));
+    return Number(n);
   } catch {
     return null;
   }

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { HttpError } from "@/lib/errors";
-import { incrWindow } from "@/lib/cache";
+import { incrWindow, cacheEnabled } from "@/lib/cache";
 
 export interface RateLimitConfig {
   /** Max requests allowed within `windowSeconds`. */
@@ -8,10 +8,13 @@ export interface RateLimitConfig {
   /** Window size in seconds. */
   windowSeconds: number;
   /**
-   * Behaviour when Redis is unavailable (an Upstash blip). Redis is the sole
-   * backend — there is no Postgres fallback — so this decides the tradeoff:
-   * `true` → deny with 429 (abuse-protection first), `false`/omitted → allow
-   * (availability first). Default is fail-open.
+   * Behaviour when Redis is *configured but unreachable* (an Upstash blip).
+   * Redis is the sole backend — there is no Postgres fallback — so this decides
+   * the tradeoff: `true` → deny with 429 (abuse-protection first),
+   * `false`/omitted → allow (availability first). Default is fail-open.
+   *
+   * Only applies when a REDIS_URL is set. With no Redis configured at all (local
+   * dev, e2e) the limiter is inert and always allows, regardless of this flag.
    */
   failClosed?: boolean;
 }
@@ -37,8 +40,11 @@ export async function rateLimit(
   const count = await incrWindow(`rl:${key}`, windowSeconds);
 
   if (count === null) {
-    // Redis unavailable — no fallback backend. Apply the per-limit policy.
-    if (failClosed) throw new HttpError(429, TOO_MANY);
+    // No count from Redis. Two distinct cases:
+    //  - Redis not configured (local dev, e2e): limiter is inert → always allow,
+    //    even for failClosed limits, so auth flows work without a Redis.
+    //  - Redis configured but unreachable (a real outage): apply failClosed.
+    if (failClosed && cacheEnabled()) throw new HttpError(429, TOO_MANY);
     return;
   }
 

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -1,5 +1,4 @@
 import "server-only";
-import { sql } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { incrWindow } from "@/lib/cache";
 
@@ -8,65 +7,59 @@ export interface RateLimitConfig {
   max: number;
   /** Window size in seconds. */
   windowSeconds: number;
+  /**
+   * Behaviour when Redis is unavailable (an Upstash blip). Redis is the sole
+   * backend — there is no Postgres fallback — so this decides the tradeoff:
+   * `true` → deny with 429 (abuse-protection first), `false`/omitted → allow
+   * (availability first). Default is fail-open.
+   */
+  failClosed?: boolean;
 }
 
+const TOO_MANY = "Too many requests — slow down and try again.";
+
 /**
- * Sliding fixed-window rate limiter backed by Postgres.
- * Each `key` gets up to `max` requests per `windowSeconds`.
- * Excess requests get a 429 HttpError thrown.
+ * Fixed-window rate limiter backed solely by Upstash (managed Redis).
+ * Each `key` gets up to `max` requests per `windowSeconds`; excess requests get
+ * a 429 HttpError thrown.
  *
  * Key format convention: `"route:identifier"` — e.g. `"login:1.2.3.4"`.
  *
- * This is intentionally simple — no Redis required. Under high load the DB
- * write contention on a single key is the bottleneck; upgrade to Upstash when
- * p95 latency becomes a concern.
+ * There is deliberately no Postgres fallback: the old DB bucket serialised on a
+ * single hot row under load. Upstash owns the counter (one atomic INCR+EXPIRE,
+ * self-expiring keys). When Redis is momentarily unreachable `incrWindow`
+ * returns null and we apply the `failClosed` policy.
  */
 export async function rateLimit(
   key: string,
-  { max, windowSeconds }: RateLimitConfig,
+  { max, windowSeconds, failClosed = false }: RateLimitConfig,
 ): Promise<void> {
-  // Prefer Redis (single INCR + EXPIRE, no DB contention). incrWindow returns
-  // null when Redis is unavailable, so we fall back to the Postgres bucket.
-  const redisCount = await incrWindow(`rl:${key}`, windowSeconds);
-  if (redisCount !== null) {
-    if (redisCount > max) {
-      throw new HttpError(429, "Too many requests — slow down and try again.");
-    }
+  const count = await incrWindow(`rl:${key}`, windowSeconds);
+
+  if (count === null) {
+    // Redis unavailable — no fallback backend. Apply the per-limit policy.
+    if (failClosed) throw new HttpError(429, TOO_MANY);
     return;
   }
 
-  const now = new Date();
-  const windowStart = new Date(
-    Math.floor(now.getTime() / (windowSeconds * 1000)) * (windowSeconds * 1000),
-  );
-  const windowStartIso = windowStart.toISOString();
-
-  // Upsert + fetch count atomically
-  const [row] = await sql<{ count: number }[]>`
-    insert into rate_limit_buckets (key, window_start, count)
-    values (${key}, ${windowStartIso}, 1)
-    on conflict (key, window_start)
-    do update set count = rate_limit_buckets.count + 1
-    returning count`;
-
-  // Amortised cleanup: delete rows older than 2 windows (no separate cron needed)
-  const cutoff = new Date(now.getTime() - windowSeconds * 2 * 1000).toISOString();
-  void sql`delete from rate_limit_buckets where key = ${key} and window_start < ${cutoff}`.catch(
-    () => null,
-  );
-
-  if (row && row.count > max) {
-    throw new HttpError(429, "Too many requests — slow down and try again.");
+  if (count > max) {
+    throw new HttpError(429, TOO_MANY);
   }
 }
 
 // ─── Pre-configured limits ────────────────────────────────────────────────────
 
-/** Auth endpoints: login, signup, forgot-password. */
-export const AUTH_LIMIT: RateLimitConfig = { max: 10, windowSeconds: 60 };
+/**
+ * Auth endpoints: login, signup, forgot-password. Fail-closed — a limiter
+ * outage must not open a credential-stuffing window.
+ */
+export const AUTH_LIMIT: RateLimitConfig = { max: 10, windowSeconds: 60, failClosed: true };
 
-/** Email-sending endpoints: verify, change-email, invite. */
-export const EMAIL_LIMIT: RateLimitConfig = { max: 5, windowSeconds: 300 };
+/**
+ * Email-sending endpoints: verify, change-email, invite. Fail-closed — protects
+ * against mail-bombing while Redis is down.
+ */
+export const EMAIL_LIMIT: RateLimitConfig = { max: 5, windowSeconds: 300, failClosed: true };
 
 /** Webhook endpoints (Stripe, Resend) — generous since legitimate traffic is high volume. */
 export const WEBHOOK_LIMIT: RateLimitConfig = { max: 500, windowSeconds: 60 };


### PR DESCRIPTION
Drop the Postgres bucket fallback from the rate limiter — it serialised on a single hot row under load. Upstash (managed Redis) is now the sole backend.

- rate-limit.ts: remove DB path; add a failClosed policy for when Redis is briefly unreachable (deny vs allow). AUTH_LIMIT + EMAIL_LIMIT fail closed (no credential-stuffing / mail-bomb window during an outage); webhook + mutation fail open (availability first).
- cache.ts: incrWindow now runs INCR + first-hit EXPIRE as one atomic Lua EVAL. Fixes an orphan-key bug (a crash between INCR and EXPIRE stranded a key with no TTL, locking that identifier out forever) and bills as one Upstash command instead of two on pay-as-you-go.
- CI: add a redis:7 service container to the smoke job (ioredis speaks the Upstash protocol) so the limiter runs for real end to end.
- Tests: mocked unit coverage (limit + fail-open/closed policy) plus a real Redis integration test proving the Lua EVAL, TTL self-reset, and 429.