### PR TITLE
fix(e2e): community journey — slow-test budget + retryable free-plan quotas

### DIFF
--- a/apps/web/e2e/journey-community.spec.ts
+++ b/apps/web/e2e/journey-community.spec.ts
@@ -24,6 +24,29 @@ test.describe.serial("community lifecycle", () => {
   let fixtureIds: string[] = [];
 
   test("run a full small tournament on the free plan", async ({ page, request }) => {
+    // On CI the dev server pays first-compile for the slideshow AND the public
+    // division page inside this single test — 60s is not enough on a 2-core
+    // runner (Turbopack took ~14s + ~19s for those two routes alone).
+    test.slow();
+
+    // A failed earlier attempt leaves its competition behind, and BOTH free
+    // ceilings then 402 the wizard on retry: competitions.max_active counts
+    // draft/published/live, and dashboard.public.max counts public rows in
+    // ANY status. Retire leftovers on both axes (TAG differs per attempt —
+    // match on the stable prefix).
+    const leftovers = await apiJson<{ items: { id: string; name: string }[] }>(
+      request,
+      "/api/v1/competitions",
+    );
+    for (const c of leftovers.data?.items ?? []) {
+      if (c.name.startsWith("Village Cup ")) {
+        await apiJson(request, `/api/v1/competitions/${c.id}`, "PATCH", {
+          status: "archived",
+          visibility: "private",
+        });
+      }
+    }
+
     competitionId = await createCompetitionViaUi(page, `Village Cup ${TAG}`, "public");
     const comp = await apiJson<{ slug: string }>(request, `/api/v1/competitions/${competitionId}`);
     competitionSlug = comp.data!.slug;


### PR DESCRIPTION
Fixes the red E2E run on main: https://github.com/ashokhein/seazn.club/actions/runs/29074401958

**Attempt 1** of `journey-community › run a full small tournament on the free plan` blew its 60s budget because the CI dev server pays Turbopack first-compile for `/slideshow/divisions/[id]` (14.2s) and `/shared/[org]/[comp]/[division]` (18.7s) inside this single test — the public page actually returned 200, just after the test had timed out. Fixed with `test.slow()` (3x budget).

**The retry** then failed deterministically: attempt 1's competition survives, so the wizard's create POST 402s — `competitions.max_active` counts the leftover, and `dashboard.public.max` counts public competitions in *any* status, so archiving alone doesn't help. The test now retires leftover `Village Cup *` competitions on both axes (`status: archived, visibility: private`) before creating.

Verified locally: full `journey-community` suite green, plus a poisoned-retry simulation (rerun of the test against an org already at both ceilings) that fails without the cleanup and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)