### PR TITLE
feat(analytics): region-aware PostHog ingest proxy + wire up stg

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { withSentryConfig } from "@sentry/nextjs";
+import { posthogIngestHosts } from "./src/lib/posthog-proxy.mjs";
 
 const securityHeaders = [
   { key: "X-Content-Type-Options", value: "nosniff" },
@@ -40,11 +41,12 @@ const nextConfig = {
   // trailing-slash API paths from being 308'd.
   skipTrailingSlashRedirect: true,
   async rewrites() {
-    const us = "https://us.i.posthog.com";
-    const usAssets = "https://us-assets.i.posthog.com";
+    // Region-derived from NEXT_PUBLIC_POSTHOG_HOST (see posthog-proxy). Must be
+    // set at build time — these rewrite destinations bake into the server.
+    const { ingest, assets } = posthogIngestHosts();
     return [
-      { source: "/ingest/static/:path*", destination: `${usAssets}/static/:path*` },
-      { source: "/ingest/:path*", destination: `${us}/:path*` },
+      { source: "/ingest/static/:path*", destination: `${assets}/static/:path*` },
+      { source: "/ingest/:path*", destination: `${ingest}/:path*` },
     ];
   },
   async headers() {

--- a/apps/web/src/lib/__tests__/posthog-proxy.test.ts
+++ b/apps/web/src/lib/__tests__/posthog-proxy.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { posthogIngestHosts } from "../posthog-proxy.mjs";
+
+// The /ingest reverse-proxy destinations (next.config rewrites) must follow the
+// PostHog region so EU projects don't silently ship events to US.
+describe("posthogIngestHosts", () => {
+  it("maps the EU dashboard host onto EU ingest + assets", () => {
+    expect(
+      posthogIngestHosts({ NEXT_PUBLIC_POSTHOG_HOST: "https://eu.posthog.com" }),
+    ).toEqual({
+      ingest: "https://eu.i.posthog.com",
+      assets: "https://eu-assets.i.posthog.com",
+    });
+  });
+
+  it("maps the US dashboard host onto US ingest + assets", () => {
+    expect(
+      posthogIngestHosts({ NEXT_PUBLIC_POSTHOG_HOST: "https://us.posthog.com" }),
+    ).toEqual({
+      ingest: "https://us.i.posthog.com",
+      assets: "https://us-assets.i.posthog.com",
+    });
+  });
+
+  it("defaults to US when the host is unset", () => {
+    expect(posthogIngestHosts({})).toEqual({
+      ingest: "https://us.i.posthog.com",
+      assets: "https://us-assets.i.posthog.com",
+    });
+  });
+
+  it("falls back to US for legacy/self-host hostnames", () => {
+    expect(
+      posthogIngestHosts({ NEXT_PUBLIC_POSTHOG_HOST: "https://app.posthog.com" }),
+    ).toEqual({
+      ingest: "https://us.i.posthog.com",
+      assets: "https://us-assets.i.posthog.com",
+    });
+  });
+
+  it("keeps US default on a malformed host", () => {
+    expect(
+      posthogIngestHosts({ NEXT_PUBLIC_POSTHOG_HOST: "not a url" }),
+    ).toEqual({
+      ingest: "https://us.i.posthog.com",
+      assets: "https://us-assets.i.posthog.com",
+    });
+  });
+});

--- a/apps/web/src/lib/posthog-proxy.mjs
+++ b/apps/web/src/lib/posthog-proxy.mjs
@@ -1,0 +1,28 @@
+// Resolve the PostHog reverse-proxy targets (see next.config rewrites) from the
+// environment instead of hardcoding a region. Single source of truth is the
+// public dashboard host NEXT_PUBLIC_POSTHOG_HOST: PostHog Cloud's dashboard,
+// event-ingest, and static-asset hosts share a region prefix
+//   dashboard  eu.posthog.com   /  us.posthog.com
+//   ingest     eu.i.posthog.com /  us.i.posthog.com
+//   assets     eu-assets.i.posthog.com / us-assets.i.posthog.com
+// so we map the dashboard host's region onto the ingest + assets hosts.
+
+/**
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {{ ingest: string, assets: string }}
+ */
+export function posthogIngestHosts(env = process.env) {
+  const ui = env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.posthog.com";
+  let region = "us";
+  try {
+    // Only PostHog Cloud EU gets the `eu` region; anything else (US cloud,
+    // legacy app.posthog.com, self-host) falls back to US ingest.
+    if (new URL(ui).hostname.split(".")[0] === "eu") region = "eu";
+  } catch {
+    // Malformed host → keep US default.
+  }
+  return {
+    ingest: `https://${region}.i.posthog.com`,
+    assets: `https://${region}-assets.i.posthog.com`,
+  };
+}

--- a/apps/web/src/lib/posthog-proxy.mjs
+++ b/apps/web/src/lib/posthog-proxy.mjs
@@ -8,7 +8,7 @@
 // so we map the dashboard host's region onto the ingest + assets hosts.
 
 /**
- * @param {NodeJS.ProcessEnv} [env]
+ * @param {Record<string, string | undefined>} [env]
  * @returns {{ ingest: string, assets: string }}
  */
 export function posthogIngestHosts(env = process.env) {

--- a/fly.stg.toml
+++ b/fly.stg.toml
@@ -14,6 +14,8 @@ primary_region = "lhr"
     NEXT_PUBLIC_SUPABASE_ANON_KEY      = "sb_publishable_jsKiT5L45u-yNlyCMIDGCg_GIIoj4H9"
     NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = "pk_test_51C2ImvAy22H0xqqxi73ya0Xen6LeJG5GlRSHm7OpTnlQ2Nw1RFHt1pzJ61HyWgeQCu1IueWV7yterQK8yIUCrzeK00YnXPGvrn"
     NEXT_PUBLIC_BASE_URL               = "https://seazn-club-stg.fly.dev"
+    NEXT_PUBLIC_POSTHOG_KEY            = "phc_rjdhs5RCqJEg5jTH3UG4Dt9DxsLemdiejW3Upkbe4ERM"
+    NEXT_PUBLIC_POSTHOG_HOST           = "https://eu.posthog.com"
     # NEXT_PUBLIC_SENTRY_DSN           = "https://..."
 
 [http_service]


### PR DESCRIPTION
The /ingest reverse-proxy destinations were hardcoded to US (us.i.posthog.com), so an EU PostHog project would silently ship events to the wrong region. Derive the ingest + assets hosts from NEXT_PUBLIC_POSTHOG_HOST via posthogIngestHosts(), defaulting to US.

Add the PostHog build args to fly.stg.toml (EU dashboard host).