### PR TITLE
fix(schedule): empty state for division-less competition board

### DIFF
--- a/apps/web/e2e/schedule-board.spec.ts
+++ b/apps/web/e2e/schedule-board.spec.ts
@@ -365,3 +365,22 @@ test.describe.serial("schedule board", () => {
     expect(auto.status).toBe(422);
   });
 });
+
+// Regression: with zero divisions the competition schedule page fed the
+// competition id into the settings lookup and crashed with 404
+// "division not found". It must render an empty state instead.
+test("competition schedule shows an empty state when there are no divisions", async ({
+  page,
+  request,
+}) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Board empty ${TAG}`,
+    visibility: "private",
+  });
+  await page.goto(`/competitions/${comp.data!.id}/schedule`);
+  await expect(
+    page.getByRole("heading", { name: /competition schedule/i }),
+  ).toBeVisible();
+  await expect(page.getByText(/no divisions yet/i)).toBeVisible();
+  await expect(page.getByText(/division not found/i)).not.toBeVisible();
+});

--- a/apps/web/src/app/competitions/[id]/schedule/page.tsx
+++ b/apps/web/src/app/competitions/[id]/schedule/page.tsx
@@ -44,6 +44,40 @@ export default async function CompetitionSchedulePage({
   }
 
   const divisions = await listDivisions(auth, id);
+  // No divisions → nothing to schedule. Bail before the settings lookup, which
+  // would otherwise be fed the competition id and 404 ("division not found").
+  if (divisions.length === 0) {
+    return (
+      <>
+        <Nav />
+        <main className="mx-auto max-w-3xl px-4 py-8">
+          <p className="text-xs text-slate-400">
+            <Link href="/dashboard" className="hover:text-purple-600">Competitions</Link>
+            {" / "}
+            <Link href={`/competitions/${id}`} className="hover:text-purple-600">
+              {competition.name}
+            </Link>
+          </p>
+          <h1 className="mt-1 mb-4 text-xl font-semibold tracking-tight text-slate-900">
+            Competition schedule — {competition.name}
+          </h1>
+          <div className="card p-6 text-sm text-slate-500">
+            No divisions yet — the schedule board fills in once this competition
+            has divisions with fixtures.{" "}
+            {canEdit && !(competition.frozen ?? false) && (
+              <Link
+                href={`/competitions/${id}/divisions/new`}
+                className="font-medium text-purple-600 hover:text-purple-700"
+              >
+                Add a division
+              </Link>
+            )}
+          </div>
+        </main>
+      </>
+    );
+  }
+
   const [boardEditable, constraints] = await Promise.all([
     hasFeature(auth.orgId, "scheduling.board"),
     hasFeature(auth.orgId, "scheduling.constraints"),


### PR DESCRIPTION
## Problem

Opening `/competitions/{id}/schedule` on a competition with **zero divisions** crashed with 404 `division not found`.

Root cause: the page's grid-config lookup fell back to the competition id (`divisions[0]?.id ?? id`) and fed it into `getScheduleSettings`, which validates the id against the `divisions` table.

## Fix

Bail out before the settings lookup when the competition has no divisions — render breadcrumb + "No divisions yet" card with an *Add a division* link (hidden when read-only or frozen).

## Test

- e2e regression in `schedule-board.spec.ts`: creates a division-less competition via API, visits `/schedule`, expects the empty state and no "division not found". Confirmed red without the fix, green with it.
- tsc, eslint, unit suite (181 passed) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)