### PR TITLE
Scoring UX wave: live set points, public per-set card, courtside pad redesign

### DIFF
--- a/apps/web/e2e/passwordless-login.spec.ts
+++ b/apps/web/e2e/passwordless-login.spec.ts
@@ -35,3 +35,23 @@ test("passwordless login: emailing a link creates the account and signs in", asy
   const cookies = await page.context().cookies();
   expect(cookies.some((c) => c.name === "seazn_session")).toBeTruthy();
 });
+
+// Invite pages (/join/{token}) send a `next` redirect with the email — both
+// the send AND consume endpoints must accept it (each once rejected it with a
+// strict schema) and the user must land on the invite page after sign-in.
+test("magic-link threads the invite-page `next` redirect through sign-in", async ({
+  request,
+  page,
+}) => {
+  const res = await request.post("/api/auth/magic-link", {
+    data: { email: `e2e-next-${Date.now().toString(36)}@example.com`, next: "/join/some-token" },
+  });
+  expect(res.ok()).toBeTruthy();
+  const body = await res.json();
+  expect(body.ok).toBe(true);
+  expect(body.data.login_url).toContain(`next=${encodeURIComponent("/join/some-token")}`);
+
+  // Opening the emailed link consumes the token and lands on the invite page.
+  await page.goto(body.data.login_url);
+  await page.waitForURL((u) => u.pathname === "/join/some-token", { timeout: 30_000 });
+});

--- a/apps/web/e2e/scoring.spec.ts
+++ b/apps/web/e2e/scoring.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { apiJson, seedScoredDivision, TAG } from "./helpers";
+import {
+  addEntrantsViaApi,
+  apiJson,
+  createStageAndGenerate,
+  seedScoredDivision,
+  TAG,
+} from "./helpers";
 
 // Scoring discoverability + sport-shaped pads (organiser feedback: the score
 // pad was hard to reach, and cricket should be over-by-over, not ball-by-ball).
