### PR TITLE
feat(public): courtside redesign of public pages, org-themeable via CSS vars

### DIFF
--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx
@@ -6,6 +6,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getPublicFixture } from "@/server/public-site/data";
 import { sportsEventJsonLd } from "@/lib/public-site";
+import { publicThemeStyle } from "@/lib/public-theme";
 import { LiveScore } from "@/components/public-site/live-score";
 
 export const revalidate = 30;
@@ -64,22 +65,25 @@ export default async function FixturePage({ params }: Props) {
   });
 
   return (
-    <div>
+    <div style={publicThemeStyle(competition.branding)}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
-      <nav className="mb-4 text-xs text-zinc-500">
-        <Link href={`/shared/${org.slug}/${competition.slug}`} className="underline">
+      <nav className="mb-4 text-xs text-ink-muted">
+        <Link
+          href={`/shared/${org.slug}/${competition.slug}`}
+          className="hover:text-accent-strong hover:underline"
+        >
           {competition.name}
         </Link>{" "}
         /{" "}
-        <Link href={basePath} className="underline">
+        <Link href={basePath} className="hover:text-accent-strong hover:underline">
           {division.name}
         </Link>
       </nav>
 
-      <h1 className="mb-1 text-xl font-semibold">
-        {home} <span className="text-zinc-400">vs</span> {away}
+      <h1 className="mb-1 font-display text-2xl font-semibold text-ink">
+        {home} <span className="text-ink-muted">vs</span> {away}
       </h1>
-      <p className="mb-4 text-sm text-zinc-500">
+      <p className="mb-4 text-sm text-ink-muted">
         {fixture.scheduled_at
           ? new Date(fixture.scheduled_at).toLocaleString("en-GB", {
               weekday: "long",

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 import { resolveModule } from "@/server/engine-db";
 import type { StandingsRow } from "@seazn/engine/competition";
 import { getPublicDivision } from "@/server/public-site/data";
+import { publicThemeStyle } from "@/lib/public-theme";
 import { Tabs } from "@/components/public-site/tabs";
 import { Schedule } from "@/components/public-site/schedule";
 import { StandingsTable } from "@/components/public-site/standings-table";
@@ -95,14 +96,20 @@ export default async function DivisionHomePage({ params }: Props) {
 
   // Rendered at the very top of the division page (above the tabs) so the
   // winner is visible on Schedule/Standings/Entrants alike — v1 parity.
+  // Gold is fixed podium vocabulary, deliberately outside the org theme.
   const championBanner = championId ? (
-    <div className="mb-6 flex items-center gap-4 rounded-xl border border-amber-200 bg-gradient-to-r from-amber-50 via-amber-50/40 to-transparent p-4 shadow-sm">
-      <span className="animate-trophy text-4xl" aria-hidden>🏆</span>
-      <div className="min-w-0">
-        <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">Champion</p>
-        <p className="truncate text-xl font-black tracking-tight text-zinc-900">
-          {entrantNames[championId] ?? "—"}
-        </p>
+    <div className="relative mb-6 overflow-hidden rounded-xl bg-court p-4 text-court-ink shadow-md">
+      <span aria-hidden className="absolute inset-y-0 left-0 w-1 bg-amber-400" />
+      <div className="flex items-center gap-4 pl-2">
+        <span className="animate-trophy text-4xl" aria-hidden>🏆</span>
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-300">
+            Champion
+          </p>
+          <p className="truncate font-display text-3xl font-bold uppercase leading-tight tracking-tight">
+            {entrantNames[championId] ?? "—"}
+          </p>
+        </div>
       </div>
     </div>
   ) : null;
@@ -115,7 +122,7 @@ export default async function DivisionHomePage({ params }: Props) {
           if (stageFixtures.length === 0) return null;
           return (
             <section key={stage.id}>
-              <h3 className="mb-3 font-medium">{stage.name}</h3>
+              <h3 className="mb-3 font-display text-lg font-semibold text-ink">{stage.name}</h3>
               <Bracket
                 kind={stage.kind as "knockout" | "double_elim" | "stepladder"}
                 fixtures={stageFixtures}
@@ -150,7 +157,9 @@ export default async function DivisionHomePage({ params }: Props) {
         );
       })}
       {standings.length === 0 && !stages.some((s) => BRACKET_KINDS.has(s.kind)) ? (
-        <p className="text-sm text-zinc-500">Standings appear after the first results.</p>
+        <p className="rounded-xl border border-dashed border-zinc-300 bg-surface p-6 text-center text-sm text-ink-muted">
+          Standings appear after the first results.
+        </p>
       ) : null}
     </div>
   );
@@ -158,24 +167,31 @@ export default async function DivisionHomePage({ params }: Props) {
   const entrantsPanel = (
     <ul className="grid gap-3 sm:grid-cols-2">
       {entrants.map((e) => (
-        <li key={e.id} className="rounded-lg border border-zinc-200 bg-white p-4 shadow-sm">
-          <p className="font-medium">
-            {e.display_name}
-            {e.seed ? <span className="ml-2 text-xs text-zinc-400">Seed {e.seed}</span> : null}
+        <li
+          key={e.id}
+          className="rounded-xl border border-zinc-200/80 bg-surface p-4 shadow-sm"
+        >
+          <p className="flex items-baseline justify-between gap-2 font-display text-lg font-semibold text-ink">
+            <span className="truncate">{e.display_name}</span>
+            {e.seed ? (
+              <span className="shrink-0 rounded-full bg-accent-soft px-2 py-0.5 font-sans text-[11px] font-medium text-accent-strong">
+                Seed {e.seed}
+              </span>
+            ) : null}
           </p>
           {e.members.length > 0 ? (
             <ul className="mt-2 space-y-1 text-sm text-zinc-600">
               {e.members.map((m, i) => (
                 <li key={i} className="flex items-center gap-2">
                   {m.squad_number != null ? (
-                    <span className="w-6 text-right text-xs tabular-nums text-zinc-400">
+                    <span className="w-6 text-right font-display text-xs font-semibold tabular-nums text-ink-muted">
                       {m.squad_number}
                     </span>
                   ) : null}
                   {m.person_id ? (
                     <Link
                       href={`/shared/${org.slug}/${competition.slug}/players/${m.person_id}`}
-                      className="underline underline-offset-2"
+                      className="underline decoration-accent-line underline-offset-2 hover:text-accent-strong hover:decoration-accent"
                     >
                       {m.name}
                     </Link>
@@ -184,7 +200,7 @@ export default async function DivisionHomePage({ params }: Props) {
                     <span>{m.name}</span>
                   )}
                   {m.position ? (
-                    <span className="text-xs text-zinc-400">{m.position}</span>
+                    <span className="text-xs text-ink-muted">{m.position}</span>
                   ) : null}
                 </li>
               ))}
@@ -193,28 +209,33 @@ export default async function DivisionHomePage({ params }: Props) {
         </li>
       ))}
       {entrants.length === 0 ? (
-        <p className="text-sm text-zinc-500">No entrants yet.</p>
+        <p className="text-sm text-ink-muted">No entrants yet.</p>
       ) : null}
     </ul>
   );
 
   return (
-    <div>
-      <nav className="mb-4 text-xs text-zinc-500">
-        <Link href={`/shared/${org.slug}`} className="underline">
+    <div style={publicThemeStyle(competition.branding)}>
+      <nav className="mb-4 text-xs text-ink-muted">
+        <Link href={`/shared/${org.slug}`} className="hover:text-accent-strong hover:underline">
           {org.name}
         </Link>{" "}
         /{" "}
-        <Link href={`/shared/${org.slug}/${competition.slug}`} className="underline">
+        <Link
+          href={`/shared/${org.slug}/${competition.slug}`}
+          className="hover:text-accent-strong hover:underline"
+        >
           {competition.name}
         </Link>
       </nav>
-      <h1 className="mb-2 text-3xl font-bold tracking-tight">{division.name}</h1>
-      <p className="mb-6 flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+      <h1 className="mb-2 font-display text-4xl font-bold uppercase leading-none tracking-tight text-ink sm:text-5xl">
+        {division.name}
+      </h1>
+      <p className="mb-6 flex flex-wrap items-center gap-2 text-xs text-ink-muted">
         <span className="font-medium text-zinc-600">
           {division.sport_name ?? division.sport_key}
         </span>
-        <span className="rounded-full bg-purple-50 px-2 py-0.5 uppercase text-purple-700">
+        <span className="rounded-full bg-accent-soft px-2 py-0.5 uppercase text-accent-strong">
           {division.variant_key}
         </span>
         {stages.map((s) => (

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
@@ -4,8 +4,10 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { ChevronRight } from "lucide-react";
 import { getPublicCompetition } from "@/server/public-site/data";
 import { publicRegistrationInfo } from "@/server/usecases/registrations";
+import { publicThemeStyle } from "@/lib/public-theme";
 
 export const revalidate = 30;
 
@@ -53,14 +55,17 @@ export default async function CompetitionHomePage({ params }: Props) {
   const totalEntrants = divisions.reduce((n, d) => n + d.entrant_count, 0);
 
   return (
-    <div>
-      <nav className="mb-4 text-xs text-zinc-500">
-        <Link href={`/shared/${org.slug}`} className="hover:underline">
+    // Pro orgs with branding.colors.primary re-theme this whole subtree —
+    // the contrast guard in publicThemeStyle falls back to violet.
+    <div style={publicThemeStyle(competition.branding)}>
+      <nav className="mb-4 text-xs text-ink-muted">
+        <Link href={`/shared/${org.slug}`} className="hover:text-accent-strong hover:underline">
           ← {org.name}
         </Link>
       </nav>
-      {/* Hero — banner photo when branded (Pro), gradient otherwise */}
-      <section className="relative mb-6 overflow-hidden rounded-2xl bg-gradient-to-br from-purple-700 via-purple-600 to-fuchsia-600 text-white shadow-lg">
+
+      {/* Hero — court slab; banner photo (Pro) sits under a slab-tinted wash */}
+      <section className="relative mb-6 overflow-hidden rounded-2xl bg-court text-court-ink shadow-lg">
         {branding.banner ? (
           <>
             {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -69,61 +74,67 @@ export default async function CompetitionHomePage({ params }: Props) {
               alt=""
               className="absolute inset-0 h-full w-full object-cover"
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/40 to-slate-950/20" />
+            <div className="absolute inset-0 bg-gradient-to-t from-court via-court/75 to-court/40" />
           </>
         ) : (
           <div
             aria-hidden
-            className="absolute inset-0 opacity-40"
+            className="absolute inset-0 opacity-50"
             style={{
               backgroundImage:
-                "radial-gradient(600px 200px at 85% 0%, rgba(255,255,255,0.25), transparent), radial-gradient(400px 300px at 0% 100%, rgba(255,255,255,0.12), transparent)",
+                "radial-gradient(560px 220px at 88% -20%, color-mix(in oklab, var(--ps-accent) 55%, transparent), transparent), radial-gradient(420px 260px at -8% 110%, color-mix(in oklab, var(--ps-accent) 30%, transparent), transparent)",
             }}
           />
         )}
-        <div className="relative flex flex-col gap-4 p-6 sm:p-8">
-          <div className="flex items-start gap-4">
+        <div className="relative flex flex-col gap-5 p-6 sm:p-8">
+          <div className="flex flex-wrap items-start gap-4">
             {branding.logo ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={branding.logo}
                 alt=""
-                className="h-14 w-14 rounded-xl bg-white/90 object-contain p-1 shadow"
+                className="h-14 w-14 rounded-xl bg-white/95 object-contain p-1 shadow"
               />
             ) : null}
             <div className="min-w-0 flex-1">
-              <h1 className="text-3xl font-bold tracking-tight">{competition.name}</h1>
-              {dateLine ? <p className="mt-1 text-sm text-white/80">{dateLine}</p> : null}
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-court-muted">
+                {org.name}
+              </p>
+              <h1 className="mt-1 font-display text-4xl font-bold uppercase leading-none tracking-tight sm:text-5xl">
+                {competition.name}
+              </h1>
+              {dateLine ? <p className="mt-2 text-sm text-court-muted">{dateLine}</p> : null}
             </div>
             {registrationOpen ? (
               <Link
                 href={`/shared/${org.slug}/${competition.slug}/register`}
-                className="shrink-0 rounded-lg bg-white px-4 py-2 text-sm font-semibold text-purple-700 shadow hover:bg-purple-50"
+                className="shrink-0 rounded-lg bg-surface px-4 py-2 text-sm font-semibold text-accent-strong shadow transition hover:bg-accent-soft"
               >
                 Register now
               </Link>
             ) : null}
           </div>
           <div className="flex flex-wrap gap-2 text-xs font-medium">
-            <span className="rounded-full bg-white/15 px-3 py-1 backdrop-blur">
+            <span className="rounded-full bg-white/12 px-3 py-1 backdrop-blur">
               {divisions.length} division{divisions.length === 1 ? "" : "s"}
             </span>
-            <span className="rounded-full bg-white/15 px-3 py-1 backdrop-blur">
+            <span className="rounded-full bg-white/12 px-3 py-1 backdrop-blur">
               {totalEntrants} entrant{totalEntrants === 1 ? "" : "s"}
             </span>
             {liveNow.length > 0 ? (
-              <span className="flex items-center gap-1.5 rounded-full bg-emerald-400/20 px-3 py-1 text-emerald-100 backdrop-blur">
+              <span className="flex items-center gap-1.5 rounded-full bg-emerald-400/20 px-3 py-1 text-emerald-200 backdrop-blur">
                 <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-300" />
                 {liveNow.length} live now
               </span>
             ) : null}
           </div>
         </div>
+        <div aria-hidden className="h-1 bg-accent" />
       </section>
 
       {liveNow.length > 0 ? (
         <section className="mb-6">
-          <h2 className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+          <h2 className="mb-2 flex items-center gap-2 font-display text-sm font-semibold uppercase tracking-[0.18em] text-emerald-700">
             <span className="animate-live-pulse h-2 w-2 rounded-full bg-emerald-500" />
             Live now
           </h2>
@@ -131,13 +142,15 @@ export default async function CompetitionHomePage({ params }: Props) {
             {liveNow.map((f) => {
               const division = divisions.find((d) => d.id === f.division_id);
               return (
-                <li key={f.id} className="min-w-56 shrink-0">
+                <li key={f.id} className="min-w-60 shrink-0">
                   <Link
                     href={`/shared/${org.slug}/${competition.slug}/${division?.slug}/fixtures/${f.id}`}
-                    className="block rounded-xl border border-emerald-200 bg-gradient-to-br from-emerald-50 to-white p-3 text-sm shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-400 hover:shadow"
+                    className="block rounded-xl bg-court p-3.5 text-sm text-court-ink shadow-md ring-1 ring-emerald-400/40 transition hover:-translate-y-0.5 hover:ring-emerald-400"
                   >
-                    <p className="text-xs text-zinc-500">{division?.name}</p>
-                    <p className="mt-1 font-semibold tabular-nums text-zinc-800">
+                    <p className="text-[11px] uppercase tracking-wide text-court-muted">
+                      {division?.name}
+                    </p>
+                    <p className="mt-1.5 font-display text-xl font-semibold tabular-nums leading-tight">
                       {f.summary?.headline ?? "In play"}
                     </p>
                   </Link>
@@ -155,26 +168,39 @@ export default async function CompetitionHomePage({ params }: Props) {
       ) : null}
 
       <section>
-        <h2 className="mb-3 text-lg font-semibold">Divisions</h2>
+        <h2 className="mb-3 font-display text-2xl font-semibold uppercase tracking-wide text-ink">
+          Divisions
+        </h2>
         {divisions.length === 0 ? (
-          <p className="text-sm text-zinc-500">No divisions published yet.</p>
+          <p className="rounded-xl border border-dashed border-zinc-300 bg-surface p-6 text-center text-sm text-ink-muted">
+            No divisions published yet.
+          </p>
         ) : (
           <ul className="grid gap-3 sm:grid-cols-2">
             {divisions.map((d) => (
               <li key={d.id}>
                 <Link
                   href={`/shared/${org.slug}/${competition.slug}/${d.slug}`}
-                  className="group block rounded-xl border border-purple-100 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-purple-300 hover:shadow-md"
+                  className="group flex h-full flex-col justify-between rounded-xl border border-zinc-200/80 bg-surface p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-accent-line hover:shadow-md"
                 >
-                  <p className="flex items-center justify-between font-semibold">
-                    {d.name}
-                    <span className="text-purple-300 transition group-hover:translate-x-0.5 group-hover:text-purple-500">
-                      →
+                  <div className="flex items-start gap-3">
+                    <span
+                      aria-hidden
+                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-accent-soft font-display text-base font-bold uppercase text-accent-strong"
+                    >
+                      {(d.sport_name ?? d.sport_key).slice(0, 1)}
                     </span>
-                  </p>
-                  <p className="mt-2 flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+                    <p className="min-w-0 flex-1 font-display text-xl font-semibold leading-tight text-ink">
+                      {d.name}
+                    </p>
+                    <ChevronRight
+                      aria-hidden
+                      className="mt-1 h-4 w-4 shrink-0 text-zinc-300 transition group-hover:translate-x-0.5 group-hover:text-accent"
+                    />
+                  </div>
+                  <p className="mt-3 flex flex-wrap items-center gap-2 text-xs text-ink-muted">
                     <span>{d.sport_name ?? d.sport_key}</span>
-                    <span className="rounded-full bg-purple-50 px-2 py-0.5 uppercase text-purple-700">
+                    <span className="rounded-full bg-accent-soft px-2 py-0.5 uppercase text-accent-strong">
                       {d.variant_key}
                     </span>
                     <span>{d.entrant_count} entrants</span>
@@ -196,14 +222,14 @@ export default async function CompetitionHomePage({ params }: Props) {
       </section>
 
       {branding.sponsors && branding.sponsors.length > 0 ? (
-        <section className="mt-8 border-t border-purple-100 pt-4">
-          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-400">
+        <section className="mt-10 border-t border-zinc-200 pt-4">
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-[0.18em] text-ink-muted">
             Sponsors
           </h2>
           <ul className="flex flex-wrap items-center gap-3">
             {branding.sponsors.map((s) => {
               const inner = (
-                <span className="flex items-center gap-2 rounded-lg border border-purple-100 bg-white px-3 py-2 text-sm text-zinc-600 shadow-sm">
+                <span className="flex items-center gap-2 rounded-lg border border-zinc-200/80 bg-surface px-3 py-2 text-sm text-zinc-600 shadow-sm">
                   {s.logo ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img src={s.logo} alt="" className="h-6 w-6 object-contain" />

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
@@ -32,8 +32,11 @@ export default async function PlayerCardPage({ params }: Props) {
 
   return (
     <div>
-      <nav className="mb-4 text-xs text-zinc-500">
-        <Link href={`/shared/${org.slug}/${competition.slug}`} className="underline">
+      <nav className="mb-4 text-xs text-ink-muted">
+        <Link
+          href={`/shared/${org.slug}/${competition.slug}`}
+          className="hover:text-accent-strong hover:underline"
+        >
           {competition.name}
         </Link>
       </nav>
@@ -43,12 +46,12 @@ export default async function PlayerCardPage({ params }: Props) {
           <img
             src={player.photo}
             alt={player.name}
-            className="h-24 w-24 rounded-lg object-cover"
+            className="h-24 w-24 rounded-xl object-cover shadow-sm"
           />
         ) : (
           <div
             aria-hidden
-            className="flex h-24 w-24 items-center justify-center rounded-lg bg-zinc-200 text-2xl font-semibold text-zinc-500"
+            className="flex h-24 w-24 items-center justify-center rounded-xl bg-accent-soft font-display text-3xl font-bold text-accent-strong"
           >
             {player.name
               .split(/\s+/)
@@ -58,22 +61,29 @@ export default async function PlayerCardPage({ params }: Props) {
           </div>
         )}
         <div>
-          <h1 className="text-2xl font-semibold">{player.name}</h1>
-          <p className="text-sm text-zinc-500">{org.name}</p>
+          <h1 className="font-display text-3xl font-bold uppercase leading-none tracking-tight text-ink">
+            {player.name}
+          </h1>
+          <p className="mt-1 text-sm text-ink-muted">{org.name}</p>
         </div>
       </div>
 
       <section className="mt-6">
-        <h2 className="mb-2 text-sm font-medium text-zinc-700">In this competition</h2>
+        <h2 className="mb-2 font-display text-sm font-semibold uppercase tracking-[0.18em] text-ink-muted">
+          In this competition
+        </h2>
         {memberships.length === 0 ? (
-          <p className="text-sm text-zinc-500">No current squad entries.</p>
+          <p className="text-sm text-ink-muted">No current squad entries.</p>
         ) : (
           <ul className="space-y-2">
             {memberships.map((m, i) => (
-              <li key={i} className="rounded border border-zinc-200 bg-white p-3 text-sm">
+              <li
+                key={i}
+                className="rounded-xl border border-zinc-200/80 bg-surface p-3 text-sm shadow-sm"
+              >
                 <Link
                   href={`/shared/${org.slug}/${competition.slug}/${m.division_slug}`}
-                  className="font-medium underline underline-offset-2"
+                  className="font-medium text-accent-strong underline decoration-accent-line underline-offset-2 hover:decoration-accent"
                 >
                   {m.division_name}
                 </Link>{" "}

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx
@@ -25,22 +25,25 @@ export default async function PosterPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-xl py-8">
-      <div className="overflow-hidden rounded-3xl border-4 border-purple-600 bg-white text-center shadow-xl print:border-2 print:shadow-none">
-        <div className="bg-gradient-to-r from-purple-700 to-fuchsia-600 px-8 py-6 text-white">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+      <div className="overflow-hidden rounded-3xl border-4 border-accent bg-surface text-center shadow-xl print:border-2 print:shadow-none">
+        <div className="bg-court px-8 py-6 text-court-ink">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-court-muted">
             {org.name}
           </p>
-          <h1 className="mt-1 text-3xl font-black tracking-tight">{competition.name}</h1>
+          <h1 className="mt-1 font-display text-4xl font-bold uppercase tracking-tight">
+            {competition.name}
+          </h1>
         </div>
+        <div aria-hidden className="h-1 bg-accent" />
         <div className="flex flex-col items-center gap-5 px-8 py-8">
-          <div className="rounded-2xl border border-purple-100 p-3 shadow-sm">
+          <div className="rounded-2xl border border-zinc-200 p-3 shadow-sm">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={qr} alt={`QR code for ${url}`} className="h-72 w-72" />
           </div>
-          <p className="text-2xl font-bold text-zinc-900">
+          <p className="font-display text-3xl font-semibold text-ink">
             Scan for live scores, fixtures & standings
           </p>
-          <p className="rounded-full bg-purple-50 px-4 py-1.5 text-sm font-medium text-purple-700">
+          <p className="rounded-full bg-accent-soft px-4 py-1.5 text-sm font-medium text-accent-strong">
             {url}
           </p>
         </div>

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/page.tsx
@@ -25,14 +25,19 @@ export default async function RegisterPage({ params }: Props) {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <p className="text-xs text-zinc-400">
-        <Link href={`/shared/${orgSlug}/${competitionSlug}`} className="hover:underline">
+      <p className="text-xs text-ink-muted">
+        <Link
+          href={`/shared/${orgSlug}/${competitionSlug}`}
+          className="hover:text-accent-strong hover:underline"
+        >
           {info.competition.name}
         </Link>{" "}
         / Register
       </p>
-      <h1 className="mt-1 text-3xl font-bold tracking-tight">Register</h1>
-      <p className="mt-1 text-sm text-zinc-500">
+      <h1 className="mt-1 font-display text-4xl font-bold uppercase tracking-tight text-ink">
+        Register
+      </h1>
+      <p className="mt-1 text-sm text-ink-muted">
         Pick a division, fill in your details — takes under a minute.
       </p>
       {info.divisions.length === 0 ? (

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/status/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/status/page.tsx
@@ -70,19 +70,22 @@ export default async function RegistrationStatusPage({ params, searchParams }: P
 
   return (
     <div className="mx-auto max-w-xl">
-      <p className="text-xs text-zinc-400">
-        <Link href={`/shared/${orgSlug}/${competitionSlug}`} className="hover:underline">
+      <p className="text-xs text-ink-muted">
+        <Link
+          href={`/shared/${orgSlug}/${competitionSlug}`}
+          className="hover:text-accent-strong hover:underline"
+        >
           {view.competition_name}
         </Link>{" "}
         / Registration
       </p>
 
-      <div className={`mt-3 rounded-lg border p-5 ${copy.tone}`}>
-        <h1 className="text-lg font-semibold">{copy.title}</h1>
+      <div className={`mt-3 rounded-xl border p-5 ${copy.tone}`}>
+        <h1 className="font-display text-2xl font-semibold">{copy.title}</h1>
         <p className="mt-1 text-sm">{copy.body}</p>
       </div>
 
-      <dl className="mt-5 space-y-2 rounded-lg border border-zinc-200 bg-white p-5 text-sm">
+      <dl className="mt-5 space-y-2 rounded-xl border border-zinc-200/80 bg-surface p-5 text-sm shadow-sm">
         <Row label="Name">{view.display_name}</Row>
         <Row label="Division">{view.division_name}</Row>
         <Row label="Competition">{view.competition_name}</Row>
@@ -104,8 +107,8 @@ export default async function RegistrationStatusPage({ params, searchParams }: P
       </dl>
 
       {view.payment_due && (
-        <div className="mt-5 rounded-lg border border-purple-200 bg-purple-50 p-5">
-          <h2 className="text-sm font-semibold text-purple-800">How to pay your entry fee</h2>
+        <div className="mt-5 rounded-xl border border-accent-line bg-accent-soft p-5">
+          <h2 className="text-sm font-semibold text-accent-strong">How to pay your entry fee</h2>
           {view.payment_instructions ? (
             <p className="mt-2 whitespace-pre-line text-sm text-zinc-700">
               {view.payment_instructions}

--- a/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
@@ -1,12 +1,33 @@
 // Public dashboard shell (doc 09 §1). No auth anywhere under this tree — all
 // reads go through the public_*_v views. Reserved slugs 404 before the DB is
 // touched; a missing org 404s identically (no existence leak).
+//
+// Visual system: "courtside" — a dark court-slab masthead over a light page,
+// scoreboard typography (Barlow Condensed, mounted only on this tree), and
+// one accent color driven by the --ps-* vars (lib/public-theme.ts) so an org
+// can re-brand the whole surface later without touching components.
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { Barlow_Condensed } from "next/font/google";
 import { isReservedSlug } from "@/lib/public-site";
 import { getPublicOrg } from "@/server/public-site/data";
 
+const displayFont = Barlow_Condensed({
+  weight: ["500", "600", "700"],
+  subsets: ["latin"],
+  variable: "--ps-font-display",
+});
+
 export const revalidate = 30;
+
+function monogram(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
 
 export default async function PublicOrgLayout({
   children,
@@ -22,26 +43,38 @@ export default async function PublicOrgLayout({
   const { org } = data;
 
   return (
-    <div className="flex min-h-screen flex-col text-zinc-900">
-      <div className="h-1 bg-gradient-to-r from-purple-600 via-fuchsia-500 to-purple-600" />
-      <header className="sticky top-0 z-40 border-b border-purple-100 bg-white/80 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center gap-3 px-4 py-3">
-          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-600 to-fuchsia-500 text-sm font-bold text-white">
-            {org.name.slice(0, 1).toUpperCase()}
+    <div
+      className={`${displayFont.variable} flex min-h-screen flex-col bg-canvas text-ink`}
+    >
+      <header className="sticky top-0 z-40 bg-court text-court-ink shadow-md">
+        <div className="mx-auto flex h-[52px] max-w-5xl items-center gap-3 px-4">
+          <span
+            aria-hidden
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent font-display text-sm font-bold text-accent-ink"
+          >
+            {monogram(org.name)}
           </span>
-          <Link href={`/shared/${org.slug}`} className="truncate font-semibold hover:text-purple-700">
+          <Link
+            href={`/shared/${org.slug}`}
+            className="min-w-0 truncate font-display text-xl font-semibold uppercase tracking-wide hover:text-white"
+          >
             {org.name}
           </Link>
+          <span className="ml-auto hidden shrink-0 text-[11px] font-medium uppercase tracking-[0.18em] text-court-muted sm:block">
+            Live scores · Schedules · Standings
+          </span>
         </div>
+        {/* Accent keel — the one line of brand color on the slab. */}
+        <div aria-hidden className="h-0.5 bg-accent" />
       </header>
-      <main className="mx-auto w-full max-w-4xl flex-1 px-4 py-6">{children}</main>
-      <footer className="border-t border-purple-100 bg-white/70 py-4 text-center text-xs text-zinc-500 backdrop-blur">
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-6">{children}</main>
+      <footer className="mt-8 py-6 text-center text-xs text-ink-muted">
         {/* Doc 09 §4: fixed platform footer for Community; removable for Pro
             (branding entitlement, resolved server-side). */}
         {org.branded ? null : (
           <p>
             Powered by{" "}
-            <a href="https://seazn.club" className="font-medium text-purple-700 underline">
+            <a href="https://seazn.club" className="font-medium text-accent-strong underline">
               seazn.club
             </a>
           </p>

--- a/apps/web/src/app/(public)/shared/[orgSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import { ChevronRight } from "lucide-react";
 import { getPublicOrg } from "@/server/public-site/data";
 
 export const revalidate = 30;
@@ -19,6 +20,34 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
+const fmtDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+
+/** Spectator-language chip over the competition vocab (draft|live|archived);
+    anything not live/archived reads as upcoming. */
+function statusChip(status: string) {
+  if (status === "live") {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-emerald-700 ring-1 ring-inset ring-emerald-200">
+        <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        On now
+      </span>
+    );
+  }
+  if (status === "archived") {
+    return (
+      <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-zinc-500">
+        Finished
+      </span>
+    );
+  }
+  return (
+    <span className="rounded-full bg-accent-soft px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-accent-strong ring-1 ring-inset ring-accent-line">
+      Upcoming
+    </span>
+  );
+}
+
 export default async function OrgLandingPage({ params }: Props) {
   const { orgSlug } = await params;
   const data = await getPublicOrg(orgSlug);
@@ -27,45 +56,65 @@ export default async function OrgLandingPage({ params }: Props) {
 
   return (
     <div>
-      <section className="mb-6 rounded-2xl bg-gradient-to-br from-purple-700 to-fuchsia-600 p-6 text-white shadow-lg sm:p-8">
-        <h1 className="text-3xl font-bold tracking-tight">{org.name}</h1>
-        <p className="mt-1 text-sm text-white/80">
-          {competitions.length} public competition{competitions.length === 1 ? "" : "s"}
-        </p>
+      <section className="mb-8 overflow-hidden rounded-2xl bg-court text-court-ink shadow-lg">
+        <div className="relative p-6 sm:p-10">
+          <div
+            aria-hidden
+            className="absolute inset-0 opacity-50"
+            style={{
+              backgroundImage:
+                "radial-gradient(560px 220px at 88% -20%, color-mix(in oklab, var(--ps-accent) 55%, transparent), transparent), radial-gradient(420px 260px at -8% 110%, color-mix(in oklab, var(--ps-accent) 30%, transparent), transparent)",
+            }}
+          />
+          <div className="relative">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-court-muted">
+              Tournament hub
+            </p>
+            <h1 className="mt-2 font-display text-5xl font-bold uppercase leading-none tracking-tight sm:text-6xl">
+              {org.name}
+            </h1>
+            <p className="mt-3 max-w-xl text-sm text-court-muted">
+              Follow live scores, match schedules and standings for every competition — no
+              account needed.
+            </p>
+          </div>
+        </div>
+        <div aria-hidden className="h-1 bg-accent" />
       </section>
+
+      <h2 className="mb-3 font-display text-2xl font-semibold uppercase tracking-wide text-ink">
+        Competitions
+      </h2>
       {competitions.length === 0 ? (
-        <p className="text-sm text-zinc-500">No public competitions right now.</p>
+        <p className="rounded-xl border border-dashed border-zinc-300 bg-surface p-6 text-center text-sm text-ink-muted">
+          No public competitions right now — check back soon.
+        </p>
       ) : (
         <ul className="grid gap-3 sm:grid-cols-2">
           {competitions.map((c) => (
             <li key={c.id}>
               <Link
                 href={`/shared/${org.slug}/${c.slug}`}
-                className="group block rounded-xl border border-purple-100 bg-white p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-purple-300 hover:shadow-md"
+                className="group flex h-full flex-col justify-between rounded-xl border border-zinc-200/80 bg-surface p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-accent-line hover:shadow-md"
               >
-                <p className="flex items-center justify-between font-semibold">
-                  {c.name}
-                  <span className="text-purple-300 transition group-hover:translate-x-0.5 group-hover:text-purple-500">
-                    →
-                  </span>
-                </p>
-                <p className="mt-1 text-xs text-zinc-500">
-                  {c.starts_on
-                    ? new Date(c.starts_on).toLocaleDateString("en-GB", {
-                        day: "numeric",
-                        month: "short",
-                        year: "numeric",
-                      })
-                    : null}
-                  {c.ends_on
-                    ? ` – ${new Date(c.ends_on).toLocaleDateString("en-GB", {
-                        day: "numeric",
-                        month: "short",
-                        year: "numeric",
-                      })}`
-                    : null}
-                  {!c.starts_on && !c.ends_on ? c.status : null}
-                </p>
+                <div className="flex items-start justify-between gap-3">
+                  <p className="font-display text-xl font-semibold leading-tight text-ink">
+                    {c.name}
+                  </p>
+                  <ChevronRight
+                    aria-hidden
+                    className="mt-0.5 h-4 w-4 shrink-0 text-zinc-300 transition group-hover:translate-x-0.5 group-hover:text-accent"
+                  />
+                </div>
+                <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-ink-muted">
+                  {statusChip(c.status)}
+                  {c.starts_on ? (
+                    <span>
+                      {fmtDate(c.starts_on)}
+                      {c.ends_on ? ` – ${fmtDate(c.ends_on)}` : ""}
+                    </span>
+                  ) : null}
+                </div>
               </Link>
             </li>
           ))}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -4,6 +4,24 @@
   --background: #faf7ff;
   --foreground: #2e1065;
   --brand: #7c3aed;
+
+  /* ---- Public-site theme tokens ("courtside" system) ----
+     Every public page derives from these vars so an org can re-brand the
+     whole surface by overriding --ps-* on a wrapper element (see
+     lib/public-theme.ts — the resolver emits the same derived values; keep
+     the two in sync, guarded by lib/__tests__/public-theme.test.ts). */
+  --ps-accent: #7c3aed;
+  --ps-accent-ink: #ffffff;
+  --ps-accent-strong: #6931c9;
+  --ps-accent-soft: #f5effe;
+  --ps-accent-line: #decefb;
+  --ps-court: #231738;
+  --ps-court-ink: #f7f5fb;
+  --ps-court-muted: rgba(247, 245, 251, 0.64);
+  --ps-canvas: #f6f5f8;
+  --ps-surface: #ffffff;
+  --ps-ink: #1d1928;
+  --ps-muted: #6f6a7c;
 }
 
 @theme inline {
@@ -12,6 +30,22 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  /* Public-site palette — themeable per org via the --ps-* vars above. */
+  --color-accent: var(--ps-accent);
+  --color-accent-ink: var(--ps-accent-ink);
+  --color-accent-strong: var(--ps-accent-strong);
+  --color-accent-soft: var(--ps-accent-soft);
+  --color-accent-line: var(--ps-accent-line);
+  --color-court: var(--ps-court);
+  --color-court-ink: var(--ps-court-ink);
+  --color-court-muted: var(--ps-court-muted);
+  --color-canvas: var(--ps-canvas);
+  --color-surface: var(--ps-surface);
+  --color-ink: var(--ps-ink);
+  --color-ink-muted: var(--ps-muted);
+  /* Display face (Barlow Condensed) is only mounted on the public tree;
+     everywhere else the utility falls back to the body face. */
+  --font-display: var(--ps-font-display, var(--font-geist-sans));
 }
 
 html,
@@ -95,6 +129,23 @@ body {
 }
 .animate-live-pulse {
   animation: live-pulse 2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-slide-in,
+  .animate-trophy,
+  .animate-slide-progress,
+  .animate-blob,
+  .animate-live-pulse {
+    animation: none;
+  }
+}
+
+/* Keyboard focus is always visible; the color follows the org accent on
+   public pages and defaults to the platform violet everywhere else. */
+:where(a, button, summary, [role="tab"]):focus-visible {
+  outline: 2px solid var(--ps-accent);
+  outline-offset: 2px;
 }
 
 @layer components {

--- a/apps/web/src/components/public-site/__tests__/live-score-data.test.ts
+++ b/apps/web/src/components/public-site/__tests__/live-score-data.test.ts
@@ -1,0 +1,48 @@
+// Regression: the public fixture endpoints respond `{ ok, data: ... }` and
+// api() unwraps `.data` once. The old LiveScore code unwrapped twice, so
+// polling replaced the scoreboard with `undefined` and the realtime-token
+// flow threw "Cannot read properties of undefined (reading 'token')".
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLiveFixture, fetchPublicRealtimeToken } from "../live-score-data";
+
+function stubFetch(payload: unknown, ok = true, status = 200) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok,
+      status,
+      json: async () => payload,
+    })),
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchLiveFixture", () => {
+  it("returns the fixture itself, not a wrapper with a .data property", async () => {
+    const fixture = { status: "in_play", summary: { headline: "1 — 0" }, outcome: null };
+    stubFetch({ ok: true, data: fixture });
+    const res = await fetchLiveFixture("fx-1");
+    expect(res.status).toBe("in_play");
+    expect(res).not.toHaveProperty("data");
+  });
+
+  it("throws on error payloads instead of resolving undefined", async () => {
+    stubFetch({ ok: false, error: "not found" }, false, 404);
+    await expect(fetchLiveFixture("fx-1")).rejects.toThrow("not found");
+  });
+});
+
+describe("fetchPublicRealtimeToken", () => {
+  it("returns token + channel directly", async () => {
+    stubFetch({ ok: true, data: { token: "jwt", channel: "fixture:fx-1" } });
+    const res = await fetchPublicRealtimeToken("fx-1");
+    expect(res.token).toBe("jwt");
+    expect(res.channel).toBe("fixture:fx-1");
+  });
+
+  it("throws when the org is not entitled (403)", async () => {
+    stubFetch({ ok: false, error: "payment required" }, false, 403);
+    await expect(fetchPublicRealtimeToken("fx-1")).rejects.toThrow("payment required");
+  });
+});

--- a/apps/web/src/components/public-site/bracket.tsx
+++ b/apps/web/src/components/public-site/bracket.tsx
@@ -29,44 +29,48 @@ function FixtureCard({
     <span
       className={
         id && id === winner
-          ? "flex items-center gap-1 font-semibold text-purple-800"
+          ? "truncate font-semibold text-ink"
           : winner
-            ? "text-zinc-400"
-            : undefined
+            ? "truncate text-ink-muted"
+            : "truncate text-ink"
       }
     >
       {sideLabel(id, entrantNames)}
-      {id && id === winner ? <span className="text-[10px]">▸</span> : null}
     </span>
   );
   const live = fixture.status === "in_play";
   return (
     <Link
       href={href}
-      className={`block rounded-lg border bg-white p-2.5 text-sm shadow-sm transition hover:-translate-y-0.5 hover:shadow ${
-        live ? "border-emerald-300 hover:border-emerald-400" : "border-purple-100 hover:border-purple-300"
+      className={`relative block overflow-hidden rounded-lg border bg-surface p-2.5 text-sm shadow-sm transition hover:-translate-y-0.5 hover:shadow ${
+        live ? "border-emerald-300 hover:border-emerald-400" : "border-zinc-200/80 hover:border-accent-line"
       }`}
     >
+      {winner ? <span aria-hidden className="absolute inset-y-0 left-0 w-0.5 bg-accent" /> : null}
+      {live ? <span aria-hidden className="absolute inset-y-0 left-0 w-0.5 bg-emerald-400" /> : null}
       <div className="flex flex-col gap-0.5">
         {side(fixture.home_entrant_id)}
         {side(fixture.away_entrant_id)}
       </div>
-      <div className="mt-1 text-xs text-zinc-500">
+      <div className="mt-1.5 text-xs text-ink-muted">
         {live ? (
-          <span className="flex items-center gap-1.5 font-semibold text-emerald-700">
+          <span className="flex items-center gap-1.5 font-bold uppercase tracking-wide text-emerald-600">
             <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-500" />
-            LIVE
+            Live
           </span>
+        ) : fixture.summary?.headline ? (
+          <span className="font-display text-sm font-semibold tabular-nums text-accent-strong">
+            {fixture.summary.headline}
+          </span>
+        ) : fixture.scheduled_at ? (
+          new Date(fixture.scheduled_at).toLocaleString("en-GB", {
+            day: "numeric",
+            month: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
         ) : (
-          (fixture.summary?.headline ??
-            (fixture.scheduled_at
-              ? new Date(fixture.scheduled_at).toLocaleString("en-GB", {
-                  day: "numeric",
-                  month: "short",
-                  hour: "2-digit",
-                  minute: "2-digit",
-                })
-              : "TBD"))
+          "TBD"
         )}
       </div>
     </Link>
@@ -100,7 +104,7 @@ export function Bracket({ kind, fixtures, entrantNames, fixtureHref }: Props) {
       <div className={kind === "stepladder" ? "flex flex-col gap-4" : "flex gap-6"}>
         {ordered.map(([roundNo, list]) => (
           <div key={roundNo} className="min-w-48">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-purple-700/70">
+            <h3 className="mb-2 font-display text-sm font-semibold uppercase tracking-[0.18em] text-ink-muted">
               {roundName(roundNo)}
             </h3>
             <div className="flex flex-col justify-around gap-3">

--- a/apps/web/src/components/public-site/live-score-data.ts
+++ b/apps/web/src/components/public-site/live-score-data.ts
@@ -1,0 +1,30 @@
+// Fetch layer for the public live scoreboard, split out so the payload
+// unwrapping is unit-testable (lib/client.ts's api() already returns the
+// endpoint's `data` — unwrapping it twice was a live bug: every 15 s poll
+// replaced the score with `undefined`).
+import { api } from "@/lib/client";
+
+export interface LiveFixtureData {
+  status: string;
+  summary: {
+    headline?: string;
+    perSide?: { entrantId: string; line: string }[];
+    detail?: unknown;
+  } | null;
+  outcome: { kind?: string; winner?: string } | null;
+}
+
+export interface PublicRealtimeToken {
+  token: string;
+  channel: string;
+}
+
+export async function fetchLiveFixture(fixtureId: string): Promise<LiveFixtureData> {
+  return api<LiveFixtureData>(`/api/v1/public/fixtures/${fixtureId}`);
+}
+
+export async function fetchPublicRealtimeToken(
+  fixtureId: string,
+): Promise<PublicRealtimeToken> {
+  return api<PublicRealtimeToken>(`/api/v1/public/fixtures/${fixtureId}/realtime-token`);
+}

--- a/apps/web/src/components/public-site/live-score.tsx
+++ b/apps/web/src/components/public-site/live-score.tsx
@@ -6,20 +6,16 @@
 // because the public page authenticates with a public token endpoint instead
 // of the org-member one.
 import { useCallback, useEffect, useState } from "react";
-import { api } from "@/lib/client";
 import { setBreakdown, stripLiveSetPoints } from "@/lib/public-site";
+import {
+  fetchLiveFixture,
+  fetchPublicRealtimeToken,
+  type LiveFixtureData,
+} from "./live-score-data";
 
 const POLL_MS = 15_000;
 
-export interface LiveFixtureData {
-  status: string;
-  summary: {
-    headline?: string;
-    perSide?: { entrantId: string; line: string }[];
-    detail?: unknown;
-  } | null;
-  outcome: { kind?: string; winner?: string } | null;
-}
+export type { LiveFixtureData };
 
 interface Props {
   fixtureId: string;
@@ -34,8 +30,7 @@ export function LiveScore({ fixtureId, initial, realtime, entrantNames, sportKey
 
   const refresh = useCallback(async () => {
     try {
-      const res = await api<{ data: LiveFixtureData }>(`/api/v1/public/fixtures/${fixtureId}`);
-      setData(res.data);
+      setData(await fetchLiveFixture(fixtureId));
     } catch {
       // transient — keep the last known score
     }
@@ -57,11 +52,7 @@ export function LiveScore({ fixtureId, initial, realtime, entrantNames, sportKey
     (async () => {
       let token: { token: string; channel: string };
       try {
-        token = (
-          await api<{ data: { token: string; channel: string } }>(
-            `/api/v1/public/fixtures/${fixtureId}/realtime-token`,
-          )
-        ).data;
+        token = await fetchPublicRealtimeToken(fixtureId);
       } catch {
         return; // not entitled or server error → polling
       }
@@ -96,57 +87,66 @@ export function LiveScore({ fixtureId, initial, realtime, entrantNames, sportKey
   }, [live, subscribed, refresh]);
 
   const inPlay = data.status === "in_play";
+  const decided = data.status === "decided" || data.status === "finalized";
   const breakdown = setBreakdown(data.summary, sportKey);
   // Kernel perSide order is [home, away]; row labels come from it.
   const sideIds = data.summary?.perSide?.map((s) => s.entrantId) ?? [];
   const showBreakdown = breakdown !== null && sideIds.length === 2;
   return (
     <div className="space-y-4">
-      <div
-        className={`rounded-2xl border p-5 shadow-sm ${
-          inPlay
-            ? "border-emerald-200 bg-gradient-to-br from-emerald-50 via-white to-white"
-            : "border-purple-100 bg-white"
-        }`}
-      >
-        {inPlay ? (
-          <p className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-emerald-700">
-            <span className="animate-live-pulse h-2 w-2 rounded-full bg-emerald-500" />
-            Live{subscribed ? " · realtime" : ""}
+      {/* Court-slab scorebug — the broadcast moment of the page. */}
+      <div className="overflow-hidden rounded-2xl bg-court text-court-ink shadow-lg">
+        <div className="p-5 sm:p-6">
+          {inPlay ? (
+            <p className="mb-3 flex items-center gap-2 text-[11px] font-bold uppercase tracking-[0.22em] text-emerald-300">
+              <span className="animate-live-pulse h-2 w-2 rounded-full bg-emerald-400" />
+              Live{subscribed ? " · realtime" : ""}
+            </p>
+          ) : (
+            <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.22em] text-court-muted">
+              {decided ? "Final" : data.status.replace("_", " ")}
+            </p>
+          )}
+          <p className="font-display text-5xl font-bold tabular-nums leading-none tracking-tight sm:text-6xl">
+            {data.summary?.headline
+              ? showBreakdown
+                ? stripLiveSetPoints(data.summary.headline)
+                : data.summary.headline
+              : "Not started"}
           </p>
-        ) : (
-          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-zinc-500">
-            {data.status.replace("_", " ")}
-          </p>
-        )}
-        <p className="text-4xl font-black tabular-nums tracking-tight text-zinc-900">
-          {data.summary?.headline
-            ? showBreakdown
-              ? stripLiveSetPoints(data.summary.headline)
-              : data.summary.headline
-            : "Not started"}
-        </p>
-        {!showBreakdown && data.summary?.perSide ? (
-          <ul className="mt-3 space-y-1.5 text-sm text-zinc-700">
-            {data.summary.perSide.map((side) => (
-              <li key={side.entrantId} className="flex items-center gap-2 tabular-nums">
-                <span className="font-medium">{entrantNames[side.entrantId] ?? "—"}</span>
-                <span className="rounded-full bg-purple-50 px-2 py-0.5 text-xs font-semibold text-purple-700">
-                  {side.line}
-                </span>
-              </li>
-            ))}
-          </ul>
-        ) : null}
-        {data.outcome?.winner ? (
-          <p className="mt-3 flex items-center gap-1.5 text-sm text-zinc-600">
-            <span className="animate-trophy">🏆</span>
-            Winner:{" "}
-            <strong className="text-zinc-900">
-              {entrantNames[data.outcome.winner] ?? data.outcome.winner}
-            </strong>
-          </p>
-        ) : null}
+          {!showBreakdown && data.summary?.perSide ? (
+            <ul className="mt-5 space-y-2">
+              {data.summary.perSide.map((side) => {
+                const isWinner = data.outcome?.winner === side.entrantId;
+                return (
+                  <li
+                    key={side.entrantId}
+                    className={`flex items-baseline justify-between gap-3 tabular-nums ${
+                      data.outcome?.winner && !isWinner ? "opacity-60" : ""
+                    }`}
+                  >
+                    <span className="truncate font-display text-xl font-semibold uppercase tracking-wide sm:text-2xl">
+                      {entrantNames[side.entrantId] ?? "—"}
+                    </span>
+                    <span className="shrink-0 font-display text-xl font-bold sm:text-2xl">
+                      {side.line}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : null}
+          {data.outcome?.winner ? (
+            <p className="mt-4 flex items-center gap-1.5 text-sm text-court-muted">
+              <span className="animate-trophy">🏆</span>
+              Winner:{" "}
+              <strong className="text-amber-300">
+                {entrantNames[data.outcome.winner] ?? data.outcome.winner}
+              </strong>
+            </p>
+          ) : null}
+        </div>
+        <div aria-hidden className={`h-1 ${inPlay ? "bg-emerald-400" : "bg-accent"}`} />
       </div>
 
       {showBreakdown ? (
@@ -169,8 +169,8 @@ function SetScoreboard({
 }) {
   const sides = ["home", "away"] as const;
   return (
-    <div className="rounded-2xl border border-purple-100 bg-white p-5 shadow-sm">
-      <p className="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-500">
+    <div className="rounded-2xl border border-zinc-200/80 bg-surface p-5 shadow-sm">
+      <p className="mb-3 font-display text-sm font-semibold uppercase tracking-[0.18em] text-ink-muted">
         Score by {breakdown.unit.toLowerCase()}
       </p>
       <div className="overflow-x-auto">
@@ -213,13 +213,13 @@ function SetScoreboard({
                   return (
                     <td
                       key={i}
-                      className={`px-3 py-2 text-center text-xl ${
+                      className={`px-3 py-2 text-center font-display text-2xl ${
                         row === 0 ? "border-b border-zinc-100" : ""
                       } ${row === 1 && liveCell ? "rounded-b-lg" : ""} ${
                         liveCell
                           ? "bg-emerald-50 font-bold text-emerald-700"
                           : wonSet
-                            ? "font-bold text-zinc-900"
+                            ? "font-bold text-ink"
                             : "font-medium text-zinc-400"
                       }`}
                     >

--- a/apps/web/src/components/public-site/schedule.tsx
+++ b/apps/web/src/components/public-site/schedule.tsx
@@ -2,8 +2,12 @@
 // Schedule tab (doc 09 §2): fixtures by round/date, entrant filter, decided
 // scorelines from ScoreSummary.headline. Client-side filter keeps the page
 // ISR-cacheable (searchParams would force dynamic rendering).
+//
+// Each fixture renders as a "scorebug" row — time/court rail, stacked sides,
+// right-aligned per-side scores — the public site's signature element.
 import Link from "next/link";
 import { useState } from "react";
+import { CalendarPlus } from "lucide-react";
 import type { PublicFixture } from "@/server/public-site/data";
 
 interface Props {
@@ -20,6 +24,98 @@ function dayKey(iso: string | null): string | null {
 
 const UNSCHEDULED = "unscheduled";
 
+const timeOf = (iso: string) =>
+  new Date(iso).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+const shortDate = (iso: string) =>
+  new Date(iso).toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" });
+
+/** Per-side score lines fit the stacked layout only when short ("3", "21").
+    Long lines (cricket innings, set strings) fall back to the headline chip. */
+function sideLines(f: PublicFixture): [string, string] | null {
+  const perSide = f.summary?.perSide;
+  if (!perSide || perSide.length !== 2) return null;
+  if (perSide.some((s) => s.line.length > 7)) return null;
+  const byId = Object.fromEntries(perSide.map((s) => [s.entrantId, s.line]));
+  const home = f.home_entrant_id ? byId[f.home_entrant_id] : undefined;
+  const away = f.away_entrant_id ? byId[f.away_entrant_id] : undefined;
+  return home != null && away != null ? [home, away] : null;
+}
+
+function ScorebugRow({
+  fixture: f,
+  entrantNames,
+  href,
+  railMode,
+}: {
+  fixture: PublicFixture;
+  entrantNames: Record<string, string>;
+  href: string;
+  railMode: "time" | "date";
+}) {
+  const live = f.status === "in_play";
+  const decided = f.status === "decided" || f.status === "finalized";
+  const winner = f.outcome?.winner ?? null;
+  const lines = decided || live ? sideLines(f) : null;
+  const homeName = f.home_entrant_id ? (entrantNames[f.home_entrant_id] ?? "?") : "TBD";
+  const awayName = f.away_entrant_id ? (entrantNames[f.away_entrant_id] ?? "?") : "TBD";
+
+  const nameCls = (id: string | null) =>
+    winner && id === winner
+      ? "truncate text-[15px] font-semibold leading-6 text-ink"
+      : winner
+        ? "truncate text-[15px] font-medium leading-6 text-ink-muted"
+        : "truncate text-[15px] font-medium leading-6 text-ink";
+  const scoreCls = (id: string | null) => {
+    const weight = winner && id === winner ? "font-bold" : "font-semibold";
+    const color = live ? "text-emerald-600" : winner && id !== winner ? "text-ink-muted" : "text-ink";
+    return `pl-2 text-right font-display text-lg tabular-nums leading-6 ${weight} ${color}`;
+  };
+
+  return (
+    <Link
+      href={href}
+      className="relative grid grid-cols-[3.25rem_minmax(0,1fr)_auto] items-center gap-x-3 px-3.5 py-2.5 transition hover:bg-accent-soft/60"
+    >
+      {live ? <span aria-hidden className="absolute inset-y-0 left-0 w-0.5 bg-emerald-400" /> : null}
+
+      <span className="row-span-2 flex flex-col items-start">
+        {live ? (
+          <span className="flex items-center gap-1 text-[11px] font-bold uppercase tracking-wide text-emerald-600">
+            <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-500" />
+            Live
+          </span>
+        ) : (
+          <span className="font-display text-sm font-semibold text-ink">
+            {decided ? "Final" : f.scheduled_at ? timeOf(f.scheduled_at) : "TBD"}
+          </span>
+        )}
+        <span className="mt-0.5 max-w-[3.25rem] truncate text-[10px] uppercase tracking-wide text-ink-muted">
+          {!decided && !live && railMode === "date" && f.scheduled_at
+            ? shortDate(f.scheduled_at)
+            : (f.court_label ?? "")}
+        </span>
+      </span>
+
+      <span className={nameCls(f.home_entrant_id)}>{homeName}</span>
+      {lines ? (
+        <span className={scoreCls(f.home_entrant_id)}>{lines[0]}</span>
+      ) : (
+        <span
+          className={`row-span-2 self-center ${
+            f.summary?.headline
+              ? "rounded-full bg-accent-soft px-2.5 py-0.5 font-display text-sm font-semibold tabular-nums text-accent-strong"
+              : "text-[11px] text-ink-muted"
+          }`}
+        >
+          {f.summary?.headline ?? (f.venue && railMode === "time" ? f.venue : "")}
+        </span>
+      )}
+      <span className={nameCls(f.away_entrant_id)}>{awayName}</span>
+      {lines ? <span className={scoreCls(f.away_entrant_id)}>{lines[1]}</span> : null}
+    </Link>
+  );
+}
+
 export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
   const [entrant, setEntrant] = useState<string>("");
   // Day view first (fixtures by date) — matches how a spectator reads a
@@ -35,8 +131,7 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
 
   const groups = new Map<string, PublicFixture[]>();
   for (const f of shown) {
-    const key =
-      mode === "day" ? (dayKey(f.scheduled_at) ?? UNSCHEDULED) : String(f.round_no);
+    const key = mode === "day" ? (dayKey(f.scheduled_at) ?? UNSCHEDULED) : String(f.round_no);
     const list = groups.get(key) ?? [];
     list.push(f);
     groups.set(key, list);
@@ -66,14 +161,14 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center gap-3">
-        <label className="text-sm text-zinc-600" htmlFor="entrant-filter">
-          Filter
+        <label className="sr-only" htmlFor="entrant-filter">
+          Show matches for
         </label>
         <select
           id="entrant-filter"
           value={entrant}
           onChange={(e) => setEntrant(e.target.value)}
-          className="rounded-lg border border-purple-200 bg-white px-2.5 py-1.5 text-sm outline-none focus:border-purple-500 focus:ring-2 focus:ring-purple-200"
+          className="rounded-lg border border-zinc-300 bg-surface px-2.5 py-1.5 text-sm text-ink outline-none transition focus:border-accent focus:ring-2 focus:ring-accent-line"
         >
           <option value="">All entrants</option>
           {options.map(([id, name]) => (
@@ -83,16 +178,21 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
           ))}
         </select>
         {anyScheduled && (
-          <div className="inline-flex overflow-hidden rounded-lg border border-purple-200 text-sm">
+          <div
+            role="group"
+            aria-label="Group fixtures by"
+            className="inline-flex overflow-hidden rounded-lg border border-zinc-300 text-sm"
+          >
             {(["day", "round"] as const).map((v) => (
               <button
                 key={v}
                 type="button"
+                aria-pressed={mode === v}
                 onClick={() => setView(v)}
                 className={`px-3 py-1.5 font-medium capitalize transition ${
                   mode === v
-                    ? "bg-purple-600 text-white"
-                    : "bg-white text-purple-700 hover:bg-purple-50"
+                    ? "bg-accent text-accent-ink"
+                    : "bg-surface text-ink-muted hover:bg-accent-soft hover:text-accent-strong"
                 }`}
               >
                 {v}
@@ -102,70 +202,44 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
         )}
         <a
           href={`${divisionPath}/calendar.ics${entrant ? `?entrant=${entrant}` : ""}`}
-          className="text-sm font-medium text-purple-700 underline underline-offset-2 hover:text-purple-900"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-accent-strong underline-offset-2 hover:underline"
         >
-          Subscribe (.ics)
+          <CalendarPlus aria-hidden className="h-4 w-4" />
+          Add to calendar
         </a>
       </div>
 
       {orderedGroups.map(([key, list]) => (
-          <section key={key} className="mb-6">
-            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-purple-700/70">
-              {groupLabel(key)}
-            </h3>
-            <ul className="divide-y divide-purple-50 overflow-hidden rounded-xl border border-purple-100 bg-white shadow-sm">
-              {[...list]
-                .sort((a, b) =>
-                  mode === "day"
-                    ? (a.scheduled_at ?? "").localeCompare(b.scheduled_at ?? "") ||
-                      a.round_no - b.round_no
-                    : a.round_no - b.round_no,
-                )
-                .map((f) => (
+        <section key={key} className="mb-6">
+          <h3 className="mb-2 flex items-center gap-3 font-display text-sm font-semibold uppercase tracking-[0.18em] text-ink-muted">
+            {groupLabel(key)}
+            <span aria-hidden className="h-px flex-1 bg-zinc-200" />
+          </h3>
+          <ul className="divide-y divide-zinc-100 overflow-hidden rounded-xl border border-zinc-200/80 bg-surface shadow-sm">
+            {[...list]
+              .sort((a, b) =>
+                mode === "day"
+                  ? (a.scheduled_at ?? "").localeCompare(b.scheduled_at ?? "") ||
+                    a.round_no - b.round_no
+                  : a.round_no - b.round_no,
+              )
+              .map((f) => (
                 <li key={f.id}>
-                  <Link
+                  <ScorebugRow
+                    fixture={f}
+                    entrantNames={entrantNames}
                     href={`${divisionPath}/fixtures/${f.id}`}
-                    className="flex flex-wrap items-center justify-between gap-2 px-4 py-2.5 text-sm transition hover:bg-purple-50/60"
-                  >
-                    <span className="font-medium">
-                      {f.home_entrant_id ? (entrantNames[f.home_entrant_id] ?? "?") : "TBD"}
-                      <span className="font-normal text-zinc-400"> vs </span>
-                      {f.away_entrant_id ? (entrantNames[f.away_entrant_id] ?? "?") : "TBD"}
-                    </span>
-                    <span className="text-xs text-zinc-500">
-                      {f.status === "in_play" ? (
-                        <span className="flex items-center gap-1.5 rounded-full bg-emerald-50 px-2 py-0.5 font-semibold text-emerald-700">
-                          <span className="animate-live-pulse h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                          LIVE
-                        </span>
-                      ) : f.summary?.headline ? (
-                        <span className="rounded-full bg-purple-50 px-2 py-0.5 font-semibold tabular-nums text-purple-700">
-                          {f.summary.headline}
-                        </span>
-                      ) : (
-                        <>
-                          {f.scheduled_at
-                            ? new Date(f.scheduled_at).toLocaleString("en-GB", {
-                                weekday: "short",
-                                day: "numeric",
-                                month: "short",
-                                hour: "2-digit",
-                                minute: "2-digit",
-                              })
-                            : "Time TBD"}
-                          {f.venue ? ` · ${f.venue}` : ""}
-                          {f.court_label ? ` · ${f.court_label}` : ""}
-                        </>
-                      )}
-                    </span>
-                  </Link>
+                    railMode={mode === "day" ? "time" : "date"}
+                  />
                 </li>
               ))}
-            </ul>
-          </section>
-        ))}
+          </ul>
+        </section>
+      ))}
       {shown.length === 0 ? (
-        <p className="text-sm text-zinc-500">No fixtures yet.</p>
+        <p className="rounded-xl border border-dashed border-zinc-300 bg-surface p-6 text-center text-sm text-ink-muted">
+          No fixtures yet — the schedule appears once the draw is made.
+        </p>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/public-site/standings-table.tsx
+++ b/apps/web/src/components/public-site/standings-table.tsx
@@ -25,7 +25,8 @@ interface Props {
 export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, caption }: Props) {
   const columns = standingsColumns(metricSpecs, cascade, rows, DERIVED_METRICS);
   const ranked = [...rows].sort((a, b) => (a.rank ?? 99) - (b.rank ?? 99));
-  // Small medal chips for the podium ranks — quick visual anchor on long tables.
+  // Podium chips are fixed vocabulary (gold/silver/bronze) — deliberately NOT
+  // org-themeable, so a red-branded org still reads gold as first place.
   const medal: Record<number, string> = {
     1: "bg-amber-300 text-amber-950",
     2: "bg-slate-300 text-slate-900",
@@ -34,8 +35,8 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
   // Fixed-size cell for every rank so podium chips and plain numbers line up.
   const rankChip = (rank: number | undefined) => (
     <span
-      className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
-        rank && medal[rank] ? medal[rank] : "font-normal text-zinc-500"
+      className={`inline-flex h-5 w-5 items-center justify-center rounded-full font-display text-[12px] font-bold ${
+        rank && medal[rank] ? medal[rank] : "text-ink-muted"
       }`}
     >
       {rank}
@@ -43,19 +44,19 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
   );
 
   return (
-    <div className="overflow-x-auto rounded-xl border border-purple-100 bg-white p-3 shadow-sm">
+    <div className="overflow-x-auto rounded-xl border border-zinc-200/80 bg-surface shadow-sm">
       <table className="w-full text-sm">
         {caption ? (
-          <caption className="px-1 pb-3 pt-1 text-left text-base font-semibold text-zinc-800">
+          <caption className="px-4 pb-1 pt-3 text-left font-display text-lg font-semibold text-ink">
             {caption}
           </caption>
         ) : null}
         <thead>
-          <tr className="border-b border-purple-100 text-left text-xs uppercase tracking-wide text-purple-700/70">
-            <th scope="col" className="w-10 py-2 pr-2 font-semibold">#</th>
-            <th scope="col" className="py-2 pr-3 font-semibold">Team</th>
+          <tr className="border-b border-zinc-200 text-left text-[11px] uppercase tracking-wider text-ink-muted">
+            <th scope="col" className="w-12 py-2.5 pl-4 pr-2 font-semibold">#</th>
+            <th scope="col" className="py-2.5 pr-3 font-semibold">Team</th>
             {columns.map((col) => (
-              <th key={col.key} scope="col" className="py-2 px-2 text-right font-semibold">
+              <th key={col.key} scope="col" className="px-2.5 py-2.5 text-right font-semibold last:pr-4">
                 {col.label}
               </th>
             ))}
@@ -65,20 +66,20 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
           {ranked.map((row) => (
             <tr
               key={row.entrantId}
-              className={`border-b border-purple-50 last:border-0 ${
+              className={`border-b border-zinc-100 last:border-0 ${
                 row.rank === 1 ? "bg-amber-50/60" : ""
               }`}
             >
-              <td className="py-2 pr-2 tabular-nums text-zinc-500">
+              <td className="py-2.5 pl-4 pr-2 tabular-nums">
                 {row.tieBreak ? (
                   <details className="relative inline-block">
-                    <summary className="cursor-help list-none">
+                    <summary className="inline-flex cursor-help list-none items-start whitespace-nowrap">
                       {rankChip(row.rank)}
-                      <span className="align-super text-[10px] text-purple-400">*</span>
+                      <span className="text-[10px] text-accent">*</span>
                     </summary>
                     <p
                       role="tooltip"
-                      className="absolute left-0 z-10 mt-1 w-56 rounded border border-zinc-200 bg-white p-2 text-xs text-zinc-700 shadow-lg"
+                      className="absolute left-0 z-10 mt-1 w-56 rounded-lg border border-zinc-200 bg-surface p-2 text-xs text-zinc-700 shadow-lg"
                     >
                       Level with{" "}
                       {row.tieBreak.with
@@ -91,14 +92,16 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
                   rankChip(row.rank)
                 )}
               </td>
-              <th scope="row" className="py-2 pr-3 text-left font-medium">
+              <th scope="row" className="py-2.5 pr-3 text-left font-medium text-ink">
                 {entrantNames[row.entrantId] ?? row.entrantId}
               </th>
               {columns.map((col) => (
                 <td
                   key={col.key}
-                  className={`py-2 px-2 text-right tabular-nums ${
-                    col.key === "points" ? "font-bold text-purple-700" : ""
+                  className={`px-2.5 py-2.5 text-right tabular-nums last:pr-4 ${
+                    col.key === "points"
+                      ? "font-display text-base font-bold text-accent-strong"
+                      : "text-zinc-600"
                   }`}
                 >
                   {col.kind === "derived"

--- a/apps/web/src/components/public-site/tabs.tsx
+++ b/apps/web/src/components/public-site/tabs.tsx
@@ -2,6 +2,8 @@
 // Minimal tab switcher for the division home (Schedule / Standings /
 // Entrants — doc 09 §2). All panels are server-rendered and shipped in the
 // ISR payload; this only toggles visibility (fast + crawlable).
+// Styled as a segmented pill bar, sticky under the court masthead so a
+// spectator can hop tabs from anywhere in a long schedule.
 import { useState, type ReactNode } from "react";
 
 interface Props {
@@ -13,22 +15,27 @@ export function Tabs({ labels, children }: Props) {
   const [active, setActive] = useState(0);
   return (
     <div>
-      <div role="tablist" className="mb-6 flex gap-1 border-b border-purple-100 sm:gap-4">
-        {labels.map((label, i) => (
-          <button
-            key={label}
-            role="tab"
-            aria-selected={i === active}
-            onClick={() => setActive(i)}
-            className={
-              i === active
-                ? "-mb-px border-b-2 border-purple-600 px-3 pb-2.5 pt-1.5 text-sm font-semibold text-purple-700"
-                : "-mb-px border-b-2 border-transparent px-3 pb-2.5 pt-1.5 text-sm font-medium text-zinc-500 transition hover:border-purple-200 hover:text-zinc-800"
-            }
-          >
-            {label}
-          </button>
-        ))}
+      <div className="sticky top-[54px] z-30 -mx-4 mb-5 bg-canvas/90 px-4 py-2 backdrop-blur">
+        <div
+          role="tablist"
+          className="inline-flex max-w-full gap-1 overflow-x-auto rounded-full border border-zinc-200/80 bg-surface p-1 shadow-sm"
+        >
+          {labels.map((label, i) => (
+            <button
+              key={label}
+              role="tab"
+              aria-selected={i === active}
+              onClick={() => setActive(i)}
+              className={
+                i === active
+                  ? "shrink-0 rounded-full bg-accent px-4 py-1.5 text-sm font-semibold text-accent-ink shadow-sm"
+                  : "shrink-0 rounded-full px-4 py-1.5 text-sm font-medium text-ink-muted transition hover:bg-accent-soft hover:text-accent-strong"
+              }
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
       {children.map((panel, i) => (
         <div key={labels[i]} role="tabpanel" hidden={i !== active}>

--- a/apps/web/src/lib/__tests__/public-theme.test.ts
+++ b/apps/web/src/lib/__tests__/public-theme.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { publicBrandColor, publicThemeStyle, resolvePublicTheme } from "../public-theme";
+
+describe("resolvePublicTheme", () => {
+  it("returns null for missing or unparsable colors", () => {
+    expect(resolvePublicTheme(undefined)).toBeNull();
+    expect(resolvePublicTheme(null)).toBeNull();
+    expect(resolvePublicTheme("")).toBeNull();
+    expect(resolvePublicTheme("purple")).toBeNull();
+    expect(resolvePublicTheme("#12")).toBeNull();
+    expect(resolvePublicTheme("#12345g")).toBeNull();
+  });
+
+  it("rejects accents that fail the contrast guard (too light for white ink)", () => {
+    expect(resolvePublicTheme("#ffe14d")).toBeNull(); // yellow
+    expect(resolvePublicTheme("#ffffff")).toBeNull();
+    expect(resolvePublicTheme("#7dd3fc")).toBeNull(); // pale sky
+  });
+
+  it("matches the --ps-* defaults in globals.css for the platform violet", () => {
+    // If this fails, globals.css and the resolver have drifted apart.
+    expect(resolvePublicTheme("#7c3aed")).toEqual({
+      "--ps-accent": "#7c3aed",
+      "--ps-accent-ink": "#ffffff",
+      "--ps-accent-strong": "#6931c9",
+      "--ps-accent-soft": "#f5effe",
+      "--ps-accent-line": "#decefb",
+      "--ps-court": "#231738",
+      "--ps-court-ink": "#f7f5fb",
+      "--ps-court-muted": "rgba(247,245,251,0.64)",
+    });
+  });
+
+  it("derives a full var set from a dark org accent", () => {
+    const theme = resolvePublicTheme("#0f766e"); // teal-700
+    expect(theme).not.toBeNull();
+    expect(theme!["--ps-accent"]).toBe("#0f766e");
+    expect(theme!["--ps-accent-ink"]).toBe("#ffffff");
+    // The masthead slab picks up the accent hue: green channel dominates red.
+    const court = theme!["--ps-court"];
+    const [r, g] = [court.slice(1, 3), court.slice(3, 5)].map((h) => parseInt(h, 16));
+    expect(g).toBeGreaterThan(r);
+  });
+
+  it("accepts #rgb shorthand", () => {
+    expect(resolvePublicTheme("#333")).not.toBeNull();
+    expect(resolvePublicTheme("#333")!["--ps-accent"]).toBe("#333333");
+  });
+});
+
+describe("publicBrandColor", () => {
+  it("extracts colors.primary from a branding blob", () => {
+    expect(publicBrandColor({ colors: { primary: "#123456" } })).toBe("#123456");
+  });
+
+  it("returns null for malformed blobs", () => {
+    expect(publicBrandColor(null)).toBeNull();
+    expect(publicBrandColor(undefined)).toBeNull();
+    expect(publicBrandColor("x")).toBeNull();
+    expect(publicBrandColor({})).toBeNull();
+    expect(publicBrandColor({ colors: null })).toBeNull();
+    expect(publicBrandColor({ colors: { primary: 7 } })).toBeNull();
+  });
+});
+
+describe("publicThemeStyle", () => {
+  it("returns undefined when there is nothing to theme", () => {
+    expect(publicThemeStyle({})).toBeUndefined();
+    expect(publicThemeStyle({ colors: { primary: "#ffe14d" } })).toBeUndefined();
+  });
+
+  it("returns the var map as a style object for a valid brand", () => {
+    const style = publicThemeStyle({ colors: { primary: "#0f766e" } });
+    expect(style).toBeDefined();
+    expect((style as Record<string, string>)["--ps-accent"]).toBe("#0f766e");
+  });
+});

--- a/apps/web/src/lib/public-theme.ts
+++ b/apps/web/src/lib/public-theme.ts
@@ -1,0 +1,109 @@
+// Public-site theming (v3/11 gap 7): an org/competition accent re-themes the
+// public "courtside" surface by overriding the --ps-* CSS vars that every
+// public component reads. The resolver derives the full var set from ONE
+// brand color, with a WCAG contrast guard — an accent too light to carry
+// white ink (or to read as link text on white) is rejected and the surface
+// falls back to the platform violet defined in globals.css.
+//
+// The default violet outputs here MUST match the --ps-* defaults in
+// app/globals.css; lib/__tests__/public-theme.test.ts pins that.
+import type { CSSProperties } from "react";
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+const WHITE: Rgb = { r: 255, g: 255, b: 255 };
+const BLACK: Rgb = { r: 0, g: 0, b: 0 };
+/** Near-black base the "court" masthead slab is mixed from (#131118). */
+const COURT_BASE: Rgb = { r: 19, g: 17, b: 24 };
+
+function parseHex(value: string): Rgb | null {
+  const hex = value.trim().replace(/^#/, "");
+  const full =
+    hex.length === 3 && /^[0-9a-f]{3}$/i.test(hex)
+      ? hex
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : hex;
+  if (!/^[0-9a-f]{6}$/i.test(full)) return null;
+  return {
+    r: parseInt(full.slice(0, 2), 16),
+    g: parseInt(full.slice(2, 4), 16),
+    b: parseInt(full.slice(4, 6), 16),
+  };
+}
+
+function toHex({ r, g, b }: Rgb): string {
+  const h = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${h(r)}${h(g)}${h(b)}`;
+}
+
+/** sRGB mix: `weight` of `a` over `1 - weight` of `b`. */
+function mix(a: Rgb, b: Rgb, weight: number): Rgb {
+  const ch = (x: number, y: number) => Math.round(x * weight + y * (1 - weight));
+  return { r: ch(a.r, b.r), g: ch(a.g, b.g), b: ch(a.b, b.b) };
+}
+
+/** WCAG 2.x relative luminance. */
+function luminance({ r, g, b }: Rgb): number {
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+function contrast(a: Rgb, b: Rgb): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+export type PublicThemeVars = Record<`--ps-${string}`, string>;
+
+/**
+ * Derive the full public-theme var set from one brand color.
+ * Returns `null` (= keep the violet defaults from globals.css) when the
+ * color is missing, unparsable, or fails the contrast guard: the accent must
+ * hold white ink AND read as text on a white card (>= 3:1 against white).
+ */
+export function resolvePublicTheme(brand?: string | null): PublicThemeVars | null {
+  if (!brand) return null;
+  const accent = parseHex(brand);
+  if (!accent) return null;
+  if (contrast(accent, WHITE) < 3) return null;
+
+  return {
+    "--ps-accent": toHex(accent),
+    "--ps-accent-ink": "#ffffff",
+    "--ps-accent-strong": toHex(mix(accent, BLACK, 0.85)),
+    "--ps-accent-soft": toHex(mix(accent, WHITE, 0.08)),
+    "--ps-accent-line": toHex(mix(accent, WHITE, 0.25)),
+    "--ps-court": toHex(mix(accent, COURT_BASE, 0.15)),
+    "--ps-court-ink": "#f7f5fb",
+    "--ps-court-muted": "rgba(247,245,251,0.64)",
+  };
+}
+
+/**
+ * Pull the brand color out of a competition/org `branding` JSON blob
+ * (`{ colors: { primary } }`). The public views already null branding for
+ * orgs without the Pro branding entitlement, so reaching here implies the
+ * org may theme its public pages.
+ */
+export function publicBrandColor(branding: unknown): string | null {
+  if (typeof branding !== "object" || branding === null) return null;
+  const colors = (branding as { colors?: unknown }).colors;
+  if (typeof colors !== "object" || colors === null) return null;
+  const primary = (colors as { primary?: unknown }).primary;
+  return typeof primary === "string" ? primary : null;
+}
+
+/** Inline-style form for a page/section wrapper; undefined = defaults. */
+export function publicThemeStyle(branding: unknown): CSSProperties | undefined {
+  const vars = resolvePublicTheme(publicBrandColor(branding));
+  return vars ? (vars as CSSProperties) : undefined;
+}

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -212,7 +212,7 @@ async function main() {
   // The advanced features are entitlement-gated — org2 must be Pro (and it
   // needs headroom past competitions.max_active for the extra competitions).
   await setPlan(org2.id, "pro");
-  await jul3Suite(admin, org2.id);
+  await jul3Suite(admin, org2.id, org2.slug);
 
   // --- Growth-wave gaps (device links, scorer seats, discovery, registration,
   // ownership transfer, downgrade freeze) — pro paths on org2, free paths on a
@@ -380,6 +380,18 @@ async function v1Suite(admin: Session, orgId: string, orgSlug: string): Promise<
   const pubComp = await v1(anon, `/api/v1/public/orgs/${orgSlug}/competitions/${compSlug}`);
   check("v1 public competition lists divisions", v1data<{ divisions: unknown[] }>(pubComp).divisions.length === 1);
 
+  // Public-page theming, free path (public redesign): the branding write is
+  // accepted, but the public view empties it for orgs without
+  // dashboard.branding — the page must NOT carry the --ps-* accent override.
+  const branded = await v1(admin, `/api/v1/competitions/${compId}`, "PATCH", {
+    branding: { colors: { primary: "#0f766e" } },
+  });
+  check("v1 branding patch accepted", branded.status === 200);
+  const freePage = await fetch(`${BASE}/shared/${orgSlug}/${compSlug}`);
+  const freeHtml = await freePage.text();
+  check("public competition page renders (community)", freePage.status === 200 && freeHtml.includes("V1 Cup"));
+  check("community public page keeps default theme", !freeHtml.includes("--ps-accent:#0f766e"));
+
   // Entitlement gate: community org → 402; Pro override → key works via Bearer.
   const denied = await v1(admin, `/api/v1/orgs/${orgId}/api-keys`, "POST", { name: "ci", scopes: ["read"] });
   check("v1 API keys 402-gated on api.access", denied.status === 402 && denied.json.error?.code === "PAYMENT_REQUIRED");
@@ -439,13 +451,22 @@ async function v1Multipart(
  * route/auth/envelope fails CI even when the usecase unit passes. Runs against
  * a Pro org (advanced features are entitlement-gated).
  */
-async function jul3Suite(admin: Session, orgId: string): Promise<void> {
+async function jul3Suite(admin: Session, orgId: string, orgSlug: string): Promise<void> {
   void orgId;
   // Fresh competition + football division (football has the richest surface:
   // scorers, cards, MOTM, scoresheets).
-  const comp = v1data<{ id: string }>(
+  const comp = v1data<{ id: string; slug: string }>(
     await v1(admin, "/api/v1/competitions", "POST", { name: `Jul3 Cup ${tag}`, visibility: "public" }),
   );
+
+  // Public-page theming, pro path (public redesign): dashboard.branding lets
+  // the brand color through the public view and the competition page inlines
+  // the --ps-* accent override for its whole subtree.
+  await v1(admin, `/api/v1/competitions/${comp.id}`, "PATCH", {
+    branding: { colors: { primary: "#0f766e" } },
+  });
+  const themedHtml = await (await fetch(`${BASE}/shared/${orgSlug}/${comp.slug}`)).text();
+  check("pro public page carries the org accent theme", themedHtml.includes("--ps-accent:#0f766e"));
   const div = await v1(admin, `/api/v1/competitions/${comp.id}/divisions`, "POST", {
     name: "Open", sport_key: "generic", variant_key: "score",
     config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },


### PR DESCRIPTION
## What

Redesigns every public `/shared` surface around a **courtside** broadcast language, built for the people who actually open these links — parents, students and players on phones at the venue:

- **Court-slab masthead + heroes**: dark slab derived from the accent color, Barlow Condensed display face (mounted only on the public tree; console untouched), accent keel line.
- **Scorebug fixture rows** (the signature element): time/court rail, stacked sides, right-aligned per-side scores, winner emphasis, live pulse — shared grammar across schedule, brackets, live rail and the match page.
- Segmented sticky tabs, cleaner standings (podium chips kept as fixed gold/silver/bronze vocabulary), champion banner as a court-slab moment, restyled poster/register/status/player pages.
- `prefers-reduced-motion` respected; visible keyboard focus everywhere.

## Theming (per-org, ready today for Pro)

All public components read `--ps-*` CSS vars. `lib/public-theme.ts` derives the full var set (accent, tints, court slab) from **one** brand hex (`branding.colors.primary`) with a WCAG contrast guard that falls back to platform violet (v3/11 gap 7). Competition/division/fixture pages inline the override — the `dashboard.branding` view gate makes this Pro-only. Org-level theming later = pass the org's color to the same helper in the layout.

Teal-branded demo: hero/tiles/keel re-theme, masthead stays violet, live/podium vocabulary fixed.

## Bug fix found while verifying

`live-score.tsx` unwrapped `api()` responses twice: the 15 s poll replaced the scoreboard with `undefined` (client crash mid-match) and the Pro realtime-token flow always threw `Cannot read properties of undefined (reading 'token')`. Fetch layer extracted to `live-score-data.ts` + regression test.

## Tests / verification

- New: `public-theme.test.ts` (pins resolver ↔ globals.css defaults, contrast guard), `live-score-data.test.ts` (regression for the double-unwrap), smoke checks (accent inlined on pro path, absent on community path).
- `tsc` clean, eslint clean, `npm run test:smoke` **99/99** against the dev server, screenshots verified at 390px/1280px incl. a >15 s poll cycle on a live fixture.
- ⚠️ Not fully re-baselined: a full `vitest run` (no DATABASE_URL) and the serial `journey-pro`+`journey-community` e2e run reported failures whose output got truncated before I could read details (journey e2e: 9 passed, 2 failed, 9 did not run). Known environmental flake per repo notes, but not confirmed — worth a CI look on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)