### PR TITLE
PROMPT-38: engine fixes — badminton headline, cricket undo, sim-replay v2, division delete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,18 @@ jobs:
       # defaults to 200 divisions per sport×format when CI=true) and the
       # coverage gate (≥90% lines; 100% on core/ and tiebreakers.ts).
       - run: npm run test:coverage --workspace packages/engine
+      # Sim matrix (v3/09 §3): bounded profile — every module × format ×
+      # SIM_SEEDS seeds + the permanent scenario suites; emits sim-report.json.
+      # A failure line prints its reproducing seed token.
+      - name: Sim matrix (bounded CI profile)
+        run: SIM_SEEDS=5 npm run sim:matrix --workspace packages/engine
+      - name: Sim report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-report
+          path: packages/engine/sim-report.json
+          if-no-files-found: ignore
       - name: Simulation failure artifacts (repro with `npm run sim:replay -- <seedToken>`)
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 scripts/.seed-demo-state.json
+packages/engine/sim-report.json

--- a/apps/web/e2e/division-archive.spec.ts
+++ b/apps/web/e2e/division-archive.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "@playwright/test";
+import {
+  addEntrantsViaApi,
+  apiJson,
+  createStageAndGenerate,
+  TAG,
+} from "./helpers";
+
+// Resulted-division lifecycle (v3/09 §4, PROMPT-38): delete 409s with the
+// archive hint, archive hides the division, restore round-trips from the
+// competition-settings "Archived divisions" surface. Own competition —
+// parallel-safe on the Pro org.
+
+test("resulted division: 409 → archive → restore round-trip", async ({ page, request }) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Arch Cycle ${TAG}`,
+    visibility: "private",
+  });
+  const compId = comp.data!.id;
+  const div = await apiJson<{ id: string; name: string }>(
+    request,
+    `/api/v1/competitions/${compId}/divisions`,
+    "POST",
+    {
+      name: "Resulted",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    },
+  );
+  expect(div.error, JSON.stringify(div.error ?? {})).toBeUndefined();
+  const divisionId = div.data!.id;
+  await addEntrantsViaApi(request, divisionId, ["Ana", "Ben"]);
+  const { fixtureIds } = await createStageAndGenerate(request, divisionId, {
+    kind: "league",
+    name: "League",
+  });
+  await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+  await apiJson(request, `/api/v1/fixtures/${fixtureIds[0]}/events`, "POST", {
+    expected_seq: 0,
+    type: "core.start",
+    payload: {},
+  });
+  await apiJson(request, `/api/v1/fixtures/${fixtureIds[0]}/events`, "POST", {
+    expected_seq: 1,
+    type: "generic.result",
+    payload: { p1Score: 2, p2Score: 0 },
+  });
+
+  // Hard delete is refused with the archive hint.
+  const refused = await apiJson(request, `/api/v1/divisions/${divisionId}`, "DELETE");
+  expect(refused.status).toBe(409);
+  expect(refused.error?.code).toBe("DIVISION_HAS_RESULTS");
+
+  // Archive from the division's danger zone (plain danger confirm, no typing).
+  await page.goto(`/divisions/${divisionId}`);
+  await page.getByRole("button", { name: "Archive division" }).click({ timeout: 20_000 });
+  await page.getByRole("dialog").getByRole("button", { name: "Archive division" }).click();
+  await page.waitForURL(`**/competitions/${compId}`, { timeout: 20_000 });
+
+  // Hidden from the console list.
+  const listed = await apiJson<{ id: string }[]>(
+    request,
+    `/api/v1/competitions/${compId}/divisions`,
+  );
+  expect(listed.data!.every((d) => d.id !== divisionId)).toBe(true);
+
+  // Restore from competition settings → Archived divisions.
+  await page.goto(`/competitions/${compId}/settings`);
+  const archivedSection = page.getByTestId("archived-divisions");
+  await expect(archivedSection.getByText("Resulted")).toBeVisible({ timeout: 20_000 });
+  // Purge is locked behind the 30-day cool-off.
+  await expect(archivedSection.getByRole("button", { name: /Purge/ })).toBeDisabled();
+  await archivedSection.getByRole("button", { name: "Restore" }).click();
+  await expect(archivedSection).toHaveCount(0, { timeout: 20_000 });
+
+  // Back in the list, results intact.
+  const relisted = await apiJson<{ id: string }[]>(
+    request,
+    `/api/v1/competitions/${compId}/divisions`,
+  );
+  expect(relisted.data!.some((d) => d.id === divisionId)).toBe(true);
+  const fixture = await apiJson<{ status: string }>(request, `/api/v1/fixtures/${fixtureIds[0]}`);
+  expect(fixture.data!.status).toBe("decided");
+});

--- a/apps/web/e2e/division-delete.spec.ts
+++ b/apps/web/e2e/division-delete.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from "@playwright/test";
+import { apiJson, TAG } from "./helpers";
+
+// Division delete on the free plan (v3/09 §4, PROMPT-38): deleting a
+// setup-state division frees the divisions.per_competition slot — the honest
+// behaviour, and the reason people ask for delete. Serial: community-org
+// quotas are shared state.
+test.use({ storageState: "e2e/.auth/community.json" });
+
+const GENERIC = {
+  sport_key: "generic",
+  variant_key: "score",
+  config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+};
+
+test("deleting a setup division lifts the free-plan divisions gate", async ({ page, request }) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Del Gate ${TAG}`,
+    visibility: "private",
+  });
+  const compId = comp.data!.id;
+
+  const first = await apiJson<{ id: string; name: string }>(
+    request,
+    `/api/v1/competitions/${compId}/divisions`,
+    "POST",
+    { name: "Only Slot", ...GENERIC },
+  );
+  expect(first.status).toBe(201);
+  const divisionId = first.data!.id;
+
+  // Community divisions.per_competition.max = 1: the second is 402-gated.
+  const gated = await apiJson(request, `/api/v1/competitions/${compId}/divisions`, "POST", {
+    name: "Second",
+    ...GENERIC,
+  });
+  expect(gated.status).toBe(402);
+
+  // Delete through the UI: Danger zone → typed-name confirm.
+  await page.goto(`/divisions/${divisionId}`);
+  await page.getByRole("button", { name: /Delete division/ }).click({ timeout: 20_000 });
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText(/Destroyed:/)).toBeVisible();
+  await expect(dialog.getByText(/Kept:/)).toBeVisible();
+  // The confirm button stays disabled until the exact name is typed.
+  await expect(dialog.getByRole("button", { name: "Delete division" })).toBeDisabled();
+  await dialog.getByRole("textbox").fill("Only Slot");
+  await dialog.getByRole("button", { name: "Delete division" }).click();
+
+  // Redirects to the competition page; the division is gone.
+  await page.waitForURL(`**/competitions/${compId}`, { timeout: 20_000 });
+  const goneRes = await apiJson(request, `/api/v1/divisions/${divisionId}`);
+  expect(goneRes.status).toBe(404);
+
+  // The gate has lifted — the slot is free again.
+  const retried = await apiJson(request, `/api/v1/competitions/${compId}/divisions`, "POST", {
+    name: "Second",
+    ...GENERIC,
+  });
+  expect(retried.status).toBe(201);
+
+  // Cleanup: free the community org's competitions.max_active slot.
+  await apiJson(request, `/api/v1/competitions/${compId}`, "PATCH", {
+    status: "archived",
+    visibility: "private",
+  });
+});

--- a/apps/web/e2e/scoring.spec.ts
+++ b/apps/web/e2e/scoring.spec.ts
@@ -89,6 +89,130 @@ test("badminton pad shows the current game number, not always game 1", async ({
   await expect(page.getByText(/games won 1/)).toBeVisible();
 });
 
+test("badminton: an entered game score lands in the header summary live (v3/09 §1a)", async ({
+  page,
+  request,
+}) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Badminton header ${TAG}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    { name: "MS", sport_key: "badminton", variant_key: "bwf", config: {}, eligibility: [] },
+  );
+  const divisionId = div.data!.id;
+  await addEntrantsViaApi(request, divisionId, ["Priya", "Sana"]);
+  const { fixtureIds } = await createStageAndGenerate(request, divisionId, {
+    kind: "knockout",
+    name: "Final",
+  });
+  const fixtureId = fixtureIds[0]!;
+  await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+  await apiJson(request, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 0,
+    type: "core.start",
+    payload: {},
+  });
+
+  await page.goto(`/fixtures/${fixtureId}`);
+  // Coarse entry: record game 1 as 21-15 through the Game-totals form. Under
+  // load the fill can land before React hydrates — re-fill until it sticks.
+  await page.getByRole("button", { name: /Game totals/ }).click({ timeout: 20_000 });
+  await expect(async () => {
+    await page.getByLabel(/Priya points/).fill("21");
+    await page.getByLabel(/Sana points/).fill("15");
+    await expect(page.getByRole("button", { name: /Record game/ })).toBeEnabled({
+      timeout: 1_000,
+    });
+  }).toPass({ timeout: 20_000 });
+  await page.getByRole("button", { name: /Record game/ }).click();
+
+  // The chosen score is reflected in the top score (intake #28a).
+  await expect(page.getByText("1 — 0 · 21–15")).toBeVisible({ timeout: 20_000 });
+});
+
+test("cricket: undo mid-over keeps the scoring panel usable (v3/09 §2)", async ({
+  page,
+  request,
+}) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Cricket undo ${TAG}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    { name: "T20", sport_key: "cricket", variant_key: "t20", config: {}, eligibility: [] },
+  );
+  const divisionId = div.data!.id;
+  const entrants = await apiJson<{ id: string }[]>(
+    request,
+    `/api/v1/divisions/${divisionId}/entrants`,
+    "POST",
+    [
+      { kind: "team", display_name: "Kings", seed: 1 },
+      { kind: "team", display_name: "Queens", seed: 2 },
+    ],
+  );
+  const stage = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/divisions/${divisionId}/stages`,
+    "POST",
+    { seq: 1, kind: "knockout", name: "Final" },
+  );
+  const gen = await apiJson<{ fixtures: { id: string }[] }>(
+    request,
+    `/api/v1/stages/${stage.data!.id}/generate`,
+    "POST",
+  );
+  const fixtureId = gen.data!.fixtures[0]!.id;
+  await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+  await apiJson(request, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 0,
+    type: "cricket.toss",
+    payload: { wonBy: entrants.data![0]!.id, elected: "bat" },
+  });
+  await apiJson(request, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 1,
+    type: "core.start",
+    payload: {},
+  });
+  await apiJson(request, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 2,
+    type: "cricket.innings.summary",
+    payload: { runs: 12, wickets: 1, legalBalls: 6, partial: true },
+  });
+
+  await page.goto(`/fixtures/${fixtureId}`);
+  await expect(page.getByText(/— total/)).toContainText("12/1", { timeout: 20_000 });
+
+  // The intake #29 repro action: Undo last (voids the over).
+  await page.getByRole("button", { name: /Undo last/ }).click();
+  await expect(page.getByText(/— total/)).toContainText("0/0", { timeout: 20_000 });
+
+  // The panel stays usable — no blank screen, no dead-end: score again.
+  await expect(page.getByRole("button", { name: "Over-by-over" })).toBeVisible();
+  await expect(async () => {
+    await page.getByLabel(/runs this over/i).fill("8");
+    await expect(page.getByRole("button", { name: /add over/i })).toBeEnabled({ timeout: 1_000 });
+  }).toPass({ timeout: 20_000 });
+  await page.getByRole("button", { name: /add over/i }).click();
+  await expect(page.getByText(/— total/)).toContainText("8/0", { timeout: 20_000 });
+
+  // Undo storms past the start: the console never dead-ends. Two more undos
+  // (the corrected over, then core.start) must land back on "Start match".
+  await page.getByRole("button", { name: /Undo last/ }).click();
+  await expect(page.getByText(/— total/)).toContainText("0/0", { timeout: 20_000 });
+  await page.getByRole("button", { name: /Undo last/ }).click();
+  await expect(page.getByRole("button", { name: "Start match" })).toBeVisible({
+    timeout: 20_000,
+  });
+});
+
 test("cricket scores over-by-over: add an over grows the total, then close innings", async ({
   page,
   request,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -20,7 +20,7 @@ const BASE = process.env.PLAYWRIGHT_BASE ?? "http://localhost:3000";
 const AUTH_STATE = "e2e/.auth/pro.json";
 
 const SERIAL_SPECS =
-  /(journey-pro|journey-community|org-management|billing|billing-states|members-roles|scorer|device-links)\.spec\.ts/;
+  /(journey-pro|journey-community|org-management|billing|billing-states|members-roles|scorer|device-links|division-delete)\.spec\.ts/;
 
 export default defineConfig({
   testDir: "./e2e",

--- a/apps/web/src/app/api/v1/competitions/[id]/divisions/route.ts
+++ b/apps/web/src/app/api/v1/competitions/[id]/divisions/route.ts
@@ -9,7 +9,10 @@ export async function GET(req: Request, { params }: Ctx) {
   return v1(async () => {
     const { id } = await params;
     const auth = await requireResourceAuth(req, "competition", id, "read");
-    return listDivisions(auth, id);
+    // ?archived=1 — the competition-settings "Archived divisions" list
+    // (v3/09 §4); default hides archived rows.
+    const includeArchived = new URL(req.url).searchParams.get("archived") === "1";
+    return listDivisions(auth, id, { includeArchived });
   });
 }
 

--- a/apps/web/src/app/api/v1/divisions/[id]/archive/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/archive/route.ts
@@ -1,0 +1,25 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { archiveDivision, restoreDivision } from "@/server/usecases/divisions";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** v3/09 §4 — archive: hidden from console/public/quota, restorable. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "write");
+    return archiveDivision(auth, id);
+  });
+}
+
+/** Restore an archived division (quota re-checked). The design doc names this
+ *  POST …/restore; that path is taken by the Jul3/03 checkpoint restore, so
+ *  un-archiving is DELETE on the archive resource instead. */
+export async function DELETE(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "write");
+    return restoreDivision(auth, id);
+  });
+}

--- a/apps/web/src/app/api/v1/divisions/[id]/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/route.ts
@@ -1,7 +1,7 @@
-import { v1, parseBody } from "@/server/api-v1/http";
+import { v1, reply, parseBody } from "@/server/api-v1/http";
 import { requireResourceAuth } from "@/server/api-v1/auth";
 import { PatchDivision } from "@/server/api-v1/schemas";
-import { getDivision, patchDivision } from "@/server/usecases/divisions";
+import { deleteDivision, getDivision, patchDivision } from "@/server/usecases/divisions";
 
 type Ctx = { params: Promise<{ id: string }> };
 
@@ -19,5 +19,16 @@ export async function PATCH(req: Request, { params }: Ctx) {
     const body = await parseBody(req, PatchDivision);
     const auth = await requireResourceAuth(req, "division", id, "write");
     return patchDivision(auth, id, body);
+  });
+}
+
+/** v3/09 §4 — setup-state hard delete (204) or archived-30d purge; started/
+ *  resulted divisions answer 409 DIVISION_HAS_RESULTS with {archive: true}. */
+export async function DELETE(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "division", id, "write");
+    await deleteDivision(auth, id);
+    return reply(204, null);
   });
 }

--- a/apps/web/src/app/competitions/[id]/settings/page.tsx
+++ b/apps/web/src/app/competitions/[id]/settings/page.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 import { Nav } from "@/components/nav";
 import { requireResourcePageAuth } from "@/server/page-auth";
 import { getCompetition } from "@/server/usecases/competitions";
+import { listDivisions } from "@/server/usecases/divisions";
 import { CompetitionSettings } from "@/components/v2/competition-settings";
+import { ArchivedDivisions } from "@/components/v2/archived-divisions";
 import { hasFeature } from "@/lib/entitlements";
 import { withTenant } from "@/lib/db";
 
@@ -27,11 +29,13 @@ export default async function CompetitionSettingsPage({
 }) {
   const { id } = await params;
   const { auth, org, canEdit } = await requireResourcePageAuth("competition", id);
-  const [competition, discoveryBranding, themeBranding] = await Promise.all([
+  const [competition, discoveryBranding, themeBranding, allDivisions] = await Promise.all([
     getCompetition(auth, id),
     hasFeature(auth.orgId, "discovery.branding"),
     hasFeature(auth.orgId, "dashboard.branding"),
+    listDivisions(auth, id, { includeArchived: true }),
   ]);
+  const archivedDivisions = allDivisions.filter((d) => d.archived_at !== null);
 
   const [agg] = await withTenant(auth.orgId, (tx) =>
     tx<{ total: number; underway: number; done: number; scheduled: number }[]>`