@@ -11,6 +17,76 @@ test("every fixture row has a Score entry point", async ({ page, request }) => {
   await expect(page.getByRole("link", { name: /^(Score|View)/ }).first()).toBeVisible({
     timeout: 20_000,
   });
+});
+
+test("forfeit dropdown closes when clicking outside", async ({ page, request }) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Badminton ${TAG}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    { name: "MS", sport_key: "badminton", variant_key: "bwf", config: {}, eligibility: [] },
+  );
+  const divisionId = div.data!.id;
+  await addEntrantsViaApi(request, divisionId, ["Asha", "Bala"]);
+  const { fixtureIds } = await createStageAndGenerate(request, divisionId, {
+    kind: "knockout",
+    name: "Final",
+  });
+  await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+
+  await page.goto(`/fixtures/${fixtureIds[0]}`);
+  await page.getByRole("button", { name: /Forfeit/ }).click({ timeout: 20_000 });
+  await expect(page.getByRole("button", { name: /forfeits$/ }).first()).toBeVisible();
+
+  // clicking anywhere outside the menu must dismiss it
+  await page.getByRole("heading", { level: 1 }).click();
+  await expect(page.getByRole("button", { name: /forfeits$/ })).toHaveCount(0);
+});
+
+test("badminton pad shows the current game number, not always game 1", async ({
+  page,
+  request,
+}) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Badminton games ${TAG}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    { name: "WS", sport_key: "badminton", variant_key: "bwf", config: {}, eligibility: [] },
+  );
+  const divisionId = div.data!.id;
+  const { ids } = await addEntrantsViaApi(request, divisionId, ["Mina", "Rita"]);
+  const { fixtureIds } = await createStageAndGenerate(request, divisionId, {
+    kind: "knockout",
+    name: "Final",
+  });
+  const fixtureId = fixtureIds[0]!;
+  await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+
+  // start + take game 1 to 21-0 via the ledger API
+  await apiJson(request, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 0,
+    type: "core.start",
+    payload: {},
+  });
+  for (let seq = 1; seq <= 21; seq++) {
+    await apiJson(request, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+      expected_seq: seq,
+      type: "badminton.rally",
+      payload: { wonBy: ids[0] },
+    });
+  }
+
+  await page.goto(`/fixtures/${fixtureId}`);
+  await expect(page.getByText("Game 2", { exact: false })).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText(/games won 1/)).toBeVisible();
 });
 
 test("cricket scores over-by-over: add an over grows the total, then close innings", async ({

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx
@@ -98,6 +98,7 @@ export default async function FixturePage({ params }: Props) {
         initial={{ status: fixture.status, summary: fixture.summary, outcome: fixture.outcome }}
         realtime={realtime}
         entrantNames={entrantNames}
+        sportKey={division.sport_key}
       />
     </div>
   );

--- a/apps/web/src/app/api/auth/magic-link/consume/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/consume/route.ts
@@ -5,7 +5,14 @@ import { consumeLoginLink } from "@/lib/login-link";
 import { rateLimit, AUTH_LIMIT } from "@/lib/rate-limit";
 import { headers } from "next/headers";
 
-const schema = z.object({ token: z.string().min(10) }).strict();
+// `next` is the post-login redirect carried by the emailed link (invite
+// pages); postAuthLanding re-validates it via safeNextPath.
+const schema = z
+  .object({
+    token: z.string().min(10),
+    next: z.string().max(500).optional(),
+  })
+  .strict();
 
 /** Consume a passwordless sign-in token and start a session. */
 export async function POST(req: Request) {
@@ -13,9 +20,8 @@ export async function POST(req: Request) {
     const ip = (await headers()).get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
     await rateLimit(`magic-link-consume:${ip}`, AUTH_LIMIT);
 
-    const body = await req.json();
-    const { token } = schema.parse(body);
-    const next = (body as { next?: unknown })?.next;
+    const body = schema.parse(await req.json());
+    const { token, next } = body;
 
     const userId = await consumeLoginLink(token);
     if (!userId) {

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -8,7 +8,14 @@ import { z } from "zod";
 import { rateLimit, EMAIL_LIMIT } from "@/lib/rate-limit";
 import { headers } from "next/headers";
 
-const schema = z.object({ email: z.string().email().max(120) }).strict();
+// `next` is the post-login redirect (e.g. /join/{token} invite pages send it);
+// it is re-validated by safeNextPath before use.
+const schema = z
+  .object({
+    email: z.string().email().max(120),
+    next: z.string().max(500).optional(),
+  })
+  .strict();
 
 /** Turn an email into a friendly default display name (the part before @). */
 function displayNameFromEmail(email: string): string {
@@ -53,9 +60,9 @@ export async function POST(req: Request) {
     const ip = (await headers()).get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
     await rateLimit(`magic-link:${ip}`, EMAIL_LIMIT);
 
-    const body = await req.json();
-    const { email } = schema.parse(body);
-    const next = safeNextPath((body as { next?: unknown })?.next);
+    const body = schema.parse(await req.json());
+    const { email } = body;
+    const next = safeNextPath(body.next);
 
     const userId = await resolveOrCreateUser(email);
 

--- a/apps/web/src/app/fixtures/[id]/page.tsx
+++ b/apps/web/src/app/fixtures/[id]/page.tsx
@@ -4,7 +4,13 @@ export const dynamic = "force-dynamic";
 import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { requireResourcePageAuth } from "@/server/page-auth";
-import { getFixture, getFixtureState, getLineup, listEvents } from "@/server/usecases/fixtures";
+import {
+  eventRecorderNames,
+  getFixture,
+  getFixtureState,
+  getLineup,
+  listEvents,
+} from "@/server/usecases/fixtures";
 import { getDivision } from "@/server/usecases/divisions";
 import { getCompetition } from "@/server/usecases/competitions";
 import { getEntrant } from "@/server/usecases/entrants";
@@ -25,10 +31,11 @@ export default async function FixturePage({
   const { auth, canScore } = await requireResourcePageAuth("fixture", id);
   const isScorer = auth.role === "scorer";
   const fixture = await getFixture(auth, id);
-  const [division, state, events] = await Promise.all([
+  const [division, state, events, recorderNames] = await Promise.all([
     getDivision(auth, fixture.division_id),
     getFixtureState(auth, id),
     listEvents(auth, id, 0),
+    eventRecorderNames(auth, id),
   ]);
   const competition = await getCompetition(auth, division.competition_id);
   const sportModule = resolveModule(division.sport_key, division.module_version);
@@ -117,9 +124,12 @@ export default async function FixturePage({
             type: e.type,
             payload: e.payload,
             recorded_at: e.recorded_at,
+            recorded_by: e.recorded_by,
             voids_event_id: e.voids_event_id,
+            device_link_id: e.device_link_id,
           }))}
           canEdit={canScore && !(competition.frozen ?? false)}
+          recorderNames={recorderNames}
         />
 
         {/* Day-of device link (doc 13 §7): editors only — scorers never mint. */}

--- a/apps/web/src/app/score/[token]/page.tsx
+++ b/apps/web/src/app/score/[token]/page.tsx
@@ -98,8 +98,9 @@ export default async function ScorePadPage({
   ]);
 
   return (
-    <main className="mx-auto max-w-2xl px-4 py-6">
-      <DeviceScorePad
+    <main className="min-h-screen bg-slate-950 px-4 py-6">
+      <div className="mx-auto max-w-2xl">
+        <DeviceScorePad
         token={token}
         deviceLinkId={link.id}
         fixture={{
@@ -137,17 +138,18 @@ export default async function ScorePadPage({
           voids_event_id: e.voids_event_id,
           device_link_id: e.device_link_id,
         }))}
-      />
+        />
+      </div>
     </main>
   );
 }
 
 function DeadLink({ message }: { message: string }) {
   return (
-    <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center px-4 text-center">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-slate-950 px-4 text-center">
       <p className="text-4xl">⏱️</p>
-      <h1 className="mt-3 text-lg font-semibold text-slate-800">{message}</h1>
-      <p className="mt-2 text-sm text-slate-500">
+      <h1 className="mt-3 text-lg font-semibold text-slate-100">{message}</h1>
+      <p className="mt-2 text-sm text-slate-400">
         Ask the organiser to hand you a fresh link.
       </p>
     </main>

--- a/apps/web/src/components/public-site/live-score.tsx
+++ b/apps/web/src/components/public-site/live-score.tsx
@@ -7,12 +7,17 @@
 // of the org-member one.
 import { useCallback, useEffect, useState } from "react";
 import { api } from "@/lib/client";
+import { setBreakdown, stripLiveSetPoints } from "@/lib/public-site";
 
 const POLL_MS = 15_000;
 
 export interface LiveFixtureData {
   status: string;
-  summary: { headline?: string; perSide?: { entrantId: string; line: string }[] } | null;
+  summary: {
+    headline?: string;
+    perSide?: { entrantId: string; line: string }[];
+    detail?: unknown;
+  } | null;
   outcome: { kind?: string; winner?: string } | null;
 }
 
@@ -21,9 +26,10 @@ interface Props {
   initial: LiveFixtureData;
   realtime: boolean; // org entitlement, resolved server-side
   entrantNames: Record<string, string>;
+  sportKey: string;
 }
 
-export function LiveScore({ fixtureId, initial, realtime, entrantNames }: Props) {
+export function LiveScore({ fixtureId, initial, realtime, entrantNames, sportKey }: Props) {
   const [data, setData] = useState<LiveFixtureData>(initial);
 
   const refresh = useCallback(async () => {
@@ -90,48 +96,142 @@ export function LiveScore({ fixtureId, initial, realtime, entrantNames }: Props)
   }, [live, subscribed, refresh]);
 
   const inPlay = data.status === "in_play";
+  const breakdown = setBreakdown(data.summary, sportKey);
+  // Kernel perSide order is [home, away]; row labels come from it.
+  const sideIds = data.summary?.perSide?.map((s) => s.entrantId) ?? [];
+  const showBreakdown = breakdown !== null && sideIds.length === 2;
   return (
-    <div
-      className={`rounded-2xl border p-5 shadow-sm ${
-        inPlay
-          ? "border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-white"
-          : "border-purple-100 bg-white"
-      }`}
-    >
-      {inPlay ? (
-        <p className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-700">
-          <span className="animate-live-pulse h-2 w-2 rounded-full bg-emerald-500" />
-          Live{subscribed ? " · realtime" : ""}
+    <div className="space-y-4">
+      <div
+        className={`rounded-2xl border p-5 shadow-sm ${
+          inPlay
+            ? "border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-white"
+            : "border-purple-100 bg-white"
+        }`}
+      >
+        {inPlay ? (
+          <p className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+            <span className="animate-live-pulse h-2 w-2 rounded-full bg-emerald-500" />
+            Live{subscribed ? " · realtime" : ""}
+          </p>
+        ) : (
+          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
+            {data.status.replace("_", " ")}
+          </p>
+        )}
+        <p className="text-4xl font-black tabular-nums tracking-tight text-zinc-900">
+          {data.summary?.headline
+            ? showBreakdown
+              ? stripLiveSetPoints(data.summary.headline)
+              : data.summary.headline
+            : "Not started"}
         </p>
-      ) : (
-        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
-          {data.status.replace("_", " ")}
-        </p>
-      )}
-      <p className="text-4xl font-black tabular-nums tracking-tight text-zinc-900">
-        {data.summary?.headline ?? "Not started"}
+        {!showBreakdown && data.summary?.perSide ? (
+          <ul className="mt-3 space-y-1.5 text-sm text-zinc-700">
+            {data.summary.perSide.map((side) => (
+              <li key={side.entrantId} className="flex items-center gap-2 tabular-nums">
+                <span className="font-medium">{entrantNames[side.entrantId] ?? "—"}</span>
+                <span className="rounded-full bg-purple-50 px-2 py-0.5 text-xs font-semibold text-purple-700">
+                  {side.line}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {data.outcome?.winner ? (
+          <p className="mt-3 flex items-center gap-1.5 text-sm text-zinc-600">
+            <span className="animate-trophy">🏆</span>
+            Winner:{" "}
+            <strong className="text-zinc-900">
+              {entrantNames[data.outcome.winner] ?? data.outcome.winner}
+            </strong>
+          </p>
+        ) : null}
+      </div>
+
+      {showBreakdown ? (
+        <SetScoreboard
+          breakdown={breakdown}
+          names={sideIds.map((id) => entrantNames[id] ?? "—")}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/** Per-set scoreboard card: one column per played set, live set tinted. */
+function SetScoreboard({
+  breakdown,
+  names,
+}: {
+  breakdown: NonNullable<ReturnType<typeof setBreakdown>>;
+  names: string[];
+}) {
+  const sides = ["home", "away"] as const;
+  return (
+    <div className="rounded-2xl border border-purple-100 bg-white p-5 shadow-sm">
+      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-500">
+        Score by {breakdown.unit.toLowerCase()}
       </p>
-      {data.summary?.perSide ? (
-        <ul className="mt-3 space-y-1.5 text-sm text-zinc-700">
-          {data.summary.perSide.map((side) => (
-            <li key={side.entrantId} className="flex items-center gap-2 tabular-nums">
-              <span className="font-medium">{entrantNames[side.entrantId] ?? "—"}</span>
-              <span className="rounded-full bg-purple-50 px-2 py-0.5 text-xs font-semibold text-purple-700">
-                {side.line}
-              </span>
-            </li>
-          ))}
-        </ul>
-      ) : null}
-      {data.outcome?.winner ? (
-        <p className="mt-3 flex items-center gap-1.5 text-sm text-zinc-600">
-          <span className="animate-trophy">🏆</span>
-          Winner:{" "}
-          <strong className="text-zinc-900">
-            {entrantNames[data.outcome.winner] ?? data.outcome.winner}
-          </strong>
-        </p>
-      ) : null}
+      <div className="overflow-x-auto">
+        <table className="w-full border-separate border-spacing-0 tabular-nums">
+          <thead>
+            <tr>
+              <th className="w-full" />
+              {breakdown.sets.map((s, i) => (
+                <th
+                  key={i}
+                  className={`min-w-14 rounded-t-lg px-3 pb-2 text-center text-xs font-medium uppercase tracking-wide ${
+                    s.closed ? "text-zinc-400" : "bg-emerald-50 text-emerald-700"
+                  }`}
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    {!s.closed && (
+                      <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                    )}
+                    {breakdown.unit} {i + 1}
+                  </span>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sides.map((side, row) => (
+              <tr key={side}>
+                <td
+                  className={`max-w-40 truncate pr-4 text-sm font-medium text-zinc-800 ${
+                    row === 0 ? "border-b border-zinc-100" : ""
+                  } py-2`}
+                >
+                  {names[row]}
+                </td>
+                {breakdown.sets.map((s, i) => {
+                  const mine = s[side];
+                  const theirs = s[side === "home" ? "away" : "home"];
+                  const wonSet = s.closed && mine > theirs;
+                  const liveCell = !s.closed;
+                  return (
+                    <td
+                      key={i}
+                      className={`px-3 py-2 text-center text-xl ${
+                        row === 0 ? "border-b border-zinc-100" : ""
+                      } ${row === 1 && liveCell ? "rounded-b-lg" : ""} ${
+                        liveCell
+                          ? "bg-emerald-50 font-bold text-emerald-700"
+                          : wonSet
+                            ? "font-bold text-zinc-900"
+                            : "font-medium text-zinc-400"
+                      }`}
+                    >
+                      {mine}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/v2/device-score-pad.tsx
+++ b/apps/web/src/components/v2/device-score-pad.tsx
@@ -139,8 +139,8 @@ export function DeviceScorePad({
     return (
       <div className="flex min-h-[60vh] flex-col items-center justify-center text-center">
         <p className="text-4xl">⏱️</p>
-        <h1 className="mt-3 text-lg font-semibold text-slate-800">{dead}</h1>
-        <p className="mt-2 text-sm text-slate-500">Ask the organiser for a fresh link.</p>
+        <h1 className="mt-3 text-lg font-semibold text-slate-100">{dead}</h1>
+        <p className="mt-2 text-sm text-slate-400">Ask the organiser for a fresh link.</p>
       </div>
     );
   }
@@ -149,6 +149,7 @@ export function DeviceScorePad({
   const decided = live.outcome !== null;
   const started = live.status !== "scheduled";
   const scoring = live.status !== "finalized" && live.status !== "cancelled";
+  const inPlay = live.status === "in_play";
 
   // Undo-own (doc 13 §7): only un-voided events THIS link recorded.
   const lastOwnVoidable = [...events]
@@ -162,26 +163,54 @@ export function DeviceScorePad({
 
   return (
     <div className="space-y-4">
-      <header className="card p-4">
-        <p className="text-xs text-slate-400">
-          {fixture.competition_name} · {fixture.division_name} · Round {fixture.round_no}
-          {fixture.court_label ? ` · ${fixture.court_label}` : ""}
-        </p>
-        <h1 className="mt-1 text-lg font-semibold text-slate-900">
-          {home?.name ?? "TBD"} <span className="text-slate-400">vs</span> {away?.name ?? "TBD"}
-        </h1>
-        <p className="mt-1 font-mono text-2xl text-slate-800">{summary?.headline ?? "—"}</p>
-        <p className="mt-1 text-[11px] text-slate-400">
+      {/* LED-scoreboard header: the one glowing thing on the dark court. */}
+      <header className="overflow-hidden rounded-2xl border border-slate-800 bg-slate-900 shadow-[0_0_40px_-12px_rgba(16,185,129,0.25)]">
+        <div className="flex items-center justify-between gap-2 border-b border-slate-800 px-4 py-2">
+          <p className="truncate text-[11px] uppercase tracking-widest text-slate-500">
+            {fixture.division_name} · Round {fixture.round_no}
+            {fixture.court_label ? ` · ${fixture.court_label}` : ""}
+          </p>
+          {inPlay ? (
+            <span className="flex shrink-0 items-center gap-1.5 text-[11px] font-semibold uppercase tracking-widest text-emerald-400">
+              <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-400" />
+              Live
+            </span>
+          ) : (
+            <span className="shrink-0 text-[11px] uppercase tracking-widest text-slate-500">
+              {live.status.replace("_", " ")}
+            </span>
+          )}
+        </div>
+        <div className="px-4 py-5 text-center">
+          <p className="flex items-baseline justify-center gap-3 text-sm font-medium text-slate-200">
+            <span className="max-w-[40%] truncate">{home?.name ?? "TBD"}</span>
+            <span className="text-[10px] uppercase tracking-widest text-slate-600">vs</span>
+            <span className="max-w-[40%] truncate">{away?.name ?? "TBD"}</span>
+          </p>
+          <p className="mt-2 font-mono text-5xl font-bold tabular-nums tracking-tight text-emerald-300 [text-shadow:0_0_24px_rgba(52,211,153,0.35)]">
+            {summary?.headline ?? "0 — 0"}
+          </p>
+        </div>
+        <p className="border-t border-slate-800 px-4 py-2 text-center text-[10px] uppercase tracking-widest text-slate-600">
           Courtside {sport.scorerLabel.toLowerCase()} pad · link active today only
         </p>
       </header>
 
-      {error && <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+      {error && (
+        <p className="rounded-md border border-red-900/50 bg-red-950/60 px-3 py-2 text-sm text-red-300">
+          {error}
+        </p>
+      )}
 
-      {scoring && home && away && (
+      {scoring && home && away && (!started || lastOwnVoidable) && (
         <div className="flex flex-wrap gap-2">
           {!started && (
-            <button type="button" disabled={busy} onClick={() => send("core.start", {})} className="btn btn-primary">
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => send("core.start", {})}
+              className="btn btn-primary h-12 flex-1 text-base"
+            >
               Start match
             </button>
           )}
@@ -190,10 +219,11 @@ export function DeviceScorePad({
               type="button"
               disabled={busy}
               onClick={() => send("core.void", { event_id: lastOwnVoidable.id })}
-              className="btn btn-ghost"
+              className="flex h-12 items-center justify-center gap-2 rounded-full border border-amber-500/30 bg-amber-500/10 px-6 text-sm font-semibold text-amber-300 transition hover:border-amber-400/60 hover:bg-amber-500/20 active:scale-[0.98] disabled:opacity-50"
               title={`Undo ${lastOwnVoidable.type} (seq ${lastOwnVoidable.seq})`}
             >
-              ⟲ Undo my last
+              <span aria-hidden className="text-base leading-none">⟲</span>
+              Undo my last entry
             </button>
           )}
         </div>
@@ -216,7 +246,7 @@ export function DeviceScorePad({
       )}
 
       {decided && scoring && (
-        <p className="rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+        <p className="rounded-md border border-emerald-900/50 bg-emerald-950/60 px-3 py-2 text-sm text-emerald-300">
           Result recorded — the organiser finalizes it. Spot a mistake in your own entries?
           Use “Undo my last”.
         </p>

--- a/apps/web/src/components/v2/fixture-console.tsx
+++ b/apps/web/src/components/v2/fixture-console.tsx
@@ -4,7 +4,7 @@
 // POST /api/v1/fixtures/{id}/events with optimistic concurrency: every event
 // carries expected_seq + an idempotency key (doc 08 §4); a 409 resyncs from
 // the ledger and replays the UI.
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { describeEvent, EVENT_TONE_STYLE } from "@/lib/event-copy";
@@ -70,7 +70,9 @@ export interface EventIn {
   type: string;
   payload: unknown;
   recorded_at: string;
+  recorded_by?: string | null;
   voids_event_id: string | null;
+  device_link_id?: string | null;
 }
 
 interface Props {
@@ -88,6 +90,8 @@ interface Props {
   initialState: LiveState;
   initialEvents: EventIn[];
   canEdit: boolean;
+  /** recorded_by → display name for Activity attribution. */
+  recorderNames?: Record<string, string>;
 }
 
 export type SendEvent = (type: string, payload: unknown) => Promise<boolean>;
@@ -112,6 +116,7 @@ export function FixtureConsole({
   initialState,
   initialEvents,
   canEdit,
+  recorderNames = {},
 }: Props) {
   const router = useRouter();
   const [live, setLive] = useState<LiveState>(initialState);
@@ -316,6 +321,13 @@ export function FixtureConsole({
             {[...events].reverse().map((e) => {
               const voided = events.some((v) => v.voids_event_id === e.id);
               const desc = describeEvent(e.type, e.payload, entrantNames);
+              // Attribution: device-link events come from the handed device;
+              // signed-in recorders show by name.
+              const recorder = e.device_link_id
+                ? `Courtside ${sport.scorerLabel.toLowerCase()} pad`
+                : e.recorded_by
+                  ? (recorderNames[e.recorded_by] ?? sport.scorerLabel)
+                  : null;
               return (
                 <li
                   key={e.id}
@@ -328,7 +340,10 @@ export function FixtureConsole({
                   >
                     {desc.label}
                   </span>
-                  <span className="min-w-0 flex-1 truncate text-slate-700">{desc.text}</span>
+                  <span className="min-w-0 flex-1 truncate text-slate-700">
+                    {desc.text}
+                    {recorder ? <span className="text-slate-400"> ({recorder})</span> : null}
+                  </span>
                   <span className="shrink-0 text-slate-400">
                     {new Date(e.recorded_at).toLocaleTimeString()}
                   </span>
@@ -368,8 +383,17 @@ function ForfeitButton({
   send: SendEvent;
 }) {
   const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
   return (
-    <div className="relative">
+    <div ref={ref} className="relative">
       <button
         type="button"
         disabled={busy}

--- a/apps/web/src/components/v2/pads/setbased-pad.tsx
+++ b/apps/web/src/components/v2/pads/setbased-pad.tsx
@@ -15,6 +15,7 @@ interface SetBasedStateView {
   phase?: string;
   sets?: SetView[];
   setsWon?: { home: number; away: number };
+  cfg?: { bestOf?: number };
 }
 
 export function SetbasedPad({
@@ -43,6 +44,13 @@ export function SetbasedPad({
   const openSet = state.sets?.find((s) => !s.closed);
   const pre = state.phase === "pre" || live.status === "scheduled";
 
+  // Badminton/table-tennis call their sets "games" (engine unitLabel).
+  const unit = sport.key === "volleyball" ? "Set" : "Game";
+  // Current set number: the open set, or the next one about to start.
+  const closedCount = state.sets?.filter((s) => s.closed).length ?? 0;
+  const currentNo = closedCount + 1;
+  const bestOf = state.cfg?.bestOf;
+
   return (
     <div className="space-y-4">
       <div className="flex gap-1 text-xs">
@@ -61,7 +69,7 @@ export function SetbasedPad({
             onClick={() => setMode("summary")}
             className={`rounded-full px-3 py-1 ${mode === "summary" ? "bg-purple-100 text-purple-700" : "text-slate-500 hover:bg-slate-100"}`}
           >
-            Set totals
+            {unit} totals
           </button>
         )}
       </div>
@@ -73,28 +81,38 @@ export function SetbasedPad({
       )}
 
       {mode === "rally" && rallyType ? (
-        <div className="grid grid-cols-2 gap-3">
-          {[
-            { side: home, score: openSet?.home ?? 0, sets: state.setsWon?.home ?? 0 },
-            { side: away, score: openSet?.away ?? 0, sets: state.setsWon?.away ?? 0 },
-          ].map(({ side, score, sets }) => (
-            <button
-              key={side.id}
-              type="button"
-              disabled={busy || pre}
-              onClick={() => send(rallyType, { wonBy: side.id })}
-              className="rounded-xl border border-purple-200 bg-white p-6 text-center transition hover:border-purple-400 hover:bg-purple-50 disabled:opacity-50"
-            >
-              <span className="block truncate text-sm font-medium text-slate-700">
-                {side.name}
-              </span>
-              <span className="mt-1 block font-mono text-4xl text-slate-900">{score}</span>
-              <span className="mt-1 block text-xs text-slate-400">sets {sets}</span>
-              <span className="mt-2 block text-xs font-medium text-purple-600">
-                + point
-              </span>
-            </button>
-          ))}
+        <div className="space-y-2">
+          {!pre && (
+            <p className="text-xs font-semibold uppercase tracking-wide text-purple-600">
+              {unit} {currentNo}
+              {bestOf ? <span className="text-slate-400"> of {bestOf}</span> : null}
+            </p>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { side: home, score: openSet?.home ?? 0, sets: state.setsWon?.home ?? 0 },
+              { side: away, score: openSet?.away ?? 0, sets: state.setsWon?.away ?? 0 },
+            ].map(({ side, score, sets }) => (
+              <button
+                key={side.id}
+                type="button"
+                disabled={busy || pre}
+                onClick={() => send(rallyType, { wonBy: side.id })}
+                className="rounded-xl border border-purple-200 bg-white p-6 text-center transition hover:border-purple-400 hover:bg-purple-50 disabled:opacity-50"
+              >
+                <span className="block truncate text-sm font-medium text-slate-700">
+                  {side.name}
+                </span>
+                <span className="mt-1 block font-mono text-4xl text-slate-900">{score}</span>
+                <span className="mt-1 block text-xs text-slate-400">
+                  {unit.toLowerCase()}s won {sets}
+                </span>
+                <span className="mt-2 block text-xs font-medium text-purple-600">
+                  + point
+                </span>
+              </button>
+            ))}
+          </div>
         </div>
       ) : (
         summaryType && (
@@ -134,10 +152,10 @@ export function SetbasedPad({
               disabled={busy || pre || sumHome === "" || sumAway === ""}
               className="btn btn-primary"
             >
-              Record set
+              Record {unit.toLowerCase()}
             </button>
             <span className="text-xs text-slate-400">
-              Enter each completed set&apos;s final points.
+              Enter each completed {unit.toLowerCase()}&apos;s final points.
             </span>
           </form>
         )
@@ -145,7 +163,7 @@ export function SetbasedPad({
 
       {(state.sets?.length ?? 0) > 0 && (
         <p className="font-mono text-xs text-slate-500">
-          Sets:{" "}
+          {unit}s:{" "}
           {state.sets!.map((s, i) => (
             <span key={i} className="mr-2">
               {s.home}–{s.away}

--- a/apps/web/src/lib/__tests__/public-site.test.ts
+++ b/apps/web/src/lib/__tests__/public-site.test.ts
@@ -6,6 +6,8 @@ import {
   sportsEventJsonLd,
   standingsColumns,
   formatMetric,
+  setBreakdown,
+  stripLiveSetPoints,
   type StandingsRowLike,
 } from "@/lib/public-site";
 
@@ -114,5 +116,48 @@ describe("formatMetric", () => {
     expect(formatMetric(undefined)).toBe("—");
     expect(formatMetric(3)).toBe("3");
     expect(formatMetric(1.5, 2)).toBe("1.50");
+  });
+});
+
+describe("setBreakdown (public per-set scoreboard)", () => {
+  const summary = {
+    headline: "1 — 0 (5–3)",
+    perSide: [
+      { entrantId: "H", line: "1" },
+      { entrantId: "A", line: "0" },
+    ],
+    detail: {
+      sets: [
+        { home: 21, away: 15, closed: true },
+        { home: 5, away: 3, closed: false },
+      ],
+      points: { home: 26, away: 18 },
+    },
+  };
+
+  it("extracts every set including the live one, unit-labelled per sport", () => {
+    expect(setBreakdown(summary, "badminton")).toEqual({
+      unit: "Game",
+      sets: [
+        { home: 21, away: 15, closed: true },
+        { home: 5, away: 3, closed: false },
+      ],
+    });
+    expect(setBreakdown(summary, "tabletennis")?.unit).toBe("Game");
+    expect(setBreakdown(summary, "volleyball")?.unit).toBe("Set");
+  });
+
+  it("returns null for non-set-based or malformed summaries", () => {
+    expect(setBreakdown(null, "badminton")).toBeNull();
+    expect(setBreakdown({ headline: "2 — 1" }, "football")).toBeNull();
+    expect(setBreakdown({ detail: { sets: [] } }, "badminton")).toBeNull();
+    // cricket-style detail with a different shape must not leak through
+    expect(setBreakdown({ detail: { innings: [{ runs: 120 }] } }, "cricket")).toBeNull();
+    expect(setBreakdown({ detail: { sets: [{ home: "21", away: 15 }] } }, "badminton")).toBeNull();
+  });
+
+  it("strips the live-points suffix from the headline (shown in the card instead)", () => {
+    expect(stripLiveSetPoints("1 — 0 (14–11)")).toBe("1 — 0");
+    expect(stripLiveSetPoints("2 — 1")).toBe("2 — 1");
   });
 });

--- a/apps/web/src/lib/public-site.ts
+++ b/apps/web/src/lib/public-site.ts
@@ -183,3 +183,46 @@ export function formatMetric(value: number | undefined, decimals?: number): stri
   if (decimals !== undefined) return value.toFixed(decimals);
   return `${value}`;
 }
+
+// ---------------------------------------------------------------------------
+// Set-based per-set breakdown for the public match page. The set-based kernel
+// (engine sports/setbased) puts every set's points in ScoreSummary.detail.sets;
+// this extracts them render-ready or returns null for non-set-based sports
+// (whose detail carries a different shape, or none).
+// ---------------------------------------------------------------------------
+export interface SetScore {
+  home: number;
+  away: number;
+  closed: boolean;
+}
+
+export interface SetBreakdown {
+  /** Column label: badminton & table tennis score "Games", volleyball "Sets". */
+  unit: string;
+  sets: SetScore[];
+}
+
+const GAME_UNIT_SPORTS = new Set(["badminton", "tabletennis"]);
+
+/** The kernel headline carries the open set's points — "1 — 0 (14–11)". The
+ *  public match page renders those in the per-set scoreboard card instead, so
+ *  it strips the suffix to keep the big scoreline sets-only. */
+export function stripLiveSetPoints(headline: string): string {
+  return headline.replace(/\s*\([^)]*\)\s*$/, "");
+}
+
+export function setBreakdown(summary: unknown, sportKey: string): SetBreakdown | null {
+  if (typeof summary !== "object" || summary === null) return null;
+  const detail = (summary as { detail?: unknown }).detail;
+  if (typeof detail !== "object" || detail === null) return null;
+  const raw = (detail as { sets?: unknown }).sets;
+  if (!Array.isArray(raw) || raw.length === 0) return null;
+  const sets: SetScore[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null) return null;
+    const { home, away, closed } = entry as Record<string, unknown>;
+    if (typeof home !== "number" || typeof away !== "number") return null;
+    sets.push({ home, away, closed: closed === true });
+  }
+  return { unit: GAME_UNIT_SPORTS.has(sportKey) ? "Game" : "Set", sets };
+}

--- a/apps/web/src/server/public-site/data.ts
+++ b/apps/web/src/server/public-site/data.ts
@@ -69,7 +69,11 @@ export interface PublicFixture {
   court_label: string | null;
   status: string;
   outcome: { kind?: string; winner?: string } | null;
-  summary: { headline?: string; perSide?: { entrantId: string; line: string }[] } | null;
+  summary: {
+    headline?: string;
+    perSide?: { entrantId: string; line: string }[];
+    detail?: unknown;
+  } | null;
   last_seq: number | null;
 }
 

--- a/apps/web/src/server/usecases/__tests__/device-links.test.ts
+++ b/apps/web/src/server/usecases/__tests__/device-links.test.ts
@@ -22,6 +22,7 @@ import {
   resolveDeviceLinkToken,
   endOfLocalDay,
 } from "../device-links";
+import { eventRecorderNames } from "../fixtures";
 
 const HAS_DB = !!process.env.DATABASE_URL;
 
@@ -158,6 +159,12 @@ describe.skipIf(!HAS_DB)("device links (doc 13 §7, PROMPT-21)", () => {
       where fixture_id = ${fixture.id} order by seq`;
     expect(events.every((e) => e.recorded_by === ownerId)).toBe(true);
     expect(events.every((e) => e.device_link_id === link.id)).toBe(true);
+
+    // Activity attribution read model: recorded_by resolves to a display name.
+    const [{ display_name: ownerName }] = await sql<{ display_name: string }[]>`
+      select display_name from users where id = ${ownerId}`;
+    const names = await eventRecorderNames(owner, fixture.id);
+    expect(names[ownerId]).toBe(ownerName);
 
     // Undo own mistake pre-finalize.
     const [{ id: resultEventId }] = await sql<{ id: string }[]>`

--- a/apps/web/src/server/usecases/fixtures.ts
+++ b/apps/web/src/server/usecases/fixtures.ts
@@ -2,7 +2,7 @@ import "server-only";
 // Fixture use-cases (doc 08 §3): schedule/venue/officials PATCH, lineups PUT,
 // ledger reads (events since_seq), live state (summary + last_seq for ETag).
 import type postgres from "postgres";
-import { withTenant } from "@/lib/db";
+import { sql, withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { PatchFixture, PutLineup } from "@/server/api-v1/schemas";
@@ -170,6 +170,27 @@ export async function listEvents(auth: AuthCtx, fixtureId: string, sinceSeq: num
       where fixture_id = ${fixtureId} and seq > ${sinceSeq}
       order by seq`;
   });
+}
+
+/** Activity attribution: recorded_by → display name for a fixture's ledger.
+ *  The ids come from the tenant-scoped ledger read; `users` has no org RLS,
+ *  so the name lookup runs on the root client (same pattern as the org
+ *  members list). */
+export async function eventRecorderNames(
+  auth: AuthCtx,
+  fixtureId: string,
+): Promise<Record<string, string>> {
+  const ids = await withTenant(
+    auth.orgId,
+    (tx) => tx<{ recorded_by: string }[]>`
+      select distinct recorded_by from score_events
+      where fixture_id = ${fixtureId} and recorded_by is not null`,
+  );
+  if (ids.length === 0) return {};
+  const users = await sql<{ id: string; display_name: string | null; email: string }[]>`
+    select id, display_name, email from users
+    where id in ${sql(ids.map((r) => r.recorded_by))}`;
+  return Object.fromEntries(users.map((u) => [u.id, u.display_name ?? u.email]));
 }
 
 export interface FixtureStateOut {

--- a/packages/engine/src/competition/qualification.test.ts
+++ b/packages/engine/src/competition/qualification.test.ts
@@ -64,8 +64,10 @@ describe("resolveQualification — topN (spec 05 §3)", () => {
     expect(resolveQualification({ topN: 2 }, { pools: [], overall })).toEqual(["L1", "L2"]);
   });
 
-  it("throws when topN exceeds the field", () => {
-    expect(() => resolveQualification({ topN: 9 }, { pools: [], overall })).toThrow(/exceeds/);
+  it("throws a human-readable message when topN exceeds the field", () => {
+    expect(() => resolveQualification({ topN: 9 }, { pools: [], overall })).toThrow(
+      /takes the top 9, but the previous stage has only 4 entrants/,
+    );
   });
 });
 

--- a/packages/engine/src/competition/qualification.ts
+++ b/packages/engine/src/competition/qualification.ts
@@ -142,9 +142,12 @@ export function resolveQualification(spec: QualificationSpec, tables: StageTable
       });
     }
     if (source.length < spec.topN) {
-      throw new EngineError("STAGE_NOT_READY", `topN=${spec.topN} exceeds ${source.length} entrants`, {
-        topN: spec.topN,
-      });
+      // Surfaces verbatim in the organiser UI — keep it human-readable.
+      throw new EngineError(
+        "STAGE_NOT_READY",
+        `This stage takes the top ${spec.topN}, but the previous stage has only ${source.length} entrant${source.length === 1 ? "" : "s"} — lower the qualifier count or add entrants`,
+        { topN: spec.topN, available: source.length },
+      );
     }
     return [...source]
       .sort((a, b) => (a.rank ?? Infinity) - (b.rank ?? Infinity))

--- a/packages/engine/src/sports/setbased/kernel.ts
+++ b/packages/engine/src/sports/setbased/kernel.ts
@@ -492,8 +492,12 @@ export function makeSetBasedModule(
     // coarse and fine folds render identically (§9.6).
     summary(state): ScoreSummary {
       const points = { home: totalPoints(state, "home"), away: totalPoints(state, "away") };
+      // While a set is mid-flight, surface its live points next to the set
+      // tally ("1 — 0 (14–11)") so rally scoring is visible at the headline.
+      const open = openSet(state);
+      const inSet = open === null ? "" : ` (${open.set.home}–${open.set.away})`;
       return {
-        headline: `${state.setsWon.home} — ${state.setsWon.away}`,
+        headline: `${state.setsWon.home} — ${state.setsWon.away}${inSet}`,
         perSide: [
           { entrantId: state.entrants.home, line: `${state.setsWon.home}` },
           { entrantId: state.entrants.away, line: `${state.setsWon.away}` },

--- a/packages/engine/src/sports/setbased/setbased.test.ts
+++ b/packages/engine/src/sports/setbased/setbased.test.ts
@@ -159,6 +159,24 @@ describe("badminton golden: 30-29 golden point", () => {
     bad(22, 19); // already won at 21-19
     bad(29, 29); // not terminal
   });
+
+  it("headline shows the open game's live points, then drops them once the game closes", () => {
+    // 3 rallies into game 1: sets 0-0, live points 2-1.
+    const winners: Side[] = ["home", "away", "home"];
+    const mid = fold(badminton, cfg, rallyMatch(badminton, winners));
+    expect(badminton.summary(mid).headline).toBe("0 — 0 (2–1)");
+
+    // Game 1 closes 21-1: no open set → no parenthetical.
+    for (let i = 0; i < 19; i++) winners.push("home");
+    const closed = fold(badminton, cfg, rallyMatch(badminton, winners));
+    expect(closed.setsWon).toEqual({ home: 1, away: 0 });
+    expect(badminton.summary(closed).headline).toBe("1 — 0");
+
+    // 1 rally into game 2: banked set plus fresh live points.
+    winners.push("away");
+    const second = fold(badminton, cfg, rallyMatch(badminton, winners));
+    expect(badminton.summary(second).headline).toBe("1 — 0 (0–1)");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Badminton/set-based scoring visibility + a batch of UX fixes found while testing.

### Scoring visibility
- **Engine kernel**: `summary().headline` now carries the open set's live points — `1 — 0 (14–11)` — so rally taps are visible immediately (was stuck at `0 — 0` until a game closed). Applies to badminton, volleyball, table tennis.
- **Public match page**: new "Score by game/set" card — one column per played game, winner bold, live game's column tinted emerald with pulsing dot. The big public scoreline is stripped back to sets-only (`stripLiveSetPoints`) since the card now carries live points.
- **Set-based pad**: "Game 2 of 3" indicator + unit-aware labels ("games won 1", "Game totals", "Record game") — the old `sets 1` caption read as a hardcoded "Set 1".

### Courtside device pad (`/score/{token}`)
- Dark LED-scoreboard redesign: glowing mono scoreline, LIVE chip, white pad card on dark court, medium amber "⟲ Undo my last entry" pill. Matching dead-link screen.

### Fixes
- **Activity ledger attribution**: each event shows who recorded it — display name, or "(Courtside umpire pad)" for device-link events (label follows the sport's official).
- **Forfeit dropdown** closes on outside click.
- **Qualification error** now human-readable: "This stage takes the top 4, but the previous stage has only 2 entrants — lower the qualifier count or add entrants" (was `topN=4 exceeds 2 entrants`).
- **Invite sign-in**: magic-link send **and** consume routes rejected the `next` redirect from `/join/{token}` pages with strict schemas → "Invalid input". Both now accept it (still re-validated via `safeNextPath`).

## Tests
- Engine: headline live-points golden; qualification message pinned (620 pass).
- Web unit: `setBreakdown` / `stripLiveSetPoints`; `eventRecorderNames` in device-links DB suite (fresh-DB pass).
- E2e: forfeit outside-click, "Game 2" after game 1 completes, full magic-link `next` journey landing on `/join/...`, device-links suite — all green.
- tsc clean both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)