### PR TITLE
feat(settings): tab competition settings page

### DIFF
--- a/apps/web/e2e/competition.spec.ts
+++ b/apps/web/e2e/competition.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { TAG } from "./helpers";
+import { TAG, apiJson } from "./helpers";
 
 // Core organiser journey: create a competition through the wizard.
 test("create a competition via the wizard", async ({ page }) => {
@@ -13,4 +13,37 @@ test("create a competition via the wizard", async ({ page }) => {
   // Lands on the competition page (add-division CTA present).
   await expect(page.getByRole("link", { name: /add division/i })).toBeVisible({ timeout: 20_000 });
   await expect(page.getByText(name)).toBeVisible();
+});
+
+// Settings are organised into tabs (General / Branding / Archived); one form
+// spans them, so an unsaved edit must survive a tab switch and save from any
+// tab. Showcase stays inline on General (under visibility, which gates it);
+// Archived only appears once something is archived.
+test("competition settings tabs share one form", async ({ page, request }) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Tabs ${TAG}`,
+    visibility: "public",
+  });
+  await page.goto(`/competitions/${comp.data!.id}/settings`);
+
+  const tablist = page.getByRole("tablist", { name: "Competition settings" });
+  await expect(tablist.getByRole("tab", { name: "General" })).toBeVisible({ timeout: 20_000 });
+  // Pro org (default storageState) → Branding tab present; nothing archived → no Archived tab.
+  await expect(tablist.getByRole("tab", { name: "Branding" })).toBeVisible();
+  await expect(tablist.getByRole("tab", { name: /Archived/ })).toHaveCount(0);
+  // Showcase sits inline on General, right under visibility.
+  await expect(page.getByText("Showcase on seazn.club")).toBeVisible();
+
+  // Edit on General, switch to Branding, save from there.
+  const renamed = `Tabs renamed ${TAG}`;
+  await page.getByRole("textbox", { name: "Name", exact: true }).fill(renamed);
+  await tablist.getByRole("tab", { name: "Branding" }).click();
+  await expect(page.getByText("Brand color")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Name", exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: /save settings/i }).click();
+  await expect(page.getByText("Saved.")).toBeVisible();
+
+  // The General edit rode along.
+  await page.reload();
+  await expect(page.getByRole("heading", { name: new RegExp(renamed) })).toBeVisible();
 });

--- a/apps/web/e2e/division-archive.spec.ts
+++ b/apps/web/e2e/division-archive.spec.ts
@@ -65,8 +65,9 @@ test("resulted division: 409 → archive → restore round-trip", async ({ page,
   );
   expect(listed.data!.every((d) => d.id !== divisionId)).toBe(true);
 
-  // Restore from competition settings → Archived divisions.
+  // Restore from competition settings → Archived tab.
   await page.goto(`/competitions/${compId}/settings`);
+  await page.getByRole("tab", { name: /Archived/ }).click({ timeout: 20_000 });
   const archivedSection = page.getByTestId("archived-divisions");
   await expect(archivedSection.getByText("Resulted")).toBeVisible({ timeout: 20_000 });
   // Purge is locked behind the 30-day cool-off.

--- a/apps/web/src/app/competitions/[id]/settings/page.tsx
+++ b/apps/web/src/app/competitions/[id]/settings/page.tsx
@@ -88,17 +88,19 @@ export default async function CompetitionSettingsPage({
           themeBranding={themeBranding}
           orgBranding={org.branding}
           suggestedStatus={suggestedStatus}
-        />
-
-        {/* v3/09 §4 — restore/purge surface for archived divisions. */}
-        <ArchivedDivisions
-          divisions={archivedDivisions.map((d) => ({
-            id: d.id,
-            name: d.name,
-            sport_key: d.sport_key,
-            archived_at: d.archived_at as string,
-          }))}
-          canEdit={canEdit}
+          archivedCount={archivedDivisions.length}
+          archivedPanel={
+            /* v3/09 §4 — restore/purge surface for archived divisions. */
+            <ArchivedDivisions
+              divisions={archivedDivisions.map((d) => ({
+                id: d.id,
+                name: d.name,
+                sport_key: d.sport_key,
+                archived_at: d.archived_at as string,
+              }))}
+              canEdit={canEdit}
+            />
+          }
         />
       </main>
     </>

--- a/apps/web/src/components/v2/archived-divisions.tsx
+++ b/apps/web/src/components/v2/archived-divisions.tsx
@@ -73,7 +73,7 @@ export function ArchivedDivisions({
     new Date(new Date(archivedAt).getTime() + PURGE_COOL_OFF_DAYS * 24 * 60 * 60 * 1000);
 
   return (
-    <section className="card mt-6 p-5" data-testid="archived-divisions">
+    <section className="card p-5" data-testid="archived-divisions">
       <h2 className="text-sm font-semibold text-slate-700">Archived divisions</h2>
       <p className="mt-1 text-xs text-slate-500">
         Hidden from your console and the public site; they don’t count against your plan.

--- a/apps/web/src/components/v2/competition-settings.tsx
+++ b/apps/web/src/components/v2/competition-settings.tsx
@@ -25,6 +25,8 @@ interface CompetitionLite {
 
 const STATUSES = ["draft", "published", "live", "completed", "archived"];
 
+type SettingsTab = "general" | "branding" | "archived";
+
 const STATUS_HINT: Record<string, string> = {
   published: "A timetable is set — publish it?",
   live: "Matches are underway — mark it live?",
@@ -46,6 +48,8 @@ export function CompetitionSettings({
   themeBranding = false,
   orgBranding = null,
   suggestedStatus = null,
+  archivedPanel = null,
+  archivedCount = 0,
 }: {
   competition: CompetitionLite;
   canEdit: boolean;
@@ -56,8 +60,13 @@ export function CompetitionSettings({
   orgBranding?: unknown;
   /** State-derived nudge, e.g. "live" once matches are underway. */
   suggestedStatus?: string | null;
+  /** Rendered under the Archived tab (outside the settings form). */
+  archivedPanel?: React.ReactNode;
+  /** The Archived tab only shows when there is something to restore. */
+  archivedCount?: number;
 }) {
   const router = useRouter();
+  const [tab, setTab] = useState<SettingsTab>("general");
   const [form, setForm] = useState({
     name: competition.name,
     description: competition.description ?? "",
@@ -152,206 +161,261 @@ export function CompetitionSettings({
     }
   }
 
+  // One form, one save — tabs only organise the fields. Form state lives in
+  // `form`, so switching tabs never loses unsaved edits. The Archived panel is
+  // a separate surface (its own API calls), so it renders outside the form.
+  const tabs: { key: SettingsTab; label: string }[] = [
+    { key: "general", label: "General" },
+    ...(themeBranding ? [{ key: "branding" as const, label: "Branding" }] : []),
+    ...(archivedCount > 0
+      ? [{ key: "archived" as const, label: `Archived (${archivedCount})` }]
+      : []),
+  ];
+  // A refresh can remove the selected tab (last archived division restored,
+  // entitlement drop) — fall back to General instead of a blank panel.
+  const activeTab: SettingsTab = tabs.some((t) => t.key === tab) ? tab : "general";
+
   return (
-    <form onSubmit={save} className="card space-y-4 p-5">
-      <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-slate-700">Settings</h2>
-        {competition.frozen && (
-          <span className="badge bg-sky-100 text-sky-700">read-only (over quota)</span>
-        )}
+    <div>
+      <div
+        role="tablist"
+        aria-label="Competition settings"
+        className="mb-4 flex flex-wrap gap-1 border-b border-slate-200"
+      >
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === t.key}
+            onClick={() => setTab(t.key)}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium transition ${
+              activeTab === t.key
+                ? "border-purple-600 text-purple-700"
+                : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
       </div>
 
-      <label className="block">
-        <span className="label">Name</span>
-        <input
-          required
-          disabled={readOnly}
-          value={form.name}
-          onChange={(e) => setForm({ ...form, name: e.target.value })}
-          className="input"
-        />
-      </label>
+      {activeTab === "archived" ? (
+        archivedPanel
+      ) : (
+        <form onSubmit={save} className="card space-y-4 p-5">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-slate-700">Settings</h2>
+            {competition.frozen && (
+              <span className="badge bg-sky-100 text-sky-700">read-only (over quota)</span>
+            )}
+          </div>
 
-      <label className="block">
-        <span className="label">Description</span>
-        <textarea
-          disabled={readOnly}
-          rows={3}
-          value={form.description}
-          onChange={(e) => setForm({ ...form, description: e.target.value })}
-          className="textarea"
-        />
-      </label>
+          {activeTab === "general" && (
+            <>
+              <label className="block">
+                <span className="label">Name</span>
+                <input
+                  required
+                  disabled={readOnly}
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  className="input"
+                />
+              </label>
 
-      <div className="grid grid-cols-2 gap-3">
-        <label className="block">
-          <span className="label">Starts</span>
-          <input
-            type="date"
-            disabled={readOnly}
-            value={form.starts_on}
-            onChange={(e) => setForm({ ...form, starts_on: e.target.value })}
-            className="input"
-          />
-        </label>
-        <label className="block">
-          <span className="label">Ends</span>
-          <input
-            type="date"
-            disabled={readOnly}
-            value={form.ends_on}
-            onChange={(e) => setForm({ ...form, ends_on: e.target.value })}
-            className="input"
-          />
-        </label>
-      </div>
+              <label className="block">
+                <span className="label">Description</span>
+                <textarea
+                  disabled={readOnly}
+                  rows={3}
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  className="textarea"
+                />
+              </label>
 
-      <div className="grid grid-cols-2 gap-3">
-        <label className="block">
-          <span className="label">Visibility</span>
-          <select
-            disabled={readOnly}
-            value={form.visibility}
-            onChange={(e) => setForm({ ...form, visibility: e.target.value })}
-            className="select"
-          >
-            <option value="private">private</option>
-            <option value="unlisted">unlisted</option>
-            <option value="public">public</option>
-          </select>
-        </label>
-        <label className="block">
-          <span className="label">Status</span>
-          <select
-            disabled={!canEdit}
-            value={form.status}
-            onChange={(e) => setForm({ ...form, status: e.target.value })}
-            className="select"
-          >
-            {STATUSES.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          {showSuggestion && (
-            <span className="mt-1.5 flex flex-wrap items-center gap-2 rounded-md bg-purple-50 px-2.5 py-1.5 text-xs text-purple-800">
-              {STATUS_HINT[suggestedStatus!] ?? `Looks like this should be “${suggestedStatus}”.`}
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => void applyStatus(suggestedStatus!)}
-                className="btn btn-primary px-2 py-0.5 text-xs"
-              >
-                Set to {suggestedStatus}
-              </button>
-            </span>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="block">
+                  <span className="label">Starts</span>
+                  <input
+                    type="date"
+                    disabled={readOnly}
+                    value={form.starts_on}
+                    onChange={(e) => setForm({ ...form, starts_on: e.target.value })}
+                    className="input"
+                  />
+                </label>
+                <label className="block">
+                  <span className="label">Ends</span>
+                  <input
+                    type="date"
+                    disabled={readOnly}
+                    value={form.ends_on}
+                    onChange={(e) => setForm({ ...form, ends_on: e.target.value })}
+                    className="input"
+                  />
+                </label>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <label className="block">
+                  <span className="label">Visibility</span>
+                  <select
+                    disabled={readOnly}
+                    value={form.visibility}
+                    onChange={(e) => setForm({ ...form, visibility: e.target.value })}
+                    className="select"
+                  >
+                    <option value="private">private</option>
+                    <option value="unlisted">unlisted</option>
+                    <option value="public">public</option>
+                  </select>
+                </label>
+                <label className="block">
+                  <span className="label">Status</span>
+                  <select
+                    disabled={!canEdit}
+                    value={form.status}
+                    onChange={(e) => setForm({ ...form, status: e.target.value })}
+                    className="select"
+                  >
+                    {STATUSES.map((s) => (
+                      <option key={s} value={s}>
+                        {s}
+                      </option>
+                    ))}
+                  </select>
+                  {showSuggestion && (
+                    <span className="mt-1.5 flex flex-wrap items-center gap-2 rounded-md bg-purple-50 px-2.5 py-1.5 text-xs text-purple-800">
+                      {STATUS_HINT[suggestedStatus!] ??
+                        `Looks like this should be “${suggestedStatus}”.`}
+                      <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => void applyStatus(suggestedStatus!)}
+                        className="btn btn-primary px-2 py-0.5 text-xs"
+                      >
+                        Set to {suggestedStatus}
+                      </button>
+                    </span>
+                  )}
+                </label>
+              </div>
+
+              {/* Showcase on seazn.club (doc 15 §1): explicit opt-in, public
+                  only — lives right under visibility, which gates it. */}
+              <fieldset className="space-y-3 rounded-lg border border-purple-100 bg-purple-50/50 p-3">
+                <label className="flex items-start gap-2">
+                  <input
+                    type="checkbox"
+                    disabled={readOnly || form.visibility !== "public"}
+                    checked={form.discoverable && form.visibility === "public"}
+                    onChange={(e) => setForm({ ...form, discoverable: e.target.checked })}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="text-sm font-semibold text-slate-700">
+                      Showcase on seazn.club
+                    </span>
+                    <span className="mt-1 block text-xs leading-relaxed text-slate-500">
+                      {SHOWCASE_CONSENT_COPY}
+                    </span>
+                  </span>
+                </label>
+                {form.visibility !== "public" && (
+                  <p className="text-xs text-amber-600">
+                    Set visibility to <b>public</b> to enable showcasing.
+                  </p>
+                )}
+                {form.discoverable && form.visibility === "public" && (
+                  <>
+                    <div className="grid grid-cols-2 gap-3">
+                      <label className="block">
+                        <span className="label">City (optional)</span>
+                        <input
+                          disabled={readOnly}
+                          value={form.city}
+                          onChange={(e) => setForm({ ...form, city: e.target.value })}
+                          className="input"
+                        />
+                      </label>
+                      <label className="block">
+                        <span className="label">Country (optional)</span>
+                        <input
+                          disabled={readOnly}
+                          value={form.country}
+                          onChange={(e) => setForm({ ...form, country: e.target.value })}
+                          className="input"
+                        />
+                      </label>
+                    </div>
+                    <label className="block">
+                      <span className="label">
+                        Tagline{" "}
+                        {!discoveryBranding && <span className="text-purple-500">(Pro)</span>}
+                      </span>
+                      <input
+                        disabled={readOnly || !discoveryBranding}
+                        value={form.tagline}
+                        onChange={(e) => setForm({ ...form, tagline: e.target.value })}
+                        placeholder={
+                          discoveryBranding ? "One line on your cards" : "Upgrade for card branding"
+                        }
+                        className="input"
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="label">
+                        Hero image URL{" "}
+                        {!discoveryBranding && <span className="text-purple-500">(Pro)</span>}
+                      </span>
+                      <input
+                        disabled={readOnly || !discoveryBranding}
+                        value={form.hero_image_path}
+                        onChange={(e) => setForm({ ...form, hero_image_path: e.target.value })}
+                        className="input"
+                      />
+                    </label>
+                  </>
+                )}
+              </fieldset>
+
+              <p className="text-xs text-slate-400">
+                Slug: <span className="font-mono">{competition.slug}</span>
+              </p>
+            </>
           )}
-        </label>
-      </div>
 
-      {themeBranding && (
-        <div>
-          <span className="label">Brand color</span>
-          <p className="mb-2 text-xs text-slate-500">
-            Colors this competition&apos;s public pages and TV noticeboard.
-          </p>
-          <BrandColorPicker
-            value={form.brand_primary}
-            onSelect={(hex) => setForm({ ...form, brand_primary: hex })}
-            disabled={readOnly}
-            defaultLabel="Same as organisation"
-            defaultHex={publicBrandColor(orgBranding) ?? "#7c3aed"}
-          />
-        </div>
-      )}
-
-      {/* Showcase on seazn.club (doc 15 §1): explicit opt-in, public only. */}
-      <fieldset className="space-y-3 rounded-lg border border-purple-100 bg-purple-50/50 p-3">
-        <label className="flex items-start gap-2">
-          <input
-            type="checkbox"
-            disabled={readOnly || form.visibility !== "public"}
-            checked={form.discoverable && form.visibility === "public"}
-            onChange={(e) => setForm({ ...form, discoverable: e.target.checked })}
-            className="mt-0.5"
-          />
-          <span>
-            <span className="text-sm font-semibold text-slate-700">Showcase on seazn.club</span>
-            <span className="mt-1 block text-xs leading-relaxed text-slate-500">
-              {SHOWCASE_CONSENT_COPY}
-            </span>
-          </span>
-        </label>
-        {form.visibility !== "public" && (
-          <p className="text-xs text-amber-600">
-            Set visibility to <b>public</b> to enable showcasing.
-          </p>
-        )}
-        {form.discoverable && form.visibility === "public" && (
-          <>
-            <div className="grid grid-cols-2 gap-3">
-              <label className="block">
-                <span className="label">City (optional)</span>
-                <input
-                  disabled={readOnly}
-                  value={form.city}
-                  onChange={(e) => setForm({ ...form, city: e.target.value })}
-                  className="input"
-                />
-              </label>
-              <label className="block">
-                <span className="label">Country (optional)</span>
-                <input
-                  disabled={readOnly}
-                  value={form.country}
-                  onChange={(e) => setForm({ ...form, country: e.target.value })}
-                  className="input"
-                />
-              </label>
+          {activeTab === "branding" && themeBranding && (
+            <div>
+              <span className="label">Brand color</span>
+              <p className="mb-2 text-xs text-slate-500">
+                Colors this competition&apos;s public pages and TV noticeboard.
+              </p>
+              <BrandColorPicker
+                value={form.brand_primary}
+                onSelect={(hex) => setForm({ ...form, brand_primary: hex })}
+                disabled={readOnly}
+                defaultLabel="Same as organisation"
+                defaultHex={publicBrandColor(orgBranding) ?? "#7c3aed"}
+              />
             </div>
-            <label className="block">
-              <span className="label">
-                Tagline {!discoveryBranding && <span className="text-purple-500">(Pro)</span>}
-              </span>
-              <input
-                disabled={readOnly || !discoveryBranding}
-                value={form.tagline}
-                onChange={(e) => setForm({ ...form, tagline: e.target.value })}
-                placeholder={discoveryBranding ? "One line on your cards" : "Upgrade for card branding"}
-                className="input"
-              />
-            </label>
-            <label className="block">
-              <span className="label">
-                Hero image URL {!discoveryBranding && <span className="text-purple-500">(Pro)</span>}
-              </span>
-              <input
-                disabled={readOnly || !discoveryBranding}
-                value={form.hero_image_path}
-                onChange={(e) => setForm({ ...form, hero_image_path: e.target.value })}
-                className="input"
-              />
-            </label>
-          </>
-        )}
-      </fieldset>
+          )}
 
-      <p className="text-xs text-slate-400">
-        Slug: <span className="font-mono">{competition.slug}</span>
-      </p>
+          {paywallFeature && <UpgradeGate feature={paywallFeature} />}
+          {error && (
+            <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+          )}
+          {saved && <p className="text-sm text-emerald-600">Saved.</p>}
 
-      {paywallFeature && <UpgradeGate feature={paywallFeature} />}
-      {error && (
-        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+          {canEdit && (
+            <button type="submit" disabled={busy} className="btn btn-primary w-full">
+              {busy ? "Saving…" : "Save settings"}
+            </button>
+          )}
+        </form>
       )}
-      {saved && <p className="text-sm text-emerald-600">Saved.</p>}
-
-      {canEdit && (
-        <button type="submit" disabled={busy} className="btn btn-primary w-full">
-          {busy ? "Saving…" : "Save settings"}
-        </button>
-      )}
-    </form>
+    </div>
   );
 }


### PR DESCRIPTION
## What

Competition settings page reorganised into tabs: **General / Branding / Archived (n)**.

- One form spans General + Branding — unsaved edits survive tab switches, single Save button.
- Showcase block stays inline on General, directly under visibility (which gates it).
- Branding tab renders only for orgs with `dashboard.branding`.
- Archived tab renders only when archived divisions exist; restoring the last one (or an entitlement drop) falls back to General instead of a blank panel.
- `ArchivedDivisions` lost its `mt-6` (now sits in a tab panel, not stacked below the form).

## Tests

- New e2e in `competition.spec.ts`: tab bar renders, Showcase inline on General, no Archived tab when nothing archived, edit on General → save from Branding tab → persisted after reload.
- `division-archive.spec.ts` updated: clicks the Archived tab before restore/purge assertions.
- tsc, eslint, unit suite (181 passed), e2e (wizard + tabs + archive-restore) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)