@@ -84,6 +88,17 @@ export default async function CompetitionSettingsPage({
           themeBranding={themeBranding}
           orgBranding={org.branding}
           suggestedStatus={suggestedStatus}
+        />
+
+        {/* v3/09 §4 — restore/purge surface for archived divisions. */}
+        <ArchivedDivisions
+          divisions={archivedDivisions.map((d) => ({
+            id: d.id,
+            name: d.name,
+            sport_key: d.sport_key,
+            archived_at: d.archived_at as string,
+          }))}
+          canEdit={canEdit}
         />
       </main>
     </>

--- a/apps/web/src/app/divisions/[id]/page.tsx
+++ b/apps/web/src/app/divisions/[id]/page.tsx
@@ -11,6 +11,7 @@ import { listDivisionFixtures } from "@/server/usecases/fixtures";
 import { listEntrants } from "@/server/usecases/entrants";
 import { resolveModule } from "@/server/engine-db";
 import { withTenant } from "@/lib/db";
+import { DivisionDangerZone } from "@/components/v2/division-danger-zone";
 import { EntrantsPanel } from "@/components/v2/entrants-panel";
 import { StagesPanel } from "@/components/v2/stages-panel";
 import { LaunchActions } from "@/components/v2/launch-actions";
@@ -218,6 +219,16 @@ export default async function DivisionPage({
         )}
 
         {tab === "stats" && <StatsPanel divisionId={id} />}
+
+        {/* Delete/archive (v3/09 §4) — owners/admins, even on frozen comps:
+            reducing usage is the honest way out of an over-quota freeze. */}
+        {canEdit && (
+          <DivisionDangerZone
+            divisionId={id}
+            divisionName={division.name}
+            competitionId={competition.id}
+          />
+        )}
       </main>
     </>
   );

--- a/apps/web/src/app/slideshow/competitions/[id]/page.tsx
+++ b/apps/web/src/app/slideshow/competitions/[id]/page.tsx
@@ -46,7 +46,12 @@ export default async function CompetitionSlideshowPage({
       backHref={`/competitions/${id}`}
       divisionIds={ordered.map((d) => d.id)}
       realtime={realtime}
-      themeStyle={publicThemeStyleChain(competition.branding, chrome.branding)}
+      // Same gate as the division board: console reads don't empty branding,
+      // so the entitlement check happens here.
+      themeStyle={publicThemeStyleChain(
+        chrome.themed ? competition.branding : null,
+        chrome.branding,
+      )}
       logo={chrome.logo}
     />
   );

--- a/apps/web/src/app/slideshow/divisions/[id]/page.tsx
+++ b/apps/web/src/app/slideshow/divisions/[id]/page.tsx
@@ -32,7 +32,14 @@ export default async function DivisionSlideshowPage({
       backHref={`/divisions/${id}`}
       divisionIds={[id]}
       realtime={realtime}
-      themeStyle={publicThemeStyleChain(competition.branding, chrome.branding)}
+      // competition.branding comes off the console read model (NOT emptied
+      // in-query like the public views) — gate it on the same entitlement,
+      // or a Community board leaks the brand color (smoke: "community
+      // slideshow keeps default theme").
+      themeStyle={publicThemeStyleChain(
+        chrome.themed ? competition.branding : null,
+        chrome.branding,
+      )}
       logo={chrome.logo}
     />
   );

--- a/apps/web/src/components/v2/archived-divisions.tsx
+++ b/apps/web/src/components/v2/archived-divisions.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+// Archived divisions (v3/09 §4) — the restore surface in competition
+// settings. Restore un-archives (quota re-checked server-side, 402 on
+// overflow); purge hard-deletes after the 30-day cool-off with a typed-name
+// confirm stating exactly what dies.
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { ConfirmDialog } from "@/components/v2/confirm-dialog";
+import { UpgradeGate } from "@/components/upgrade-gate";
+
+export interface ArchivedDivisionLite {
+  id: string;
+  name: string;
+  sport_key: string;
+  archived_at: string;
+}
+
+const PURGE_COOL_OFF_DAYS = 30;
+
+export function ArchivedDivisions({
+  divisions,
+  canEdit,
+}: {
+  divisions: ArchivedDivisionLite[];
+  canEdit: boolean;
+}) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [paywallFeature, setPaywallFeature] = useState<string | null>(null);
+  const [purging, setPurging] = useState<ArchivedDivisionLite | null>(null);
+  // Stable per mount — cool-off is measured in days, render-time drift is noise.
+  const [now] = useState(() => Date.now());
+
+  if (divisions.length === 0) return null;
+
+  async function restore(id: string) {
+    setBusy(true);
+    setError(null);
+    setPaywallFeature(null);
+    try {
+      await apiV1(`/api/v1/divisions/${id}/archive`, { method: "DELETE" });
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiV1Error && err.code === "PAYMENT_REQUIRED") {
+        setPaywallFeature(String(err.extra.feature_key ?? ""));
+      } else {
+        setError(err instanceof Error ? err.message : "Restore failed");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function purge(id: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      await apiV1(`/api/v1/divisions/${id}`, { method: "DELETE" });
+      setPurging(null);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Purge failed");
+      setPurging(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const purgeReadyAt = (archivedAt: string) =>
+    new Date(new Date(archivedAt).getTime() + PURGE_COOL_OFF_DAYS * 24 * 60 * 60 * 1000);
+
+  return (
+    <section className="card mt-6 p-5" data-testid="archived-divisions">
+      <h2 className="text-sm font-semibold text-slate-700">Archived divisions</h2>
+      <p className="mt-1 text-xs text-slate-500">
+        Hidden from your console and the public site; they don’t count against your plan.
+        Restore brings everything back exactly as it was.
+      </p>
+      {error && (
+        <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+      )}
+      {paywallFeature && (
+        <div className="mt-2">
+          <UpgradeGate feature={paywallFeature} />
+        </div>
+      )}
+      <ul className="mt-3 divide-y divide-slate-100">
+        {divisions.map((d) => {
+          const purgeReady = purgeReadyAt(d.archived_at).getTime() <= now;
+          return (
+            <li key={d.id} className="flex items-center gap-3 py-2 text-sm">
+              <span className="min-w-0 flex-1 truncate text-slate-700">{d.name}</span>
+              <span className="chip">{d.sport_key}</span>
+              <span className="shrink-0 text-xs text-slate-400">
+                archived {new Date(d.archived_at).toLocaleDateString()}
+              </span>
+              {canEdit && (
+                <>
+                  <button
+                    type="button"
+                    className="btn btn-ghost text-xs"
+                    disabled={busy}
+                    onClick={() => void restore(d.id)}
+                  >
+                    Restore
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-ghost text-xs text-red-500"
+                    disabled={busy || !purgeReady}
+                    title={
+                      purgeReady
+                        ? "Permanently delete this archived division"
+                        : `Purge unlocks ${purgeReadyAt(d.archived_at).toLocaleDateString()} (30-day cool-off)`
+                    }
+                    onClick={() => setPurging(d)}
+                  >
+                    Purge…
+                  </button>
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      <ConfirmDialog
+        open={purging !== null}
+        title={`Purge ${purging?.name ?? ""}?`}
+        confirmLabel="Purge permanently"
+        typedName={purging?.name ?? ""}
+        busy={busy}
+        onConfirm={() => purging && void purge(purging.id)}
+        onCancel={() => setPurging(null)}
+      >
+        <p>
+          <strong>Destroyed:</strong> the division with every stage, fixture, result and
+          entrant entry — including recorded scores.
+        </p>
+        <p>
+          <strong>Kept:</strong> people, teams and clubs at the organisation level.
+        </p>
+        <p>This cannot be undone.</p>
+      </ConfirmDialog>
+    </section>
+  );
+}

--- a/apps/web/src/components/v2/confirm-dialog.tsx
+++ b/apps/web/src/components/v2/confirm-dialog.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+// Modal confirmation (v3/03 §3 — replaces window.confirm for destructive
+// actions). `typedName` escalates to type-to-confirm: the button stays
+// disabled until the user types the resource name exactly (v3/09 §4 division
+// delete). Body copy must state what is destroyed vs kept.
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+interface Props {
+  open: boolean;
+  title: string;
+  children: ReactNode; // body copy: exactly what happens, destroyed vs kept
+  confirmLabel: string;
+  /** Require typing this exact string to enable the confirm button. */
+  typedName?: string;
+  busy?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  children,
+  confirmLabel,
+  typedName,
+  busy = false,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [typed, setTyped] = useState("");
+  const [lastOpen, setLastOpen] = useState(open);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset the typed challenge on every open (adjust-state-during-render — no
+  // effect, no cascading re-render).
+  if (open !== lastOpen) {
+    setLastOpen(open);
+    if (open) setTyped("");
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    inputRef.current?.focus();
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+  const armed = typedName === undefined || typed === typedName;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="card w-full max-w-md space-y-4 p-6 shadow-xl">
+        <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+        <div className="space-y-2 text-sm text-slate-600">{children}</div>
+        {typedName !== undefined && (
+          <label className="block">
+            <span className="label">
+              Type <span className="font-mono font-semibold">{typedName}</span> to confirm
+            </span>
+            <input
+              ref={inputRef}
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              className="input w-full"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+        )}
+        <div className="flex justify-end gap-2">
+          <button type="button" className="btn btn-ghost" onClick={onCancel} disabled={busy}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn-danger"
+            onClick={onConfirm}
+            disabled={busy || !armed}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/v2/device-score-pad.tsx
+++ b/apps/web/src/components/v2/device-score-pad.tsx
@@ -7,6 +7,7 @@
 // Offline-tolerant: sends retry with the SAME idempotency key (doc 08 §4).
 import { useCallback, useState } from "react";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { ScoringErrorBoundary } from "@/components/v2/scoring-error-boundary";
 import { GenericPad } from "@/components/v2/pads/generic-pad";
 import { BoardgamePad } from "@/components/v2/pads/boardgame-pad";
 import { SetbasedPad } from "@/components/v2/pads/setbased-pad";
@@ -242,17 +243,19 @@ export function DeviceScorePad({
 
       {scoring && !decided && home && away && (
         <section className="card p-4">
-          {sport.key === "cricket" ? (
-            <CricketPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
-          ) : sport.key === "football" ? (
-            <FootballPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
-          ) : SETBASED.has(sport.key) ? (
-            <SetbasedPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
-          ) : sport.key === "boardgame" ? (
-            <BoardgamePad home={home} away={away} send={send} busy={busy} started={started} />
-          ) : (
-            <GenericPad sport={sport} home={home} away={away} send={send} busy={busy} />
-          )}
+          <ScoringErrorBoundary>
+            {sport.key === "cricket" ? (
+              <CricketPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
+            ) : sport.key === "football" ? (
+              <FootballPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
+            ) : SETBASED.has(sport.key) ? (
+              <SetbasedPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
+            ) : sport.key === "boardgame" ? (
+              <BoardgamePad home={home} away={away} send={send} busy={busy} started={started} />
+            ) : (
+              <GenericPad sport={sport} home={home} away={away} send={send} busy={busy} />
+            )}
+          </ScoringErrorBoundary>
         </section>
       )}
 

--- a/apps/web/src/components/v2/division-danger-zone.tsx
+++ b/apps/web/src/components/v2/division-danger-zone.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+// Division delete/archive (v3/09 §4). Delete asks for the typed division
+// name and states exactly what is destroyed vs kept; a 409
+// DIVISION_HAS_RESULTS pivots the dialog to the archive suggestion. Archive
+// uses a plain danger confirm — it is reversible from competition settings.
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { ConfirmDialog } from "@/components/v2/confirm-dialog";
+
+interface Props {
+  divisionId: string;
+  divisionName: string;
+  competitionId: string;
+}
+
+export function DivisionDangerZone({ divisionId, divisionName, competitionId }: Props) {
+  const router = useRouter();
+  const [dialog, setDialog] = useState<"none" | "delete" | "archive">("none");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [suggestArchive, setSuggestArchive] = useState(false);
+
+  async function doDelete() {
+    setBusy(true);
+    setError(null);
+    try {
+      await apiV1(`/api/v1/divisions/${divisionId}`, { method: "DELETE" });
+      router.push(`/competitions/${competitionId}`);
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiV1Error && err.code === "DIVISION_HAS_RESULTS") {
+        setSuggestArchive(true);
+        setDialog("archive");
+      } else {
+        setError(err instanceof Error ? err.message : "Delete failed");
+        setDialog("none");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function doArchive() {
+    setBusy(true);
+    setError(null);
+    try {
+      await apiV1(`/api/v1/divisions/${divisionId}/archive`, { method: "POST" });
+      router.push(`/competitions/${competitionId}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Archive failed");
+      setDialog("none");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="card mt-8 border-red-100 p-5">
+      <h2 className="text-sm font-semibold text-red-700">Danger zone</h2>
+      <p className="mt-1 text-xs text-slate-500">
+        Archiving hides this division from your console and the public site — restore it any
+        time from competition settings. Deleting is permanent and only possible before the
+        division starts.
+      </p>
+      {error && (
+        <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+      )}
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="btn btn-ghost text-slate-600"
+          onClick={() => {
+            setSuggestArchive(false);
+            setDialog("archive");
+          }}
+          disabled={busy}
+        >
+          Archive division
+        </button>
+        <button
+          type="button"
+          className="btn btn-danger"
+          onClick={() => setDialog("delete")}
+          disabled={busy}
+        >
+          Delete division…
+        </button>
+      </div>
+
+      <ConfirmDialog
+        open={dialog === "delete"}
+        title={`Delete ${divisionName}?`}
+        confirmLabel="Delete division"
+        typedName={divisionName}
+        busy={busy}
+        onConfirm={() => void doDelete()}
+        onCancel={() => setDialog("none")}
+      >
+        <p>
+          <strong>Destroyed:</strong> this division, its stages, fixtures, schedules and
+          entrant entries.
+        </p>
+        <p>
+          <strong>Kept:</strong> people, teams and clubs — they belong to your organisation,
+          not this division.
+        </p>
+        <p>This cannot be undone.</p>
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={dialog === "archive"}
+        title={`Archive ${divisionName}?`}
+        confirmLabel="Archive division"
+        busy={busy}
+        onConfirm={() => void doArchive()}
+        onCancel={() => setDialog("none")}
+      >
+        {suggestArchive && (
+          <p className="rounded-md bg-amber-50 px-3 py-2 text-amber-700">
+            This division has started or has recorded results, so it can’t be deleted —
+            archiving keeps every result and stays restorable.
+          </p>
+        )}
+        <p>
+          The division disappears from your console and the public site and stops counting
+          against your plan. Nothing is destroyed — restore it any time from competition
+          settings → Archived divisions.
+        </p>
+      </ConfirmDialog>
+    </section>
+  );
+}

--- a/apps/web/src/components/v2/fixture-console.tsx
+++ b/apps/web/src/components/v2/fixture-console.tsx
@@ -10,6 +10,7 @@ import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { describeEvent, EVENT_TONE_STYLE } from "@/lib/event-copy";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { LineupEditor } from "@/components/v2/lineup-editor";
+import { ScoringErrorBoundary } from "@/components/v2/scoring-error-boundary";
 import { GenericPad } from "@/components/v2/pads/generic-pad";
 import { BoardgamePad } from "@/components/v2/pads/boardgame-pad";
 import { SetbasedPad } from "@/components/v2/pads/setbased-pad";
@@ -272,17 +273,19 @@ export function FixtureConsole({
       {scoring && !decided && home && away && (
         <section className="card p-5">
           <h2 className="mb-3 text-sm font-semibold text-slate-700">Scoring</h2>
-          {sport.key === "cricket" ? (
-            <CricketPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
-          ) : sport.key === "football" ? (
-            <FootballPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
-          ) : SETBASED.has(sport.key) ? (
-            <SetbasedPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
-          ) : sport.key === "boardgame" ? (
-            <BoardgamePad home={home} away={away} send={send} busy={busy} started={started} />
-          ) : (
-            <GenericPad sport={sport} home={home} away={away} send={send} busy={busy} />
-          )}
+          <ScoringErrorBoundary fixtureId={fixture.id}>
+            {sport.key === "cricket" ? (
+              <CricketPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
+            ) : sport.key === "football" ? (
+              <FootballPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
+            ) : SETBASED.has(sport.key) ? (
+              <SetbasedPad sport={sport} home={home} away={away} live={live} send={send} busy={busy} />
+            ) : sport.key === "boardgame" ? (
+              <BoardgamePad home={home} away={away} send={send} busy={busy} started={started} />
+            ) : (
+              <GenericPad sport={sport} home={home} away={away} send={send} busy={busy} />
+            )}
+          </ScoringErrorBoundary>
         </section>
       )}
 

--- a/apps/web/src/components/v2/scoring-error-boundary.tsx
+++ b/apps/web/src/components/v2/scoring-error-boundary.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+// Defence in depth for the scoring surface (v3/09 §2): a render crash in a
+// sport pad must NEVER leave a blank panel courtside. The boundary renders a
+// recovery message with the fixture link so the scorer always has a way back.
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  /** Console surface: link back to the fixture page. Omit (device pad, where
+   *  dl_ tokens cannot open /fixtures) to reload the current page instead. */
+  fixtureId?: string;
+  children: ReactNode;
+}
+
+interface State {
+  crashed: boolean;
+}
+
+const ACTION_CLASS =
+  "mt-3 inline-block rounded-md border border-amber-300 bg-white px-3 py-1.5 font-medium text-amber-800 hover:bg-amber-100";
+
+export class ScoringErrorBoundary extends Component<Props, State> {
+  override state: State = { crashed: false };
+
+  static getDerivedStateFromError(): State {
+    return { crashed: true };
+  }
+
+  override render() {
+    if (!this.state.crashed) return this.props.children;
+    return (
+      <div
+        role="alert"
+        data-testid="scoring-error-boundary"
+        className="rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-800"
+      >
+        <p className="font-semibold">Something went wrong — reload scoring</p>
+        <p className="mt-1">
+          The score is safe: every entry is already saved. Reload to continue scoring.
+        </p>
+        {this.props.fixtureId ? (
+          <a href={`/fixtures/${this.props.fixtureId}`} className={ACTION_CLASS}>
+            Reload scoring
+          </a>
+        ) : (
+          <button type="button" onClick={() => window.location.reload()} className={ACTION_CLASS}>
+            Reload scoring
+          </button>
+        )}
+      </div>
+    );
+  }
+}

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -3,12 +3,15 @@ export class AuthError extends Error {}
 
 /** Thrown inside handlers to emit a specific HTTP status code. `code`
  *  overrides the generic status→code mapping in the /api/v1 envelope (e.g.
- *  LINK_EXPIRED on a 401 so the device-link pad can render it, doc 13 §7). */
+ *  LINK_EXPIRED on a 401 so the device-link pad can render it, doc 13 §7).
+ *  `extra` fields merge into the error body — machine-readable hints like
+ *  DIVISION_HAS_RESULTS carrying `{archive: true}` (v3/09 §4). */
 export class HttpError extends Error {
   constructor(
     public readonly status: number,
     message: string,
     public readonly code?: string,
+    public readonly extra?: Record<string, unknown>,
   ) {
     super(message);
   }

--- a/apps/web/src/server/api-v1/http.ts
+++ b/apps/web/src/server/api-v1/http.ts
@@ -83,6 +83,10 @@ export async function v1<T>(fn: () => Promise<T | Reply<T>>): Promise<NextRespon
   try {
     const result = await fn();
     if (result instanceof Reply) {
+      // 204 carries no body by definition (v3/09 §4 — DELETE division).
+      if (result.status === 204) {
+        return new NextResponse(null, { status: 204, headers: result.headers });
+      }
       return NextResponse.json(
         { ok: true, data: result.data, requestId },
         { status: result.status, headers: result.headers },
@@ -131,7 +135,13 @@ export async function v1<T>(fn: () => Promise<T | Reply<T>>): Promise<NextRespon
     }
     if (err instanceof HttpError) {
       if (err.status >= 500) Sentry.captureException(err);
-      return errorResponse(requestId, err.status, err.code ?? statusCode(err.status), err.message);
+      return errorResponse(
+        requestId,
+        err.status,
+        err.code ?? statusCode(err.status),
+        err.message,
+        err.extra,
+      );
     }
     Sentry.captureException(err);
     const message = err instanceof Error ? err.message : "Server error";

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -50,6 +50,9 @@ export const ROUTES: RouteSpec[] = [
   { path: "/competitions/{id}/divisions", method: "post", summary: "Create a division (pins sport module version)", tag: "divisions", request: S.CreateDivision, response: S.Division, status: 201, errors: [409, 422] },
   { path: "/divisions/{id}", method: "get", summary: "Get a division", tag: "divisions", response: S.Division },
   { path: "/divisions/{id}", method: "patch", summary: "Update a division", tag: "divisions", request: S.PatchDivision, response: S.Division },
+  { path: "/divisions/{id}", method: "delete", summary: "Delete a setup division (204) or purge a 30-day archive; started/resulted → 409 DIVISION_HAS_RESULTS {archive: true}", tag: "divisions", status: 204, errors: [409] },
+  { path: "/divisions/{id}/archive", method: "post", summary: "Archive: hidden from console/public/quota, restorable", tag: "divisions", response: S.Division, errors: [409] },
+  { path: "/divisions/{id}/archive", method: "delete", summary: "Restore an archived division (quota re-checked)", tag: "divisions", response: S.Division, errors: [402] },
   // Entrants
   { path: "/divisions/{id}/entrants", method: "get", summary: "List entrants", tag: "entrants", response: z.array(S.Entrant) },
   { path: "/divisions/{id}/entrants", method: "post", summary: "Register entrant(s) — object or bulk array", tag: "entrants", request: S.CreateEntrants, response: z.union([S.Entrant, z.array(S.Entrant)]), status: 201, errors: [422] },

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -136,6 +136,7 @@ export const Division = z.object({
   officials_hide_names: z.boolean(),
   scheduling_mode: z.enum(["timed", "flexible"]),
   auto_progress: z.boolean(),
+  archived_at: z.string().nullable(), // v3/09 §4 — set = archived (hidden, restorable)
   created_at: z.string(),
 });
 

--- a/apps/web/src/server/engine-db/__tests__/undo-status.test.ts
+++ b/apps/web/src/server/engine-db/__tests__/undo-status.test.ts
@@ -1,0 +1,279 @@
+// Undo/status coherence — v3/09 §1+§2 (PROMPT-38). The cricket "undo last made
+// scoring disappear" regression (intake #29) was fixtures.status drifting from
+// the fold after a void: status said in_play while the fold was back in the
+// pre phase, so the console rendered neither a Start button nor a pad. These
+// tests pin status to the void-resolved ledger at the persistence layer, the
+// 409 nothing-to-undo contract at the usecase layer, and the badminton
+// headline (intake #28a) at the state read the header renders from.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { badminton } from "@seazn/engine/sports/setbased";
+import { cricket } from "@seazn/engine/sports/cricket";
+import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { appendEvent } from "../append-event";
+import { getFixtureState } from "@/server/usecases/fixtures";
+import { scoreEvent } from "@/server/usecases/scoring";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+interface Seed {
+  orgId: string;
+  fixtureId: string;
+  home: string;
+  away: string;
+  auth: AuthCtx;
+}
+
+// Fresh org → competition → ACTIVE division (scoring open) → fixture.
+async function seed(sportKey: string, config: unknown): Promise<Seed> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Org " + suffix}, ${"org-" + suffix})
+    returning id
+  `;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values (${sportKey}, ${sportKey}, '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing
+  `;
+  const [{ id: competitionId }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug, visibility)
+    values (${orgId}, ${"Comp " + suffix}, ${"comp-" + suffix}, 'private')
+    returning id
+  `;
+  const [{ id: divisionId }] = await sql<{ id: string }[]>`
+    insert into divisions (competition_id, name, slug, sport_key, variant_key, config, module_version, status)
+    values (${competitionId}, 'Div', ${"div-" + suffix}, ${sportKey}, 'default',
+            ${sql.json(config as never)}, '1.0.0', 'active')
+    returning id
+  `;
+  const [{ id: stageId }] = await sql<{ id: string }[]>`
+    insert into stages (division_id, seq, kind, name) values (${divisionId}, 1, 'league', 'League')
+    returning id
+  `;
+  const [{ id: home }] = await sql<{ id: string }[]>`
+    insert into entrants (division_id, kind, display_name, seed) values (${divisionId}, 'individual', 'Home', 1)
+    returning id
+  `;
+  const [{ id: away }] = await sql<{ id: string }[]>`
+    insert into entrants (division_id, kind, display_name, seed) values (${divisionId}, 'individual', 'Away', 2)
+    returning id
+  `;
+  const [{ id: fixtureId }] = await sql<{ id: string }[]>`
+    insert into fixtures (stage_id, division_id, round_no, seq_in_round, home_entrant_id, away_entrant_id)
+    values (${stageId}, ${divisionId}, 1, 1, ${home}, ${away})
+    returning id
+  `;
+  const auth: AuthCtx = { orgId, via: "session", userId: null, role: "owner", keyId: null };
+  return { orgId, fixtureId, home, away, auth };
+}
+
+async function fixtureStatus(fixtureId: string): Promise<string> {
+  const [row] = await sql<{ status: string }[]>`
+    select status from fixtures where id = ${fixtureId}
+  `;
+  return row.status;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+const CRICKET_CFG = cricket.configSchema.parse({ ballsPerInnings: 30 });
+const BADMINTON_CFG = badminton.configSchema.parse({});
+
+describe.skipIf(!HAS_DB)("undo keeps fixtures.status coherent with the fold (v3/09 §2)", () => {
+  it("undoing core.start returns the fixture to scheduled (was: stuck in_play)", async () => {
+    const s = await seed("cricket", CRICKET_CFG);
+    const toss = await appendEvent(s.orgId, s.fixtureId, 0, {
+      type: "cricket.toss",
+      payload: { wonBy: s.home, elected: "bat" },
+    });
+    const start = await appendEvent(s.orgId, s.fixtureId, toss.seq, {
+      type: "core.start",
+      payload: {},
+    });
+    expect(start.status).toBe("in_play");
+
+    const undone = await appendEvent(s.orgId, s.fixtureId, start.seq, {
+      type: "core.void",
+      payload: {},
+      voids: start.event.id,
+    });
+    // The fold is back in the pre phase — the status must follow, or the
+    // console shows neither a Start button nor a scoring pad (blank panel).
+    expect(undone.status).toBe("scheduled");
+    expect(await fixtureStatus(s.fixtureId)).toBe("scheduled");
+
+    // …and scoring can CONTINUE: re-start and record an over.
+    const restart = await appendEvent(s.orgId, s.fixtureId, undone.seq, {
+      type: "core.start",
+      payload: {},
+    });
+    expect(restart.status).toBe("in_play");
+    const over = await appendEvent(s.orgId, s.fixtureId, restart.seq, {
+      type: "cricket.innings.summary",
+      payload: { runs: 8, wickets: 0, legalBalls: 6, partial: true },
+    });
+    expect(over.summary).toBeTruthy();
+    expect(over.status).toBe("in_play");
+  });
+
+  it("undoing mid-innings keeps the panel state renderable and scoring continues", async () => {
+    const s = await seed("cricket", CRICKET_CFG);
+    let seq = 0;
+    const send = async (type: string, payload: unknown, voids?: string) => {
+      const r = await appendEvent(s.orgId, s.fixtureId, seq, {
+        type,
+        payload,
+        ...(voids ? { voids } : {}),
+      });
+      seq = r.seq;
+      return r;
+    };
+    await send("cricket.toss", { wonBy: s.away, elected: "bowl" });
+    await send("core.start", {});
+    await send("cricket.innings.summary", { runs: 10, wickets: 1, legalBalls: 6, partial: true });
+    const over2 = await send("cricket.innings.summary", {
+      runs: 22,
+      wickets: 1,
+      legalBalls: 12,
+      partial: true,
+    });
+
+    // Undo the last over (the intake #29 repro action).
+    const undone = await send("core.void", {}, over2.event.id);
+    expect(undone.status).toBe("in_play");
+    expect(undone.summary).toBeTruthy();
+    const state = await getFixtureState(s.auth, s.fixtureId);
+    expect(state.summary).toBeTruthy();
+    expect(state.status).toBe("in_play");
+
+    // Continue scoring: the corrected over goes straight back in.
+    const corrected = await send("cricket.innings.summary", {
+      runs: 18,
+      wickets: 2,
+      legalBalls: 12,
+      partial: true,
+    });
+    expect(corrected.status).toBe("in_play");
+  });
+
+  it("undoing a forfeit reopens the fixture (was: stuck forfeited)", async () => {
+    const s = await seed("badminton", BADMINTON_CFG);
+    await appendEvent(s.orgId, s.fixtureId, 0, { type: "core.start", payload: {} });
+    const forfeit = await appendEvent(s.orgId, s.fixtureId, 1, {
+      type: "core.forfeit",
+      payload: { by: s.away, reason: "walkover" },
+    });
+    expect(forfeit.status).toBe("forfeited");
+
+    const undone = await appendEvent(s.orgId, s.fixtureId, forfeit.seq, {
+      type: "core.void",
+      payload: {},
+      voids: forfeit.event.id,
+    });
+    expect(undone.status).toBe("in_play");
+    expect(undone.outcome).toBeNull();
+  });
+
+  it("undoing the deciding game drops a decided fixture back to in_play", async () => {
+    const s = await seed("badminton", BADMINTON_CFG);
+    await appendEvent(s.orgId, s.fixtureId, 0, { type: "core.start", payload: {} });
+    await appendEvent(s.orgId, s.fixtureId, 1, {
+      type: "badminton.game.summary",
+      payload: { home: 21, away: 15 },
+    });
+    const decider = await appendEvent(s.orgId, s.fixtureId, 2, {
+      type: "badminton.game.summary",
+      payload: { home: 21, away: 18 },
+    });
+    expect(decider.status).toBe("decided");
+
+    const undone = await appendEvent(s.orgId, s.fixtureId, decider.seq, {
+      type: "core.void",
+      payload: {},
+      voids: decider.event.id,
+    });
+    expect(undone.status).toBe("in_play");
+    expect(undone.outcome).toBeNull();
+  });
+});
+
+describe.skipIf(!HAS_DB)("nothing to undo is a 409, never a crash (v3/09 §2)", () => {
+  const expect409 = async (fn: () => Promise<unknown>) => {
+    try {
+      await fn();
+      expect.unreachable("expected a 409 HttpError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).status).toBe(409);
+    }
+  };
+
+  it("void with no event_id, an unknown id, and a double-undo all answer 409", async () => {
+    const s = await seed("badminton", BADMINTON_CFG);
+    // Empty ledger, no target at all.
+    await expect409(() =>
+      scoreEvent(s.auth, s.fixtureId, { expected_seq: 0, type: "core.void", payload: {} }),
+    );
+    // Unknown target id.
+    await expect409(() =>
+      scoreEvent(s.auth, s.fixtureId, {
+        expected_seq: 0,
+        type: "core.void",
+        payload: { event_id: randomUUID() },
+      }),
+    );
+
+    const start = await scoreEvent(s.auth, s.fixtureId, {
+      expected_seq: 0,
+      type: "core.start",
+      payload: {},
+    });
+    const game = await scoreEvent(s.auth, s.fixtureId, {
+      expected_seq: start.seq,
+      type: "badminton.game.summary",
+      payload: { home: 21, away: 12 },
+    });
+    const [gameEvent] = await sql<{ id: string }[]>`
+      select id from score_events where fixture_id = ${s.fixtureId} and seq = ${game.seq}
+    `;
+    const undo = await scoreEvent(s.auth, s.fixtureId, {
+      expected_seq: game.seq,
+      type: "core.void",
+      payload: { event_id: gameEvent.id },
+    });
+    expect(undo.status).toBe("in_play");
+
+    // Undoing the same entry twice: the second attempt is a calm 409.
+    await expect409(() =>
+      scoreEvent(s.auth, s.fixtureId, {
+        expected_seq: undo.seq,
+        type: "core.void",
+        payload: { event_id: gameEvent.id },
+      }),
+    );
+  });
+});
+
+describe.skipIf(!HAS_DB)("badminton entered game score reaches the header state (intake #28a)", () => {
+  it("game.summary 21-15 shows in the summary the header renders from", async () => {
+    const s = await seed("badminton", BADMINTON_CFG);
+    await appendEvent(s.orgId, s.fixtureId, 0, { type: "core.start", payload: {} });
+    await appendEvent(s.orgId, s.fixtureId, 1, {
+      type: "badminton.game.summary",
+      payload: { home: 21, away: 15 },
+    });
+    const state = await getFixtureState(s.auth, s.fixtureId);
+    const headline = (state.summary as { headline?: string } | null)?.headline ?? "";
+    expect(headline).toContain("1 — 0");
+    expect(headline).toContain("21–15");
+  });
+});

--- a/apps/web/src/server/engine-db/append-event.ts
+++ b/apps/web/src/server/engine-db/append-event.ts
@@ -4,6 +4,7 @@ import { withTenant } from "@/lib/db";
 import {
   EngineError,
   foldMatch,
+  resolveVoids,
   type EventEnvelope,
   type MatchOutcome,
   type ScoreSummary,
@@ -62,17 +63,24 @@ interface EventRow {
 // Terminal DB statuses that lock the ledger against further appends.
 const LOCKED = new Set(["finalized", "cancelled"]);
 
-// Map the decided event / outcome onto the fixtures.status enum.
-function nextStatus(current: string, type: string, outcome: MatchOutcome | null): string {
-  if (type === "core.finalize") return "finalized";
-  if (type === "core.abandon") return "abandoned";
-  if (type === "core.forfeit") return "forfeited";
-  if (outcome !== null) return "decided";
-  if (current === "scheduled" && type === "core.start") return "in_play";
-  // Undo of the deciding event (doc 08 §4): the fold no longer yields an
-  // outcome, so a decided fixture drops back to in_play.
-  if (current === "decided" && type === "core.void") return "in_play";
-  return current;
+// Map the folded ledger onto the fixtures.status enum. Derived from the
+// ACTIVE (void-resolved) events, not from event-type transitions: a void can
+// erase core.start / core.forfeit / core.abandon / the deciding event, and the
+// status must follow the fold or the console dead-ends (v3/09 §2 — the cricket
+// "undo made scoring disappear" regression was status=in_play with the fold
+// back in the pre phase, so neither the Start button nor the pad rendered).
+function nextStatus(
+  candidateType: string,
+  outcome: MatchOutcome | null,
+  active: readonly EventEnvelope[],
+): string {
+  if (candidateType === "core.finalize") return "finalized";
+  const has = (type: string) => active.some((event) => event.type === type);
+  // Abandon first: cricket abandon folds to a no_result OUTCOME, but the
+  // fixture status stays "abandoned" (replay policy owns it from here).
+  if (has("core.abandon")) return "abandoned";
+  if (outcome !== null) return has("core.forfeit") ? "forfeited" : "decided";
+  return has("core.start") ? "in_play" : "scheduled";
 }
 
 /**
@@ -182,9 +190,11 @@ export async function appendEvent(
     // Fold-validate the full stream INCLUDING the candidate. A throwing module
     // (invalid event, already-decided, …) aborts the tx before any insert, so
     // the ledger only ever holds valid events (spec 03 §2 guarantee 2).
-    const state = foldMatch(sportModule, division.config, lineups, [...prior, candidate]);
+    const stream = [...prior, candidate];
+    const state = foldMatch(sportModule, division.config, lineups, stream);
     const summary = sportModule.summary(state);
     const outcome = sportModule.outcome(state);
+    const active = resolveVoids(stream);
 
     await tx`
       insert into score_events (id, fixture_id, seq, type, payload, recorded_by, recorded_at, voids_event_id, device_link_id)
@@ -201,7 +211,7 @@ export async function appendEvent(
         summary = excluded.summary, updated_at = now()
     `;
 
-    const status = nextStatus(fixture.status, candidate.type, outcome);
+    const status = nextStatus(candidate.type, outcome, active);
     // Fire once, on the transition from no-result to a decided result.
     const firstResult: FirstResult | null =
       fixture.outcome === null && outcome !== null

--- a/apps/web/src/server/public-site/revalidate.ts
+++ b/apps/web/src/server/public-site/revalidate.ts
@@ -21,10 +21,14 @@ export function fireDivisionRevalidate(divisionId: string, competitionId?: strin
 }
 
 /** Org chrome changes (name, logo, brand color) show on every page of the
- *  org's public tree — bust the whole org tag. */
+ *  org's public tree — bust the whole org tag. `{ expire: 0 }`, NOT 'max':
+ *  'max' is stale-while-revalidate, so the organiser's very next look at
+ *  their public page would still show the old chrome (exactly the smoke
+ *  failure "pro org landing carries the org color"). Chrome edits are
+ *  read-your-own-writes; scoring pages keep SWR above. */
 export function fireOrgRevalidate(orgSlug: string): void {
   try {
-    revalidateTag(orgTag(orgSlug), "max");
+    revalidateTag(orgTag(orgSlug), { expire: 0 });
   } catch {
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }

--- a/apps/web/src/server/slideshow-data.ts
+++ b/apps/web/src/server/slideshow-data.ts
@@ -38,11 +38,13 @@ export type Slide =
 /**
  * Org chrome for the noticeboard masthead — brand color blob and logo URL,
  * entitlement-gated like the public pages (theme: dashboard.branding,
- * logo: branding).
+ * logo: branding). `themed` is exposed so callers gate the OTHER links of the
+ * theme chain (competition.branding) with the same read-entitlement — the
+ * console read model doesn't empty branding the way the public views do.
  */
 export async function orgBoardChrome(
   auth: AuthCtx,
-): Promise<{ branding: unknown; logo: string | null }> {
+): Promise<{ branding: unknown; logo: string | null; themed: boolean }> {
   const [themed, logoBranded, [org]] = await Promise.all([
     hasFeature(auth.orgId, "dashboard.branding"),
     hasFeature(auth.orgId, "branding"),
@@ -53,6 +55,7 @@ export async function orgBoardChrome(
   return {
     branding: themed ? (org?.branding ?? null) : null,
     logo: logoBranded ? resolveLogoUrl(org?.logo_storage_path, org?.logo_url) : null,
+    themed,
   };
 }
 

--- a/apps/web/src/server/usecases/__tests__/division-delete.test.ts
+++ b/apps/web/src/server/usecases/__tests__/division-delete.test.ts
@@ -1,0 +1,272 @@
+// Division delete / archive / restore — v3/09 §4 (PROMPT-38). Graduated
+// destructiveness: setup divisions hard-delete (entities that outlive the
+// division survive), started/resulted divisions 409 with the archive hint,
+// archive hides + frees quota + restores, purge honours the 30-day cool-off,
+// and open registration blocks the destructive paths.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { HttpError, PaymentRequiredError } from "@/lib/errors";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition } from "@/server/usecases/competitions";
+import {
+  archiveDivision,
+  createDivision,
+  deleteDivision,
+  listDivisions,
+  restoreDivision,
+} from "@/server/usecases/divisions";
+import { createEntrants } from "@/server/usecases/entrants";
+import { scoreEvent } from "@/server/usecases/scoring";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+async function seedOrg(plan: "community" | "pro" = "pro"): Promise<{ auth: AuthCtx }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Del " + suffix}, ${"del-" + suffix})
+    returning id`;
+  if (plan !== "community") {
+    await sql`
+      insert into subscriptions (org_id, plan_key, status)
+      values (${orgId}, ${plan}, 'active')
+      on conflict (org_id) do update set plan_key = ${plan}`;
+  }
+  await invalidateOrgEntitlements(orgId);
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(GENERIC_CONFIG)}, true)
+    on conflict do nothing`;
+  return { auth: { orgId, via: "session", userId: null, role: "owner", keyId: null } };
+}
+
+async function seedDivision(auth: AuthCtx, name = "Open") {
+  const comp = await createCompetition(auth, {
+    name: `Cup ${randomUUID().slice(0, 6)}`,
+    visibility: "private",
+    branding: {},
+  });
+  const division = await createDivision(auth, comp.id, {
+    name,
+    slug: `${name.toLowerCase()}-${randomUUID().slice(0, 6)}`,
+    sport_key: "generic",
+    variant_key: "score",
+    config: GENERIC_CONFIG,
+    eligibility: [],
+  });
+  return { comp, division };
+}
+
+// A division with one DECIDED fixture (started → has results).
+async function seedDecidedDivision(auth: AuthCtx) {
+  const { comp, division } = await seedDivision(auth);
+  const entrants = await createEntrants(auth, division.id, [
+    { kind: "individual" as const, display_name: "A", seed: 1, members: [] },
+    { kind: "individual" as const, display_name: "B", seed: 2, members: [] },
+  ]);
+  const list = Array.isArray(entrants) ? entrants : [entrants];
+  const [{ id: stageId }] = await sql<{ id: string }[]>`
+    insert into stages (division_id, seq, kind, name) values (${division.id}, 1, 'league', 'League')
+    returning id`;
+  const [{ id: fixtureId }] = await sql<{ id: string }[]>`
+    insert into fixtures (stage_id, division_id, round_no, seq_in_round, home_entrant_id, away_entrant_id)
+    values (${stageId}, ${division.id}, 1, 1, ${list[0]!.id}, ${list[1]!.id})
+    returning id`;
+  await sql`update divisions set status = 'active' where id = ${division.id}`;
+  await scoreEvent(auth, fixtureId, { expected_seq: 0, type: "core.start", payload: {} });
+  await scoreEvent(auth, fixtureId, {
+    expected_seq: 1,
+    type: "generic.result",
+    payload: { p1Score: 2, p2Score: 1 },
+  });
+  return { comp, division, fixtureId };
+}
+
+async function auditTypes(competitionId: string): Promise<string[]> {
+  const rows = await sql<{ type: string }[]>`
+    select type from competition_events where competition_id = ${competitionId} order by created_at`;
+  return rows.map((r) => r.type);
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("division delete (v3/09 §4)", () => {
+  it("hard-deletes a setup division; org-level entities survive; audit lands on the competition ledger", async () => {
+    const { auth } = await seedOrg();
+    const { comp, division } = await seedDivision(auth);
+    // A person attached via an entrant member must outlive the division.
+    const [{ id: personId }] = await sql<{ id: string }[]>`
+      insert into persons (org_id, full_name) values (${auth.orgId}, 'Keeper') returning id`;
+    const created = await createEntrants(auth, division.id, [
+      {
+        kind: "individual" as const,
+        display_name: "Keeper",
+        seed: 1,
+        members: [{ person_id: personId, is_captain: false, roles: [] }],
+      },
+    ]);
+    expect(created).toBeTruthy();
+
+    await deleteDivision(auth, division.id);
+
+    const [gone] = await sql`select 1 from divisions where id = ${division.id}`;
+    expect(gone).toBeUndefined();
+    const [person] = await sql`select 1 from persons where id = ${personId}`;
+    expect(person).toBeTruthy();
+    expect(await auditTypes(comp.id)).toContain("division_deleted");
+  });
+
+  it("409 DIVISION_HAS_RESULTS with the archive hint once results exist", async () => {
+    const { auth } = await seedOrg();
+    const { division } = await seedDecidedDivision(auth);
+    try {
+      await deleteDivision(auth, division.id);
+      expect.unreachable("expected 409");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).status).toBe(409);
+      expect((err as HttpError).code).toBe("DIVISION_HAS_RESULTS");
+      expect((err as HttpError).extra).toEqual({ archive: true });
+    }
+    const [still] = await sql`select 1 from divisions where id = ${division.id}`;
+    expect(still).toBeTruthy();
+  });
+
+  it("open registration blocks delete AND archive — the error says close first", async () => {
+    const { auth } = await seedOrg();
+    const { division } = await seedDivision(auth);
+    await sql`
+      insert into registration_settings (division_id, enabled)
+      values (${division.id}, true)`;
+    for (const action of [() => deleteDivision(auth, division.id), () => archiveDivision(auth, division.id)]) {
+      try {
+        await action();
+        expect.unreachable("expected 409 REGISTRATION_OPEN");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).status).toBe(409);
+        expect((err as HttpError).code).toBe("REGISTRATION_OPEN");
+        expect((err as HttpError).message).toContain("close registration");
+      }
+    }
+  });
+});
+
+describe.skipIf(!HAS_DB)("division archive / restore (v3/09 §4)", () => {
+  it("archive hides from the console list, the public view, and frees the plan slot", async () => {
+    const { auth } = await seedOrg("community"); // divisions.per_competition.max = 1
+    const comp = await createCompetition(auth, {
+      name: `Arch ${randomUUID().slice(0, 6)}`,
+      visibility: "public",
+      branding: {},
+    });
+    const division = await createDivision(auth, comp.id, {
+      name: "First",
+      slug: "first",
+      sport_key: "generic",
+      variant_key: "score",
+      config: GENERIC_CONFIG,
+      eligibility: [],
+    });
+
+    // The community quota (1) is used up — a second division is 402-gated.
+    await expect(
+      createDivision(auth, comp.id, {
+        name: "Second",
+        slug: "second",
+        sport_key: "generic",
+        variant_key: "score",
+        config: GENERIC_CONFIG,
+        eligibility: [],
+      }),
+    ).rejects.toBeInstanceOf(PaymentRequiredError);
+
+    const archived = await archiveDivision(auth, division.id);
+    expect(archived.archived_at).not.toBeNull();
+
+    // Console default list hides it; includeArchived shows it.
+    expect(await listDivisions(auth, comp.id)).toHaveLength(0);
+    expect(await listDivisions(auth, comp.id, { includeArchived: true })).toHaveLength(1);
+
+    // Public view: archived divisions vanish (404 upstream).
+    const pub = await sql`select 1 from public_divisions_v where id = ${division.id}`;
+    expect(pub).toHaveLength(0);
+
+    // Archiving freed the slot — the gate lifts (the honest behaviour).
+    const second = await createDivision(auth, comp.id, {
+      name: "Second",
+      slug: "second",
+      sport_key: "generic",
+      variant_key: "score",
+      config: GENERIC_CONFIG,
+      eligibility: [],
+    });
+    expect(second.id).toBeTruthy();
+
+    // Restore would now exceed the quota again → 402, not a silent overflow.
+    await expect(restoreDivision(auth, division.id)).rejects.toBeInstanceOf(PaymentRequiredError);
+
+    // Free the slot and the restore round-trips.
+    await deleteDivision(auth, second.id);
+    const restored = await restoreDivision(auth, division.id);
+    expect(restored.archived_at).toBeNull();
+    expect(await auditTypes(comp.id)).toEqual(
+      expect.arrayContaining(["division_archived", "division_deleted", "division_restored"]),
+    );
+  });
+
+  it("a resulted division archives and restores with results intact", async () => {
+    const { auth } = await seedOrg();
+    const { comp, division, fixtureId } = await seedDecidedDivision(auth);
+    await archiveDivision(auth, division.id);
+    const restored = await restoreDivision(auth, division.id);
+    expect(restored.archived_at).toBeNull();
+    const [fixture] = await sql<{ status: string }[]>`
+      select status from fixtures where id = ${fixtureId}`;
+    expect(fixture.status).toBe("decided");
+    expect(await auditTypes(comp.id)).toEqual(
+      expect.arrayContaining(["division_archived", "division_restored"]),
+    );
+  });
+
+  it("purge honours the 30-day cool-off, then hard-deletes with an audit event", async () => {
+    const { auth } = await seedOrg();
+    const { comp, division } = await seedDecidedDivision(auth);
+    await archiveDivision(auth, division.id);
+
+    // Too fresh: 409 ARCHIVE_COOL_OFF.
+    try {
+      await deleteDivision(auth, division.id);
+      expect.unreachable("expected 409 cool-off");
+    } catch (err) {
+      expect(err).toBeInstanceOf(HttpError);
+      expect((err as HttpError).code).toBe("ARCHIVE_COOL_OFF");
+    }
+
+    // Backdate the archive 31 days → purge proceeds.
+    await sql`
+      update divisions set archived_at = now() - interval '31 days' where id = ${division.id}`;
+    await deleteDivision(auth, division.id);
+    const [gone] = await sql`select 1 from divisions where id = ${division.id}`;
+    expect(gone).toBeUndefined();
+    expect(await auditTypes(comp.id)).toContain("division_purged");
+  });
+});

--- a/apps/web/src/server/usecases/divisions.ts
+++ b/apps/web/src/server/usecases/divisions.ts
@@ -2,6 +2,7 @@ import "server-only";
 // Division use-cases (doc 08 §3, doc 06). Creation snapshots the merged
 // variant config and PINS the sport module version (doc 02 §4) so a running
 // division always replays under the rules it started with.
+import type postgres from "postgres";
 import { withTenant } from "@/lib/db";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
 import { withinLimit, requireFeature } from "@/lib/entitlements";
@@ -30,22 +31,31 @@ export interface DivisionRow {
   scheduling_mode: string;
   auto_progress: boolean;
   schedule_locked: boolean;
+  archived_at: string | null;
   created_at: string;
 }
 
 const COLS = [
   "id", "competition_id", "name", "slug", "sport_key", "variant_key", "config",
   "module_version", "eligibility", "tiebreakers", "status", "officials_hide_names",
-  "scheduling_mode", "auto_progress", "schedule_locked", "created_at",
+  "scheduling_mode", "auto_progress", "schedule_locked", "archived_at", "created_at",
 ] as const;
 
-export async function listDivisions(auth: AuthCtx, competitionId: string): Promise<DivisionRow[]> {
+export async function listDivisions(
+  auth: AuthCtx,
+  competitionId: string,
+  opts: { includeArchived?: boolean } = {},
+): Promise<DivisionRow[]> {
   return withTenant(auth.orgId, async (tx) => {
     const [comp] = await tx`select 1 from competitions where id = ${competitionId}`;
     if (!comp) throw new HttpError(404, "competition not found");
+    // Archived divisions are hidden from the console (v3/09 §4) — only the
+    // competition-settings "Archived divisions" list asks for them.
     return tx<DivisionRow[]>`
       select ${tx(COLS)} from divisions
-      where competition_id = ${competitionId} order by created_at, id`;
+      where competition_id = ${competitionId}
+      ${opts.includeArchived ? tx`` : tx`and archived_at is null`}
+      order by created_at, id`;
   });
 }
 
@@ -61,9 +71,11 @@ export async function createDivision(
     await assertCompetitionNotFrozen(auth.orgId, competitionId, tx);
 
     // Doc 10 §1: `divisions.per_competition.max` (Community's real bite: 1).
-    // Count in the same tx as the insert (doc 10 §2 rule 1).
+    // Count in the same tx as the insert (doc 10 §2 rule 1). Archived
+    // divisions don't count — archiving frees the slot (v3/09 §4).
     const [{ n }] = await tx<{ n: number }[]>`
-      select count(*)::int as n from divisions where competition_id = ${competitionId}`;
+      select count(*)::int as n from divisions
+      where competition_id = ${competitionId} and archived_at is null`;
     const quota = await withinLimit(auth.orgId, "divisions.per_competition.max", n + 1);
     if (!quota.ok) throw new PaymentRequiredError("divisions.per_competition.max");
 
@@ -122,6 +134,175 @@ export async function getDivision(auth: AuthCtx, id: string): Promise<DivisionRo
     const [row] = await tx<DivisionRow[]>`select ${tx(COLS)} from divisions where id = ${id}`;
     if (!row) throw new HttpError(404, "division not found");
     return row;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Delete / archive / restore — v3/09 §4 (PROMPT-38). Graduated
+// destructiveness: setup divisions hard-delete; started/resulted divisions
+// archive (hidden + restorable); archived divisions purge after a 30-day
+// cool-off. Owner/admin only (the route enforces the role).
+// ---------------------------------------------------------------------------
+
+const PURGE_COOL_OFF_DAYS = 30;
+
+interface DeleteTarget {
+  id: string;
+  competition_id: string;
+  name: string;
+  slug: string;
+  sport_key: string;
+  status: string;
+  archived_at: string | null;
+}
+
+async function auditCompetition(
+  tx: postgres.TransactionSql,
+  competitionId: string,
+  type: string,
+  payload: Record<string, unknown>,
+  actorId: string | null,
+): Promise<void> {
+  await tx`
+    insert into competition_events (competition_id, type, payload, actor_id)
+    values (${competitionId}, ${type}, ${tx.json(payload as never)}, ${actorId})`;
+}
+
+// Open registration blocks delete AND archive: registrants could still be
+// paying into a division that is about to vanish (v3/09 §4).
+async function assertRegistrationClosed(
+  tx: postgres.TransactionSql,
+  divisionId: string,
+  action: "delete" | "archive",
+): Promise<void> {
+  const [settings] = await tx<{ enabled: boolean; closes_at: string | null }[]>`
+    select enabled, closes_at from registration_settings where division_id = ${divisionId}`;
+  const open =
+    settings?.enabled === true &&
+    (settings.closes_at === null || new Date(settings.closes_at).getTime() > Date.now());
+  if (open) {
+    throw new HttpError(
+      409,
+      `Registration is open for this division — close registration first, then ${action} it`,
+      "REGISTRATION_OPEN",
+    );
+  }
+}
+
+/**
+ * DELETE semantics: setup division (never started, nothing decided) → hard
+ * delete; archived ≥30 days → purge (hard delete); anything else → 409
+ * DIVISION_HAS_RESULTS with the `{archive: true}` hint. Frozen competitions
+ * are NOT blocked: deleting reduces usage, which is the honest way out of an
+ * over-quota freeze.
+ */
+export async function deleteDivision(auth: AuthCtx, id: string): Promise<void> {
+  await withTenant(auth.orgId, async (tx) => {
+    const [division] = await tx<DeleteTarget[]>`
+      select id, competition_id, name, slug, sport_key, status, archived_at
+      from divisions where id = ${id}`;
+    if (!division) throw new HttpError(404, "division not found");
+    await assertRegistrationClosed(tx, id, "delete");
+
+    const [{ decided }] = await tx<{ decided: number }[]>`
+      select count(*)::int as decided from fixtures
+      where division_id = ${id} and status in ('decided', 'finalized', 'forfeited')`;
+
+    if (division.archived_at !== null) {
+      // Purge path: archived divisions hard-delete after the cool-off.
+      const ageMs = Date.now() - new Date(division.archived_at).getTime();
+      const coolOffMs = PURGE_COOL_OFF_DAYS * 24 * 60 * 60 * 1000;
+      if (ageMs < coolOffMs) {
+        const daysLeft = Math.ceil((coolOffMs - ageMs) / (24 * 60 * 60 * 1000));
+        throw new HttpError(
+          409,
+          `An archived division can be purged ${PURGE_COOL_OFF_DAYS} days after archiving — ${daysLeft} day(s) to go`,
+          "ARCHIVE_COOL_OFF",
+        );
+      }
+    } else if (division.status !== "setup" || decided > 0) {
+      throw new HttpError(
+        409,
+        "This division has started or has recorded results — archive it instead (restorable), or purge it 30 days after archiving",
+        "DIVISION_HAS_RESULTS",
+        { archive: true },
+      );
+    }
+
+    const [{ entrants }] = await tx<{ entrants: number }[]>`
+      select count(*)::int as entrants from entrants where division_id = ${id}`;
+    const [{ fixtures }] = await tx<{ fixtures: number }[]>`
+      select count(*)::int as fixtures from fixtures where division_id = ${id}`;
+
+    // The division ledger dies with the row (ON DELETE CASCADE); the audit
+    // fact lives on the competition ledger, which survives (v3/09 §4).
+    // Persons/teams/clubs are org-level rows — untouched by design.
+    await auditCompetition(
+      tx,
+      division.competition_id,
+      division.archived_at !== null ? "division_purged" : "division_deleted",
+      {
+        division_id: id,
+        name: division.name,
+        slug: division.slug,
+        sport_key: division.sport_key,
+        entrants,
+        fixtures,
+        decided_fixtures: decided,
+      },
+      auth.userId,
+    );
+    await tx`delete from divisions where id = ${id}`;
+  });
+}
+
+/** Archive: hide from console/public/quota, restorable. Idempotent. */
+export async function archiveDivision(auth: AuthCtx, id: string): Promise<DivisionRow> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [existing] = await tx<DivisionRow[]>`
+      select ${tx(COLS)} from divisions where id = ${id}`;
+    if (!existing) throw new HttpError(404, "division not found");
+    if (existing.archived_at !== null) return existing;
+    await assertRegistrationClosed(tx, id, "archive");
+
+    const [row] = await tx<DivisionRow[]>`
+      update divisions set archived_at = now() where id = ${id} returning ${tx(COLS)}`;
+    await auditCompetition(
+      tx,
+      existing.competition_id,
+      "division_archived",
+      { division_id: id, name: existing.name, slug: existing.slug },
+      auth.userId,
+    );
+    return row as DivisionRow;
+  });
+}
+
+/** Restore an archived division. Re-checks the divisions quota — restoring
+ *  must not smuggle a competition back over its plan limit. */
+export async function restoreDivision(auth: AuthCtx, id: string): Promise<DivisionRow> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [existing] = await tx<DivisionRow[]>`
+      select ${tx(COLS)} from divisions where id = ${id}`;
+    if (!existing) throw new HttpError(404, "division not found");
+    if (existing.archived_at === null) return existing;
+
+    const [{ n }] = await tx<{ n: number }[]>`
+      select count(*)::int as n from divisions
+      where competition_id = ${existing.competition_id} and archived_at is null`;
+    const quota = await withinLimit(auth.orgId, "divisions.per_competition.max", n + 1);
+    if (!quota.ok) throw new PaymentRequiredError("divisions.per_competition.max");
+
+    const [row] = await tx<DivisionRow[]>`
+      update divisions set archived_at = null where id = ${id} returning ${tx(COLS)}`;
+    await auditCompetition(
+      tx,
+      existing.competition_id,
+      "division_restored",
+      { division_id: id, name: existing.name, slug: existing.slug },
+      auth.userId,
+    );
+    return row as DivisionRow;
   });
 }
 

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -57,6 +57,7 @@ export async function scoreEvent(
   }
 
   await assertEntitledToScore(auth, fixtureId, input);
+  if (input.type === "core.void") await assertUndoTarget(auth, fixtureId, input);
 
   const result = await appendEvent(auth.orgId, fixtureId, input.expected_seq, {
     type: input.type,
@@ -97,6 +98,33 @@ export async function scoreEvent(
     .catch(() => null);
   void invalidatePublicCache(auth.orgId, fixtureId, movesDiscovery);
   return out;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// Undo with nothing to undo is a 409, never a crash (v3/09 §2): a missing /
+// unknown / already-voided target answers CONFLICT before the fold would 422,
+// so a double-tapped "Undo last" degrades to a calm "already undone".
+async function assertUndoTarget(
+  auth: AuthCtx,
+  fixtureId: string,
+  input: AppendEventRequest,
+): Promise<void> {
+  const eventId = (input.payload as { event_id?: unknown } | null)?.event_id;
+  if (typeof eventId !== "string" || !UUID_RE.test(eventId)) {
+    throw new HttpError(409, "Nothing to undo");
+  }
+  const [target] = await withTenant(auth.orgId, (tx) => tx<{ type: string; voided: boolean }[]>`
+    select e.type,
+           exists (select 1 from score_events v
+                   where v.fixture_id = e.fixture_id and v.voids_event_id = e.id) as voided
+    from score_events e
+    where e.id = ${eventId} and e.fixture_id = ${fixtureId}`);
+  if (!target) throw new HttpError(409, "Nothing to undo — that entry does not exist");
+  if (target.voided) throw new HttpError(409, "Nothing to undo — that entry is already undone");
+  if (target.type === "core.void") {
+    throw new HttpError(409, "An undo cannot be undone — re-record the entry instead");
+  }
 }
 
 // Entitlement gates at THE scoring door (doc 10 §2 rules 2 & 4):

--- a/db/migration/deltas/V261__division_archive.sql
+++ b/db/migration/deltas/V261__division_archive.sql
@@ -1,0 +1,9 @@
+-- v3/09 §4 (PROMPT-38) — division archive lifecycle. Archived divisions are
+-- hidden from the console, the public site (404) and entitlement counts, and
+-- restorable from competition settings; hard delete stays reserved for
+-- setup-state divisions and 30-day-old archives (purge).
+alter table divisions add column if not exists archived_at timestamptz;
+
+-- Quota counts and console lists read active divisions per competition.
+create index if not exists divisions_active_idx
+  on divisions(competition_id) where archived_at is null;

--- a/db/migration/deltas/V262__public_divisions_hide_archived.sql
+++ b/db/migration/deltas/V262__public_divisions_hide_archived.sql
@@ -1,0 +1,10 @@
+-- v3/09 §4 (PROMPT-38) — archived divisions vanish from the public site (404).
+-- One view feeds every public surface (competition home, division pages,
+-- schedule/standings JSON, discovery), so the filter lives here.
+create or replace view public_divisions_v as
+  select d.id, d.competition_id, d.name, d.slug, d.sport_key, d.variant_key,
+         d.status, d.created_at, d.module_version, d.tiebreakers
+  from divisions d
+  join competitions c on c.id = d.competition_id
+  where c.visibility in ('public','unlisted')
+    and d.archived_at is null;

--- a/design/v2/README.md
+++ b/design/v2/README.md
@@ -87,7 +87,10 @@ checklists:
 
 Ordered. Each prompt is self-contained: context, task, files, acceptance criteria.
 
-**Status:** 00–15 ✅ implemented · 16–20 open.
+**Status:** 00–15 ✅ implemented · 16–20 open. PROMPT-38 (v3) hardened this wave's
+engine: setbased headline carries per-set points, fixture status derives from the
+void-resolved ledger, sim harness → matrix runner (`sim:matrix`, sim-report.json,
+undo-storm/boundary/officials/points/carry-over/americano/ladder scenarios).
 
 | Prompt | Delivers | Depends on |
 |--------|----------|-----------|

--- a/design/v3/09-engine-fixes-and-sim.md
+++ b/design/v3/09-engine-fixes-and-sim.md
@@ -98,3 +98,32 @@ archives; restore round-trips. Smoke extended: delete path on free, archive on p
 
 Related: engine/04 (scoring specs), engine/sports/badminton.md + cricket.md (normative),
 Jul3/03 (undo semantics), [[v3/03]] ConfirmDialog.
+
+## 6. Implementation notes (PROMPT-38, 2026-07-10)
+
+Landed on `feat/engine-fixes-prompt-38`. Deviations/diagnoses vs the sketches above:
+
+- **§1a root cause (engine, not client):** the setbased kernel's fold and set
+  predicate were correct; the divergence was `summary()` collapsing the headline
+  to sets-won only ("1 — 0"), so a summary-entered game score never appeared in
+  the top score. Fixed in the kernel: headlines now carry per-set points
+  ("2 — 0 · 21–15, 21–18", open set in parens). §1b set-end rules verified
+  correct — the boundary matrices are now permanent tests + sim scenarios.
+- **§2 root cause (persistence, not fold):** `resolveVoids` already hides
+  compensating events from modules; the regression was `fixtures.status`
+  drifting from the fold after a void (undo of `core.start`/`core.forfeit`/
+  `core.abandon` left the status stuck), dead-ending the console. Status is now
+  derived from the void-resolved ledger in `appendEvent`. Undo-of-nothing is a
+  usecase-level 409 (`REGISTRATION_OPEN`-style typed code: no target / already
+  undone / undoing an undo). The scoring-panel error boundary landed as
+  defence in depth (`ScoringErrorBoundary`).
+- **§4 route naming:** `POST /divisions/{id}/restore` was already taken by the
+  Jul3/03 checkpoint restore, so un-archiving is `DELETE /divisions/{id}/archive`
+  (archive as a resource). Purge reuses `DELETE /divisions/{id}` on an archived
+  division (409 `ARCHIVE_COOL_OFF` inside 30 days). Open registration blocks
+  archive as well as delete. Restore re-checks the divisions quota (402 rather
+  than silently exceeding the plan).
+- **§3:** `league_legs2` joined the division-matrix templates; americano/ladder
+  are engine-level scenario suites (StageKind stays the six-kind enum — those
+  formats are app-level stage configs). `npm run sim:matrix` emits
+  `packages/engine/sim-report.json`; CI runs `SIM_SEEDS=5` and uploads it.

--- a/design/v3/README.md
+++ b/design/v3/README.md
@@ -6,8 +6,12 @@ engine**: mobile, navigation, pricing/packaging, self-serve growth, documentatio
 handful of correctness fixes. Intake: the 9 Jul 2026 organiser/founder list (31 items,
 captured verbatim in [00-intake-backlog.md](00-intake-backlog.md)).
 
-> **Status: designed, not implemented.** Prompts numbered PROMPT-30…39 (continuing
-> Jul3's 21–29). Numbering of design docs is independent of `engine/` docs.
+> **Status: designed; PROMPT-38 implemented** (2026-07-10, branch
+> `feat/engine-fixes-prompt-38`) — badminton headline + set-end matrix, cricket
+> undo/status coherence + scoring error boundary, sim-replay v2 (matrix +
+> `sim-report.json` + CI profile), division delete/archive/restore. The rest are
+> designed, not implemented. Prompts numbered PROMPT-30…39 (continuing Jul3's
+> 21–29). Numbering of design docs is independent of `engine/` docs.
 
 ## Theme
 

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -2083,6 +2083,16 @@
                           "auto_progress": {
                             "type": "boolean"
                           },
+                          "archived_at": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
                           "created_at": {
                             "type": "string"
                           }
@@ -2102,6 +2112,7 @@
                           "officials_hide_names",
                           "scheduling_mode",
                           "auto_progress",
+                          "archived_at",
                           "created_at"
                         ],
                         "additionalProperties": false
@@ -2429,6 +2440,16 @@
                         "auto_progress": {
                           "type": "boolean"
                         },
+                        "archived_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
                         }
@@ -2448,6 +2469,7 @@
                         "officials_hide_names",
                         "scheduling_mode",
                         "auto_progress",
+                        "archived_at",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -2793,6 +2815,16 @@
                         "auto_progress": {
                           "type": "boolean"
                         },
+                        "archived_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
                         }
@@ -2812,6 +2844,7 @@
                         "officials_hide_names",
                         "scheduling_mode",
                         "auto_progress",
+                        "archived_at",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -3130,6 +3163,16 @@
                         "auto_progress": {
                           "type": "boolean"
                         },
+                        "archived_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
                         }
@@ -3149,6 +3192,7 @@
                         "officials_hide_names",
                         "scheduling_mode",
                         "auto_progress",
+                        "archived_at",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -3208,6 +3252,894 @@
           },
           "401": {
             "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Delete a setup division (204) or purge a 30-day archive; started/resulted → 409 DIVISION_HAS_RESULTS {archive: true}",
+        "tags": [
+          "divisions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/divisions/{id}/archive": {
+      "post": {
+        "summary": "Archive: hidden from console/public/quota, restorable",
+        "tags": [
+          "divisions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "competition_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "sport_key": {
+                          "type": "string"
+                        },
+                        "variant_key": {
+                          "type": "string"
+                        },
+                        "config": {},
+                        "module_version": {
+                          "type": "string"
+                        },
+                        "eligibility": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "tiebreakers": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "setup",
+                            "scheduled",
+                            "active",
+                            "completed"
+                          ]
+                        },
+                        "officials_hide_names": {
+                          "type": "boolean"
+                        },
+                        "scheduling_mode": {
+                          "type": "string",
+                          "enum": [
+                            "timed",
+                            "flexible"
+                          ]
+                        },
+                        "auto_progress": {
+                          "type": "boolean"
+                        },
+                        "archived_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "created_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "competition_id",
+                        "name",
+                        "slug",
+                        "sport_key",
+                        "variant_key",
+                        "config",
+                        "module_version",
+                        "eligibility",
+                        "tiebreakers",
+                        "status",
+                        "officials_hide_names",
+                        "scheduling_mode",
+                        "auto_progress",
+                        "archived_at",
+                        "created_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Restore an archived division (quota re-checked)",
+        "tags": [
+          "divisions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "competition_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "slug": {
+                          "type": "string"
+                        },
+                        "sport_key": {
+                          "type": "string"
+                        },
+                        "variant_key": {
+                          "type": "string"
+                        },
+                        "config": {},
+                        "module_version": {
+                          "type": "string"
+                        },
+                        "eligibility": {
+                          "type": "array",
+                          "items": {}
+                        },
+                        "tiebreakers": {
+                          "anyOf": [
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "setup",
+                            "scheduled",
+                            "active",
+                            "completed"
+                          ]
+                        },
+                        "officials_hide_names": {
+                          "type": "boolean"
+                        },
+                        "scheduling_mode": {
+                          "type": "string",
+                          "enum": [
+                            "timed",
+                            "flexible"
+                          ]
+                        },
+                        "auto_progress": {
+                          "type": "boolean"
+                        },
+                        "archived_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "created_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "competition_id",
+                        "name",
+                        "slug",
+                        "sport_key",
+                        "variant_key",
+                        "config",
+                        "module_version",
+                        "eligibility",
+                        "tiebreakers",
+                        "status",
+                        "officials_hide_names",
+                        "scheduling_mode",
+                        "auto_progress",
+                        "archived_at",
+                        "created_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Plan upgrade required",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Pure tournament engine for seazn.club — zero effectful deps (design corpus: engine/).",
+  "description": "Pure tournament engine for seazn.club \u2014 zero effectful deps (design corpus: engine/).",
   "exports": {
     "./core": "./src/core/index.ts",
     "./sport": "./src/sport/index.ts",
@@ -22,9 +22,10 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "sim": "vitest run src/testkit/simulation.test.ts src/testkit/chaos.test.ts",
+    "sim": "vitest run src/testkit/simulation.test.ts src/testkit/chaos.test.ts src/testkit/undo-sweep.test.ts",
     "sim:replay": "node --experimental-strip-types scripts/sim-replay.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "sim:matrix": "node --experimental-strip-types scripts/sim-replay.ts --matrix"
   },
   "peerDependencies": {
     "zod": "^4.4.3"

--- a/packages/engine/scripts/sim-replay.ts
+++ b/packages/engine/scripts/sim-replay.ts
@@ -1,74 +1,350 @@
-// Deterministic simulation replay — PROMPT-14 §3.
+// Deterministic simulation runner — PROMPT-14 §3, upgraded by PROMPT-38
+// (v3/09 §3) with a full coverage matrix and a machine-readable report.
 //
-//   npm run sim:replay -- <sport:format:seed>
-//   npm run sim:replay -- sim-failures/<artifact>.json
+//   npm run sim:replay -- <sport:format:seed>       # replay one failure
+//   npm run sim:replay -- sim-failures/<a>.json     # replay a CI artifact
+//   npm run sim:matrix                              # full matrix + report
+//   npm run sim:matrix -- --seeds 3 --report out.json   # bounded profile
 //
-// Re-runs the exact division a CI failure artifact points at (same seed ⇒ same
-// entrant count, fixture ids, event ids, injection), re-checks the global
-// invariants and the double-run determinism property, and exits non-zero when
-// the failure reproduces.
-import { readFileSync } from "node:fs";
+// Matrix mode runs every registered sport module × every stage-graph template
+// × N seeds, plus the permanent scenario suites (undo storms, set-end boundary
+// matrices, officials, custom points, carry-over, americano, ladder), writes
+// `packages/engine/sim-report.json` and prints a table. Every failure line
+// carries the reproducing seed token — determinism (engine ground rule 1)
+// makes each one replayable via the first form.
+import { readFileSync, writeFileSync } from "node:fs";
 import { builtinModules } from "../src/sports/index.ts";
 import {
   assertDivisionInvariants,
+  FORMAT_TEMPLATES,
   parseSeedToken,
   simOptionsFor,
   simulateDivision,
   SimInvariantError,
+  type FormatTemplate,
 } from "../src/testkit/simulation.ts";
+import {
+  runAmericanoScenario,
+  runBoundaryMatrices,
+  runCarryOverScenario,
+  runCustomPointsScenario,
+  runLadderScenario,
+  runOfficialsScenario,
+  runUndoStorm,
+} from "../src/testkit/scenarios.ts";
 
-const arg = process.argv[2];
-if (arg === undefined) {
-  console.error("usage: npm run sim:replay -- <sport:format:seed | path/to/failure.json>");
-  process.exit(2);
+interface MatrixCell {
+  sport: string;
+  format: FormatTemplate;
+  seeds: number;
+  fixtures: number;
+  events: number;
+  injectionsApplied: number;
+  injectionsRejected: number;
+  ok: boolean;
 }
 
-const token = arg.endsWith(".json")
-  ? (JSON.parse(readFileSync(arg, "utf8")) as { seedToken: string }).seedToken
-  : arg;
-const { sport, format, seed } = parseSeedToken(token);
-const module = builtinModules.find((m) => m.key === sport);
-if (module === undefined) {
-  console.error(`unknown sport "${sport}" — shipped: ${builtinModules.map((m) => m.key).join(", ")}`);
-  process.exit(2);
+interface Failure {
+  where: string; // seed token or scenario id — the reproduction handle
+  error: string;
+  detail?: unknown;
 }
 
-const opts = simOptionsFor(module, format, seed);
-console.log(`replaying ${token} …`);
+interface SimReport {
+  version: 2;
+  startedAt: string;
+  durationMs: number;
+  seedsPerCell: number;
+  divisionMatrix: MatrixCell[];
+  scenarios: {
+    undoStorm: { sport: string; positions: number; accepted: number; rejected: number }[];
+    boundaryMatrix: { preset: string; cases: number }[];
+    officials: { fixtures: number; assignments: number; blockConflicts: number } | null;
+    customPoints: { sport: string; fixtures: number }[];
+    carryOver: { rows: number } | null;
+    americano: { sport: string; players: number; rounds: number; matches: number }[];
+    ladder: { sport: string; entrants: number; challenges: number; swaps: number }[];
+  };
+  coverage: {
+    modules: string[];
+    formats: string[];
+    scenarios: string[];
+  };
+  failures: Failure[];
+}
 
-try {
-  const sim = simulateDivision(opts);
-  const fixtures = sim.stages.reduce((acc, stage) => acc + stage.fixtures.length, 0);
-  const events = sim.stages.reduce(
-    (acc, stage) => acc + stage.fixtures.reduce((a, f) => a + f.events.length, 0),
-    0,
-  );
-  console.log(
-    `  entrants=${sim.entrants.length} stages=[${sim.stages.map((s) => `${s.id}:${s.kind}`).join(", ")}] fixtures=${fixtures} events=${events}`,
-  );
-  if (sim.injection !== undefined) {
-    console.log(
-      `  void injection: fixture=${sim.injection.fixtureId} event=${sim.injection.voidedEventId} applied=${sim.injection.applied}${sim.injection.rejectedCode === undefined ? "" : ` rejected=${sim.injection.rejectedCode}`} outcomeChanged=${sim.injection.outcomeChanged}`,
-    );
+function fail(failures: Failure[], where: string, error: unknown): void {
+  failures.push({
+    where,
+    error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+    ...(error instanceof SimInvariantError && error.detail !== undefined
+      ? { detail: error.detail }
+      : {}),
+  });
+  console.error(`  FAIL ${where}\n       ${error instanceof Error ? error.message : String(error)}`);
+  if (where.includes(":")) console.error(`       reproduce: npm run sim:replay -- ${where}`);
+}
+
+// ---------------------------------------------------------------------------
+// Replay mode (unchanged contract): one token, exit non-zero on reproduction.
+// ---------------------------------------------------------------------------
+
+function replayToken(tokenArg: string): never {
+  const token = tokenArg.endsWith(".json")
+    ? (JSON.parse(readFileSync(tokenArg, "utf8")) as { seedToken: string }).seedToken
+    : tokenArg;
+  const { sport, format, seed } = parseSeedToken(token);
+  const module = builtinModules.find((m) => m.key === sport);
+  if (module === undefined) {
+    console.error(`unknown sport "${sport}" — shipped: ${builtinModules.map((m) => m.key).join(", ")}`);
+    process.exit(2);
   }
-  console.log(`  champion=${sim.champion} finalRanks=[${sim.finalRanks.slice(0, 8).join(", ")}${sim.finalRanks.length > 8 ? ", …" : ""}]`);
 
-  assertDivisionInvariants(sim, module, opts.cfg);
-  console.log("  invariants: OK");
+  const opts = simOptionsFor(module, format, seed);
+  console.log(`replaying ${token} …`);
+  try {
+    const sim = simulateDivision(opts);
+    const fixtures = sim.stages.reduce((acc, stage) => acc + stage.fixtures.length, 0);
+    const events = sim.stages.reduce(
+      (acc, stage) => acc + stage.fixtures.reduce((a, f) => a + f.events.length, 0),
+      0,
+    );
+    console.log(
+      `  entrants=${sim.entrants.length} stages=[${sim.stages.map((s) => `${s.id}:${s.kind}`).join(", ")}] fixtures=${fixtures} events=${events}`,
+    );
+    if (sim.injection !== undefined) {
+      console.log(
+        `  void injection: fixture=${sim.injection.fixtureId} event=${sim.injection.voidedEventId} applied=${sim.injection.applied}${sim.injection.rejectedCode === undefined ? "" : ` rejected=${sim.injection.rejectedCode}`} outcomeChanged=${sim.injection.outcomeChanged}`,
+      );
+    }
+    console.log(
+      `  champion=${sim.champion} finalRanks=[${sim.finalRanks.slice(0, 8).join(", ")}${sim.finalRanks.length > 8 ? ", …" : ""}]`,
+    );
 
-  const replay = simulateDivision(opts);
-  if (JSON.stringify(replay) !== JSON.stringify(sim)) {
-    console.error("  determinism: FAILED — the same seed produced a different division");
+    assertDivisionInvariants(sim, module, opts.cfg);
+    console.log("  invariants: OK");
+
+    const replay = simulateDivision(opts);
+    if (JSON.stringify(replay) !== JSON.stringify(sim)) {
+      console.error("  determinism: FAILED — the same seed produced a different division");
+      process.exit(1);
+    }
+    console.log("  determinism: OK (double run byte-identical)");
+    process.exit(0);
+  } catch (error) {
+    console.error("  failure reproduced:");
+    if (error instanceof SimInvariantError) {
+      console.error(`  ${error.message}`);
+      if (error.detail !== undefined) console.error(`  detail: ${JSON.stringify(error.detail)}`);
+    } else {
+      console.error(error);
+    }
     process.exit(1);
   }
-  console.log("  determinism: OK (double run byte-identical)");
-} catch (error) {
-  console.error("  failure reproduced:");
-  if (error instanceof SimInvariantError) {
-    console.error(`  ${error.message}`);
-    if (error.detail !== undefined) console.error(`  detail: ${JSON.stringify(error.detail)}`);
-  } else {
-    console.error(error);
-  }
-  process.exit(1);
 }
+
+// ---------------------------------------------------------------------------
+// Matrix mode.
+// ---------------------------------------------------------------------------
+
+function runMatrix(seedsPerCell: number, reportPath: string): never {
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+  const failures: Failure[] = [];
+  const cells: MatrixCell[] = [];
+
+  console.log(
+    `sim matrix: ${builtinModules.length} modules × ${FORMAT_TEMPLATES.length} formats × ${seedsPerCell} seeds`,
+  );
+
+  for (const module of builtinModules) {
+    for (const format of FORMAT_TEMPLATES) {
+      const cell: MatrixCell = {
+        sport: module.key,
+        format,
+        seeds: 0,
+        fixtures: 0,
+        events: 0,
+        injectionsApplied: 0,
+        injectionsRejected: 0,
+        ok: true,
+      };
+      for (let seed = 1; seed <= seedsPerCell; seed++) {
+        const token = `${module.key}:${format}:${seed}`;
+        try {
+          const opts = simOptionsFor(module, format, seed);
+          const sim = simulateDivision(opts);
+          assertDivisionInvariants(sim, module, opts.cfg);
+          if (seed === 1) {
+            // Determinism slice: the first seed of every cell double-runs.
+            const replay = simulateDivision(opts);
+            if (JSON.stringify(replay) !== JSON.stringify(sim)) {
+              throw new SimInvariantError("determinism: double run diverged");
+            }
+          }
+          cell.seeds++;
+          cell.fixtures += sim.stages.reduce((a, s) => a + s.fixtures.length, 0);
+          cell.events += sim.stages.reduce(
+            (a, s) => a + s.fixtures.reduce((x, f) => x + f.events.length, 0),
+            0,
+          );
+          if (sim.injection !== undefined) {
+            if (sim.injection.applied) cell.injectionsApplied++;
+            else cell.injectionsRejected++;
+          }
+        } catch (error) {
+          cell.ok = false;
+          fail(failures, token, error);
+        }
+      }
+      cells.push(cell);
+    }
+  }
+
+  // Scenario suites — the permanent regressions + Jul3 feature coverage.
+  const scenarios: SimReport["scenarios"] = {
+    undoStorm: [],
+    boundaryMatrix: [],
+    officials: null,
+    customPoints: [],
+    carryOver: null,
+    americano: [],
+    ladder: [],
+  };
+
+  for (const module of builtinModules) {
+    try {
+      const stats = runUndoStorm(module, 1);
+      scenarios.undoStorm.push(stats);
+    } catch (error) {
+      fail(failures, `scenario:undo-storm:${module.key}`, error);
+    }
+    try {
+      scenarios.customPoints.push(runCustomPointsScenario(module, 1));
+    } catch (error) {
+      fail(failures, `scenario:custom-points:${module.key}`, error);
+    }
+  }
+
+  try {
+    scenarios.boundaryMatrix = runBoundaryMatrices();
+  } catch (error) {
+    fail(failures, "scenario:boundary-matrix", error);
+  }
+  try {
+    scenarios.officials = runOfficialsScenario(1);
+  } catch (error) {
+    fail(failures, "scenario:officials", error);
+  }
+  try {
+    // Carry a real simulated league table (generic module, seed 1).
+    const generic = builtinModules.find((m) => m.key === "generic");
+    if (generic) {
+      const opts = simOptionsFor(generic, "league", 1);
+      const sim = simulateDivision(opts);
+      const rows = sim.stages[0]?.tables?.pools[0]?.rows ?? [];
+      scenarios.carryOver = runCarryOverScenario(rows as never);
+    }
+  } catch (error) {
+    fail(failures, "scenario:carry-over", error);
+  }
+  // Americano/ladder run on the set-based + generic modules (the formats the
+  // app offers them for); every module would multiply time without new signal.
+  for (const key of ["badminton", "tabletennis", "generic"]) {
+    const module = builtinModules.find((m) => m.key === key);
+    if (!module) continue;
+    try {
+      scenarios.americano.push({ sport: key, ...runAmericanoScenario(module, 1) });
+    } catch (error) {
+      fail(failures, `scenario:americano:${key}`, error);
+    }
+    try {
+      scenarios.ladder.push({ sport: key, ...runLadderScenario(module, 1) });
+    } catch (error) {
+      fail(failures, `scenario:ladder:${key}`, error);
+    }
+  }
+
+  const report: SimReport = {
+    version: 2,
+    startedAt,
+    durationMs: Date.now() - t0,
+    seedsPerCell,
+    divisionMatrix: cells,
+    scenarios,
+    coverage: {
+      modules: builtinModules.map((m) => m.key),
+      formats: [...FORMAT_TEMPLATES],
+      scenarios: [
+        "undo-storm",
+        "boundary-matrix",
+        "officials",
+        "custom-points",
+        "carry-over",
+        "americano",
+        "ladder",
+      ],
+    },
+    failures,
+  };
+  writeFileSync(reportPath, JSON.stringify(report, null, 2));
+
+  // Human table.
+  console.log("\nsport        format           seeds  fixtures  events  inj+  inj-  ok");
+  for (const cell of cells) {
+    console.log(
+      [
+        cell.sport.padEnd(12),
+        cell.format.padEnd(16),
+        String(cell.seeds).padStart(5),
+        String(cell.fixtures).padStart(9),
+        String(cell.events).padStart(7),
+        String(cell.injectionsApplied).padStart(5),
+        String(cell.injectionsRejected).padStart(5),
+        cell.ok ? "  ok" : "  FAIL",
+      ].join(" "),
+    );
+  }
+  const storms = scenarios.undoStorm.reduce((a, s) => a + s.positions, 0);
+  const boundary = scenarios.boundaryMatrix.reduce((a, s) => a + s.cases, 0);
+  console.log(
+    `\nscenarios: undo-storm ${storms} positions · boundary ${boundary} cases · officials ${scenarios.officials?.assignments ?? 0} assignments · custom-points ${scenarios.customPoints.reduce((a, s) => a + s.fixtures, 0)} fixtures · carry-over ${scenarios.carryOver?.rows ?? 0} rows · americano ${scenarios.americano.reduce((a, s) => a + s.matches, 0)} matches · ladder ${scenarios.ladder.reduce((a, s) => a + s.challenges, 0)} challenges`,
+  );
+  console.log(`report: ${reportPath} (${report.durationMs} ms)`);
+
+  if (failures.length > 0) {
+    console.error(`\n${failures.length} failure(s) — each line above carries its reproduction handle.`);
+    process.exit(1);
+  }
+  console.log("all green");
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+if (args.includes("--matrix") || args.length === 0) {
+  const seedsFlag = args.indexOf("--seeds");
+  const reportFlag = args.indexOf("--report");
+  const seeds = seedsFlag >= 0 ? Number(args[seedsFlag + 1]) : Number(process.env.SIM_SEEDS ?? 5);
+  const reportPath =
+    reportFlag >= 0
+      ? (args[reportFlag + 1] as string)
+      : new URL("../sim-report.json", import.meta.url).pathname;
+  if (!Number.isInteger(seeds) || seeds < 1) {
+    console.error("--seeds must be a positive integer");
+    process.exit(2);
+  }
+  runMatrix(seeds, reportPath);
+}
+
+const tokenArg = args.find((a) => !a.startsWith("--"));
+if (tokenArg === undefined) {
+  console.error(
+    "usage: npm run sim:replay -- <sport:format:seed | path/to/failure.json>\n       npm run sim:matrix [-- --seeds N --report path]",
+  );
+  process.exit(2);
+}
+replayToken(tokenArg);

--- a/packages/engine/src/sports/setbased/boundary.test.ts
+++ b/packages/engine/src/sports/setbased/boundary.test.ts
@@ -1,0 +1,218 @@
+// Set-end boundary matrix — v3/09 §1 (PROMPT-38). The founder-reported
+// badminton defects: (a) summary diverging from the event ledger, (b) set-end
+// rules around deuce and the cap. The same parametric kernel drives badminton,
+// table tennis and volleyball, so the matrix runs on all three presets — a
+// preset-parameter bug here is probably shared (v3/09 §1b).
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { foldMatch, type EventEnvelope } from "../../core/events.ts";
+import { mulberry32 } from "../../core/rng.ts";
+import type { ModuleEvent } from "../../sport/module.ts";
+import { defaultLineupPair, makeEnvelope } from "../../testkit/helpers.ts";
+import { badminton } from "./badminton.ts";
+import { tabletennis } from "./tabletennis.ts";
+import { volleyball } from "./volleyball.ts";
+import type { SetBasedState } from "./kernel.ts";
+
+// Drive one rally set to exactly (h, a) alternating trailing points so no
+// intermediate score is terminal by accident (winner's points last).
+function ralliesTo(rallyType: string, h: number, a: number): ModuleEvent[] {
+  const out: ModuleEvent[] = [];
+  const lo = Math.min(h, a);
+  for (let i = 0; i < lo; i++) {
+    out.push({ type: rallyType, payload: { wonBy: "H" } });
+    out.push({ type: rallyType, payload: { wonBy: "A" } });
+  }
+  const leader = h > a ? "H" : "A";
+  for (let i = 0; i < Math.abs(h - a); i++) {
+    out.push({ type: rallyType, payload: { wonBy: leader } });
+  }
+  return out;
+}
+
+function fold(module: typeof badminton, events: ModuleEvent[], cfg: unknown = {}) {
+  const envs: EventEnvelope[] = events.map((e, i) => makeEnvelope(i, e));
+  return foldMatch(module, module.configSchema.parse(cfg), defaultLineupPair(module.positions), [
+    makeEnvelope(0, { type: "core.start", payload: {} }),
+    ...envs.map((e, i) => ({ ...e, seq: i + 1, id: `e-${i + 1}` })),
+  ]);
+}
+
+interface MatrixCase {
+  score: [number, number];
+  ends: boolean;
+}
+
+// One preset's boundary matrix: rally streams must end (or not end) the set at
+// exactly these scores, and completed-set summaries must accept exactly the
+// reachable ones.
+function runMatrix(
+  module: typeof badminton,
+  rally: string,
+  summaryType: string,
+  cases: MatrixCase[],
+  rejectedSummaries: [number, number][],
+  cfg: unknown = {},
+) {
+  describe(`${module.key}: set-end matrix`, () => {
+    for (const { score, ends } of cases) {
+      const [h, a] = score;
+      it(`rally to ${h}-${a} ${ends ? "ends" : "does NOT end"} the set`, () => {
+        const state = fold(module, ralliesTo(rally, h, a), cfg) as SetBasedState;
+        const set = state.sets[0];
+        expect(set, "first set exists").toBeDefined();
+        expect(set!.home).toBe(h);
+        expect(set!.away).toBe(a);
+        expect(set!.closed, `closed at ${h}-${a}`).toBe(ends);
+      });
+      if (ends) {
+        it(`summary ${h}-${a} is accepted as a completed set`, () => {
+          const state = fold(module, [{ type: summaryType, payload: { home: h, away: a } }], cfg) as SetBasedState;
+          expect(state.sets[0]?.closed).toBe(true);
+          expect(state.setsWon.home + state.setsWon.away).toBe(1);
+        });
+      }
+    }
+    for (const [h, a] of rejectedSummaries) {
+      it(`summary ${h}-${a} is rejected (unreachable/overshoot)`, () => {
+        expect(() =>
+          fold(module, [{ type: summaryType, payload: { home: h, away: a } }], cfg),
+        ).toThrowError(/reachable|INVALID/i);
+      });
+    }
+  });
+}
+
+// Badminton (BWF, spec 04 §4): 21, win-by-2 from 20-20, hard cap 30.
+runMatrix(
+  badminton,
+  "badminton.rally",
+  "badminton.game.summary",
+  [
+    { score: [21, 19], ends: true },
+    { score: [21, 20], ends: false }, // deuce: 20-20 was passed, needs 2 clear
+    { score: [22, 20], ends: true },
+    { score: [25, 23], ends: true },
+    { score: [29, 28], ends: false }, // margin 1 below the cap
+    { score: [30, 29], ends: true }, // golden point AT the cap
+    { score: [30, 28], ends: true }, // 29-28 → +1 = win by 2 at 30
+    { score: [21, 0], ends: true }, // no skunk rule
+  ],
+  [
+    [31, 30], // beyond the cap
+    [22, 19], // decided earlier at 21-19
+    [30, 27], // cap score but 29-27 was already terminal
+    [20, 18], // not terminal at all
+  ],
+);
+
+// Table tennis (ITTF, spec 04 §5): 11, win-by-2, NO cap (deuce runs 12-10…).
+runMatrix(
+  tabletennis,
+  "tabletennis.rally",
+  "tabletennis.game.summary",
+  [
+    { score: [11, 9], ends: true },
+    { score: [11, 10], ends: false },
+    { score: [12, 10], ends: true },
+    { score: [15, 13], ends: true }, // uncapped deuce endgame
+    { score: [11, 0], ends: true },
+  ],
+  [
+    [12, 9], // decided at 11-9
+    [11, 10], // margin 1, no cap to save it
+    [13, 10], // decided at 12-10
+  ],
+);
+
+// Volleyball (FIVB indoor, spec 04 §3): 25, win-by-2, no cap; 5th set to 15.
+runMatrix(
+  volleyball,
+  "volleyball.rally",
+  "volleyball.set.summary",
+  [
+    { score: [25, 23], ends: true },
+    { score: [25, 24], ends: false },
+    { score: [26, 24], ends: true },
+    { score: [32, 30], ends: true },
+    { score: [25, 0], ends: true },
+  ],
+  [
+    [26, 23], // decided at 25-23
+    [33, 30], // decided at 32-30
+  ],
+);
+
+// Deciding-set target: volleyball's 5th set plays to 15 — a 15-13 summary must
+// close it, and a 25-23 fifth-set summary is an overshoot (decided at 15-13).
+describe("volleyball: deciding set uses finalSetTo", () => {
+  const summaries = (scores: [number, number][]): ModuleEvent[] =>
+    scores.map(([home, away]) => ({ type: "volleyball.set.summary", payload: { home, away } }));
+
+  it("closes the 5th set at 15-13", () => {
+    const state = fold(volleyball, [
+      ...summaries([[25, 20], [20, 25], [25, 20], [20, 25]]),
+      ...summaries([[15, 13]]),
+    ]) as SetBasedState;
+    expect(state.setsWon).toEqual({ home: 3, away: 2 });
+    expect(state.outcome?.kind).toBe("win");
+  });
+
+  it("rejects an overshoot in the 5th set (decided earlier under finalSetTo)", () => {
+    // 25-20 with a to-15 target: 24-20 was already terminal, so 25-20 is
+    // unreachable. (25-23 would be legal — an uncapped deuce from 14-14.)
+    expect(() =>
+      fold(volleyball, [
+        ...summaries([[25, 20], [20, 25], [25, 20], [20, 25]]),
+        ...summaries([[25, 20]]),
+      ]),
+    ).toThrowError(/reachable/i);
+  });
+});
+
+// Badminton `short` variant (11/15 cap): the cap must follow the variant, not
+// the shipped default — a wrong parameter here is the "set ends at the wrong
+// score" class of bug.
+describe("badminton short variant: 11 with cap 15", () => {
+  const cfg = { setTo: 11, finalSetTo: 11, cap: 15 };
+  it("golden point at 15-14; 16-15 impossible", () => {
+    const state = fold(badminton, ralliesTo("badminton.rally", 15, 14), cfg) as SetBasedState;
+    expect(state.sets[0]?.closed).toBe(true);
+    expect(() =>
+      fold(badminton, [{ type: "badminton.game.summary", payload: { home: 16, away: 15 } }], cfg),
+    ).toThrowError(/reachable/i);
+  });
+});
+
+// Property (v3/09 §1): after EVERY event, the summary of the incrementally
+// folded state equals the summary of a from-scratch recount of the same
+// prefix. This is the engine half of the "chosen score not reflected in the
+// top score" decision tree — any incremental-vs-recount divergence fails here.
+describe("summary equals recount-from-events at every prefix", () => {
+  for (const module of [badminton, tabletennis, volleyball]) {
+    it(`${module.key}: incremental fold and recount agree at every prefix`, () => {
+      fc.assert(
+        fc.property(fc.integer({ min: 1, max: 10_000 }), (seed) => {
+          const cfg = module.configSchema.parse({});
+          const pair = defaultLineupPair(module.positions);
+          const rng = mulberry32(seed);
+          let state = module.init(cfg, pair);
+          const events: EventEnvelope[] = [];
+          for (let i = 0; i < 200; i++) {
+            const next = module.arbitraryEvent?.call(module, state, rng);
+            if (!next) break;
+            const env = makeEnvelope(events.length, next);
+            state = module.apply(state, env as never);
+            events.push(env);
+            const recount = foldMatch(module, cfg, pair, events);
+            expect(JSON.stringify(module.summary(recount as never))).toBe(
+              JSON.stringify(module.summary(state as never)),
+            );
+            if (module.outcome(state as never) !== null) break;
+          }
+        }),
+        { numRuns: Number(process.env.SIM_RUNS ?? 25) },
+      );
+    });
+  }
+});

--- a/packages/engine/src/sports/setbased/kernel.ts
+++ b/packages/engine/src/sports/setbased/kernel.ts
@@ -489,15 +489,23 @@ export function makeSetBasedModule(
     outcome: (state) => state.outcome,
 
     // §9.5 — defined at every prefix; reads only the folded set ledger so
-    // coarse and fine folds render identically (§9.6).
+    // coarse and fine folds render identically (§9.6). The headline carries the
+    // per-set points, racquet-scoreline style ("2 — 0 · 21–15, 21–18"): a
+    // just-entered set summary must be visible in the top score (v3/09 §1a —
+    // "chosen score not reflected in top score").
     summary(state): ScoreSummary {
       const points = { home: totalPoints(state, "home"), away: totalPoints(state, "away") };
+      const closedSets = state.sets.filter((set) => set.closed);
+      const setLine =
+        closedSets.length === 0
+          ? ""
+          : ` · ${closedSets.map((set) => `${set.home}–${set.away}`).join(", ")}`;
       // While a set is mid-flight, surface its live points next to the set
-      // tally ("1 — 0 (14–11)") so rally scoring is visible at the headline.
+      // tally ("1 — 0 · 21–15 (14–11)") so rally scoring is visible too.
       const open = openSet(state);
       const inSet = open === null ? "" : ` (${open.set.home}–${open.set.away})`;
       return {
-        headline: `${state.setsWon.home} — ${state.setsWon.away}${inSet}`,
+        headline: `${state.setsWon.home} — ${state.setsWon.away}${setLine}${inSet}`,
         perSide: [
           { entrantId: state.entrants.home, line: `${state.setsWon.home}` },
           { entrantId: state.entrants.away, line: `${state.setsWon.away}` },

--- a/packages/engine/src/sports/setbased/setbased.test.ts
+++ b/packages/engine/src/sports/setbased/setbased.test.ts
@@ -65,7 +65,8 @@ describe("volleyball golden: 3-2 → 2:1 points split", () => {
     const state = fold(volleyball, cfg, events);
     expect(state.outcome).toEqual({ kind: "win", winner: "H", loser: "A", method: "regulation" });
     expect(state.setsWon).toEqual({ home: 3, away: 2 });
-    expect(volleyball.summary(state).headline).toBe("3 — 2");
+    // v3/09 §1a: the headline carries the per-set points (racquet scoreline).
+    expect(volleyball.summary(state).headline).toBe("3 — 2 · 25–20, 23–25, 25–18, 24–26, 15–13");
   });
 
   it("pays the FIVB 3-2 split 2:1 with integer point ledgers", () => {
@@ -160,22 +161,31 @@ describe("badminton golden: 30-29 golden point", () => {
     bad(29, 29); // not terminal
   });
 
-  it("headline shows the open game's live points, then drops them once the game closes", () => {
+  it("headline shows the open game's live points AND keeps banked game points (v3/09 §1a)", () => {
     // 3 rallies into game 1: sets 0-0, live points 2-1.
     const winners: Side[] = ["home", "away", "home"];
     const mid = fold(badminton, cfg, rallyMatch(badminton, winners));
     expect(badminton.summary(mid).headline).toBe("0 — 0 (2–1)");
 
-    // Game 1 closes 21-1: no open set → no parenthetical.
+    // Game 1 closes 21-1: the entered/earned points stay in the top score —
+    // the intake #28a regression was the headline collapsing to just "1 — 0".
     for (let i = 0; i < 19; i++) winners.push("home");
     const closed = fold(badminton, cfg, rallyMatch(badminton, winners));
     expect(closed.setsWon).toEqual({ home: 1, away: 0 });
-    expect(badminton.summary(closed).headline).toBe("1 — 0");
+    expect(badminton.summary(closed).headline).toBe("1 — 0 · 21–1");
 
-    // 1 rally into game 2: banked set plus fresh live points.
+    // 1 rally into game 2: banked set points plus fresh live points.
     winners.push("away");
     const second = fold(badminton, cfg, rallyMatch(badminton, winners));
-    expect(badminton.summary(second).headline).toBe("1 — 0 (0–1)");
+    expect(badminton.summary(second).headline).toBe("1 — 0 · 21–1 (0–1)");
+  });
+
+  it("a game entered as a summary is reflected in the headline (intake #28a)", () => {
+    const one = fold(badminton, cfg, summaryMatch(badminton, [[21, 15]]));
+    expect(badminton.summary(one).headline).toBe("1 — 0 · 21–15");
+    const two = fold(badminton, cfg, summaryMatch(badminton, [[21, 15], [21, 18]]));
+    expect(badminton.summary(two).headline).toBe("2 — 0 · 21–15, 21–18");
+    expect(two.outcome).toMatchObject({ kind: "win", winner: "H" });
   });
 });
 

--- a/packages/engine/src/testkit/scenarios.test.ts
+++ b/packages/engine/src/testkit/scenarios.test.ts
@@ -1,0 +1,64 @@
+// The sim scenario suites (v3/09 §3) run under vitest too: CI exercises the
+// exact code the sim:matrix runner ships (coverage included), and a scenario
+// violation fails the unit gate without waiting for the matrix job.
+import { describe, expect, it } from "vitest";
+import { builtinModules } from "../sports/index.ts";
+import { simOptionsFor, simulateDivision } from "./simulation.ts";
+import {
+  runAmericanoScenario,
+  runBoundaryMatrices,
+  runCarryOverScenario,
+  runCustomPointsScenario,
+  runLadderScenario,
+  runOfficialsScenario,
+  runUndoStorm,
+} from "./scenarios.ts";
+
+describe("sim scenarios", () => {
+  for (const module of builtinModules) {
+    it(`undo storm — ${module.key}`, { timeout: 60_000 }, () => {
+      const stats = runUndoStorm(module, 1);
+      expect(stats.positions).toBeGreaterThan(0);
+      expect(stats.accepted + stats.rejected).toBe(stats.positions);
+    });
+
+    it(`custom points rule — ${module.key}`, { timeout: 60_000 }, () => {
+      const stats = runCustomPointsScenario(module, 1);
+      expect(stats.fixtures).toBeGreaterThan(0);
+    });
+  }
+
+  it("set-end boundary matrices (setbased presets)", () => {
+    const stats = runBoundaryMatrices();
+    expect(stats.map((s) => s.preset).sort()).toEqual(["badminton", "tabletennis", "volleyball"]);
+    for (const s of stats) expect(s.cases).toBeGreaterThan(5);
+  });
+
+  it("officials assignment holds the no-double-booking invariant", () => {
+    const stats = runOfficialsScenario(1);
+    expect(stats.assignments).toBeGreaterThan(0);
+  });
+
+  it("carry-over conserves a simulated league table", () => {
+    const generic = builtinModules.find((m) => m.key === "generic");
+    expect(generic).toBeDefined();
+    const sim = simulateDivision(simOptionsFor(generic!, "league", 1));
+    const rows = sim.stages[0]?.tables?.pools[0]?.rows ?? [];
+    expect(rows.length).toBeGreaterThan(1);
+    expect(runCarryOverScenario(rows as never).rows).toBe(rows.length);
+  });
+
+  for (const key of ["badminton", "generic"]) {
+    const module = builtinModules.find((m) => m.key === key)!;
+    it(`americano rounds — ${key}`, { timeout: 60_000 }, () => {
+      const stats = runAmericanoScenario(module, 1);
+      expect(stats.matches).toBeGreaterThan(0);
+      expect(stats.rounds).toBe(5);
+    });
+
+    it(`ladder challenges — ${key}`, { timeout: 60_000 }, () => {
+      const stats = runLadderScenario(module, 1);
+      expect(stats.challenges).toBeGreaterThan(0);
+    });
+  }
+});

--- a/packages/engine/src/testkit/scenarios.ts
+++ b/packages/engine/src/testkit/scenarios.ts
@@ -1,0 +1,498 @@
+// Permanent sim scenarios — v3/09 §3 (PROMPT-38). Framework-free runners the
+// sim-replay script (and any test) can call: each returns counters and THROWS
+// SimInvariantError on violation, so a failure always carries a reproducing
+// seed. The first two encode the two founder-reported bugs as permanent
+// coverage: mid-match undo storms (intake #29) and the set-end boundary
+// matrices (intake #28). The rest fold Jul3 features into the sim loop:
+// officials assignment (Jul3/02), custom points + carry-over (Jul3/05), and
+// the americano / ladder formats (Jul3/08).
+import { EngineError } from "../core/errors.ts";
+import { foldMatch, type EventEnvelope } from "../core/events.ts";
+import { mulberry32 } from "../core/rng.ts";
+import type { EntrantId, LineupPair, MatchOutcome } from "../core/types.ts";
+import { applyPointsRule, carryDeltas, PointsRule } from "../competition/points.ts";
+import type { FixtureResult } from "../competition/standings.ts";
+import { assignOfficials } from "../officials/assign.ts";
+import type { AssignPolicy, OfficialFixture, OfficialSpec } from "../officials/types.ts";
+import { generateAmericano } from "../scheduling/americano.ts";
+import type { AnySportModule, ModuleEvent } from "../sport/module.ts";
+import { badminton } from "../sports/setbased/badminton.ts";
+import { tabletennis } from "../sports/setbased/tabletennis.ts";
+import { volleyball } from "../sports/setbased/volleyball.ts";
+import type { SetBasedState } from "../sports/setbased/kernel.ts";
+import { defaultLineupPair, lineupFromCatalog, makeEnvelope } from "./helpers.ts";
+import { deriveSeed, SimInvariantError, SIM_CONFIGS } from "./simulation.ts";
+
+// ---------------------------------------------------------------------------
+// Shared: walk a module's generator to a decided stream.
+// ---------------------------------------------------------------------------
+
+function decidedStream(
+  module: AnySportModule,
+  cfg: unknown,
+  lineups: LineupPair,
+  seed: number,
+  maxEvents = 600,
+): { events: EventEnvelope[]; state: unknown } | null {
+  const generate = module.arbitraryEvent;
+  if (!generate) throw new Error(`module "${module.key}" lacks arbitraryEvent`);
+  const rng = mulberry32(seed);
+  let state = module.init(cfg, lineups);
+  const events: EventEnvelope[] = [];
+  for (let i = 0; i < maxEvents; i++) {
+    const next = generate.call(module, state, rng) as ModuleEvent | null;
+    if (next === null) break;
+    const env = makeEnvelope(events.length, next);
+    state = module.apply(state, env);
+    events.push(env);
+    if (module.outcome(state) !== null) return { events, state };
+  }
+  return null;
+}
+
+function moduleCfg(module: AnySportModule): unknown {
+  return module.configSchema.parse(SIM_CONFIGS[module.key] ?? {});
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1 — undo storm (intake #29, every sport). Voids every event
+// position of a decided stream; each fold must reject with a typed
+// EngineError or yield a renderable summary from which scoring resumes.
+// ---------------------------------------------------------------------------
+
+export interface UndoStormStats {
+  sport: string;
+  positions: number;
+  accepted: number;
+  rejected: number;
+}
+
+export function runUndoStorm(module: AnySportModule, seed: number): UndoStormStats {
+  const cfg = moduleCfg(module);
+  const lineups = defaultLineupPair(module.positions);
+  const label = (i: number, type: string) => `[undo-storm ${module.key}:${seed}] seq=${i} ${type}`;
+
+  let stream: { events: EventEnvelope[] } | null = null;
+  for (let s = 0; s < 8 && stream === null; s++) {
+    stream = decidedStream(module, cfg, lineups, deriveSeed(seed + s, module.key, "storm"));
+  }
+  if (stream === null) {
+    throw new SimInvariantError(`[undo-storm ${module.key}:${seed}] generator never decided`);
+  }
+
+  const stats: UndoStormStats = { sport: module.key, positions: 0, accepted: 0, rejected: 0 };
+  for (let i = 0; i < stream.events.length; i++) {
+    const target = stream.events[i] as EventEnvelope;
+    const withVoid = [
+      ...stream.events,
+      makeEnvelope(stream.events.length, { type: "core.void", payload: {} }, target.id),
+    ];
+    stats.positions++;
+
+    let state: unknown;
+    try {
+      state = foldMatch(module, cfg, lineups, withVoid);
+    } catch (err) {
+      if (!EngineError.is(err)) {
+        throw new SimInvariantError(`${label(i, target.type)} fold threw non-EngineError: ${String(err)}`);
+      }
+      stats.rejected++;
+      continue;
+    }
+    stats.accepted++;
+
+    // Renderable summary + resumable scoring — the blank-panel guarantees.
+    let summary: { headline?: unknown };
+    try {
+      summary = module.summary(state as never) as { headline?: unknown };
+    } catch (err) {
+      throw new SimInvariantError(`${label(i, target.type)} summary() threw: ${String(err)}`);
+    }
+    if (typeof summary.headline !== "string") {
+      throw new SimInvariantError(`${label(i, target.type)} headline not a string`);
+    }
+    if (module.outcome(state as never) === null) {
+      const rng = mulberry32(deriveSeed(seed, module.key, "storm-resume", i));
+      let resumed = state;
+      for (let n = 0; n < 600; n++) {
+        const next = module.arbitraryEvent?.call(module, resumed as never, rng) as ModuleEvent | null;
+        if (next === null || next === undefined) break;
+        try {
+          resumed = module.apply(resumed as never, makeEnvelope(withVoid.length + n, next));
+        } catch (err) {
+          if (!EngineError.is(err)) {
+            throw new SimInvariantError(`${label(i, target.type)} resume threw non-EngineError: ${String(err)}`);
+          }
+          break;
+        }
+        if (module.outcome(resumed as never) !== null) break;
+      }
+    }
+  }
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 2 — set-end boundary matrices (intake #28, setbased presets).
+// The kernel's set predicate at the deuce/cap corners, per preset.
+// ---------------------------------------------------------------------------
+
+interface BoundaryCase {
+  score: [number, number];
+  ends: boolean;
+}
+
+interface PresetMatrix {
+  module: AnySportModule;
+  rallyType: string;
+  summaryType: string;
+  cases: BoundaryCase[];
+  rejectedSummaries: [number, number][];
+}
+
+// BWF 21/2/30 · ITTF 11/2/uncapped · FIVB 25/2/uncapped (spec 04 §3–5).
+const MATRICES: PresetMatrix[] = [
+  {
+    module: badminton,
+    rallyType: "badminton.rally",
+    summaryType: "badminton.game.summary",
+    cases: [
+      { score: [21, 19], ends: true },
+      { score: [21, 20], ends: false },
+      { score: [22, 20], ends: true },
+      { score: [29, 28], ends: false },
+      { score: [30, 29], ends: true },
+      { score: [21, 0], ends: true },
+    ],
+    rejectedSummaries: [
+      [31, 30],
+      [22, 19],
+      [30, 27],
+    ],
+  },
+  {
+    module: tabletennis,
+    rallyType: "tabletennis.rally",
+    summaryType: "tabletennis.game.summary",
+    cases: [
+      { score: [11, 9], ends: true },
+      { score: [11, 10], ends: false },
+      { score: [12, 10], ends: true },
+      { score: [15, 13], ends: true },
+    ],
+    rejectedSummaries: [
+      [12, 9],
+      [13, 10],
+    ],
+  },
+  {
+    module: volleyball,
+    rallyType: "volleyball.rally",
+    summaryType: "volleyball.set.summary",
+    cases: [
+      { score: [25, 23], ends: true },
+      { score: [25, 24], ends: false },
+      { score: [26, 24], ends: true },
+      { score: [32, 30], ends: true },
+    ],
+    rejectedSummaries: [
+      [26, 23],
+      [33, 30],
+    ],
+  },
+];
+
+export interface BoundaryMatrixStats {
+  preset: string;
+  cases: number;
+}
+
+export function runBoundaryMatrices(): BoundaryMatrixStats[] {
+  const out: BoundaryMatrixStats[] = [];
+  for (const matrix of MATRICES) {
+    const cfg = matrix.module.configSchema.parse({});
+    const lineups = defaultLineupPair(matrix.module.positions);
+    let cases = 0;
+    const fold = (events: ModuleEvent[]) =>
+      foldMatch(matrix.module, cfg, lineups, [
+        makeEnvelope(0, { type: "core.start", payload: {} }),
+        ...events.map((e, i) => ({ ...makeEnvelope(i + 1, e) })),
+      ]) as SetBasedState;
+
+    for (const { score, ends } of matrix.cases) {
+      const [h, a] = score;
+      const rallies: ModuleEvent[] = [];
+      for (let i = 0; i < Math.min(h, a); i++) {
+        rallies.push({ type: matrix.rallyType, payload: { wonBy: "H" } });
+        rallies.push({ type: matrix.rallyType, payload: { wonBy: "A" } });
+      }
+      for (let i = 0; i < Math.abs(h - a); i++) {
+        rallies.push({ type: matrix.rallyType, payload: { wonBy: h > a ? "H" : "A" } });
+      }
+      const state = fold(rallies);
+      const set = state.sets[0];
+      if (set?.home !== h || set?.away !== a || set?.closed !== ends) {
+        throw new SimInvariantError(
+          `[boundary ${matrix.module.key}] rally ${h}-${a}: expected closed=${ends}, got ${JSON.stringify(set)}`,
+        );
+      }
+      cases++;
+    }
+    for (const [h, a] of matrix.rejectedSummaries) {
+      let rejected = false;
+      try {
+        fold([{ type: matrix.summaryType, payload: { home: h, away: a } }]);
+      } catch (err) {
+        rejected = EngineError.is(err, "INVALID_EVENT");
+      }
+      if (!rejected) {
+        throw new SimInvariantError(
+          `[boundary ${matrix.module.key}] summary ${h}-${a} must be rejected as unreachable`,
+        );
+      }
+      cases++;
+    }
+    out.push({ preset: matrix.module.key, cases });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 3 — officials assignment over a simulated round (Jul3/02).
+// ---------------------------------------------------------------------------
+
+export interface OfficialsStats {
+  fixtures: number;
+  officials: number;
+  assignments: number;
+  blockConflicts: number;
+}
+
+export function runOfficialsScenario(seed: number): OfficialsStats {
+  const rng = mulberry32(deriveSeed(seed, "officials"));
+  const courts = ["C1", "C2"];
+  const fixtures: OfficialFixture[] = [];
+  // Two courts × 6 slots of 30 minutes.
+  for (let slot = 0; slot < 6; slot++) {
+    for (const [c, court] of courts.entries()) {
+      const id = `f-${slot}-${court}`;
+      fixtures.push({
+        id,
+        startAt: slot * 30 * 60_000,
+        endAt: (slot + 1) * 30 * 60_000,
+        court,
+        entrants: [`e${slot * 2 + c}a`, `e${slot * 2 + c}b`],
+      });
+    }
+  }
+  const officials: OfficialSpec[] = Array.from({ length: 5 }, (_, i) => ({
+    id: `o${i + 1}`,
+    roleKeys: ["referee"],
+    ...(rng() < 0.4 ? { maxPerDay: 4 } : {}),
+  }));
+  const policy: AssignPolicy = {
+    roles: ["referee"],
+    poolLock: false,
+    blockStay: true,
+    fairness: "tournament",
+    teamRefKeepDivision: false,
+    restMinMinutes: 0,
+    blockGapMinutes: 30,
+  };
+  const result = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: `sim-${seed}` });
+
+  // Hard invariant: no official on two overlapping fixtures.
+  const byOfficial = new Map<string, { from: number; to: number }[]>();
+  for (const a of result.assignments) {
+    const fixture = fixtures.find((f) => f.id === a.fixtureId);
+    if (!fixture) throw new SimInvariantError(`[officials:${seed}] assignment to unknown fixture`);
+    const spans = byOfficial.get(a.officialId) ?? [];
+    for (const span of spans) {
+      if (span.from < fixture.endAt && fixture.startAt < span.to) {
+        throw new SimInvariantError(`[officials:${seed}] official ${a.officialId} double-booked`);
+      }
+    }
+    spans.push({ from: fixture.startAt, to: fixture.endAt });
+    byOfficial.set(a.officialId, spans);
+  }
+  return {
+    fixtures: fixtures.length,
+    officials: officials.length,
+    assignments: result.assignments.length,
+    blockConflicts: result.conflicts.filter((c) => c.severity === "block").length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — custom points + carry-over (Jul3/05) over live module output.
+// ---------------------------------------------------------------------------
+
+export interface CustomPointsStats {
+  sport: string;
+  fixtures: number;
+}
+
+const CUSTOM_RULE = PointsRule.parse({
+  base: { win: 5, draw: 2, loss: 1 },
+});
+
+export function runCustomPointsScenario(module: AnySportModule, seed: number): CustomPointsStats {
+  const cfg = moduleCfg(module);
+  const lineups = defaultLineupPair(module.positions);
+  let fixtures = 0;
+  for (let s = 0; s < 4; s++) {
+    const played = decidedStream(module, cfg, lineups, deriveSeed(seed + s, module.key, "points"));
+    if (played === null) continue;
+    const outcome = module.outcome(played.state as never) as MatchOutcome;
+    if (outcome.kind === "no_result") continue;
+    const pair = module.standingsDelta(outcome, cfg as never, { kind: "league" }, played.state as never);
+    const mapped = applyPointsRule(outcome, pair as FixtureResult, CUSTOM_RULE);
+    for (const [i, delta] of mapped.entries()) {
+      const want = delta.won === 1 ? 5 : delta.drawn === 1 ? 2 : delta.lost === 1 ? 1 : 0;
+      // Forfeits without a configured forfeit block still pay base points.
+      if (delta.points !== want) {
+        throw new SimInvariantError(
+          `[points ${module.key}:${seed}] side ${i} expected ${want} points, got ${delta.points}`,
+          { outcome, delta },
+        );
+      }
+      const original = (pair as FixtureResult)[i as 0 | 1];
+      if (JSON.stringify(delta.metrics) !== JSON.stringify(original.metrics)) {
+        throw new SimInvariantError(`[points ${module.key}:${seed}] metrics ledger mutated by rule`);
+      }
+    }
+    fixtures++;
+  }
+  return { sport: module.key, fixtures };
+}
+
+export interface CarryOverStats {
+  rows: number;
+}
+
+export function runCarryOverScenario(rows: readonly { entrantId: EntrantId; played: number; won: number; drawn: number; lost: number; points: number; metrics: Record<string, number> }[]): CarryOverStats {
+  const asRows = rows as never[];
+  const pointsOnly = carryDeltas(asRows, "points");
+  const full = carryDeltas(asRows, "full");
+  const sum = (list: readonly { points: number }[]) => list.reduce((a, r) => a + r.points, 0);
+  if (sum(pointsOnly) !== sum(rows) || sum(full) !== sum(rows)) {
+    throw new SimInvariantError("[carry-over] points not conserved across carry");
+  }
+  for (const [i, delta] of pointsOnly.entries()) {
+    if (delta.played !== 0 || Object.keys(delta.metrics).length > 0) {
+      throw new SimInvariantError("[carry-over] points mode must carry points only", { i, delta });
+    }
+  }
+  for (const [i, delta] of full.entries()) {
+    const row = rows[i] as (typeof rows)[number];
+    if (delta.played !== row.played || delta.won !== row.won) {
+      throw new SimInvariantError("[carry-over] full mode must carry the whole row", { i, delta });
+    }
+  }
+  return { rows: rows.length };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — americano rounds played through a module (Jul3/08 §3).
+// ---------------------------------------------------------------------------
+
+export interface AmericanoStats {
+  players: number;
+  rounds: number;
+  matches: number;
+}
+
+export function runAmericanoScenario(module: AnySportModule, seed: number, players = 8): AmericanoStats {
+  const cfg = moduleCfg(module);
+  const ids: EntrantId[] = Array.from({ length: players }, (_, i) => `p${String(i + 1).padStart(2, "0")}`);
+  const rounds = generateAmericano(ids, { mode: "americano", courtCount: 2, rounds: 5 });
+  const personal = new Map<EntrantId, number>(ids.map((id) => [id, 0]));
+  let matches = 0;
+  let awarded = 0;
+
+  for (const round of rounds) {
+    const seen = new Set<EntrantId>();
+    for (const match of round.matches) {
+      for (const p of [...match.team1, ...match.team2]) {
+        if (seen.has(p)) {
+          throw new SimInvariantError(`[americano:${seed}] ${p} plays twice in round ${round.roundNo}`);
+        }
+        seen.add(p);
+      }
+      // Pair entrants are synthetic per match; the module never inspects them.
+      const home = match.team1.join("+");
+      const away = match.team2.join("+");
+      const lineups: LineupPair = {
+        home: lineupFromCatalog(module.positions, home),
+        away: lineupFromCatalog(module.positions, away),
+      };
+      let played: { events: EventEnvelope[]; state: unknown } | null = null;
+      for (let s = 0; s < 6 && played === null; s++) {
+        played = decidedStream(module, cfg, lineups, deriveSeed(seed + s, match.id, "americano"));
+      }
+      if (played === null) {
+        throw new SimInvariantError(`[americano:${seed}] match ${match.id} never decided`);
+      }
+      const outcome = module.outcome(played.state as never) as MatchOutcome;
+      if (outcome.kind === "win" || outcome.kind === "award") {
+        const winners = outcome.winner === home ? match.team1 : match.team2;
+        for (const p of winners) personal.set(p, (personal.get(p) ?? 0) + 1);
+        awarded += 2; // both winning partners bank a personal point
+      }
+      matches++;
+    }
+  }
+  const total = [...personal.values()].reduce((a, b) => a + b, 0);
+  if (total !== awarded) {
+    throw new SimInvariantError(`[americano:${seed}] personal points not conserved (${total} ≠ ${awarded})`);
+  }
+  return { players, rounds: rounds.length, matches };
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 6 — ladder challenges (Jul3/08 §6): winner takes the position.
+// ---------------------------------------------------------------------------
+
+export interface LadderStats {
+  entrants: number;
+  challenges: number;
+  swaps: number;
+}
+
+export function runLadderScenario(module: AnySportModule, seed: number, entrants = 8): LadderStats {
+  const cfg = moduleCfg(module);
+  const rng = mulberry32(deriveSeed(seed, module.key, "ladder"));
+  let order: EntrantId[] = Array.from({ length: entrants }, (_, i) => `L${String(i + 1).padStart(2, "0")}`);
+  const initial = [...order];
+  let swaps = 0;
+  const challenges = entrants * 2;
+
+  for (let c = 0; c < challenges; c++) {
+    // Challenger picks someone above them (the app allows a bounded reach;
+    // the swap rule is what the sim checks, not the reach policy).
+    const ci = 1 + Math.floor(rng() * (order.length - 1));
+    const ti = Math.floor(rng() * ci);
+    const challenger = order[ci] as EntrantId;
+    const target = order[ti] as EntrantId;
+    const lineups: LineupPair = {
+      home: lineupFromCatalog(module.positions, target),
+      away: lineupFromCatalog(module.positions, challenger),
+    };
+    let played: { state: unknown } | null = null;
+    for (let s = 0; s < 6 && played === null; s++) {
+      played = decidedStream(module, cfg, lineups, deriveSeed(seed + s, `ladder-${c}`, "match"));
+    }
+    if (played === null) continue; // undecidable challenge — ladder unchanged
+    const outcome = module.outcome(played.state as never) as MatchOutcome;
+    const winner = outcome.kind === "win" || outcome.kind === "award" ? outcome.winner : null;
+    if (winner === challenger) {
+      // scoring.ts onDecided ladder rule: challenger takes the position.
+      [order[ci], order[ti]] = [order[ti] as EntrantId, order[ci] as EntrantId];
+      swaps++;
+    }
+    if ([...order].sort().join(",") !== [...initial].sort().join(",")) {
+      throw new SimInvariantError(`[ladder ${module.key}:${seed}] order is no longer a permutation`);
+    }
+  }
+  return { entrants, challenges, swaps };
+}

--- a/packages/engine/src/testkit/simulation.ts
+++ b/packages/engine/src/testkit/simulation.ts
@@ -48,9 +48,11 @@ import { lineupFromCatalog, TEST_INSTANT } from "./helpers.ts";
 // Templates & options
 // ---------------------------------------------------------------------------
 
-// The five stage-graph templates the harness exercises (PROMPT-14 §1).
+// The stage-graph templates the harness exercises (PROMPT-14 §1; v3/09 §3
+// added league_legs2 — the Jul3/08 §2 multi-leg round robin).
 export const FORMAT_TEMPLATES = [
   "league",
+  "league_legs2",
   "group_knockout",
   "swiss_knockout",
   "double_elim",
@@ -105,6 +107,7 @@ export interface SimStageRecord {
   fixtures: SimFixtureRecord[];
   tables?: StageTables;
   cascade?: TiebreakerKey[]; // table stages: the ranking cascade applied
+  legs?: number; // round robins: pairings repeat exactly this often (Jul3/08 §2)
   finalRanks: EntrantId[];
   qualification?: { spec: QualificationSpec; seeds: EntrantId[] }; // feed to the next stage
 }
@@ -477,6 +480,7 @@ function playRoundRobinStage(
   kind: Extract<StageKind, "league" | "group">,
   pools: readonly { poolId: string; entrants: readonly EntrantId[] }[],
   seeds: ReadonlyMap<EntrantId, number>,
+  legs = 1,
 ): PlayedTableStage {
   ctx.divisionEvents.push(...openStage(stageId));
 
@@ -485,10 +489,10 @@ function playRoundRobinStage(
   const tableFixtures: TableFixture[] = [];
 
   for (const pool of pools) {
-    const schedule = generateRoundRobin({ entrants: pool.entrants, seeds });
-    if (schedule.fixtures.length !== roundRobinFixtureCount(pool.entrants.length)) {
+    const schedule = generateRoundRobin({ entrants: pool.entrants, seeds, config: { legs } });
+    if (schedule.fixtures.length !== roundRobinFixtureCount(pool.entrants.length, legs)) {
       throw new SimInvariantError(
-        `round robin incomplete: pool "${pool.poolId}" produced ${schedule.fixtures.length} fixtures for ${pool.entrants.length} entrants`,
+        `round robin incomplete: pool "${pool.poolId}" produced ${schedule.fixtures.length} fixtures for ${pool.entrants.length} entrants over ${legs} legs`,
       );
     }
     for (const fixture of schedule.fixtures) {
@@ -537,6 +541,7 @@ function playRoundRobinStage(
       fixtures: records,
       tables: completed.tables,
       cascade: [...stage.cascade],
+      ...(legs === 1 ? {} : { legs }),
       finalRanks,
     },
     tables: completed.tables,
@@ -828,6 +833,21 @@ export function simulateDivision(opts: SimOptions): SimulationResult {
       break;
     }
 
+    case "league_legs2": {
+      // Jul3/08 §2 — double round robin: every pairing twice, mirrored venues.
+      const stage = playRoundRobinStage(
+        ctx,
+        "league",
+        "league",
+        [{ poolId: "P1", entrants }],
+        seeds,
+        2,
+      );
+      stages.push(stage.record);
+      finalRanks = stage.finalRanks;
+      break;
+    }
+
     case "group_knockout": {
       // Pools of ~4 dealt by seed; single pool below 8 entrants.
       const poolCount = Math.max(1, Math.floor(n / 4));
@@ -1072,8 +1092,12 @@ export function assertDivisionInvariants(
         inRound.add(fixture.away);
         perRound.set(roundKey, inRound);
       }
+      // Multi-leg round robins (Jul3/08 §2) meet exactly `legs` times.
+      const maxMeets = stage.legs ?? 1;
       for (const [key, count] of pairs) {
-        if (count > 1) fail(sim, `stage "${stage.id}" pair met ${count} times: ${key}`);
+        if (count > maxMeets) {
+          fail(sim, `stage "${stage.id}" pair met ${count} times (legs=${maxMeets}): ${key}`);
+        }
       }
     }
 

--- a/packages/engine/src/testkit/undo-sweep.test.ts
+++ b/packages/engine/src/testkit/undo-sweep.test.ts
@@ -1,0 +1,153 @@
+// Undo sweep — v3/09 §2 (PROMPT-38). For EVERY sport module and EVERY event
+// position of a simulated match: append a core.void of that event and assert
+// the fold either rejects it with a typed EngineError (ledger unchanged) or
+// yields a state whose summary is renderable — headline string, two perSide
+// lines — and from which scoring can continue to a decision. The cricket
+// "undo last made scoring disappear" regression (intake #29) is exactly a
+// fold that neither rejected nor produced a renderable state.
+import { describe, expect, it } from "vitest";
+import { EngineError } from "../core/errors.ts";
+import { foldMatch, type EventEnvelope } from "../core/events.ts";
+import { mulberry32 } from "../core/rng.ts";
+import type { LineupPair, MatchOutcome, ScoreSummary } from "../core/types.ts";
+import type { AnySportModule, ModuleEvent } from "../sport/module.ts";
+import { builtinModules } from "../sports/index.ts";
+import { defaultLineupPair, makeEnvelope } from "./helpers.ts";
+import { deriveSeed, SIM_CONFIGS } from "./simulation.ts";
+
+const SWEEP_SEEDS = Number(process.env.SIM_RUNS ?? (process.env.CI ? 12 : 4));
+
+// Walk the module's generator to a decision (chaos.test.ts pattern).
+function decidedStream(
+  module: AnySportModule,
+  cfg: unknown,
+  lineups: LineupPair,
+  seed: number,
+): EventEnvelope[] | null {
+  const generate = module.arbitraryEvent;
+  if (!generate) throw new Error(`module "${module.key}" lacks arbitraryEvent`);
+  const rng = mulberry32(seed);
+  let state = module.init(cfg, lineups);
+  const events: EventEnvelope[] = [];
+  for (let i = 0; i < 600; i++) {
+    const next = generate.call(module, state, rng) as ModuleEvent | null;
+    if (next === null) break;
+    const env = makeEnvelope(events.length, next);
+    state = module.apply(state, env);
+    events.push(env);
+    if (module.outcome(state) !== null) return events;
+  }
+  return null;
+}
+
+// A summary the scoring panel can always render (spec 03 §3 summary contract).
+function expectRenderable(module: AnySportModule, summary: ScoreSummary, label: string): void {
+  expect(typeof summary.headline, `${label}: headline must be a string`).toBe("string");
+  expect(summary.perSide.length, `${label}: perSide must list both sides`).toBe(2);
+  for (const side of summary.perSide) {
+    expect(typeof side.entrantId, `${label}: perSide entrantId`).toBe("string");
+    expect(typeof side.line, `${label}: perSide line`).toBe("string");
+  }
+}
+
+for (const module of builtinModules) {
+  const cfg = module.configSchema.parse(SIM_CONFIGS[module.key] ?? {});
+  const lineups = defaultLineupPair(module.positions);
+
+  describe(`undo sweep — ${module.key}@${module.version}`, () => {
+    it(
+      "undo of every event position folds to a renderable state or a typed rejection, then scoring continues",
+      { timeout: 120_000 },
+      () => {
+        let exercised = 0;
+        for (let seed = 1; exercised < SWEEP_SEEDS && seed <= SWEEP_SEEDS * 4; seed++) {
+          const events = decidedStream(module, cfg, lineups, deriveSeed(seed, module.key, "undo-sweep"));
+          if (events === null) continue;
+          exercised++;
+
+          for (let i = 0; i < events.length; i++) {
+            const target = events[i] as EventEnvelope;
+            const label = `${module.key} seed=${seed} void seq=${i} (${target.type})`;
+            const withVoid = [
+              ...events,
+              makeEnvelope(events.length, { type: "core.void", payload: {} }, target.id),
+            ];
+
+            let state: unknown;
+            try {
+              state = foldMatch(module, cfg, lineups, withVoid);
+            } catch (err) {
+              // A rejection is legal — but it MUST be a typed EngineError, and
+              // the pre-void ledger must still fold (ledger never corrupted).
+              expect(
+                EngineError.is(err),
+                `${label}: fold threw a non-EngineError: ${String(err)}`,
+              ).toBe(true);
+              expect(() => foldMatch(module, cfg, lineups, events), `${label}: baseline refold`).not.toThrow();
+              continue;
+            }
+
+            // Accepted void → summary + outcome must be derivable (the panel
+            // renders these; a throw here is the blank-screen bug).
+            let summary: ScoreSummary | undefined;
+            expect(() => {
+              summary = module.summary(state as never);
+            }, `${label}: summary() must not throw after an accepted void`).not.toThrow();
+            expectRenderable(module, summary as ScoreSummary, label);
+            let outcome: MatchOutcome | null = null;
+            expect(() => {
+              outcome = module.outcome(state as never);
+            }, `${label}: outcome() must not throw after an accepted void`).not.toThrow();
+
+            // Scoring must be able to CONTINUE on the post-undo state: the
+            // generator resumes and every generated event applies cleanly.
+            if (outcome === null) {
+              const rng = mulberry32(deriveSeed(seed, module.key, "undo-resume", i));
+              let resumed = state;
+              let decided = false;
+              for (let n = 0; n < 600 && !decided; n++) {
+                const next = module.arbitraryEvent?.call(module, resumed as never, rng) as ModuleEvent | null;
+                if (next === null || next === undefined) break;
+                const env = makeEnvelope(withVoid.length + n, next);
+                try {
+                  resumed = module.apply(resumed as never, env);
+                } catch (err) {
+                  expect(
+                    EngineError.is(err),
+                    `${label}: resume apply threw non-EngineError: ${String(err)}`,
+                  ).toBe(true);
+                  break;
+                }
+                decided = module.outcome(resumed as never) !== null;
+              }
+              expect(() => module.summary(resumed as never), `${label}: post-resume summary`).not.toThrow();
+            }
+          }
+        }
+        expect(exercised, "generator must reach decisions or the sweep proves nothing").toBeGreaterThan(0);
+      },
+    );
+
+    it("undoing with nothing to undo is a typed rejection, never a crash", () => {
+      // core.void as the only event: no prior target can exist.
+      const orphanVoid = [makeEnvelope(0, { type: "core.void", payload: {} }, "no-such-event")];
+      let thrown: unknown;
+      try {
+        foldMatch(module, cfg, lineups, orphanVoid);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(EngineError.is(thrown), `expected typed EngineError, got ${String(thrown)}`).toBe(true);
+
+      // core.void without any target id at all.
+      const bareVoid = [makeEnvelope(0, { type: "core.void", payload: {} })];
+      let bare: unknown;
+      try {
+        foldMatch(module, cfg, lineups, bareVoid);
+      } catch (err) {
+        bare = err;
+      }
+      expect(EngineError.is(bare), `expected typed EngineError, got ${String(bare)}`).toBe(true);
+    });
+  });
+}

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -214,6 +214,10 @@ async function main() {
   await setPlan(org2.id, "pro");
   await jul3Suite(admin, org2.id, org2.slug);
 
+  // --- Division delete/archive lifecycle (PROMPT-38, v3/09 §4): delete on a
+  // free org lifts the divisions quota; archive/restore on the Pro org.
+  await divisionLifecycleSuite(admin, org2.id);
+
   // --- Growth-wave gaps (device links, scorer seats, discovery, registration,
   // ownership transfer, downgrade freeze) — pro paths on org2, free paths on a
   // fresh community owner. Destructive downgrade runs last.
@@ -642,6 +646,126 @@ async function jul3Suite(admin: Session, orgId: string, orgSlug: string): Promis
  * downgrade → competition-freeze path. `proOrgId` (org2) must be Pro on
  * entry; the downgrade at the end deliberately flips it to community.
  */
+// PROMPT-38 (v3/09 §4): division delete on free, archive/restore on pro.
+async function divisionLifecycleSuite(admin: Session, proOrgId: string): Promise<void> {
+  const genericDivision = {
+    sport_key: "generic",
+    variant_key: "score",
+    config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+  };
+
+  // --- Free path: a fresh org (no subscription row) is community — the
+  // divisions.per_competition quota is 1, and DELETE frees the slot. Creating
+  // the org switches the active-org cookie onto it.
+  await call(admin, "/api/orgs", "POST", { name: `Del Org ${tag}` });
+  const comp = await v1(admin, "/api/v1/competitions", "POST", { name: `Del Cup ${tag}` });
+  const compId = v1data<{ id: string }>(comp).id;
+  const first = await v1(admin, `/api/v1/competitions/${compId}/divisions`, "POST", {
+    name: "First",
+    ...genericDivision,
+  });
+  check("del: free org creates division 1", first.status === 201);
+  const firstId = v1data<{ id: string }>(first).id;
+  const blocked = await v1(admin, `/api/v1/competitions/${compId}/divisions`, "POST", {
+    name: "Second",
+    ...genericDivision,
+  });
+  check("del: division 2 blocked on free (402)", blocked.status === 402);
+
+  // Open registration blocks delete; closing it unblocks.
+  await v1(admin, `/api/v1/divisions/${firstId}/registration-settings`, "PUT", {
+    enabled: true,
+    entrant_kind: "individual",
+    fee_cents: 0,
+    currency: "gbp",
+    form_fields: [],
+  });
+  const regBlocked = await v1(admin, `/api/v1/divisions/${firstId}`, "DELETE");
+  check(
+    "del: open registration blocks delete (409 REGISTRATION_OPEN)",
+    regBlocked.status === 409 && regBlocked.json.error?.code === "REGISTRATION_OPEN",
+  );
+  await v1(admin, `/api/v1/divisions/${firstId}/registration-settings`, "PUT", {
+    enabled: false,
+    entrant_kind: "individual",
+    fee_cents: 0,
+    currency: "gbp",
+    form_fields: [],
+  });
+
+  const deleted = await v1(admin, `/api/v1/divisions/${firstId}`, "DELETE");
+  check("del: setup division hard-deletes (204)", deleted.status === 204);
+  const retried = await v1(admin, `/api/v1/competitions/${compId}/divisions`, "POST", {
+    name: "Second",
+    ...genericDivision,
+  });
+  check("del: delete lifted the free-plan gate", retried.status === 201);
+
+  // --- Pro path: a resulted division 409s with the archive hint, archives,
+  // hides from the console list, then restores with results intact.
+  await raw(admin, "/api/orgs/active", "POST", { org_id: proOrgId });
+  const proComp = await v1(admin, "/api/v1/competitions", "POST", { name: `Arch Cup ${tag}` });
+  const proCompId = v1data<{ id: string }>(proComp).id;
+  const div = await v1(admin, `/api/v1/competitions/${proCompId}/divisions`, "POST", {
+    name: "Resulted",
+    ...genericDivision,
+    config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+  });
+  const divId = v1data<{ id: string }>(div).id;
+  await v1(
+    admin,
+    `/api/v1/divisions/${divId}/entrants`,
+    "POST",
+    ["DA", "DB"].map((n, i) => ({ kind: "individual", display_name: n, seed: i + 1 })),
+  );
+  const stage = await v1(admin, `/api/v1/divisions/${divId}/stages`, "POST", {
+    seq: 1,
+    kind: "league",
+    name: "League",
+  });
+  const gen = await v1(admin, `/api/v1/stages/${v1data<{ id: string }>(stage).id}/generate`, "POST");
+  const fixtureId = v1data<{ fixtures: { id: string }[] }>(gen).fixtures[0]!.id;
+  await v1(admin, `/api/v1/divisions/${divId}/start`, "POST");
+  await v1(admin, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 0,
+    type: "core.start",
+    payload: {},
+  });
+  await v1(admin, `/api/v1/fixtures/${fixtureId}/events`, "POST", {
+    expected_seq: 1,
+    type: "generic.result",
+    payload: { p1Score: 3, p2Score: 1 },
+  });
+
+  const hardDelete = await v1(admin, `/api/v1/divisions/${divId}`, "DELETE");
+  check(
+    "arch: resulted division delete 409s with archive hint",
+    hardDelete.status === 409 &&
+      hardDelete.json.error?.code === "DIVISION_HAS_RESULTS" &&
+      (hardDelete.json.error as { archive?: boolean }).archive === true,
+  );
+  const archived = await v1(admin, `/api/v1/divisions/${divId}/archive`, "POST");
+  check(
+    "arch: archive succeeds on pro",
+    archived.status === 200 && v1data<{ archived_at: string | null }>(archived).archived_at !== null,
+  );
+  const listed = await v1(admin, `/api/v1/competitions/${proCompId}/divisions`);
+  check(
+    "arch: archived division hidden from console list",
+    v1data<{ id: string }[]>(listed).every((d) => d.id !== divId),
+  );
+  const restored = await v1(admin, `/api/v1/divisions/${divId}/archive`, "DELETE");
+  check(
+    "arch: restore round-trips",
+    restored.status === 200 && v1data<{ archived_at: string | null }>(restored).archived_at === null,
+  );
+  const fixture = await v1(admin, `/api/v1/fixtures/${fixtureId}`);
+  check(
+    "arch: results intact after restore",
+    v1data<{ status: string }>(fixture).status === "decided",
+  );
+}
+
 async function gapSuite(admin: Session, org1Id: string, proOrgId: string): Promise<void> {
   // A dedicated started division in the Pro org for device links + scorers.
   const comp = await v1(admin, "/api/v1/competitions", "POST", { name: `Gap Cup ${tag}` });


### PR DESCRIPTION
Implements [v3/09](design/v3/09-engine-fixes-and-sim.md) per [PROMPT-38](design/v3/prompts/PROMPT-38-engine-fixes-and-sim.md). Correctness wave — intake #28, #29, #27, #8.

## What the diagnosis actually found

The doc's decision trees pointed at the fold; the fold was innocent both times:

- **Badminton "chosen score not reflected in top score" (#28a)** — engine `summary()`, not client invalidation: the headline collapsed to sets-won ("1 — 0"), so a summary-entered `21-15` never surfaced. Headlines now carry per-set points: `2 — 0 · 21–15, 21–18` (open set in parens). Set-end rules (21 / win-by-2 from 20-20 / 30-cap at 29-29) verified correct and pinned by a golden matrix across badminton + table tennis + volleyball (shared kernel), plus a summary==recount-at-every-prefix property test.
- **Cricket "undo made scoring disappear" (#29)** — persistence, not the fold: `resolveVoids` already hides compensating events from modules, but `nextStatus` kept stale `fixtures.status` after a void (undo of `core.start` → status `in_play` with the fold in `pre`: no Start button, no pad — the blank panel). Status now derives from the void-resolved ledger. Undo-of-nothing answers **409** (no target / unknown / already undone / undoing an undo). `ScoringErrorBoundary` wraps both scoring surfaces (defence in depth, "reload scoring" + fixture link).
- **Undo sweep (chaos extension)** — every sport × every event position: apply→void→fold must typed-reject or yield a renderable summary from which scoring resumes to a decision (`testkit/undo-sweep.test.ts`).

## Sim-replay v2 (#27)

`npm run sim:matrix` — every module × format (`league_legs2` joins the templates) × N seeds + permanent scenarios: undo storms (every sport), set-end boundary matrices (setbased), officials assignment, custom points, carry-over, americano, ladder (`testkit/scenarios.ts`). Emits `packages/engine/sim-report.json` + stdout table; every failure prints its reproducing seed token. CI runs `SIM_SEEDS=5` and uploads the report artifact. Token-replay mode unchanged.

## Division delete / archive / restore (#8)

Graduated destructiveness: `DELETE /api/v1/divisions/{id}` → 204 hard delete (setup) or purge (archived ≥30d, else 409 `ARCHIVE_COOL_OFF`); started/resulted → **409 `DIVISION_HAS_RESULTS` + `{archive: true}`**. `POST …/archive` hides from console/public (`public_divisions_v` filter → 404)/quota; `DELETE …/archive` restores (quota re-checked → 402). Open registration blocks both. Audit events land on the competition ledger. UI: typed-name `ConfirmDialog` danger zone (destroyed-vs-kept copy) + Archived-divisions restore/purge surface in competition settings. Migrations V261 (`archived_at`) + V262 (view filter).

**Deviation** (noted in v3/09 §6): un-archive is `DELETE /divisions/{id}/archive` — `POST …/restore` already belongs to the Jul3/03 checkpoint restore.

## House rule: tests fail pre-fix (stash run)

`git stash` of the three fix files, rerun of `undo-status.test.ts`: **4/6 fail** exactly at the fixed behaviours — `expected 'in_play' to be 'scheduled'`, `expected 'forfeited' to be 'in_play'`, `expected EngineError … to be instance of HttpError` (409), `expected '1 — 0' to contain '21–15'`. Boundary/property additions likewise fail on the old headline.

## Verification

- engine: tsc + 692 tests green (incl. new formats/sweep); `sim:matrix` all green (48 cells + 7 scenario suites)
- web: tsc green, lint 0 errors (2 new-component compiler warnings fixed), unit 151 green, DB-backed `src/server` 224 green on a fresh :54329 Postgres
- e2e: badminton header live update, cricket undo mid-over + undo-past-start stays usable, community delete lifts the divisions gate (serial), resulted 409→archive→restore round-trip — all green locally
- smoke: 10 new checks green (`del:` free path, `arch:` pro path); the 2 failing branding checks fail identically on clean main (pre-existing dev-server ISR flake, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)