### PR TITLE
feat(ui): match-day cards + mobile pass (PROMPT-32/31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - run: npm run typecheck --workspace apps/web
       - run: npm run typecheck --workspace packages/engine
       - run: npm run engine:boundary
+      # v3/03 §6: retired plan tier must never reappear in UI copy.
+      - name: Plan-scrub grep gate (PROMPT-32)
+        run: bash scripts/check-plan-scrub.sh
       - name: OpenAPI spec drift gate (PROMPT-11)
         run: |
           npm run openapi:gen

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -1,5 +1,32 @@
 import { expect, type APIRequestContext, type Page } from "@playwright/test";
 
+/**
+ * v3/02 §4 viewport gate: the page-level rule is "no horizontal scroll,
+ * ever" — anything wide must scroll inside its own container. Run on every
+ * audited route in the mobile project.
+ */
+export async function expectNoHorizontalScroll(page: Page): Promise<void> {
+  const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(
+    scrollWidth,
+    `page scrolls horizontally (${scrollWidth}px content in ${clientWidth}px viewport)`,
+  ).toBeLessThanOrEqual(clientWidth);
+}
+
+/**
+ * Native dialogs are banned (v3/03 §3). Arm this before any delete-ish click:
+ * a window.confirm/alert firing anywhere fails the test.
+ */
+export function failOnNativeDialog(page: Page): void {
+  page.on("dialog", (dialog) => {
+    void dialog.dismiss();
+    throw new Error(`native ${dialog.type}() fired — use the ConfirmDialog provider`);
+  });
+}
+
 // Shared test tag so parallel/rerun state never collides.
 export const TAG = Date.now().toString(36);
 export const proEmail = () => `e2e-pro-${TAG}@example.com`;

--- a/apps/web/e2e/mobile.spec.ts
+++ b/apps/web/e2e/mobile.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import { TAG, apiJson, activeOrg, expectNoHorizontalScroll, addEntrantsViaApi } from "./helpers";
+
+// v3/02 §4 viewport gate — runs ONLY in the mobile-se / mobile-14 projects
+// (375×667, 390×844). Every audited route must render with zero page-level
+// horizontal scroll; key surfaces must pass axe (serious/critical) and the
+// public dashboard + registration page must LCP under 2.5 s on Fast-3G
+// (v3/11 gaps 11, 12, 15).
+test.describe.configure({ mode: "serial" });
+
+let compId = "";
+let compSlug = "";
+let divisionId = "";
+let orgSlug = "";
+
+test("setup: public competition with an entrant-ready division", async ({ page, request }) => {
+  const comp = await apiJson<{ id: string; slug: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Mobile Gate ${TAG}`,
+    visibility: "public",
+  });
+  expect(comp.status).toBeLessThan(300);
+  compId = comp.data!.id;
+  compSlug = comp.data!.slug;
+
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${compId}/divisions`,
+    "POST",
+    {
+      name: "Mobile Singles",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    },
+  );
+  expect(div.status).toBeLessThan(300);
+  divisionId = div.data!.id;
+  await addEntrantsViaApi(request, divisionId, ["Ada M", "Bea M", "Cal M", "Dev M"]);
+
+  const settings = await apiJson(
+    request,
+    `/api/v1/divisions/${divisionId}/registration-settings`,
+    "PUT",
+    {
+      enabled: true,
+      entrant_kind: "individual",
+      capacity: 10,
+      fee_cents: 0,
+      currency: "gbp",
+      form_fields: [],
+    },
+  );
+  expect(settings.status).toBeLessThan(300);
+  orgSlug = (await activeOrg(page)).slug;
+});
+
+// "load" + a short settle instead of networkidle — the dev server's HMR
+// socket keeps the network permanently busy and cold compiles already eat
+// the budget.
+async function auditRoute(page: Page, path: string) {
+  await page.goto(path, { waitUntil: "load" });
+  await page.waitForTimeout(300);
+  await expectNoHorizontalScroll(page);
+}
+
+test("console routes: no horizontal scroll", async ({ page }) => {
+  const routes = [
+    "/dashboard",
+    `/competitions/${compId}`,
+    `/competitions/${compId}/settings`,
+    `/divisions/${divisionId}`,
+    `/divisions/${divisionId}?tab=fixtures`,
+    `/divisions/${divisionId}?tab=standings`,
+    `/divisions/${divisionId}/registrations`,
+    "/settings?tab=organization",
+    "/settings?tab=team",
+    "/settings?tab=api",
+    "/settings?tab=account",
+    "/settings/billing",
+    "/directory",
+    "/import",
+    "/my-matches",
+  ];
+  for (const path of routes) {
+    await auditRoute(page, path);
+  }
+});
+
+test("public surfaces: no horizontal scroll (v3/11 gap 12)", async ({ browser }) => {
+  // Anonymous context — public pages must hold without the authed shell.
+  const anonCtx = await browser.newContext();
+  try {
+    const anon = await anonCtx.newPage();
+    const routes = [
+      "/",
+      "/pricing",
+      `/shared/${orgSlug}`,
+      `/shared/${orgSlug}/${compSlug}`,
+      `/shared/${orgSlug}/${compSlug}/register`,
+    ];
+    for (const path of routes) {
+      await anon.goto(path, { waitUntil: "load" });
+      await anon.waitForTimeout(300);
+      await expectNoHorizontalScroll(anon);
+    }
+  } finally {
+    await anonCtx.close();
+  }
+});
+
+test("axe: no serious/critical violations on key surfaces (v3/11 gap 11)", async ({ page }) => {
+  const routes = [
+    "/dashboard",
+    `/competitions/${compId}`,
+    `/divisions/${divisionId}?tab=standings`,
+    "/settings?tab=organization",
+    "/settings/billing",
+    `/shared/${orgSlug}/${compSlug}`,
+  ];
+  for (const path of routes) {
+    await page.goto(path, { waitUntil: "load" });
+    await page.waitForTimeout(300);
+    const results = await new AxeBuilder({ page }).withTags(["wcag2a", "wcag2aa"]).analyze();
+    const blocking = results.violations.filter(
+      (v) => v.impact === "serious" || v.impact === "critical",
+    );
+    expect(
+      blocking.map((v) => `${path}: ${v.id} — ${v.nodes[0]?.html}`),
+      `axe serious/critical on ${path}`,
+    ).toEqual([]);
+  }
+});
+
+test("page smokes: settings save + invoice/plan card render", async ({ page }) => {
+  // Org rename round-trip proves forms submit on a phone viewport.
+  await page.goto("/settings?tab=organization");
+  const nameInput = page.getByLabel(/organi[sz]ation name/i);
+  await expect(nameInput).toBeVisible();
+  // Two "Save" buttons live on this tab (rename + payment details) — scope
+  // to the rename form's own label container.
+  const renameForm = page.locator("label", { has: nameInput });
+  const orgName = await nameInput.inputValue();
+  await nameInput.fill(`${orgName} ✓`);
+  await renameForm.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(renameForm.getByText("Saved.")).toBeVisible();
+  // Restore — other specs assert on the org name.
+  await nameInput.fill(orgName);
+  await renameForm.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(renameForm.getByText("Saved.")).toBeVisible();
+
+  // Billing: the plan card is the invoice-adjacent surface every org has.
+  await page.goto("/settings/billing");
+  await expect(page.getByRole("heading", { name: /plan & billing/i })).toBeVisible();
+  await expect(page.getByText(/current plan/i).first()).toBeVisible();
+  await expectNoHorizontalScroll(page);
+});
+
+// v3/11 gap 15: LCP < 2.5 s on Fast-3G for the money pages. CDP network
+// emulation (Chromium only — the mobile projects are Chromium).
+const FAST_3G = {
+  offline: false,
+  downloadThroughput: (1.6 * 1024 * 1024) / 8,
+  uploadThroughput: (750 * 1024) / 8,
+  latency: 150,
+};
+
+async function measureLcp(page: Page, path: string): Promise<number> {
+  // Pre-warm: the dev server compiles a route on first hit — that cost is
+  // build tooling, not page weight, so it stays out of the measurement.
+  await page.request.get(path);
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Network.enable");
+  await cdp.send("Network.emulateNetworkConditions", FAST_3G);
+  await page.goto(path);
+  const lcp = await page.evaluate(
+    () =>
+      new Promise<number>((resolve) => {
+        new PerformanceObserver((list) => {
+          const entries = list.getEntries();
+          const last = entries[entries.length - 1];
+          if (last) resolve(last.startTime);
+        }).observe({ type: "largest-contentful-paint", buffered: true });
+        // No LCP entry (already settled) — fall back to nav timing.
+        setTimeout(() => resolve(performance.now()), 4000);
+      }),
+  );
+  await cdp.send("Network.emulateNetworkConditions", {
+    offline: false,
+    downloadThroughput: -1,
+    uploadThroughput: -1,
+    latency: 0,
+  });
+  await cdp.detach();
+  return lcp;
+}
+
+test("LCP < 2.5s on Fast-3G: public dashboard + registration (v3/11 gap 15)", async ({
+  browser,
+}) => {
+  const anonCtx = await browser.newContext();
+  try {
+    const anon = await anonCtx.newPage();
+    for (const path of [`/shared/${orgSlug}/${compSlug}`, `/shared/${orgSlug}/${compSlug}/register`]) {
+      const lcp = await measureLcp(anon, path);
+      expect(lcp, `LCP on ${path}`).toBeLessThan(2500);
+    }
+  } finally {
+    await anonCtx.close();
+  }
+});

--- a/apps/web/e2e/schedule-panels.spec.ts
+++ b/apps/web/e2e/schedule-panels.spec.ts
@@ -43,8 +43,10 @@ test("history (PROMPT-23): undo then redo round-trips without error", async ({ p
   const { divisionId } = await seedScoredDivision(request);
   await page.goto(`/divisions/${divisionId}/schedule?tab=history`);
 
-  const undo = page.getByRole("button", { name: /Undo/ });
-  const redo = page.getByRole("button", { name: /Redo/ });
+  // Exact labels: the panel's Tip ⓘ ("About: Undo and save points") would
+  // otherwise collide with a loose /Undo/ match.
+  const undo = page.getByRole("button", { name: "↩ Undo" });
+  const redo = page.getByRole("button", { name: "↪ Redo" });
   await expect(undo).toBeEnabled({ timeout: 20_000 });
   await expect(page.getByRole("heading", { name: "Recent edits" })).toBeVisible();
 

--- a/apps/web/e2e/ui-system.spec.ts
+++ b/apps/web/e2e/ui-system.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+import { TAG, apiJson, activeOrg, failOnNativeDialog } from "./helpers";
+
+// PROMPT-32 acceptance: match-day cards navigate, ConfirmDialog replaced
+// window.confirm everywhere, and the visibility picker surfaces the share
+// URL with unchanged noindex behaviour.
+
+test("card grid: competition card renders match-day anatomy and navigates", async ({
+  page,
+  request,
+}) => {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Card Nav ${TAG}`,
+    visibility: "private",
+  });
+  expect(comp.status).toBeLessThan(300);
+
+  await page.goto("/dashboard");
+  const card = page
+    .locator("article")
+    .filter({ hasText: `Card Nav ${TAG}` })
+    .first();
+  await expect(card).toBeVisible();
+  // Status chip vocabulary (v3/03 §1): a fresh competition reads "Draft".
+  await expect(card.getByText("Draft", { exact: true })).toBeVisible();
+  // Whole card is the click target (stretched link).
+  await card.getByRole("link", { name: `Card Nav ${TAG}` }).click();
+  await page.waitForURL(new RegExp(`/competitions/${comp.data!.id}`));
+  await expect(page.getByRole("heading", { name: `Card Nav ${TAG}` })).toBeVisible();
+});
+
+test("destructive action uses ConfirmDialog — a native confirm() fails the test", async ({
+  page,
+  request,
+}) => {
+  // Clubs delete is a canonical destructive flow reachable on every plan.
+  const club = await apiJson<{ id: string; name: string }>(request, "/api/v1/clubs", "POST", {
+    name: `Doomed Club ${TAG}`,
+  });
+  expect(club.status).toBeLessThan(300);
+
+  failOnNativeDialog(page); // any window.confirm/alert = instant failure
+  await page.goto("/directory?tab=clubs");
+  const row = page.getByRole("row", { name: new RegExp(`Doomed Club ${TAG}`) });
+  await row.getByRole("button", { name: "Delete" }).click();
+
+  // The app-owned dialog, not the browser's.
+  const dialog = page.getByRole("alertdialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText(/its teams stay/i)).toBeVisible();
+  await dialog.getByRole("button", { name: "Delete club" }).click();
+  await expect(row).toHaveCount(0);
+});
+
+test("visibility picker: Link only surfaces a copyable URL; public page stays noindex", async ({
+  page,
+  request,
+}) => {
+  const comp = await apiJson<{ id: string; slug: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Vis Flip ${TAG}`,
+    visibility: "private",
+  });
+  expect(comp.status).toBeLessThan(300);
+  const orgSlug = (await activeOrg(page)).slug;
+
+  await page.goto(`/competitions/${comp.data!.id}/settings`);
+  // Radio cards speak plain language (v3/03 §7).
+  await expect(page.getByText("Only your team can see it.")).toBeVisible();
+  await page.getByRole("radio", { name: /link only/i }).check();
+  // The consequence is immediate: share URL + copy affordance appear.
+  await expect(page.getByText(`/shared/${orgSlug}/${comp.data!.slug}`).first()).toBeVisible();
+  await expect(page.getByRole("button", { name: /copy link/i })).toBeVisible();
+  await page.getByRole("button", { name: /save settings/i }).click();
+  await expect(page.getByText("Saved.").first()).toBeVisible();
+
+  // Keys/noindex behaviour unchanged: unlisted pages serve a robots noindex.
+  const res = await page.request.get(`/shared/${orgSlug}/${comp.data!.slug}`);
+  expect(res.status()).toBe(200);
+  const html = await res.text();
+  expect(html).toMatch(/noindex/);
+});

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -21,6 +21,23 @@ const eslintConfig = defineConfig([
       "react-hooks/static-components": "warn",
     },
   },
+  {
+    // v3/03 §3: native dialogs are banned — use useConfirm() from
+    // components/ui/confirm-provider (regression gate for PROMPT-32).
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        { name: "confirm", message: "Use useConfirm() from components/ui/confirm-provider." },
+        { name: "alert", message: "Render inline feedback, not alert()." },
+      ],
+      "no-restricted-properties": [
+        "error",
+        { object: "window", property: "confirm", message: "Use useConfirm() from components/ui/confirm-provider." },
+        { object: "window", property: "alert", message: "Render inline feedback, not window.alert()." },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([".next/**", "out/**", "build/**", "next-env.d.ts"]),
 ]);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:e2e": "playwright test --project=parallel && playwright test --project=serial --workers=1",
+    "test:e2e": "playwright test --project=parallel && playwright test --project=serial --workers=1 && playwright test --project=mobile-se --project=mobile-14",
     "test:e2e:all": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },
@@ -41,6 +41,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     { name: "setup", testMatch: /auth\.setup\.ts/ },
     {
       name: "parallel",
-      testIgnore: SERIAL_SPECS,
+      testIgnore: [SERIAL_SPECS, /mobile\.spec\.ts/],
       use: { ...devices["Desktop Chrome"], storageState: AUTH_STATE },
       dependencies: ["setup"],
     },
@@ -48,6 +48,28 @@ export default defineConfig({
       testMatch: SERIAL_SPECS,
       fullyParallel: false,
       use: { ...devices["Desktop Chrome"], storageState: AUTH_STATE },
+      dependencies: ["setup"],
+    },
+    // v3/02 §4 viewport gate: mobile.spec.ts runs at both reference phones —
+    // iPhone SE (375×667) and iPhone 14 (390×844). Desktop projects ignore it.
+    {
+      name: "mobile-se",
+      testMatch: /mobile\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 375, height: 667 },
+        storageState: AUTH_STATE,
+      },
+      dependencies: ["setup"],
+    },
+    {
+      name: "mobile-14",
+      testMatch: /mobile\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 390, height: 844 },
+        storageState: AUTH_STATE,
+      },
       dependencies: ["setup"],
     },
   ],

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
@@ -7,7 +7,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { resolveModule } from "@/server/engine-db";
 import type { StandingsRow } from "@seazn/engine/competition";
-import { getPublicDivision } from "@/server/public-site/data";
+import { getPublicDivision, resolveLogoUrl } from "@/server/public-site/data";
 import { publicThemeStyle } from "@/lib/public-theme";
 import { Tabs } from "@/components/public-site/tabs";
 import { Schedule } from "@/components/public-site/schedule";
@@ -54,6 +54,10 @@ export default async function DivisionHomePage({ params }: Props) {
   }
 
   const entrantNames = Object.fromEntries(entrants.map((e) => [e.id, e.display_name]));
+  // Badge chips (v3/03 §5): team → club resolved by the view; URL resolved here.
+  const entrantLogos = Object.fromEntries(
+    entrants.map((e) => [e.id, resolveLogoUrl(e.team_display?.logo_path ?? null, null)]),
+  );
   const basePath = `/shared/${org.slug}/${competition.slug}/${division.slug}`;
   const poolName = new Map(pools.map((p) => [p.id, p.name]));
   const stageById = new Map(stages.map((s) => [s.id, s]));
@@ -145,6 +149,7 @@ export default async function DivisionHomePage({ params }: Props) {
                   metricSpecs={metricSpecs}
                   cascade={cascade}
                   entrantNames={entrantNames}
+                  entrantLogos={entrantLogos}
                   caption={
                     snap.pool_id
                       ? `${stage.name} — ${poolName.get(snap.pool_id) ?? "Pool"}`

--- a/apps/web/src/app/api/v1/teams/[id]/logo/route.ts
+++ b/apps/web/src/app/api/v1/teams/[id]/logo/route.ts
@@ -1,0 +1,32 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { HttpError } from "@/lib/errors";
+import { setTeamLogo, removeTeamLogo } from "@/server/usecases/teams";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** POST /api/v1/teams/{id}/logo — multipart single 'file' (v3/03 §5; mirrors
+ *  the club badge pipeline). DELETE clears the pointer; the team then falls
+ *  back to its club badge via team_display_v. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "team", id, "write");
+    const form = await req.formData();
+    const entry = form.get("file");
+    if (!(entry instanceof File)) throw new HttpError(400, "multipart 'file' required");
+    return setTeamLogo(auth, id, {
+      contentType: entry.type,
+      bytes: Buffer.from(await entry.arrayBuffer()),
+    });
+  });
+}
+
+export async function DELETE(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "team", id, "write");
+    await removeTeamLogo(auth, id);
+    return { ok: true };
+  });
+}

--- a/apps/web/src/app/competitions/[id]/page.tsx
+++ b/apps/web/src/app/competitions/[id]/page.tsx
@@ -1,11 +1,21 @@
 export const dynamic = "force-dynamic";
-// Competition overview: division list; settings live on their own page.
+// Competition overview: divisions as match-day cards (v3/03 §2); settings
+// live on their own page.
 import Link from "next/link";
-import { Settings } from "lucide-react";
+import { CalendarRange, Globe, MonitorPlay, Settings } from "lucide-react";
 import { Nav } from "@/components/nav";
 import { requireResourcePageAuth } from "@/server/page-auth";
 import { getCompetition } from "@/server/usecases/competitions";
 import { listDivisions } from "@/server/usecases/divisions";
+import { listDivisionCardStats, nextLine, formatLabel } from "@/server/usecases/card-stats";
+import { EntityCard } from "@/components/ui/entity-card";
+import { CardMenu } from "@/components/ui/card-menu";
+import { ViewToggleContainer } from "@/components/ui/view-toggle";
+import { StatusChip, divisionChipState, CHIP_SORT } from "@/components/ui/status-chip";
+import { SPORT_EMOJI } from "@/components/discovery-cards";
+import { divisionAccent } from "@/lib/division-hue";
+import { routes } from "@/lib/routes";
+import { msg } from "@/lib/messages";
 import { sql } from "@/lib/db";
 
 export default async function CompetitionPage({
@@ -15,9 +25,10 @@ export default async function CompetitionPage({
 }) {
   const { id } = await params;
   const { auth, org, canEdit } = await requireResourcePageAuth("competition", id);
-  const [competition, divisions, [orgRow]] = await Promise.all([
+  const [competition, divisions, stats, [orgRow]] = await Promise.all([
     getCompetition(auth, id),
     listDivisions(auth, id),
+    listDivisionCardStats(auth, id),
     sql<{ slug: string }[]>`select slug from organizations where id = ${auth.orgId}`,
   ]);
   const publicPath =
@@ -31,7 +42,7 @@ export default async function CompetitionPage({
       <main className="mx-auto max-w-6xl px-4 py-8">
         <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-xs text-slate-400">
+            <p className="text-xs text-slate-500">
               <Link href="/dashboard" className="hover:text-purple-600">
                 Competitions
               </Link>{" "}
@@ -41,28 +52,44 @@ export default async function CompetitionPage({
               {competition.name}
             </h1>
           </div>
+          {/* Header actions: icon + label on desktop, icon-only under `sm`
+              (v3/02 pattern 5 — labels move into aria-label, 44px targets). */}
           <div className="flex flex-wrap items-center gap-2">
             <Link
-              href={`/slideshow/competitions/${competition.id}`}
+              href={routes.slideshowCompetition(competition.id)}
               target="_blank"
-              className="btn btn-ghost"
+              aria-label="Slideshow (opens in a new tab)"
+              className="btn btn-ghost gap-1.5"
             >
-              Slideshow ↗
+              <MonitorPlay className="h-4 w-4" strokeWidth={1.75} />
+              <span className="hidden sm:inline">Slideshow ↗</span>
             </Link>
-            <Link href={`/competitions/${competition.id}/schedule`} className="btn btn-ghost">
-              Schedule board
+            <Link
+              href={routes.competitionSchedule(competition.id)}
+              aria-label="Schedule board"
+              className="btn btn-ghost gap-1.5"
+            >
+              <CalendarRange className="h-4 w-4" strokeWidth={1.75} />
+              <span className="hidden sm:inline">Schedule board</span>
             </Link>
             {publicPath && (
-              <Link href={publicPath} className="btn btn-ghost" target="_blank">
-                View public page ↗
+              <Link
+                href={publicPath}
+                target="_blank"
+                aria-label="View public page (opens in a new tab)"
+                className="btn btn-ghost gap-1.5"
+              >
+                <Globe className="h-4 w-4" strokeWidth={1.75} />
+                <span className="hidden sm:inline">View public page ↗</span>
               </Link>
             )}
             <Link
-              href={`/competitions/${competition.id}/settings`}
-              className="btn btn-ghost flex items-center gap-1.5"
+              href={routes.competitionSettings(competition.id)}
+              aria-label="Settings"
+              className="btn btn-ghost gap-1.5"
             >
               <Settings className="h-4 w-4" strokeWidth={1.75} />
-              Settings
+              <span className="hidden sm:inline">Settings</span>
             </Link>
           </div>
         </div>
@@ -80,40 +107,59 @@ export default async function CompetitionPage({
               )}
             </div>
             {divisions.length === 0 ? (
-              <div className="card p-6 text-sm text-slate-500">
-                No divisions yet. A division picks the sport, its variant and
-                format — entrants and fixtures live inside it.
+              <div className="card p-6 text-center text-sm text-slate-500">
+                <p>{msg("card.empty.divisions")}</p>
+                {canEdit && !competition.frozen && (
+                  <Link href={routes.divisionNew(competition.id)} className="btn btn-primary mt-4">
+                    {msg("card.empty.divisions.cta")}
+                  </Link>
+                )}
               </div>
             ) : (
-              <ul className="space-y-2">
-                {divisions.map((d) => (
-                  <li key={d.id}>
-                    <Link
-                      href={`/divisions/${d.id}`}
-                      className="group flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm transition hover:border-purple-300"
-                    >
-                      <span className="min-w-0">
-                        <span className="block truncate text-sm font-medium text-slate-800 group-hover:text-purple-700">
-                          {d.name}
-                        </span>
-                        <span className="mt-0.5 block text-xs text-slate-400">
-                          {d.sport_key} · {d.variant_key} · module v{d.module_version}
-                        </span>
-                      </span>
-                      <span className={`badge ${statusStyle(d.status)}`}>{d.status}</span>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
+              <ViewToggleContainer storageKey="seazn.view.divisions" toggle={divisions.length > 20}>
+                {divisions
+                  .map((d) => ({
+                    d,
+                    chip: divisionChipState(d.status, {
+                      registrationOpen: stats.get(d.id)?.registration_open,
+                    }),
+                  }))
+                  .sort((a, b) => CHIP_SORT[a.chip] - CHIP_SORT[b.chip])
+                  .map(({ d, chip }) => {
+                    const s = stats.get(d.id);
+                    const entrantsLabel = s
+                      ? `${s.entrants}${s.capacity ? `/${s.capacity}` : ""} entrant${s.entrants === 1 && !s.capacity ? "" : "s"}`
+                      : null;
+                    return (
+                      <EntityCard
+                        key={d.id}
+                        href={routes.division(d.id)}
+                        glyph={SPORT_EMOJI[d.sport_key] ?? "🏅"}
+                        name={d.name}
+                        accent={divisionAccent(d.id)}
+                        chip={<StatusChip state={chip} />}
+                        meta={[formatLabel(s?.stage_kinds ?? []), entrantsLabel]
+                          .filter(Boolean)
+                          .join(" · ")}
+                        next={s ? nextLine(s.next) : null}
+                        progress={s ? { played: s.played, total: s.total } : null}
+                        menu={
+                          <CardMenu
+                            name={d.name}
+                            items={[
+                              { label: "Schedule", href: routes.divisionSchedule(d.id) },
+                              { label: "Registrations", href: routes.divisionRegistrations(d.id) },
+                              { label: "Slideshow", href: routes.slideshowDivision(d.id), external: true },
+                            ]}
+                          />
+                        }
+                      />
+                    );
+                  })}
+              </ViewToggleContainer>
             )}
           </section>
       </main>
     </>
   );
-}
-
-function statusStyle(status: string): string {
-  if (status === "active") return "bg-amber-100 text-amber-700";
-  if (status === "completed") return "bg-emerald-100 text-emerald-700";
-  return "bg-slate-100 text-slate-600";
 }

--- a/apps/web/src/app/competitions/[id]/settings/page.tsx
+++ b/apps/web/src/app/competitions/[id]/settings/page.tsx
@@ -8,7 +8,7 @@ import { listDivisions } from "@/server/usecases/divisions";
 import { CompetitionSettings } from "@/components/v2/competition-settings";
 import { ArchivedDivisions } from "@/components/v2/archived-divisions";
 import { hasFeature } from "@/lib/entitlements";
-import { withTenant } from "@/lib/db";
+import { withTenant, sql } from "@/lib/db";
 
 /** State-derived status nudge: published → live → completed as matches progress. */
 function suggestStatus(
@@ -36,6 +36,23 @@ export default async function CompetitionSettingsPage({
     listDivisions(auth, id, { includeArchived: true }),
   ]);
   const archivedDivisions = allDivisions.filter((d) => d.archived_at !== null);
+
+  // Youth flag (v3/11 gap 8): any live division with a U-age eligibility rule
+  // raises the guardian-consent interstitial before the competition leaves
+  // Private. Org slug feeds the picker's share URL.
+  const [[youthRow], [orgRow]] = await Promise.all([
+    withTenant(auth.orgId, (tx) =>
+      tx<{ youth: boolean }[]>`
+        select exists(
+          select 1 from divisions d,
+                 jsonb_array_elements(d.eligibility) r
+          where d.competition_id = ${id} and d.archived_at is null
+            and r->>'kind' = 'age'
+            and coalesce((r->>'maxAgeAt')::int, 99) < 18
+        ) as youth`,
+    ),
+    sql<{ slug: string }[]>`select slug from organizations where id = ${auth.orgId}`,
+  ]);
 
   const [agg] = await withTenant(auth.orgId, (tx) =>
     tx<{ total: number; underway: number; done: number; scheduled: number }[]>`
@@ -88,6 +105,8 @@ export default async function CompetitionSettingsPage({
           themeBranding={themeBranding}
           orgBranding={org.branding}
           suggestedStatus={suggestedStatus}
+          sharePath={orgRow ? `/shared/${orgRow.slug}/${competition.slug}` : null}
+          hasYouthDivisions={youthRow?.youth ?? false}
           archivedCount={archivedDivisions.length}
           archivedPanel={
             /* v3/09 §4 — restore/purge surface for archived divisions. */

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,25 +1,18 @@
 export const dynamic = "force-dynamic";
-// Organiser home — competitions on the v2 engine (PROMPT-15 task 1).
+// Organiser home — competitions as match-day cards (v3/03 §2).
 import Link from "next/link";
 import { Trophy } from "lucide-react";
 import { Nav } from "@/components/nav";
 import { BillingBanner } from "@/components/billing-banner";
 import { requirePageAuth } from "@/server/page-auth";
 import { listCompetitions } from "@/server/usecases/competitions";
-
-const STATUS_STYLE: Record<string, string> = {
-  draft: "bg-slate-100 text-slate-600",
-  published: "bg-sky-100 text-sky-700",
-  live: "bg-amber-100 text-amber-700",
-  completed: "bg-emerald-100 text-emerald-700",
-  archived: "bg-slate-100 text-slate-400",
-};
-
-const VISIBILITY_STYLE: Record<string, string> = {
-  public: "bg-emerald-50 text-emerald-600",
-  unlisted: "bg-sky-50 text-sky-600",
-  private: "bg-slate-50 text-slate-500",
-};
+import { listCompetitionCardStats, nextLine } from "@/server/usecases/card-stats";
+import { EntityCard } from "@/components/ui/entity-card";
+import { CardMenu } from "@/components/ui/card-menu";
+import { ViewToggleContainer } from "@/components/ui/view-toggle";
+import { StatusChip, competitionChipState, CHIP_SORT } from "@/components/ui/status-chip";
+import { routes } from "@/lib/routes";
+import { msg } from "@/lib/messages";
 
 export default async function DashboardPage() {
   const { auth, org, canEdit } = await requirePageAuth();
@@ -33,6 +26,13 @@ export default async function DashboardPage() {
   }
 
   const { items: competitions } = await listCompetitions(auth, { cursor: null, limit: 100 });
+  const stats = await listCompetitionCardStats(auth);
+
+  // Live first, then Registration open, Draft, Completed (v3/03 §2);
+  // secondary = the query's recency order, kept by stable sort.
+  const sorted = competitions
+    .map((c) => ({ c, chip: competitionChipState(c.status) }))
+    .sort((a, b) => CHIP_SORT[a.chip] - CHIP_SORT[b.chip]);
 
   return (
     <>
@@ -58,7 +58,7 @@ export default async function DashboardPage() {
               Directory
             </Link>
             {canEdit && (
-              <Link href="/competitions/new" data-tour="new-competition" className="btn btn-primary">
+              <Link href={routes.competitionNew()} data-tour="new-competition" className="btn btn-primary">
                 + New Competition
               </Link>
             )}
@@ -73,55 +73,47 @@ export default async function DashboardPage() {
               </div>
               <div>
                 <h2 className="text-xl font-semibold text-slate-800">
-                  No competitions yet
+                  {msg("card.empty.competitions")}
                 </h2>
-                <p className="mt-1 text-sm text-slate-500">
-                  Create your first competition, add a division for your sport,
-                  register entrants and you&apos;re live.
-                </p>
               </div>
-              <Link href="/competitions/new" className="btn btn-primary">
-                Create your first competition
+              <Link href={routes.competitionNew()} className="btn btn-primary">
+                {msg("card.empty.competitions.cta")}
               </Link>
             </div>
           ) : (
             <p className="text-sm text-slate-500">No competitions yet.</p>
           )
         ) : (
-          <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {competitions.map((c) => (
-              <li key={c.id}>
-                <Link
-                  href={`/competitions/${c.id}`}
-                  className="group block rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-purple-300 hover:shadow"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="block truncate text-sm font-semibold text-slate-800 group-hover:text-purple-700">
-                      {c.name}
-                    </span>
-                    <span className={`badge shrink-0 ${STATUS_STYLE[c.status] ?? STATUS_STYLE.draft}`}>
-                      {c.frozen ? "frozen" : c.status}
-                    </span>
-                  </div>
-                  <p className="mt-1 line-clamp-2 text-xs text-slate-500">
-                    {c.description ?? "—"}
-                  </p>
-                  <div className="mt-3 flex items-center gap-2 text-[11px]">
-                    <span className={`badge ${VISIBILITY_STYLE[c.visibility] ?? VISIBILITY_STYLE.private}`}>
-                      {c.visibility}
-                    </span>
-                    <span className="font-mono text-slate-400">{c.slug}</span>
-                    {c.starts_on && (
-                      <span className="text-slate-400">
-                        {c.starts_on}
-                        {c.ends_on ? ` → ${c.ends_on}` : ""}
-                      </span>
-                    )}
-                  </div>
-                </Link>
-              </li>
-            ))}
-          </ul>
+          <ViewToggleContainer storageKey="seazn.view.competitions" toggle={competitions.length > 20}>
+            {sorted.map(({ c, chip }) => {
+              const s = stats.get(c.id);
+              return (
+                <EntityCard
+                  key={c.id}
+                  href={routes.competition(c.id)}
+                  name={c.name}
+                  chip={<StatusChip state={c.frozen ? "frozen" : chip} />}
+                  meta={
+                    s
+                      ? `${s.divisions} division${s.divisions === 1 ? "" : "s"} · ${s.entrants} entrant${s.entrants === 1 ? "" : "s"}`
+                      : null
+                  }
+                  next={s ? nextLine(s.next) : null}
+                  progress={s ? { played: s.played, total: s.total } : null}
+                  menu={
+                    <CardMenu
+                      name={c.name}
+                      items={[
+                        { label: "Schedule board", href: routes.competitionSchedule(c.id) },
+                        { label: "Settings", href: routes.competitionSettings(c.id) },
+                        { label: "Slideshow", href: routes.slideshowCompetition(c.id), external: true },
+                      ]}
+                    />
+                  }
+                />
+              );
+            })}
+          </ViewToggleContainer>
         )}
       </main>
     </>

--- a/apps/web/src/app/divisions/[id]/page.tsx
+++ b/apps/web/src/app/divisions/[id]/page.tsx
@@ -2,13 +2,17 @@ export const dynamic = "force-dynamic";
 // Division console (PROMPT-15 task 1): entrants & rosters, fixture console
 // (per stage: generate/complete/schedule), standings with the cascade trace.
 import Link from "next/link";
+import { ClipboardList, MonitorPlay } from "lucide-react";
 import { Nav } from "@/components/nav";
+import { StatusChip, divisionChipState } from "@/components/ui/status-chip";
+import { routes } from "@/lib/routes";
 import { requireResourcePageAuth } from "@/server/page-auth";
 import { getDivision } from "@/server/usecases/divisions";
 import { getCompetition } from "@/server/usecases/competitions";
 import { listStages, getStandings } from "@/server/usecases/stages";
 import { listDivisionFixtures } from "@/server/usecases/fixtures";
 import { listEntrants } from "@/server/usecases/entrants";
+import { listEntrantLogoUrls } from "@/server/usecases/teams";
 import { resolveModule } from "@/server/engine-db";
 import { withTenant } from "@/lib/db";
 import { DivisionDangerZone } from "@/components/v2/division-danger-zone";
@@ -49,6 +53,9 @@ export default async function DivisionPage({
   ]);
   const sportModule = resolveModule(division.sport_key, division.module_version);
   const entrantNames = Object.fromEntries(entrants.map((e) => [e.id, e.display_name]));
+  // Badge chips on standings rows (v3/03 §5) — resolved once per render.
+  const entrantLogos =
+    tab === "standings" ? await listEntrantLogoUrls(auth, id) : undefined;
   const cascade = division.tiebreakers ?? sportModule.defaultTiebreakers;
 
   // Standings per table stage (+ per pool), with pool labels.
@@ -83,7 +90,7 @@ export default async function DivisionPage({
       <Nav />
       <main className="mx-auto max-w-6xl px-4 py-8">
         <div className="mb-6">
-          <p className="text-xs text-slate-400">
+          <p className="text-xs text-slate-500">
             <Link href="/dashboard" className="hover:text-purple-600">
               Competitions
             </Link>{" "}
@@ -102,16 +109,26 @@ export default async function DivisionPage({
             <span className="chip">
               {division.sport_key} · {division.variant_key}
             </span>
-            <span className={`badge ${divisionStatusStyle(division.status)}`}>
-              {division.status}
-            </span>
-            {frozen && <span className="badge bg-sky-100 text-sky-700">read-only</span>}
+            <StatusChip state={divisionChipState(division.status)} />
+            {frozen && <StatusChip state="frozen" />}
             <div className="flex-1" />
-            <Link href={`/slideshow/divisions/${id}`} target="_blank" className="btn btn-ghost">
-              Slideshow ↗
+            {/* Icon + label on desktop, icon-only under `sm` (v3/02 pattern 5). */}
+            <Link
+              href={routes.slideshowDivision(id)}
+              target="_blank"
+              aria-label="Slideshow (opens in a new tab)"
+              className="btn btn-ghost gap-1.5"
+            >
+              <MonitorPlay className="h-4 w-4" strokeWidth={1.75} />
+              <span className="hidden sm:inline">Slideshow ↗</span>
             </Link>
-            <Link href={`/divisions/${id}/registrations`} className="btn btn-ghost">
-              Registrations
+            <Link
+              href={routes.divisionRegistrations(id)}
+              aria-label="Registrations"
+              className="btn btn-ghost gap-1.5"
+            >
+              <ClipboardList className="h-4 w-4" strokeWidth={1.75} />
+              <span className="hidden sm:inline">Registrations</span>
             </Link>
             {editable && (
               <InviteScorer
@@ -124,7 +141,8 @@ export default async function DivisionPage({
           </div>
         </div>
 
-        <nav className="mb-6 flex gap-1 border-b border-slate-200">
+        {/* v3/02 §3.3: tabs scroll horizontally with an edge fade — never wrap. */}
+        <nav className="scroll-x scroll-x-fade mb-6 flex gap-1 whitespace-nowrap border-b border-slate-200">
           {TABS.map((t) => (
             <Link
               key={t}
@@ -198,12 +216,13 @@ export default async function DivisionPage({
                       metricSpecs={sportModule.metrics as MetricSpecLike[]}
                       cascade={cascade}
                       entrantNames={entrantNames}
+                      entrantLogos={entrantLogos}
                       caption={caption}
                     />
                   </div>
                 ))}
                 {/* Cascade trace (doc 05 §4): the exact tie-break order in force. */}
-                <p className="mt-3 border-t border-slate-100 pt-3 text-xs text-slate-400">
+                <p className="mt-3 border-t border-slate-100 pt-3 text-xs text-slate-500">
                   Tie-break cascade:{" "}
                   {cascade.map((key, i) => (
                     <span key={key}>
@@ -232,11 +251,4 @@ export default async function DivisionPage({
       </main>
     </>
   );
-}
-
-function divisionStatusStyle(status: string): string {
-  if (status === "active") return "bg-amber-100 text-amber-700";
-  if (status === "scheduled") return "bg-sky-100 text-sky-700";
-  if (status === "completed") return "bg-emerald-100 text-emerald-700";
-  return "bg-slate-100 text-slate-600";
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -50,6 +50,10 @@
 
 html,
 body {
+  /* v3/02 pattern 4: no page-level horizontal scroll, ever. `clip` (not
+     `hidden`) so position:sticky descendants keep working; wide widgets
+     scroll inside their own .scroll-x containers. */
+  overflow-x: clip;
   background:
     radial-gradient(1100px 600px at 90% -10%, rgba(168, 85, 247, 0.14), transparent),
     radial-gradient(800px 500px at -10% 0%, rgba(124, 58, 237, 0.1), transparent),
@@ -131,12 +135,28 @@ body {
   animation: live-pulse 2s ease-in-out infinite;
 }
 
+/* Live status chip pulse (v3/03 §1) — violet system chip, not the green
+   slideshow pulse above. */
+@keyframes chip-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.55);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(255, 255, 255, 0);
+  }
+}
+.chip-pulse-dot {
+  animation: chip-pulse 2s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-slide-in,
   .animate-trophy,
   .animate-slide-progress,
   .animate-blob,
-  .animate-live-pulse {
+  .animate-live-pulse,
+  .chip-pulse-dot {
     animation: none;
   }
 }
@@ -157,7 +177,9 @@ body {
   }
 
   .label {
-    @apply mb-1 block text-xs font-medium text-purple-700/70;
+    /* Full-strength purple-700: the /70 opacity variant failed WCAG AA
+       contrast (axe gate, v3/11 gap 11). */
+    @apply mb-1 block text-xs font-medium text-purple-700;
   }
 
   .input,
@@ -186,11 +208,22 @@ body {
     @apply rounded-full bg-purple-50 px-2.5 py-0.5 text-xs capitalize text-purple-700 ring-1 ring-inset ring-purple-100;
   }
 
+  /* Dialogs are bottom sheets under `sm` (v3/02 pattern 3): full-width,
+     drag handle, internal scroll; centered modal from `sm` up. */
   .modal-overlay {
-    @apply fixed inset-0 z-50 flex items-center justify-center bg-purple-950/30 p-4 backdrop-blur-sm;
+    @apply fixed inset-0 z-50 flex items-end justify-center bg-purple-950/30 backdrop-blur-sm sm:items-center sm:p-4;
   }
   .modal {
-    @apply w-full max-w-md rounded-2xl border border-purple-100 bg-white p-6 shadow-2xl;
+    @apply w-full max-w-none rounded-t-2xl border border-purple-100 bg-white p-6 shadow-2xl sm:max-w-md sm:rounded-2xl;
+    padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  }
+  @media (min-width: 40rem) {
+    .modal {
+      padding-bottom: 1.5rem;
+    }
+  }
+  .sheet-handle {
+    @apply mx-auto mb-4 block h-1 w-10 rounded-full bg-slate-200 sm:hidden;
   }
 
   .table {
@@ -211,4 +244,60 @@ body {
   .table tbody tr:nth-child(even) {
     @apply bg-purple-50/30;
   }
+
+  /* ── v3/02 mobile primitives ── */
+
+  /* Pattern 4: anything genuinely wide opts into its own scroll container
+     with a right-edge fade affordance so cut-off content reads as scrollable. */
+  .scroll-x {
+    @apply overflow-x-auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .scroll-x-fade {
+    @apply relative;
+  }
+  .scroll-x-fade::after {
+    content: "";
+    @apply pointer-events-none absolute inset-y-0 right-0 w-6;
+    background: linear-gradient(to left, var(--background), transparent);
+  }
+
+  /* Pattern 2: primary page action docks to a safe-area-aware bottom bar on
+     phones, renders inline on desktop. */
+  .bottom-bar {
+    @apply fixed inset-x-0 bottom-0 z-40 border-t border-purple-100 bg-white/95 px-4 pt-3 backdrop-blur sm:static sm:z-auto sm:border-0 sm:bg-transparent sm:p-0 sm:backdrop-blur-none;
+    padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));
+  }
+  @media (min-width: 40rem) {
+    .bottom-bar {
+      padding-bottom: 0;
+    }
+  }
+  /* Spacer so content never hides behind the fixed bar. */
+  .bottom-bar-spacer {
+    @apply h-20 sm:hidden;
+  }
+}
+
+/* Pattern 5: ≥16px input font under `sm` blocks iOS zoom-on-focus. Element
+   selector on purpose — covers every form control, not just .input users. */
+@media (max-width: 39.99rem) {
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+
+/* Compact list mode (v3/03 §2 toggle): same card DOM, quieter rendering —
+   secondary lines collapse, the card reads as a row. */
+.ecard-list .ecard {
+  @apply px-4 py-2.5;
+}
+.ecard-list .ecard .ecard-meta,
+.ecard-list .ecard .ecard-progress {
+  display: none;
+}
+.ecard-list .ecard .ecard-next {
+  @apply mt-0.5;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AnalyticsBootstrap } from "@/components/analytics-bootstrap";
 import { CookieConsent } from "@/components/cookie-consent";
+import { ConfirmProvider } from "@/components/ui/confirm-provider";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({
@@ -54,7 +55,9 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full font-sans">
-        {children}
+        {/* Confirmation dialogs everywhere (v3/03 §3) — console and public
+            trees both have destructive actions. */}
+        <ConfirmProvider>{children}</ConfirmProvider>
         {/* Identifies the logged-in user for PostHog; a no-op for anon traffic.
             Suspense keeps its DB reads off the page's render-blocking path. */}
         <Suspense fallback={null}>

--- a/apps/web/src/app/legal/cookie-policy/page.tsx
+++ b/apps/web/src/app/legal/cookie-policy/page.tsx
@@ -23,7 +23,7 @@ export default function CookiePolicyPage() {
 
           <section>
             <h2 className="mb-2 text-lg font-semibold text-slate-800">Cookies we set</h2>
-            <div className="overflow-hidden rounded-xl border border-purple-100 bg-white">
+            <div className="scroll-x scroll-x-fade rounded-xl border border-purple-100 bg-white">
               <table className="table w-full">
                 <thead>
                   <tr>

--- a/apps/web/src/app/legal/sub-processors/page.tsx
+++ b/apps/web/src/app/legal/sub-processors/page.tsx
@@ -46,7 +46,7 @@ export default function SubProcessorsPage() {
           and operate under equivalent data protection standards.
         </p>
 
-        <div className="overflow-hidden rounded-2xl border border-purple-100 bg-white">
+        <div className="scroll-x scroll-x-fade rounded-2xl border border-purple-100 bg-white">
           <table className="table w-full">
             <thead>
               <tr>

--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -129,7 +129,7 @@ export default function PricingPage() {
           </div>
 
           {/* Feature comparison table */}
-          <div className="mt-12 overflow-hidden rounded-2xl border border-purple-100 bg-white">
+          <div className="scroll-x scroll-x-fade mt-12 rounded-2xl border border-purple-100 bg-white">
             <table className="table w-full">
               <thead>
                 <tr>

--- a/apps/web/src/app/settings/billing/page.tsx
+++ b/apps/web/src/app/settings/billing/page.tsx
@@ -115,7 +115,7 @@ export default async function BillingPage({
 
         {/* Current plan */}
         <section className="card mb-6 p-5">
-          <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-400">
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-600">
             Current plan
           </h2>
           <div className="flex items-center justify-between gap-4">
@@ -157,7 +157,7 @@ export default async function BillingPage({
 
         {/* Usage */}
         <section className="card mb-6 p-5">
-          <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-400">
+          <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-600">
             Usage
           </h2>
           <div className="space-y-3">
@@ -183,10 +183,11 @@ export default async function BillingPage({
         {/* Upgrade / plan comparison */}
         {!isPro && isOwner && (
           <section className="card p-5">
-            <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-400">
+            <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-600">
               Upgrade to Pro
             </h2>
-            <div className="mb-5 grid grid-cols-2 gap-3 text-sm">
+            {/* Stacks under `xs` — two 160px columns don't fit a 375px phone. */}
+            <div className="mb-5 grid gap-3 text-sm xs:grid-cols-2">
               <div className="rounded-xl border border-slate-200 p-4">
                 <p className="mb-1 font-semibold text-slate-700">Community</p>
                 <p className="text-2xl font-bold text-slate-800">
@@ -219,7 +220,7 @@ export default async function BillingPage({
                 </ul>
               </div>
             </div>
-            <p className="mb-4 text-xs text-slate-400">
+            <p className="mb-4 text-xs text-slate-500">
               14-day free trial · no card required · cancel anytime
             </p>
             <div className="flex flex-wrap gap-3">
@@ -251,7 +252,7 @@ function UsageRow({
       <div className="flex justify-between text-sm">
         <span className="text-slate-600">
           {label}
-          {note && <span className="ml-1 text-xs text-slate-400">({note})</span>}
+          {note && <span className="ml-1 text-xs text-slate-500">({note})</span>}
         </span>
         <span className="font-medium text-slate-800">
           {current !== null ? `${current} / ` : ""}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -49,8 +49,8 @@ function SectionHeader({ icon: Icon, children, action }: {
 function SubSection({ icon: Icon, label }: { icon: LucideIcon; label: string }) {
   return (
     <div className="mb-2 flex items-center gap-1.5">
-      <Icon className="h-3.5 w-3.5 text-slate-400" strokeWidth={1.75} />
-      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{label}</p>
+      <Icon className="h-3.5 w-3.5 text-slate-500" strokeWidth={1.75} />
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</p>
     </div>
   );
 }
@@ -97,7 +97,8 @@ export default async function SettingsPage({
   const canBrand =
     tab === "organization" ? await hasFeature(active.id, "branding") : false;
 
-  // Platform API tab (doc 10 §1): api.access = Pro, api.write = Business.
+  // Platform API tab (doc 10 §1): api.access = Pro; api.write sits above Pro
+  // (hidden plan key — v3/03 §6 scrub).
   let hasApiAccess = false;
   let hasApiWrite = false;
   if (tab === "api") {
@@ -135,29 +136,30 @@ export default async function SettingsPage({
   return (
     <>
       <Nav />
-      <div className="mx-auto max-w-5xl px-4 py-8">
-        <div className="flex gap-8">
+      <div className="mx-auto max-w-5xl px-4 py-4 md:py-8">
+        <div className="flex flex-col gap-4 md:flex-row md:gap-8">
 
-          {/* ── Left sidebar ── */}
-          <aside className="w-44 shrink-0">
-            <p className="mb-3 px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+          {/* ── Sidebar on desktop; sticky scrollable tab row on phones
+                 (v3/02 §3.1 — no more desktop-width rows in one long scroll). ── */}
+          <aside className="w-full md:w-44 md:shrink-0">
+            <p className="mb-3 hidden px-3 text-[11px] font-semibold uppercase tracking-wider text-slate-500 md:block">
               Settings
             </p>
-            <nav className="space-y-0.5">
+            <nav className="scroll-x scroll-x-fade sticky top-0 z-30 -mx-4 flex gap-1 whitespace-nowrap bg-[var(--background)]/90 px-4 py-2 backdrop-blur md:static md:z-auto md:mx-0 md:block md:space-y-0.5 md:bg-transparent md:p-0 md:backdrop-blur-none">
               {NAV_ITEMS.map(({ tab: t, label, icon: Icon }) => {
                 const active = tab === t;
                 return (
                   <Link
                     key={t}
                     href={`/settings?tab=${t}`}
-                    className={`flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition ${
+                    className={`flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition ${
                       active
                         ? "bg-purple-100 font-medium text-purple-800"
                         : "text-slate-600 hover:bg-purple-50 hover:text-purple-700"
                     }`}
                   >
                     <Icon
-                      className={`h-4 w-4 shrink-0 ${active ? "text-purple-600" : "text-slate-400"}`}
+                      className={`h-4 w-4 shrink-0 ${active ? "text-purple-600" : "text-slate-500"}`}
                       strokeWidth={1.75}
                     />
                     {label}
@@ -167,16 +169,16 @@ export default async function SettingsPage({
               {/* Plan & billing is its own route (owns Stripe reconciliation). */}
               <Link
                 href={BILLING_NAV.href}
-                className="flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-slate-600 transition hover:bg-purple-50 hover:text-purple-700"
+                className="flex shrink-0 items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-slate-600 transition hover:bg-purple-50 hover:text-purple-700"
               >
-                <BILLING_NAV.icon className="h-4 w-4 shrink-0 text-slate-400" strokeWidth={1.75} />
+                <BILLING_NAV.icon className="h-4 w-4 shrink-0 text-slate-500" strokeWidth={1.75} />
                 {BILLING_NAV.label}
               </Link>
             </nav>
-            <div className="my-4 border-t border-purple-100" />
+            <div className="my-4 hidden border-t border-purple-100 md:block" />
             <Link
               href="/dashboard"
-              className="block rounded-lg px-3 py-2 text-sm text-slate-400 transition hover:bg-slate-50 hover:text-slate-600"
+              className="hidden rounded-lg px-3 py-2 text-sm text-slate-500 transition hover:bg-slate-50 hover:text-slate-600 md:block"
             >
               ← Dashboard
             </Link>
@@ -196,7 +198,7 @@ export default async function SettingsPage({
                   </span>
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-semibold text-slate-800">{active.name}</p>
-                    <p className="truncate font-mono text-xs text-purple-400">{active.slug}</p>
+                    <p className="truncate font-mono text-xs text-purple-600">{active.slug}</p>
                   </div>
                   <span className={`badge ${ROLE_BADGE[active.role]}`}>{active.role}</span>
                 </div>
@@ -221,7 +223,7 @@ export default async function SettingsPage({
                         }
                       />
                     ) : (
-                      <p className="flex items-center gap-2 text-sm text-slate-400">
+                      <p className="flex items-center gap-2 text-sm text-slate-500">
                         <PlanBadge feature="branding" />
                         Org logo requires{" "}
                         <Link href="/settings/billing" className="text-purple-600 underline">
@@ -238,7 +240,7 @@ export default async function SettingsPage({
                     {canBrand ? (
                       <OrgBrandColor orgId={active.id} initialBranding={active.branding} />
                     ) : (
-                      <p className="flex items-center gap-2 text-sm text-slate-400">
+                      <p className="flex items-center gap-2 text-sm text-slate-500">
                         <PlanBadge feature="branding" />
                         Brand color requires{" "}
                         <Link href="/settings/billing" className="text-purple-600 underline">
@@ -286,13 +288,13 @@ export default async function SettingsPage({
               <section className="card p-6">
                 <SectionHeader icon={KeyRound}>Platform API</SectionHeader>
                 {!canEdit ? (
-                  <p className="text-sm text-slate-400">
+                  <p className="text-sm text-slate-500">
                     Only owners and admins can manage API keys.
                   </p>
                 ) : hasApiAccess ? (
                   <ApiKeysPanel orgId={active.id} canWriteScope={hasApiWrite} />
                 ) : (
-                  <p className="flex items-center gap-2 text-sm text-slate-400">
+                  <p className="flex items-center gap-2 text-sm text-slate-500">
                     <PlanBadge feature="api.access" />
                     Platform API keys require{" "}
                     <Link href="/settings/billing" className="text-purple-600 underline">
@@ -327,7 +329,7 @@ export default async function SettingsPage({
                     Email: <span className="font-medium text-slate-700">{user.email}</span>
                   </p>
                   <p className="text-sm text-slate-500">
-                    Account ID: <span className="font-mono text-xs text-purple-400">{user.id}</span>
+                    Account ID: <span className="font-mono text-xs text-purple-600">{user.id}</span>
                   </p>
                 </section>
 
@@ -387,7 +389,7 @@ export default async function SettingsPage({
                             <div className="flex items-center justify-between">
                               <div>
                                 <p className="font-medium text-slate-800">{org.name}</p>
-                                <p className="text-xs text-slate-400 font-mono">{org.slug}</p>
+                                <p className="text-xs text-slate-500 font-mono">{org.slug}</p>
                               </div>
                               <span
                                 className={`badge text-xs ${
@@ -411,7 +413,7 @@ export default async function SettingsPage({
                               <LeaveOrgButton orgId={org.id} orgName={org.name} />
                             )}
                             {org.role === "owner" && members.length === 1 && (
-                              <p className="text-xs text-slate-400">
+                              <p className="text-xs text-slate-500">
                                 Sole owner — invite others before you can transfer or leave.
                               </p>
                             )}

--- a/apps/web/src/components/account-actions.tsx
+++ b/apps/web/src/components/account-actions.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { msg } from "@/lib/messages";
 
 // ---------------------------------------------------------------------------
 // Display name form
@@ -145,11 +147,18 @@ export function ChangeEmailForm({ currentEmail }: { currentEmail: string }) {
 
 export function LeaveOrgButton({ orgId, orgName }: { orgId: string; orgName: string }) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
   async function handleLeave() {
-    if (!confirm(`Leave "${orgName}"? You will lose access immediately.`)) return;
+    const ok = await confirm({
+      title: msg("confirm.leaveOrg.title"),
+      body: msg("confirm.leaveOrg.body", { name: orgName }),
+      confirmLabel: msg("confirm.leaveOrg.label"),
+      tone: "danger",
+    });
+    if (!ok) return;
     setLoading(true);
     setError("");
     try {
@@ -192,6 +201,7 @@ export function TransferOwnerForm({
   members: { user_id: string; display_name: string; email: string; role: string }[];
 }) {
   const router = useRouter();
+  const confirm = useConfirm();
   const [newOwnerId, setNewOwnerId] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -201,7 +211,13 @@ export function TransferOwnerForm({
 
   async function handleTransfer(e: React.FormEvent) {
     e.preventDefault();
-    if (!confirm("Transfer ownership? You will become an admin and cannot undo this yourself.")) return;
+    const ok = await confirm({
+      title: msg("confirm.transferOwner.title"),
+      body: msg("confirm.transferOwner.body"),
+      confirmLabel: msg("confirm.transferOwner.label"),
+      tone: "danger",
+    });
+    if (!ok) return;
     setLoading(true);
     setError("");
     try {

--- a/apps/web/src/components/api-keys.tsx
+++ b/apps/web/src/components/api-keys.tsx
@@ -3,6 +3,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { Copy, Check, KeyRound } from "lucide-react";
 import { PlanBadge } from "@/components/plan-badge";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { Tip } from "@/components/ui/tip";
+import { msg } from "@/lib/messages";
 
 interface ApiKeyRow {
   id: string;
@@ -45,9 +48,10 @@ export function ApiKeysPanel({
   canWriteScope,
 }: {
   orgId: string;
-  /** api.write entitlement (Business): allows minting write-scoped keys. */
+  /** api.write entitlement (above Pro): allows minting write-scoped keys. */
   canWriteScope: boolean;
 }) {
+  const confirmDialog = useConfirm();
   const [keys, setKeys] = useState<ApiKeyRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState("");
@@ -90,9 +94,13 @@ export function ApiKeysPanel({
   }
 
   async function revoke(key: ApiKeyRow) {
-    if (!window.confirm(`Revoke "${key.name}"? Integrations using it will stop working immediately.`)) {
-      return;
-    }
+    const ok = await confirmDialog({
+      title: msg("confirm.revokeKey.title"),
+      body: msg("confirm.revokeKey.body", { name: key.name }),
+      confirmLabel: msg("confirm.revokeKey.label"),
+      tone: "danger",
+    });
+    if (!ok) return;
     setError(null);
     try {
       await v1(`/api/v1/orgs/${orgId}/api-keys/${key.id}`, { method: "DELETE" });
@@ -175,10 +183,11 @@ export function ApiKeysPanel({
             disabled={!canWriteScope}
           />
           Allow writes
+          <Tip id="api.key-scopes" />
           {!canWriteScope && (
             <>
               <PlanBadge feature="api.write" />
-              <span className="text-xs text-slate-400">(read-only on Pro)</span>
+              <span className="text-xs text-slate-500">(read-only on Pro)</span>
             </>
           )}
         </label>
@@ -186,9 +195,9 @@ export function ApiKeysPanel({
 
       {/* Active keys */}
       {keys === null ? (
-        <p className="text-sm text-slate-400">Loading…</p>
+        <p className="text-sm text-slate-500">Loading…</p>
       ) : active.length === 0 ? (
-        <p className="text-sm text-slate-400">
+        <p className="text-sm text-slate-500">
           No API keys yet. Create one to call the platform API with{" "}
           <code className="font-mono text-xs">Authorization: Bearer sc_…</code>
         </p>
@@ -199,7 +208,7 @@ export function ApiKeysPanel({
               <KeyRound className="h-4 w-4 shrink-0 text-purple-400" strokeWidth={1.75} />
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-slate-800">{key.name}</p>
-                <p className="text-xs text-slate-400">
+                <p className="text-xs text-slate-500">
                   {key.scopes.join(" + ")} · created {fmt(key.created_at)} · last used{" "}
                   {fmt(key.last_used_at)}
                 </p>
@@ -217,7 +226,7 @@ export function ApiKeysPanel({
       )}
 
       {revoked.length > 0 && (
-        <details className="text-sm text-slate-400">
+        <details className="text-sm text-slate-500">
           <summary className="cursor-pointer">Revoked keys ({revoked.length})</summary>
           <ul className="mt-2 space-y-1">
             {revoked.map((key) => (

--- a/apps/web/src/components/billing-actions.tsx
+++ b/apps/web/src/components/billing-actions.tsx
@@ -5,6 +5,8 @@ import { loadStripe } from "@stripe/stripe-js";
 import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe-js";
 import { track, EVENTS } from "@/lib/analytics";
 import { fetchCheckoutClientSecret } from "@/lib/billing-checkout-client";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { msg } from "@/lib/messages";
 
 // Load Stripe.js once for the whole app (publishable key is public).
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY ?? "");
@@ -41,9 +43,14 @@ export function UpgradeButton({
   if (clientSecret) {
     return (
       <div className="mt-2">
-        <EmbeddedCheckoutProvider stripe={stripePromise} options={{ clientSecret }}>
-          <EmbeddedCheckout />
-        </EmbeddedCheckoutProvider>
+        {/* Full-bleed at phone widths (v3/02 §3.2 — the reported 375px break):
+            escape the card p-5 + main px-4 so the Stripe iframe gets the full
+            viewport; no fixed min-width parent. */}
+        <div className="-mx-9 w-auto sm:mx-0">
+          <EmbeddedCheckoutProvider stripe={stripePromise} options={{ clientSecret }}>
+            <EmbeddedCheckout />
+          </EmbeddedCheckoutProvider>
+        </div>
         <button
           type="button"
           onClick={() => setClientSecret(null)}
@@ -70,11 +77,18 @@ export function UpgradeButton({
 }
 
 export function DowngradeButton() {
+  const confirm = useConfirm();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function go() {
-    if (!confirm("Downgrade to Community? Pro features become unavailable immediately.")) return;
+    const ok = await confirm({
+      title: msg("confirm.downgrade.title"),
+      body: msg("confirm.downgrade.body"),
+      confirmLabel: msg("confirm.downgrade.label"),
+      tone: "danger",
+    });
+    if (!ok) return;
     setLoading(true);
     setError(null);
     const res = await fetch("/api/billing/downgrade", {

--- a/apps/web/src/components/modal.tsx
+++ b/apps/web/src/components/modal.tsx
@@ -22,16 +22,18 @@ export function Modal({
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  const maxW = size === "lg" ? "max-w-2xl" : "max-w-md";
+  const maxW = size === "lg" ? "sm:max-w-2xl" : "sm:max-w-md";
 
   return (
     <div className="modal-overlay" onClick={onClose}>
+      {/* Bottom sheet under `sm`, centered modal above (v3/02 pattern 3). */}
       <div
-        className={`flex max-h-[85vh] w-full ${maxW} flex-col rounded-2xl border border-purple-100 bg-white p-6 shadow-2xl`}
+        className={`flex max-h-[85vh] w-full ${maxW} flex-col rounded-t-2xl border border-purple-100 bg-white p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] shadow-2xl sm:rounded-2xl sm:pb-6`}
         role="dialog"
         aria-modal="true"
         onClick={(e) => e.stopPropagation()}
       >
+        <span className="sheet-handle" aria-hidden />
         <div className="mb-3 flex shrink-0 items-center justify-between">
           <h3 className="text-lg font-semibold text-purple-900">{title}</h3>
           <button

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -68,8 +68,11 @@ export async function Nav() {
         {user ? (
           <div className="flex items-center gap-1">
             <nav className="flex items-center gap-0.5">
+              {/* Labels collapse to icons under `sm` — aria-label keeps the
+                  accessible name (axe link-name, v3/11 gap 11). */}
               <Link
                 href="/dashboard"
+                aria-label="Dashboard"
                 className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
               >
                 <LayoutDashboard className="h-4 w-4" strokeWidth={1.75} />
@@ -77,6 +80,7 @@ export async function Nav() {
               </Link>
               <Link
                 href="/directory"
+                aria-label="Directory"
                 className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
               >
                 <Users className="h-4 w-4" strokeWidth={1.75} />
@@ -84,6 +88,7 @@ export async function Nav() {
               </Link>
               <Link
                 href="/settings"
+                aria-label="Settings"
                 className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
               >
                 <Settings className="h-4 w-4" strokeWidth={1.75} />

--- a/apps/web/src/components/org-payment-instructions.tsx
+++ b/apps/web/src/components/org-payment-instructions.tsx
@@ -42,7 +42,7 @@ export function OrgPaymentInstructions({
   return (
     <label className="block">
       <span className="label">Cash / bank transfer instructions</span>
-      <p className="mb-2 text-xs text-slate-400">
+      <p className="mb-2 text-xs text-slate-500">
         Shown to registrants of paid divisions and included in their confirmation email.
         e.g. bank name, account number, sort code / IBAN, reference to use, or &ldquo;pay cash on
         the day&rdquo;.

--- a/apps/web/src/components/org-switcher.tsx
+++ b/apps/web/src/components/org-switcher.tsx
@@ -82,7 +82,7 @@ export function OrgSwitcher({
                         Active
                       </span>
                     ) : busy === o.id ? (
-                      <span className="text-xs text-slate-400">Switching…</span>
+                      <span className="text-xs text-slate-500">Switching…</span>
                     ) : null}
                   </span>
                 </button>

--- a/apps/web/src/components/org-team.tsx
+++ b/apps/web/src/components/org-team.tsx
@@ -111,30 +111,32 @@ export function OrgTeam({
       )}
 
       {/* Members */}
-      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-purple-400">
+      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-purple-600">
         Members
       </h4>
       {!members ? (
-        <p className="text-sm text-slate-400">Loading…</p>
+        <p className="text-sm text-slate-500">Loading…</p>
       ) : (
         <ul className="space-y-2">
           {members.map((m) => (
             <li
               key={m.user_id}
-              className="flex items-center gap-3 rounded-lg border border-purple-50 bg-white px-3 py-2"
+              className="flex flex-wrap items-center gap-3 rounded-lg border border-purple-50 bg-white px-3 py-2"
             >
               <Avatar name={m.display_name} src={m.avatar_url} size={32} />
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-slate-800">
                   {m.display_name}
                   {m.user_id === currentUserId && (
-                    <span className="ml-1 text-xs text-slate-400">(you)</span>
+                    <span className="ml-1 text-xs text-slate-500">(you)</span>
                   )}
                 </p>
-                <p className="truncate text-xs text-slate-400">{m.email}</p>
+                <p className="truncate text-xs text-slate-500">{m.email}</p>
               </div>
               {isOwner && m.user_id !== currentUserId ? (
-                <div className="flex shrink-0 items-center gap-2">
+                /* Actions wrap to their own full-width line on phones —
+                   thumb-sized targets instead of a cramped row (v3/02 §3.1). */
+                <div className="flex w-full items-center justify-end gap-2 sm:w-auto sm:shrink-0">
                   <select
                     value={m.role}
                     disabled={busy}
@@ -170,7 +172,7 @@ export function OrgTeam({
       {/* Invite links */}
       {isEditor && (
         <>
-          <h4 className="mb-2 mt-6 text-xs font-semibold uppercase tracking-wide text-purple-400">
+          <h4 className="mb-2 mt-6 text-xs font-semibold uppercase tracking-wide text-purple-600">
             Invite links
           </h4>
           <div className="flex flex-wrap items-end gap-2">
@@ -191,7 +193,7 @@ export function OrgTeam({
             <button
               onClick={createInvite}
               disabled={busy}
-              className="btn btn-primary"
+              className="btn btn-primary w-full sm:w-auto"
             >
               + Create link
             </button>
@@ -209,7 +211,7 @@ export function OrgTeam({
                   </span>
                   <InviteLink token={i.token} />
                   {i.expires_at && (
-                    <span className="shrink-0 text-xs text-slate-400">
+                    <span className="shrink-0 text-xs text-slate-500">
                       expires <ClientTime value={i.expires_at} mode="time" />
                     </span>
                   )}

--- a/apps/web/src/components/plan-badge.tsx
+++ b/apps/web/src/components/plan-badge.tsx
@@ -1,5 +1,9 @@
 // Tiny plan pill shown on any gated button/panel so users see the required
 // tier before they click (doc 10 §3). Server- and client-safe (no hooks).
+//
+// v3/03 §6 plan scrub: `business` survives only as a hidden DB plan key
+// (grandfathering / enterprise deals) — the UI never names it. Features that
+// sit above Pro render the generic "Upgrade" pill; everything else says Pro.
 import { featurePlan, type PaidPlan } from "@/lib/feature-copy";
 
 const STYLE: Record<PaidPlan, string> = {
@@ -9,7 +13,7 @@ const STYLE: Record<PaidPlan, string> = {
 
 const LABEL: Record<PaidPlan, string> = {
   pro: "Pro ✦",
-  business: "Business ◆",
+  business: "Upgrade ◆",
 };
 
 export function PlanBadge({ plan, feature }: { plan?: PaidPlan; feature?: string }) {

--- a/apps/web/src/components/public-site/registration-actions.tsx
+++ b/apps/web/src/components/public-site/registration-actions.tsx
@@ -5,6 +5,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1 } from "@/lib/client-v1";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { msg } from "@/lib/messages";
 
 export function RegistrationActions({
   registrationId,
@@ -18,6 +20,7 @@ export function RegistrationActions({
   paymentDue: boolean;
 }) {
   const router = useRouter();
+  const confirmDialog = useConfirm();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -37,7 +40,13 @@ export function RegistrationActions({
   }
 
   async function withdraw() {
-    if (!window.confirm("Withdraw this registration? This frees your spot.")) return;
+    const ok = await confirmDialog({
+      title: msg("confirm.withdrawOwnRegistration.title"),
+      body: msg("confirm.withdrawOwnRegistration.body"),
+      confirmLabel: msg("confirm.withdrawOwnRegistration.label"),
+      tone: "danger",
+    });
+    if (!ok) return;
     setBusy(true);
     setError(null);
     try {

--- a/apps/web/src/components/public-site/standings-table.tsx
+++ b/apps/web/src/components/public-site/standings-table.tsx
@@ -13,16 +13,27 @@ import {
   formatMetric,
   type MetricSpecLike,
 } from "@/lib/public-site";
+import { EntityLogo } from "@/components/ui/entity-logo";
 
 interface Props {
   rows: StandingsRow[];
   metricSpecs: MetricSpecLike[];
   cascade: readonly string[];
   entrantNames: Record<string, string>;
+  /** entrant_id → badge URL (v3/03 §5 placement matrix). Omit = no badge
+   *  column at all; null values fall back to initials via EntityLogo. */
+  entrantLogos?: Record<string, string | null>;
   caption?: string;
 }
 
-export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, caption }: Props) {
+export function StandingsTable({
+  rows,
+  metricSpecs,
+  cascade,
+  entrantNames,
+  entrantLogos,
+  caption,
+}: Props) {
   const columns = standingsColumns(metricSpecs, cascade, rows, DERIVED_METRICS);
   const ranked = [...rows].sort((a, b) => (a.rank ?? 99) - (b.rank ?? 99));
   // Podium chips are fixed vocabulary (gold/silver/bronze) — deliberately NOT
@@ -53,7 +64,7 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
         ) : null}
         <thead>
           <tr className="border-b border-zinc-200 text-left text-[11px] uppercase tracking-wider text-ink-muted">
-            <th scope="col" className="w-12 py-2.5 pl-4 pr-2 font-semibold">#</th>
+            <th scope="col" className="sticky left-0 z-10 w-12 bg-surface py-2.5 pl-4 pr-2 font-semibold">#</th>
             <th scope="col" className="py-2.5 pr-3 font-semibold">Team</th>
             {columns.map((col) => (
               <th key={col.key} scope="col" className="px-2.5 py-2.5 text-right font-semibold last:pr-4">
@@ -70,7 +81,13 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
                 row.rank === 1 ? "bg-amber-50/60" : ""
               }`}
             >
-              <td className="py-2.5 pl-4 pr-2 tabular-nums">
+              {/* Rank column frozen inside the scroll container (v3/02 §3.3)
+                  — solid bg so scrolled columns pass underneath, not through. */}
+              <td
+                className={`sticky left-0 z-10 py-2.5 pl-4 pr-2 tabular-nums ${
+                  row.rank === 1 ? "bg-amber-50" : "bg-surface"
+                }`}
+              >
                 {row.tieBreak ? (
                   <details className="relative inline-block">
                     <summary className="inline-flex cursor-help list-none items-start whitespace-nowrap">
@@ -93,6 +110,14 @@ export function StandingsTable({ rows, metricSpecs, cascade, entrantNames, capti
                 )}
               </td>
               <th scope="row" className="py-2.5 pr-3 text-left font-medium text-ink">
+                {entrantLogos && (
+                  <EntityLogo
+                    src={entrantLogos[row.entrantId]}
+                    name={entrantNames[row.entrantId] ?? ""}
+                    size={20}
+                    className="mr-2"
+                  />
+                )}
                 {entrantNames[row.entrantId] ?? row.entrantId}
               </th>
               {columns.map((col) => (

--- a/apps/web/src/components/ui/action-bar.tsx
+++ b/apps/web/src/components/ui/action-bar.tsx
@@ -1,0 +1,18 @@
+// Sticky bottom action bar (v3/02 pattern 2): the page's primary action
+// docks above the thumb on phones (safe-area aware) and renders inline on
+// desktop. Wrap the existing button(s); add nothing else — one primary
+// action per page.
+import type { ReactNode } from "react";
+
+export function ActionBar({ children, className = "" }: { children: ReactNode; className?: string }) {
+  return (
+    <>
+      <div className={`bottom-bar ${className}`}>
+        <div className="flex items-center justify-end gap-2 [&>*]:flex-1 sm:[&>*]:flex-none">
+          {children}
+        </div>
+      </div>
+      <div className="bottom-bar-spacer" aria-hidden />
+    </>
+  );
+}

--- a/apps/web/src/components/ui/card-menu.tsx
+++ b/apps/web/src/components/ui/card-menu.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+// ⋯ overflow menu for EntityCard (v3/03 §1): card actions live here so the
+// card body stays one clean click target. Link items only — mutating actions
+// belong on the page they navigate to.
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { msg } from "@/lib/messages";
+
+export interface CardMenuItem {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+export function CardMenu({ items, name }: { items: CardMenuItem[]; name: string }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`${msg("card.actions")}: ${name}`}
+        onClick={() => setOpen((v) => !v)}
+        className="grid h-8 w-8 place-items-center rounded-lg text-slate-400 transition hover:bg-purple-50 hover:text-purple-700"
+      >
+        <MoreHorizontal className="h-4 w-4" strokeWidth={2} />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-9 z-20 w-44 rounded-xl border border-purple-100 bg-white py-1 shadow-lg"
+        >
+          {items.map((item) => (
+            <Link
+              key={item.href}
+              role="menuitem"
+              href={item.href}
+              target={item.external ? "_blank" : undefined}
+              onClick={() => setOpen(false)}
+              className="block px-3 py-2 text-sm text-slate-700 hover:bg-purple-50 hover:text-purple-800"
+            >
+              {item.label}
+              {item.external ? " ↗" : ""}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/confirm-provider.tsx
+++ b/apps/web/src/components/ui/confirm-provider.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+// Promise-based confirmation (v3/03 §3) — the ONE replacement for
+// window.confirm. `const ok = await confirm({...})` from any client
+// component; a single provider in the root layout renders the dialog:
+// centered modal ≥sm, bottom sheet with a drag handle under sm (v3/02
+// pattern 3). tone:"danger" requires an explicit click (Enter never
+// submits); `typedName` keeps the button disabled until the user types the
+// resource name exactly. Focus-trapped, Esc cancels, focus restored.
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { msg } from "@/lib/messages";
+import { isConfirmArmed } from "@/lib/typed-confirm";
+
+export interface ConfirmOptions {
+  title: string;
+  body: ReactNode;
+  confirmLabel: string;
+  tone?: "default" | "danger";
+  /** Require typing this exact string before the confirm button arms. */
+  typedName?: string;
+}
+
+type ConfirmFn = (opts: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFn | null>(null);
+
+export function useConfirm(): ConfirmFn {
+  const fn = useContext(ConfirmContext);
+  if (!fn) throw new Error("useConfirm needs <ConfirmProvider> in the tree");
+  return fn;
+}
+
+interface Pending {
+  opts: ConfirmOptions;
+  resolve: (ok: boolean) => void;
+}
+
+export function ConfirmProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<Pending | null>(null);
+
+  const confirm = useCallback<ConfirmFn>((opts) => {
+    return new Promise<boolean>((resolve) => {
+      // One dialog at a time: a second request cancels the first.
+      setPending((prev) => {
+        prev?.resolve(false);
+        return { opts, resolve };
+      });
+    });
+  }, []);
+
+  const settle = useCallback(
+    (ok: boolean) => {
+      setPending((prev) => {
+        prev?.resolve(ok);
+        return null;
+      });
+    },
+    [],
+  );
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {pending && <ConfirmSurface key={pending.opts.title} opts={pending.opts} settle={settle} />}
+    </ConfirmContext.Provider>
+  );
+}
+
+/** Split the typed-challenge copy around its {name} slot so the name can
+ *  render in mono without the message layer knowing about JSX. */
+function typedInstruction(): { before: string; after: string } {
+  const [before = "", after = ""] = msg("confirm.typed.instruction").split("{name}");
+  return { before, after };
+}
+
+function ConfirmSurface({
+  opts,
+  settle,
+}: {
+  opts: ConfirmOptions;
+  settle: (ok: boolean) => void;
+}) {
+  const { title, body, confirmLabel, tone = "default", typedName } = opts;
+  const [typed, setTyped] = useState("");
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+  const armed = isConfirmArmed(typedName, typed);
+
+  useEffect(() => {
+    restoreRef.current = document.activeElement as HTMLElement | null;
+    const dialog = dialogRef.current;
+    // Focus the first focusable control (typed input, else Cancel).
+    const focusables = () =>
+      Array.from(
+        dialog?.querySelectorAll<HTMLElement>(
+          'button, input, [href], [tabindex]:not([tabindex="-1"])',
+        ) ?? [],
+      );
+    focusables()[0]?.focus();
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        settle(false);
+      }
+      if (e.key === "Tab") {
+        // Minimal focus trap: wrap at the edges.
+        const items = focusables();
+        if (items.length === 0) return;
+        const first = items[0];
+        const last = items[items.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("keydown", onKey, true);
+      restoreRef.current?.focus?.();
+    };
+  }, [settle]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-purple-950/30 backdrop-blur-sm sm:items-center sm:p-4"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) settle(false);
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="alertdialog"
+        aria-modal="true"
+        aria-label={title}
+        className="flex max-h-[85vh] w-full flex-col overflow-y-auto rounded-t-2xl border border-purple-100 bg-white p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] shadow-2xl sm:max-w-md sm:rounded-2xl sm:pb-6"
+      >
+        {/* Sheet drag handle — visual affordance only, phones only. */}
+        <div aria-hidden className="mx-auto mb-4 h-1 w-10 rounded-full bg-slate-200 sm:hidden" />
+        <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+        <div className="mt-2 space-y-2 text-sm text-slate-600">{body}</div>
+        {typedName !== undefined && (
+          <label className="mt-4 block">
+            <span className="label">
+              {typedInstruction().before}
+              <span className="font-mono font-semibold">{typedName}</span>
+              {typedInstruction().after}
+            </span>
+            <input
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              className="input w-full"
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </label>
+        )}
+        <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <button type="button" className="btn btn-ghost" onClick={() => settle(false)}>
+            {msg("confirm.cancel")}
+          </button>
+          <button
+            type={tone === "danger" ? "button" : "submit"}
+            className={`btn ${tone === "danger" ? "btn-danger" : "btn-primary"}`}
+            disabled={!armed}
+            onClick={() => settle(true)}
+            onKeyDown={(e) => {
+              // Danger never submits on Enter — explicit click/Space only.
+              if (tone === "danger" && e.key === "Enter") e.preventDefault();
+            }}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/entity-card.tsx
+++ b/apps/web/src/components/ui/entity-card.tsx
@@ -1,0 +1,95 @@
+// EntityCard (v3/03 §1) — the match-day card, v3's signature primitive.
+// Broadcast-scorebug anatomy: glyph · name · status chip / meta line /
+// "what's next" line / progress meter, with a 3px division-hue left border
+// for cross-page wayfinding. Server-safe: interactivity (⋯ menu, view
+// toggle) comes in as client children.
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { msg } from "@/lib/messages";
+
+export function EntityCard({
+  href,
+  glyph,
+  name,
+  chip,
+  meta,
+  next,
+  progress,
+  accent,
+  menu,
+}: {
+  href: string;
+  /** Sport emoji / logo block, ~20px. */
+  glyph?: ReactNode;
+  name: string;
+  chip: ReactNode;
+  /** Format · capacity line, e.g. "Knockout · 14/16 entrants". */
+  meta?: string | null;
+  /** "Next: Arun vs Dev · Court 2 · 14:30" — null renders the quiet fallback. */
+  next?: string | null;
+  progress?: { played: number; total: number } | null;
+  /** Division hue border color; omit for competition cards (violet hairline). */
+  accent?: string;
+  /** Client overflow menu; rendered above the stretched link. */
+  menu?: ReactNode;
+}) {
+  return (
+    <article
+      className="ecard group relative rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-purple-300 hover:shadow"
+      style={accent ? { borderLeft: `3px solid ${accent}` } : undefined}
+    >
+      <div className="flex items-start gap-2">
+        {glyph && (
+          <span aria-hidden className="mt-px shrink-0 text-base leading-5">
+            {glyph}
+          </span>
+        )}
+        {/* Stretched link: the whole card is the target, the name is the label. */}
+        <h3 className="min-w-0 flex-1 text-sm font-semibold text-slate-800 group-hover:text-purple-700">
+          <Link href={href} className="after:absolute after:inset-0 focus-visible:outline-none">
+            <span className="block truncate">{name}</span>
+          </Link>
+        </h3>
+        {chip}
+        {menu && <span className="relative z-10 -my-1 shrink-0">{menu}</span>}
+      </div>
+      {meta && <p className="ecard-meta mt-1 truncate text-xs text-slate-500">{meta}</p>}
+      <p className="ecard-next mt-2 truncate text-xs text-slate-600">
+        {next ? (
+          <>
+            <span className="font-medium text-purple-700">Next:</span> {next}
+          </>
+        ) : (
+          <span className="text-slate-500">{msg("card.next.none")}</span>
+        )}
+      </p>
+      <div className="ecard-progress mt-2">
+        {progress && progress.total > 0 ? (
+          <div className="flex items-center gap-2">
+            <span
+              role="progressbar"
+              aria-valuemin={0}
+              aria-valuemax={progress.total}
+              aria-valuenow={progress.played}
+              aria-label={`${progress.played} of ${progress.total} played`}
+              className="h-1 w-16 shrink-0 overflow-hidden rounded-full bg-slate-100"
+            >
+              <span
+                className="block h-full rounded-full"
+                style={{
+                  width: `${Math.round((progress.played / progress.total) * 100)}%`,
+                  background: accent ?? "#7c3aed",
+                }}
+              />
+            </span>
+            <span className="text-[11px] tabular-nums text-slate-500">
+              {progress.played} of {progress.total} played
+            </span>
+          </div>
+        ) : (
+          <span className="text-[11px] text-slate-500">{msg("card.progress.none")}</span>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/components/ui/entity-logo.tsx
+++ b/apps/web/src/components/ui/entity-logo.tsx
@@ -1,0 +1,62 @@
+// EntityLogo (v3/03 §5): THE badge renderer. One fallback chain everywhere —
+// team logo → club logo → org monogram → initials — so a surface never
+// decides badge logic itself. Server-safe (no hooks). team_display_v already
+// coalesces team→club, so most callers pass one resolved `src`.
+//
+// Placement rule (the §5 matrix): one logo per level per surface. This
+// component renders the ENTITY level; org chrome (nav, mastheads) keeps its
+// own org logo and never passes it here as `src`.
+
+const SIZE_CLASS: Record<20 | 24 | 40, string> = {
+  20: "h-5 w-5 text-[9px]",
+  24: "h-6 w-6 text-[10px]",
+  40: "h-10 w-10 text-sm",
+};
+
+export function EntityLogo({
+  src,
+  name,
+  orgName,
+  size = 20,
+  className = "",
+}: {
+  /** Resolved badge URL (team, or club via team_display_v). */
+  src?: string | null;
+  /** Entity display name — initials fallback + alt text. */
+  name: string;
+  /** Org name: enables the monogram step of the chain (violet letter mark). */
+  orgName?: string | null;
+  size?: 20 | 24 | 40;
+  className?: string;
+}) {
+  const base = `inline-flex shrink-0 items-center justify-center overflow-hidden rounded-md align-middle ${SIZE_CLASS[size]} ${className}`;
+
+  if (src) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={src} alt="" aria-hidden className={`${base} bg-white object-contain`} />
+    );
+  }
+  if (orgName) {
+    return (
+      <span
+        aria-hidden
+        className={`${base} bg-gradient-to-br from-purple-500 to-fuchsia-500 font-bold text-white`}
+      >
+        {orgName.charAt(0).toUpperCase()}
+      </span>
+    );
+  }
+  return (
+    <span aria-hidden className={`${base} bg-slate-100 font-semibold text-slate-500`}>
+      {initials(name)}
+    </span>
+  );
+}
+
+export function initials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0]!.slice(0, 2).toUpperCase();
+  return (words[0]![0]! + words[words.length - 1]![0]!).toUpperCase();
+}

--- a/apps/web/src/components/ui/responsive-table.tsx
+++ b/apps/web/src/components/ui/responsive-table.tsx
@@ -1,0 +1,72 @@
+// ResponsiveTable (v3/02 pattern 1): every data table's stacked-card
+// rendering under `sm`, implemented once. Desktop keeps the semantic
+// `.table`; phones get a card list — primary line, 2–3 key fields, actions
+// in the caller's overflow. Server-safe (no hooks) — interactive cells come
+// in through `render`/`renderCard` as client children.
+import type { ReactNode } from "react";
+
+export interface ResponsiveColumn<T> {
+  key: string;
+  header: ReactNode;
+  /** Cell renderer; defaults align left, pass className for numeric right-align etc. */
+  render: (row: T) => ReactNode;
+  className?: string;
+  headerClassName?: string;
+}
+
+export function ResponsiveTable<T>({
+  columns,
+  rows,
+  keyOf,
+  renderCard,
+  empty = null,
+  "aria-label": ariaLabel,
+}: {
+  columns: ResponsiveColumn<T>[];
+  rows: T[];
+  keyOf: (row: T) => string;
+  /** The `sm`-down card for one row: name line + key fields + `⋯` actions. */
+  renderCard: (row: T) => ReactNode;
+  empty?: ReactNode;
+  "aria-label"?: string;
+}) {
+  if (rows.length === 0) return <>{empty}</>;
+
+  return (
+    <>
+      {/* Desktop: real table semantics. */}
+      <div className="scroll-x scroll-x-fade hidden sm:block">
+        <table className="table" aria-label={ariaLabel}>
+          <thead>
+            <tr>
+              {columns.map((col) => (
+                <th key={col.key} className={col.headerClassName}>
+                  {col.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={keyOf(row)}>
+                {columns.map((col) => (
+                  <td key={col.key} className={col.className}>
+                    {col.render(row)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {/* Phones: stacked cards, thumb-sized targets. */}
+      <ul className="space-y-2 sm:hidden" aria-label={ariaLabel}>
+        {rows.map((row) => (
+          <li key={keyOf(row)} className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+            {renderCard(row)}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/apps/web/src/components/ui/status-chip.tsx
+++ b/apps/web/src/components/ui/status-chip.tsx
@@ -1,0 +1,81 @@
+// Status-chip vocabulary (v3/03 §1): the ONE way lifecycle state renders —
+// cards, page headers, fixture rows. Copy comes from lib/messages so the
+// vocabulary is a data table, not scattered class strings.
+import { msg, type MessageKey } from "@/lib/messages";
+
+export type ChipState =
+  | "draft"
+  | "registration"
+  | "scheduled"
+  | "live"
+  | "completed"
+  | "archived"
+  | "frozen";
+
+const CHIP_STYLE: Record<ChipState, string> = {
+  draft: "bg-slate-100 text-slate-600",
+  registration: "border border-purple-300 bg-white text-purple-700",
+  scheduled: "border border-purple-200 bg-purple-50 text-purple-700",
+  live: "bg-purple-600 text-white",
+  completed: "bg-slate-100 text-slate-500",
+  archived: "border border-slate-200 bg-transparent text-slate-400",
+  frozen: "bg-sky-100 text-sky-700",
+};
+
+const CHIP_KEY: Record<ChipState, MessageKey> = {
+  draft: "chip.draft",
+  registration: "chip.registration",
+  scheduled: "chip.scheduled",
+  live: "chip.live",
+  completed: "chip.completed",
+  archived: "chip.archived",
+  frozen: "chip.frozen",
+};
+
+/** Sort weight: Live first, then Registration open, Draft, rest (v3/03 §2). */
+export const CHIP_SORT: Record<ChipState, number> = {
+  live: 0,
+  registration: 1,
+  scheduled: 2,
+  draft: 3,
+  completed: 4,
+  frozen: 4,
+  archived: 5,
+};
+
+export function competitionChipState(
+  status: string,
+  opts: { archived?: boolean } = {},
+): ChipState {
+  if (opts.archived || status === "archived") return "archived";
+  if (status === "live") return "live";
+  if (status === "published") return "registration";
+  if (status === "completed") return "completed";
+  return "draft";
+}
+
+export function divisionChipState(
+  status: string,
+  opts: { archived?: boolean; registrationOpen?: boolean } = {},
+): ChipState {
+  if (opts.archived) return "archived";
+  if (status === "active") return "live";
+  if (status === "completed") return "completed";
+  if (status === "scheduled") return "scheduled";
+  // 'setup' — registration window promotes the chip (the organiser's real state)
+  return opts.registrationOpen ? "registration" : "draft";
+}
+
+export function StatusChip({ state, className = "" }: { state: ChipState; className?: string }) {
+  return (
+    <span
+      data-chip={state}
+      className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium ${CHIP_STYLE[state]} ${className}`}
+    >
+      {state === "live" && (
+        <span aria-hidden className="chip-pulse-dot h-1.5 w-1.5 rounded-full bg-white" />
+      )}
+      {msg(CHIP_KEY[state])}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/tip.tsx
+++ b/apps/web/src/components/ui/tip.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+// Tips framework (v3/03 §4): <Tip id> renders an inline ⓘ whose popover
+// explains one concept in 1–3 sentences; <TipCallout id> is the dismissible
+// first-run banner variant (dismissal remembered per browser). All copy
+// comes from config/tips.ts; "Learn more →" renders only when the /help
+// article actually resolves (PROMPT-35) — never a dead link.
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { Info, X } from "lucide-react";
+import { TIPS, type TipId } from "@/config/tips";
+import { helpUrl } from "@/lib/help";
+
+export function Tip({ id, className = "" }: { id: TipId; className?: string }) {
+  const { title, body, helpSlug } = TIPS[id];
+  const href = helpUrl(helpSlug);
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("pointerdown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <span ref={rootRef} className={`relative inline-flex ${className}`}>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-label={`About: ${title}`}
+        onClick={() => setOpen((v) => !v)}
+        className="grid h-5 w-5 place-items-center rounded-full text-slate-400 transition hover:text-purple-600"
+      >
+        <Info className="h-3.5 w-3.5" strokeWidth={2} />
+      </button>
+      {open && (
+        <span
+          role="note"
+          className="absolute left-1/2 top-7 z-30 w-64 -translate-x-1/2 rounded-xl border border-purple-100 bg-white p-3 text-left shadow-lg"
+        >
+          <span className="block text-xs font-semibold text-slate-800">{title}</span>
+          <span className="mt-1 block text-xs leading-relaxed text-slate-600">{body}</span>
+          {href && (
+            <Link href={href} className="mt-2 block text-xs font-medium text-purple-600 hover:underline">
+              Learn more →
+            </Link>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function TipCallout({ id, className = "" }: { id: TipId; className?: string }) {
+  const { title, body, helpSlug } = TIPS[id];
+  const href = helpUrl(helpSlug);
+  const storageKey = `seazn.tip.${id}`;
+  // Start hidden; show after the dismissed check so a dismissed callout
+  // never flashes.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (window.localStorage.getItem(storageKey) !== "1") setVisible(true);
+  }, [storageKey]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="note"
+      className={`flex items-start gap-3 rounded-xl border border-purple-100 bg-purple-50/60 px-4 py-3 ${className}`}
+    >
+      <Info aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-purple-500" strokeWidth={2} />
+      <div className="min-w-0 flex-1 text-sm">
+        <p className="font-medium text-purple-900">{title}</p>
+        <p className="mt-0.5 text-purple-800/80">{body}</p>
+        {href && (
+          <Link href={href} className="mt-1 inline-block text-xs font-medium text-purple-700 hover:underline">
+            Learn more →
+          </Link>
+        )}
+      </div>
+      <button
+        type="button"
+        aria-label="Dismiss tip"
+        onClick={() => {
+          window.localStorage.setItem(storageKey, "1");
+          setVisible(false);
+        }}
+        className="grid h-6 w-6 shrink-0 place-items-center rounded-md text-purple-400 transition hover:bg-purple-100 hover:text-purple-700"
+      >
+        <X className="h-3.5 w-3.5" strokeWidth={2} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/view-toggle.tsx
+++ b/apps/web/src/components/ui/view-toggle.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+// Cards ⇄ compact list toggle (v3/03 §2, for orgs with >20 comps). The grid
+// itself is server-rendered; this wrapper only flips a data attribute the
+// .ecard styles respond to, and remembers the choice per browser.
+import { useEffect, useState, type ReactNode } from "react";
+import { LayoutGrid, Rows3 } from "lucide-react";
+import { msg } from "@/lib/messages";
+
+type View = "cards" | "list";
+
+export function ViewToggleContainer({
+  storageKey,
+  toggle,
+  children,
+}: {
+  storageKey: string;
+  /** Show the toggle control at all (hidden for short lists). */
+  toggle: boolean;
+  children: ReactNode;
+}) {
+  const [view, setView] = useState<View>("cards");
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(storageKey);
+    if (saved === "list" || saved === "cards") setView(saved);
+  }, [storageKey]);
+
+  function pick(next: View) {
+    setView(next);
+    window.localStorage.setItem(storageKey, next);
+  }
+
+  return (
+    <div data-view={view}>
+      {toggle && (
+        <div className="mb-3 flex justify-end">
+          <div role="group" aria-label="View" className="flex rounded-lg border border-purple-100 bg-white p-0.5">
+            {(
+              [
+                { v: "cards" as const, label: msg("card.view.cards"), Icon: LayoutGrid },
+                { v: "list" as const, label: msg("card.view.list"), Icon: Rows3 },
+              ]
+            ).map(({ v, label, Icon }) => (
+              <button
+                key={v}
+                type="button"
+                aria-pressed={view === v}
+                onClick={() => pick(v)}
+                className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition ${
+                  view === v ? "bg-purple-100 text-purple-800" : "text-slate-500 hover:text-purple-700"
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5" strokeWidth={2} />
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className={view === "list" ? "ecard-list space-y-2" : "grid gap-4 sm:grid-cols-2 lg:grid-cols-3"}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/visibility-picker.tsx
+++ b/apps/web/src/components/ui/visibility-picker.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+// Visibility radio cards (v3/03 §7): plain language over engineer vocabulary
+// — every option shows its consequence permanently, because the decision IS
+// the consequence. Maps 1:1 onto the existing private/unlisted/public keys
+// (no schema change; noindex behaviour unchanged). After a shareable choice
+// the share URL surfaces right here with a copy button.
+//
+// Youth guard (v3/11 gap 8): when the surface contains youth divisions,
+// leaving Private first raises a consent-responsibility interstitial — the
+// organiser confirms they hold guardian consent before names go public.
+import { useEffect, useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { msg, type MessageKey } from "@/lib/messages";
+
+export type VisibilityKey = "private" | "unlisted" | "public";
+
+const OPTIONS: { value: VisibilityKey; label: MessageKey; consequence: MessageKey }[] = [
+  { value: "private", label: "visibility.private.label", consequence: "visibility.private.consequence" },
+  { value: "unlisted", label: "visibility.unlisted.label", consequence: "visibility.unlisted.consequence" },
+  { value: "public", label: "visibility.public.label", consequence: "visibility.public.consequence" },
+];
+
+export function VisibilityPicker({
+  value,
+  onChange,
+  disabled = false,
+  sharePath,
+  hasYouthDivisions = false,
+}: {
+  value: VisibilityKey | string;
+  onChange: (next: VisibilityKey) => void;
+  disabled?: boolean;
+  /** Site-relative public path (e.g. /shared/org/comp) — shown as a full URL
+   *  with a copy button once the choice is shareable. */
+  sharePath?: string | null;
+  /** v3/11 gap 8: raises the guardian-consent interstitial when leaving Private. */
+  hasYouthDivisions?: boolean;
+}) {
+  const confirm = useConfirm();
+  const [copied, setCopied] = useState(false);
+  const [origin, setOrigin] = useState("");
+  useEffect(() => setOrigin(window.location.origin), []);
+  const shareUrl = sharePath ? `${origin}${sharePath}` : null;
+
+  async function pick(next: VisibilityKey) {
+    if (next === value) return;
+    if (hasYouthDivisions && value === "private" && next !== "private") {
+      const ok = await confirm({
+        title: msg("visibility.youth.title"),
+        body: msg("visibility.youth.body"),
+        confirmLabel: msg("visibility.youth.confirm"),
+      });
+      if (!ok) return;
+    }
+    onChange(next);
+  }
+
+  async function copy() {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    // min-w-0 matters: a fieldset's UA default is min-inline-size:min-content,
+    // which makes it burst out of narrow cards instead of shrinking.
+    <fieldset className="min-w-0 space-y-2 [min-inline-size:0]">
+      <legend className="label">{msg("visibility.legend")}</legend>
+      {OPTIONS.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <label
+            key={opt.value}
+            className={`flex cursor-pointer items-start gap-3 rounded-xl border p-3 transition ${
+              active
+                ? "border-purple-400 bg-purple-50/60 ring-1 ring-purple-200"
+                : "border-slate-200 bg-white hover:border-purple-200"
+            } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+          >
+            <input
+              type="radio"
+              name="visibility"
+              value={opt.value}
+              checked={active}
+              disabled={disabled}
+              onChange={() => void pick(opt.value)}
+              className="mt-1"
+            />
+            <span className="min-w-0">
+              <span className="block text-sm font-semibold text-slate-800">
+                {msg(opt.label)}
+              </span>
+              <span className="mt-0.5 block text-xs leading-relaxed text-slate-500">
+                {msg(opt.consequence)}
+              </span>
+            </span>
+          </label>
+        );
+      })}
+      {value !== "private" && shareUrl && (
+        <div className="flex min-w-0 items-center gap-2 rounded-lg bg-purple-50/70 px-3 py-2">
+          <span className="label !mb-0 shrink-0">{msg("visibility.share.label")}</span>
+          <code className="min-w-0 flex-1 truncate font-mono text-xs text-slate-700">
+            {shareUrl}
+          </code>
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="btn btn-ghost shrink-0 px-2 py-1 text-xs"
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5 text-green-600" />
+                {msg("visibility.share.copied")}
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                {msg("visibility.share.copy")}
+              </>
+            )}
+          </button>
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/apps/web/src/components/v2/archived-divisions.tsx
+++ b/apps/web/src/components/v2/archived-divisions.tsx
@@ -91,14 +91,16 @@ export function ArchivedDivisions({
         {divisions.map((d) => {
           const purgeReady = purgeReadyAt(d.archived_at).getTime() <= now;
           return (
-            <li key={d.id} className="flex items-center gap-3 py-2 text-sm">
+            // Wrapping row (v3/02 pattern 5): the action pair drops to its own
+            // full-width line on phones instead of pushing past the card edge.
+            <li key={d.id} className="flex flex-wrap items-center gap-x-3 gap-y-2 py-2 text-sm">
               <span className="min-w-0 flex-1 truncate text-slate-700">{d.name}</span>
               <span className="chip">{d.sport_key}</span>
-              <span className="shrink-0 text-xs text-slate-400">
+              <span className="shrink-0 text-xs text-slate-500">
                 archived {new Date(d.archived_at).toLocaleDateString()}
               </span>
               {canEdit && (
-                <>
+                <div className="flex w-full items-center justify-end gap-2 sm:w-auto sm:shrink-0">
                   <button
                     type="button"
                     className="btn btn-ghost text-xs"
@@ -120,7 +122,7 @@ export function ArchivedDivisions({
                   >
                     Purge…
                   </button>
-                </>
+                </div>
               )}
             </li>
           );

--- a/apps/web/src/components/v2/clubs-panel.tsx
+++ b/apps/web/src/components/v2/clubs-panel.tsx
@@ -6,6 +6,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { msg } from "@/lib/messages";
 
 interface PersonLite {
   id: string;
@@ -54,6 +56,7 @@ export function ClubsPanel({
   canEdit: boolean;
 }) {
   const router = useRouter();
+  const confirmDialog = useConfirm();
   const [error, setError] = useState<string | null>(null);
   const [paywallFeature, setPaywallFeature] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -189,7 +192,7 @@ export function ClubsPanel({
       {paywallFeature && <UpgradeGate feature={paywallFeature} />}
       {error && <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
 
-      <section className="card overflow-hidden">
+      <section className="card scroll-x scroll-x-fade">
         <table className="table">
           <thead>
             <tr>
@@ -232,8 +235,14 @@ export function ClubsPanel({
                       type="button"
                       className="text-sm text-red-600 hover:underline"
                       disabled={busy}
-                      onClick={() => {
-                        if (!confirm(`Delete ${c.name}? Its teams stay, badges fall back to none.`)) return;
+                      onClick={async () => {
+                        const ok = await confirmDialog({
+                          title: msg("confirm.deleteClub.title"),
+                          body: msg("confirm.deleteClub.body", { name: c.name }),
+                          confirmLabel: msg("confirm.deleteClub.label"),
+                          tone: "danger",
+                        });
+                        if (!ok) return;
                         void run(() => apiV1(`/api/v1/clubs/${c.id}`, { method: "DELETE" }));
                       }}
                     >
@@ -265,10 +274,12 @@ export function ClubsPanel({
                 <TeamDetailRow
                   key={t.id}
                   team={t}
+                  storageBase={storageBase}
                   persons={persons}
                   canEdit={canEdit}
                   onError={setError}
                   onPaywall={setPaywallFeature}
+                  onLogoChanged={() => reloadDetail(detail.id)}
                 />
               ))}
             </ul>
@@ -403,19 +414,50 @@ function AddTeamForm({
 // One team in the club detail: its division entries + an expandable squad editor.
 function TeamDetailRow({
   team,
+  storageBase,
   persons,
   canEdit,
   onError,
   onPaywall,
+  onLogoChanged,
 }: {
-  team: { id: string; name: string; entries: { division_id: string; division_name: string }[] };
+  team: {
+    id: string;
+    name: string;
+    logo_path: string | null;
+    entries: { division_id: string; division_name: string }[];
+  };
+  storageBase: string;
   persons: PersonLite[];
   canEdit: boolean;
   onError: (msg: string) => void;
   onPaywall: (feature: string) => void;
+  onLogoChanged: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [squad, setSquad] = useState<SquadMember[] | null>(null);
+  const logoInputRef = useRef<HTMLInputElement>(null);
+  const [logoBusy, setLogoBusy] = useState(false);
+
+  // Team-level badge (v3/03 §5): overrides the club badge for this team only.
+  async function uploadLogo(file: File | undefined) {
+    if (!file) return;
+    setLogoBusy(true);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch(`/api/v1/teams/${team.id}/logo`, { method: "POST", body: form });
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok || payload?.ok === false) {
+        throw new Error(payload?.error?.message ?? `Upload failed (${res.status})`);
+      }
+      onLogoChanged();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Logo upload failed");
+    } finally {
+      setLogoBusy(false);
+    }
+  }
 
   async function toggle() {
     const next = !open;
@@ -444,6 +486,15 @@ function TeamDetailRow({
         >
           ▸
         </span>
+        {team.logo_path ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={`${storageBase}/${team.logo_path}`}
+            alt=""
+            aria-hidden
+            className="h-5 w-5 rounded object-contain"
+          />
+        ) : null}
         <span className="font-medium text-slate-800">{team.name}</span>
         {team.entries.map((e) => (
           <span key={e.division_id} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
@@ -451,6 +502,28 @@ function TeamDetailRow({
           </span>
         ))}
       </button>
+      {canEdit && (
+        <div className="flex items-center gap-2 px-2 pb-1 pl-6">
+          <button
+            type="button"
+            disabled={logoBusy}
+            onClick={() => logoInputRef.current?.click()}
+            className="text-xs text-purple-600 hover:underline disabled:opacity-50"
+          >
+            {logoBusy ? "Uploading…" : team.logo_path ? "Change badge" : "Set team badge"}
+          </button>
+          <input
+            ref={logoInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/svg+xml"
+            className="hidden"
+            onChange={(e) => {
+              void uploadLogo(e.target.files?.[0]);
+              e.target.value = "";
+            }}
+          />
+        </div>
+      )}
       {open && (
         <div className="px-2 pb-2 pl-6">
           {squad === null ? (

--- a/apps/web/src/components/v2/competition-settings.tsx
+++ b/apps/web/src/components/v2/competition-settings.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { BrandColorPicker } from "@/components/brand-color-picker";
+import { VisibilityPicker } from "@/components/ui/visibility-picker";
+import { Tip } from "@/components/ui/tip";
 import { publicBrandColor } from "@/lib/public-theme";
 
 interface CompetitionLite {
@@ -50,10 +52,16 @@ export function CompetitionSettings({
   suggestedStatus = null,
   archivedPanel = null,
   archivedCount = 0,
+  sharePath = null,
+  hasYouthDivisions = false,
 }: {
   competition: CompetitionLite;
   canEdit: boolean;
   discoveryBranding: boolean;
+  /** Public path for the share-URL row of the visibility picker (v3/03 §7). */
+  sharePath?: string | null;
+  /** Any U-age division in this competition (v3/11 gap 8 interstitial). */
+  hasYouthDivisions?: boolean;
   /** Org has dashboard.branding — public pages/noticeboard honor brand color. */
   themeBranding?: boolean;
   /** Org-level branding blob — the color this competition inherits. */
@@ -258,20 +266,22 @@ export function CompetitionSettings({
                 </label>
               </div>
 
-              <div className="grid grid-cols-2 gap-3">
-                <label className="block">
-                  <span className="label">Visibility</span>
-                  <select
-                    disabled={readOnly}
+              {/* v3/03 §7: radio cards with consequence sentences replace the
+                  engineer-vocabulary select; share URL surfaces on selection. */}
+              <div className="flex items-start gap-1.5">
+                <div className="min-w-0 flex-1">
+                  <VisibilityPicker
                     value={form.visibility}
-                    onChange={(e) => setForm({ ...form, visibility: e.target.value })}
-                    className="select"
-                  >
-                    <option value="private">private</option>
-                    <option value="unlisted">unlisted</option>
-                    <option value="public">public</option>
-                  </select>
-                </label>
+                    disabled={readOnly}
+                    sharePath={sharePath}
+                    hasYouthDivisions={hasYouthDivisions}
+                    onChange={(next) => setForm({ ...form, visibility: next })}
+                  />
+                </div>
+                <Tip id="division.visibility" className="mt-0.5" />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
                 <label className="block">
                   <span className="label">Status</span>
                   <select

--- a/apps/web/src/components/v2/competition-wizard.tsx
+++ b/apps/web/src/components/v2/competition-wizard.tsx
@@ -6,12 +6,8 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
+import { VisibilityPicker } from "@/components/ui/visibility-picker";
 
-const VISIBILITIES = [
-  { key: "private", label: "Private", help: "Only your organisation can see it." },
-  { key: "unlisted", label: "Unlisted", help: "Anyone with the link; not indexed." },
-  { key: "public", label: "Public", help: "On your public dashboard, indexable." },
-] as const;
 
 export function CompetitionWizard() {
   const router = useRouter();
@@ -84,32 +80,9 @@ export function CompetitionWizard() {
         />
       </label>
 
-      <fieldset>
-        <legend className="label">Visibility</legend>
-        <div className="grid gap-2 sm:grid-cols-3">
-          {VISIBILITIES.map((v) => (
-            <label
-              key={v.key}
-              className={`cursor-pointer rounded-lg border p-3 text-sm transition ${
-                visibility === v.key
-                  ? "border-purple-500 bg-purple-50 text-purple-800"
-                  : "border-slate-200 bg-white text-slate-600 hover:border-purple-200"
-              }`}
-            >
-              <input
-                type="radio"
-                name="visibility"
-                value={v.key}
-                checked={visibility === v.key}
-                onChange={() => setVisibility(v.key)}
-                className="sr-only"
-              />
-              <span className="block font-medium">{v.label}</span>
-              <span className="mt-0.5 block text-xs text-slate-500">{v.help}</span>
-            </label>
-          ))}
-        </div>
-      </fieldset>
+      {/* v3/03 §7: the one visibility component everywhere. No share URL at
+          create time (the competition has no public page yet). */}
+      <VisibilityPicker value={visibility} onChange={setVisibility} />
 
       <div className="grid gap-4 sm:grid-cols-2">
         <label className="block">

--- a/apps/web/src/components/v2/confirm-dialog.tsx
+++ b/apps/web/src/components/v2/confirm-dialog.tsx
@@ -5,6 +5,7 @@
 // disabled until the user types the resource name exactly (v3/09 §4 division
 // delete). Body copy must state what is destroyed vs kept.
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { isConfirmArmed } from "@/lib/typed-confirm";
 
 interface Props {
   open: boolean;
@@ -50,11 +51,11 @@ export function ConfirmDialog({
   }, [open, onCancel]);
 
   if (!open) return null;
-  const armed = typedName === undefined || typed === typedName;
+  const armed = isConfirmArmed(typedName, typed);
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+      className="fixed inset-0 z-50 flex items-end justify-center bg-slate-900/40 sm:items-center sm:p-4"
       role="dialog"
       aria-modal="true"
       aria-label={title}
@@ -62,7 +63,9 @@ export function ConfirmDialog({
         if (e.target === e.currentTarget) onCancel();
       }}
     >
-      <div className="card w-full max-w-md space-y-4 p-6 shadow-xl">
+      {/* Bottom sheet under `sm` (v3/02 pattern 3). */}
+      <div className="card w-full space-y-4 rounded-t-2xl rounded-b-none p-6 pb-[calc(1.5rem+env(safe-area-inset-bottom))] shadow-xl sm:max-w-md sm:rounded-2xl sm:pb-6">
+        <span className="sheet-handle" aria-hidden />
         <h2 className="text-base font-semibold text-slate-900">{title}</h2>
         <div className="space-y-2 text-sm text-slate-600">{children}</div>
         {typedName !== undefined && (

--- a/apps/web/src/components/v2/entrants-panel.tsx
+++ b/apps/web/src/components/v2/entrants-panel.tsx
@@ -308,7 +308,7 @@ export function EntrantsPanel({
         </label>
       )}
 
-      <section className="card overflow-hidden">
+      <section className="card scroll-x scroll-x-fade">
         <table className="table">
           <thead>
             <tr>

--- a/apps/web/src/components/v2/history-panel.tsx
+++ b/apps/web/src/components/v2/history-panel.tsx
@@ -8,6 +8,9 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { Tip } from "@/components/ui/tip";
+import { msg } from "@/lib/messages";
 
 interface HistoryRow {
   seq: number;
@@ -53,6 +56,7 @@ export function HistoryPanel({
   canEdit: boolean;
 }) {
   const router = useRouter();
+  const confirmDialog = useConfirm();
   const [history, setHistory] = useState<HistoryOut | null>(null);
   const [checkpoints, setCheckpoints] = useState<Checkpoint[]>([]);
   const [label, setLabel] = useState("");
@@ -112,7 +116,12 @@ export function HistoryPanel({
   return (
     <section className="mt-8 space-y-4" aria-label="Schedule history">
       <div className="flex flex-wrap items-center gap-2">
-        <h2 className="text-lg font-semibold tracking-tight text-slate-900">History</h2>
+        {/* Tip sits OUTSIDE the h2 — inside it would pollute the heading's
+            accessible name ("History About: …"). */}
+        <div className="flex items-center gap-1.5">
+          <h2 className="text-lg font-semibold tracking-tight text-slate-900">History</h2>
+          <Tip id="schedule.undo-watermark" />
+        </div>
         {canEdit && (
           <>
             <button type="button" className="btn" disabled={busy} onClick={() => void step("undo")}>
@@ -210,8 +219,13 @@ export function HistoryPanel({
                       type="button"
                       className="ml-auto text-xs text-purple-600 hover:underline"
                       disabled={busy}
-                      onClick={() => {
-                        if (!confirm(`Restore "${cp.label}"? Edits after it are undone (results are never touched).`)) return;
+                      onClick={async () => {
+                        const ok = await confirmDialog({
+                          title: msg("confirm.restoreCheckpoint.title"),
+                          body: msg("confirm.restoreCheckpoint.body", { name: cp.label }),
+                          confirmLabel: msg("confirm.restoreCheckpoint.label"),
+                        });
+                        if (!ok) return;
                         void run(() =>
                           apiV1(`/api/v1/divisions/${divisionId}/restore`, {
                             method: "POST",
@@ -241,8 +255,14 @@ export function HistoryPanel({
             type="button"
             className="btn mt-2 border-red-200 text-red-700 hover:bg-red-50"
             disabled={busy}
-            onClick={() => {
-              if (!confirm("Clear the division's unlocked timetable slots?")) return;
+            onClick={async () => {
+              const ok = await confirmDialog({
+                title: msg("confirm.clearSlots.title"),
+                body: msg("confirm.clearSlots.body"),
+                confirmLabel: msg("confirm.clearSlots.label"),
+                tone: "danger",
+              });
+              if (!ok) return;
               void run(() =>
                 apiV1("/api/v1/schedule/clear", {
                   method: "POST",

--- a/apps/web/src/components/v2/ladder-panel.tsx
+++ b/apps/web/src/components/v2/ladder-panel.tsx
@@ -66,7 +66,7 @@ export function LadderPanel({
       {paywall && <UpgradeGate feature={paywall} />}
       {error && <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
 
-      <div className="card overflow-hidden">
+      <div className="card scroll-x scroll-x-fade">
         <table className="table">
           <thead>
             <tr>

--- a/apps/web/src/components/v2/officials-panel.tsx
+++ b/apps/web/src/components/v2/officials-panel.tsx
@@ -400,7 +400,7 @@ export function OfficialsPanel({
       )}
 
       {/* per-fixture manual assignment */}
-      <div className="card overflow-hidden">
+      <div className="card scroll-x scroll-x-fade">
         <table className="table">
           <thead>
             <tr>

--- a/apps/web/src/components/v2/persons-panel.tsx
+++ b/apps/web/src/components/v2/persons-panel.tsx
@@ -101,7 +101,7 @@ export function PersonsPanel({
         className="input max-w-xs"
       />
 
-      <section className="card overflow-hidden">
+      <section className="card scroll-x scroll-x-fade">
         <table className="table">
           <thead>
             <tr>

--- a/apps/web/src/components/v2/registrations-panel.tsx
+++ b/apps/web/src/components/v2/registrations-panel.tsx
@@ -8,6 +8,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { PlanBadge } from "@/components/plan-badge";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { Tip } from "@/components/ui/tip";
+import { msg } from "@/lib/messages";
 
 interface FormField {
   key: string;
@@ -80,6 +83,7 @@ export function RegistrationsPanel({
   /** registration.paid entitlement — false shows the plan badge on the fee field. */
   paidAllowed?: boolean;
 }) {
+  const confirmDialog = useConfirm();
   const [settings, setSettings] = useState<Settings | null>(null);
   const [regs, setRegs] = useState<Registration[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -169,9 +173,24 @@ export function RegistrationsPanel({
     });
   }
 
-  function action(id: string, verb: "confirm" | "waitlist" | "withdraw" | "refund") {
-    if (verb === "withdraw" && !window.confirm("Withdraw this registration?")) return;
-    if (verb === "refund" && !window.confirm("Refund the remaining amount?")) return;
+  async function action(id: string, verb: "confirm" | "waitlist" | "withdraw" | "refund") {
+    if (verb === "withdraw" || verb === "refund") {
+      const ok = await confirmDialog(
+        verb === "withdraw"
+          ? {
+              title: msg("confirm.withdrawRegistration.title"),
+              body: msg("confirm.withdrawRegistration.body"),
+              confirmLabel: msg("confirm.withdrawRegistration.label"),
+              tone: "danger",
+            }
+          : {
+              title: msg("confirm.refundRegistration.title"),
+              body: msg("confirm.refundRegistration.body"),
+              confirmLabel: msg("confirm.refundRegistration.label"),
+            },
+      );
+      if (!ok) return;
+    }
     void run(() => apiV1(`/api/v1/registrations/${id}/${verb}`, { method: "POST", json: {} }));
   }
 
@@ -337,8 +356,9 @@ export function RegistrationsPanel({
 
       <section>
         <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-slate-700">
+          <h2 className="flex items-center gap-1.5 text-sm font-semibold text-slate-700">
             Registrations <span className="text-slate-400">({regs.length})</span>
+            <Tip id="registration.ref-number" />
           </h2>
           <a
             href={`/api/v1/divisions/${divisionId}/registrations/export`}

--- a/apps/web/src/components/v2/slideshow.tsx
+++ b/apps/web/src/components/v2/slideshow.tsx
@@ -292,8 +292,12 @@ export function Slideshow({
                       <span className="font-display text-xl font-semibold uppercase text-court-muted">
                         R{f.round}
                       </span>
-                      <span className="min-w-0 truncate text-right font-display text-4xl font-semibold">
-                        {f.home}
+                      <span className="flex min-w-0 items-center justify-end gap-3 text-right font-display text-4xl font-semibold">
+                        <span className="min-w-0 truncate">{f.home}</span>
+                        {f.homeLogo && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={f.homeLogo} alt="" aria-hidden className="h-10 w-10 shrink-0 rounded-md bg-white/90 object-contain p-0.5" />
+                        )}
                       </span>
                       <span
                         className={`shrink-0 px-2 text-center font-display tabular-nums ${
@@ -304,8 +308,12 @@ export function Slideshow({
                       >
                         {f.line ?? "vs"}
                       </span>
-                      <span className="min-w-0 truncate font-display text-4xl font-semibold">
-                        {f.away}
+                      <span className="flex min-w-0 items-center gap-3 font-display text-4xl font-semibold">
+                        {f.awayLogo && (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={f.awayLogo} alt="" aria-hidden className="h-10 w-10 shrink-0 rounded-md bg-white/90 object-contain p-0.5" />
+                        )}
+                        <span className="min-w-0 truncate">{f.away}</span>
                       </span>
                       <span className="flex items-center justify-end gap-2 font-display text-lg font-semibold uppercase tracking-wide">
                         {live ? (

--- a/apps/web/src/components/v2/stages-panel.tsx
+++ b/apps/web/src/components/v2/stages-panel.tsx
@@ -8,6 +8,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
 import { UpgradeGate } from "@/components/upgrade-gate";
+import { useConfirm } from "@/components/ui/confirm-provider";
+import { TipCallout } from "@/components/ui/tip";
+import { msg } from "@/lib/messages";
 
 interface StageRow {
   id: string;
@@ -52,6 +55,7 @@ const FIXTURE_STATUS_STYLE: Record<string, string> = {
 };
 
 export function StagesPanel({ divisionId, stages, fixtures, entrantNames, canEdit }: Props) {
+  const confirmDialog = useConfirm();
   const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [paywallFeature, setPaywallFeature] = useState<string | null>(null);
@@ -117,6 +121,7 @@ export function StagesPanel({ divisionId, stages, fixtures, entrantNames, canEdi
 
   return (
     <div className="space-y-6">
+      {canEdit && <TipCallout id="division.start-locks" />}
       {notice && (
         <p className="rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{notice}</p>
       )}
@@ -180,14 +185,14 @@ export function StagesPanel({ divisionId, stages, fixtures, entrantNames, canEdi
                 <button
                   type="button"
                   disabled={busy !== null}
-                  onClick={() => {
-                    if (
-                      window.confirm(
-                        `Delete stage "${stage.name}"? Its ${stageFixtures.length} fixture(s) and pools are removed too. This cannot be undone.`,
-                      )
-                    ) {
-                      void act(stage.id, "delete");
-                    }
+                  onClick={async () => {
+                    const ok = await confirmDialog({
+                      title: msg("confirm.deleteStage.title"),
+                      body: msg("confirm.deleteStage.body", { name: stage.name }),
+                      confirmLabel: msg("confirm.deleteStage.label"),
+                      tone: "danger",
+                    });
+                    if (ok) void act(stage.id, "delete");
                   }}
                   className="btn btn-danger px-3 py-1.5 text-xs"
                 >

--- a/apps/web/src/config/tips.ts
+++ b/apps/web/src/config/tips.ts
@@ -1,0 +1,76 @@
+// Tips registry (v3/03 §4): every contextual tip in one reviewable file —
+// id → {title, body, helpSlug}. Components render <Tip id="…"/>; copy never
+// lives inline. helpSlug deep-links into /help once PROMPT-35 ships it;
+// until then lib/help.ts resolves nothing and the link doesn't render.
+
+export interface TipEntry {
+  title: string;
+  body: string;
+  /** /help article slug — rendered as "Learn more →" only when it resolves. */
+  helpSlug?: string;
+}
+
+export const TIPS = {
+  "division.visibility": {
+    title: "Who can see a division",
+    body: "A division follows its competition: Private is team-only, Link only means anyone with the link, Public is findable on Google and our discover page.",
+    helpSlug: "sharing/visibility",
+  },
+  "division.start-locks": {
+    title: "Starting locks the setup",
+    body: "Once scoring starts, entrants and format are locked so results stay fair. Finish seeding and structure first.",
+    helpSlug: "divisions/lifecycle",
+  },
+  "scoring.seq-conflict": {
+    title: "Someone else scored first",
+    body: "Two scorers updated the same match at once. The app refreshed to the latest score — re-enter your point if it's still missing.",
+    helpSlug: "scoring/conflicts",
+  },
+  "entrants.kinds": {
+    title: "Teams, individuals and pairs",
+    body: "A division registers one kind of entrant: whole teams, individual players, or fixed pairs (doubles). Pick the kind that matches who plays a fixture.",
+    helpSlug: "entrants/kinds",
+  },
+  "formats.picker": {
+    title: "Choosing a format",
+    body: "League plays everyone once and ranks by points. Knockout eliminates losers. Groups + knockout qualifies the top of each group. Swiss pairs equals with equals — good for big fields on short time.",
+    helpSlug: "formats/overview",
+  },
+  "billing.downgrade-freeze": {
+    title: "What downgrading freezes",
+    body: "Nothing is deleted. Anything over the Community limits becomes read-only until you upgrade again or archive something.",
+    helpSlug: "billing/downgrade",
+  },
+  "billing.event-pass": {
+    title: "What an Event Pass covers",
+    body: "A pass upgrades one competition for its lifetime — every division inside it gets Pro features. It doesn't carry to next season's edition.",
+    helpSlug: "billing/event-pass",
+  },
+  "registration.ref-number": {
+    title: "Reference numbers",
+    body: "Every registration gets a short reference like R-7F3K. Players use it to find, pay for or withdraw their entry — no account needed.",
+    helpSlug: "registration/reference-numbers",
+  },
+  "schedule.locking": {
+    title: "Locked slots",
+    body: "Locking a slot pins it — the auto-scheduler and clear actions leave it exactly where it is.",
+    helpSlug: "scheduling/locks",
+  },
+  "schedule.undo-watermark": {
+    title: "Undo and save points",
+    body: "Every schedule change is undoable, and a save point marks a known-good timetable you can restore. Match results are never touched by either.",
+    helpSlug: "scheduling/undo",
+  },
+  "api.key-scopes": {
+    title: "Key scopes",
+    body: "Read keys can only fetch data. Write keys can change it — treat them like passwords and revoke any key you no longer use.",
+    helpSlug: "api/keys",
+  },
+  "slideshow.url": {
+    title: "The slideshow URL",
+    body: "Open it on any TV or projector browser — it cycles standings and matchups by itself and keeps itself up to date.",
+    helpSlug: "sharing/slideshow",
+  },
+} as const satisfies Record<string, TipEntry>;
+
+export type TipId = keyof typeof TIPS;

--- a/apps/web/src/lib/__tests__/ui-system.test.ts
+++ b/apps/web/src/lib/__tests__/ui-system.test.ts
@@ -1,0 +1,102 @@
+// PROMPT-32 golden/unit acceptance: chip-state vocabulary, logo fallback
+// chain, typed-confirm arming, messages interpolation, division hue
+// stability. All pure — the e2e suite covers the rendered behaviour.
+import { describe, expect, it } from "vitest";
+import {
+  competitionChipState,
+  divisionChipState,
+  CHIP_SORT,
+} from "@/components/ui/status-chip";
+import { initials } from "@/components/ui/entity-logo";
+import { isConfirmArmed } from "@/lib/typed-confirm";
+import { msg, messages } from "@/lib/messages";
+import { divisionHue, divisionAccent } from "@/lib/division-hue";
+import { formatLabel, nextLine } from "@/server/usecases/card-stats";
+
+describe("status chip vocabulary (v3/03 §1)", () => {
+  it("maps competition statuses to the five chip states", () => {
+    expect(competitionChipState("draft")).toBe("draft");
+    expect(competitionChipState("published")).toBe("registration");
+    expect(competitionChipState("live")).toBe("live");
+    expect(competitionChipState("completed")).toBe("completed");
+    expect(competitionChipState("archived")).toBe("archived");
+    expect(competitionChipState("live", { archived: true })).toBe("archived");
+  });
+
+  it("maps division statuses; a registration window promotes setup", () => {
+    expect(divisionChipState("setup")).toBe("draft");
+    expect(divisionChipState("setup", { registrationOpen: true })).toBe("registration");
+    expect(divisionChipState("scheduled")).toBe("scheduled");
+    expect(divisionChipState("active")).toBe("live");
+    expect(divisionChipState("completed")).toBe("completed");
+    expect(divisionChipState("active", { archived: true })).toBe("archived");
+  });
+
+  it("sorts Live first, then Registration open, Draft, Completed, Archived", () => {
+    const order = ["archived", "draft", "live", "completed", "registration"] as const;
+    const sorted = [...order].sort((a, b) => CHIP_SORT[a] - CHIP_SORT[b]);
+    expect(sorted).toEqual(["live", "registration", "draft", "completed", "archived"]);
+  });
+});
+
+describe("EntityLogo fallback chain (v3/03 §5)", () => {
+  it("initials: single word takes two letters, multi-word takes first+last", () => {
+    expect(initials("Riverside")).toBe("RI");
+    expect(initials("Northside Netters")).toBe("NN");
+    expect(initials("A B C United")).toBe("AU");
+    expect(initials("  ")).toBe("?");
+  });
+});
+
+describe("typed-confirm arming (v3/03 §3)", () => {
+  it("no challenge → armed", () => {
+    expect(isConfirmArmed(undefined, "")).toBe(true);
+  });
+  it("mismatch blocks confirm; exact match arms", () => {
+    expect(isConfirmArmed("U16 Boys", "")).toBe(false);
+    expect(isConfirmArmed("U16 Boys", "u16 boys")).toBe(false);
+    expect(isConfirmArmed("U16 Boys", "U16 Boys ")).toBe(false);
+    expect(isConfirmArmed("U16 Boys", "U16 Boys")).toBe(true);
+  });
+});
+
+describe("messages layer (v3/11 gap 4)", () => {
+  it("interpolates placeholders and leaves unknown ones intact", () => {
+    expect(msg("confirm.leaveOrg.body", { name: "Acme" })).toContain("Acme");
+    expect(msg("confirm.typed.instruction")).toContain("{name}");
+  });
+  it("every message is non-empty English", () => {
+    for (const [key, value] of Object.entries(messages)) {
+      expect(value.length, key).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("division hue (v3/03 §1)", () => {
+  it("is stable for an id and stays off the brand violet band (260–290°)", () => {
+    const id = "3c9f1c2e-1111-4eee-9c60-000000000042";
+    expect(divisionHue(id)).toBe(divisionHue(id));
+    for (let i = 0; i < 50; i++) {
+      const hue = divisionHue(`division-${i}`);
+      expect(hue < 260 || hue > 290).toBe(true);
+    }
+    expect(divisionAccent(id)).toMatch(/^hsl\(\d+ 62% 48%\)$/);
+  });
+});
+
+describe("card meta lines (v3/03 §1)", () => {
+  it("formatLabel names real structures", () => {
+    expect(formatLabel([])).toBeNull();
+    expect(formatLabel(["knockout"])).toBe("Knockout");
+    expect(formatLabel(["group", "knockout"])).toBe("Groups + Knockout");
+  });
+  it("nextLine is null-safe on TBD entrants and unscheduled fixtures", () => {
+    expect(nextLine(null)).toBeNull();
+    expect(
+      nextLine({ home: "Arun", away: null, court_label: null, scheduled_at: null, in_play: false }),
+    ).toBe("Arun vs TBD");
+    expect(
+      nextLine({ home: "A", away: "B", court_label: "Court 2", scheduled_at: null, in_play: true }),
+    ).toBe("Now: A vs B · Court 2");
+  });
+});

--- a/apps/web/src/lib/division-hue.ts
+++ b/apps/web/src/lib/division-hue.ts
@@ -1,0 +1,27 @@
+// Per-division hue (v3/03 §1): the 3px card border and the v3/04 board lanes
+// derive the same colour from the division id, so a division looks the same
+// on every page without storing a colour anywhere. Twelve stops around the
+// wheel, skipping the 260–290° band the brand violet owns so a division never
+// impersonates system chrome.
+
+const HUES = [4, 24, 44, 76, 104, 140, 168, 190, 210, 232, 312, 336] as const;
+
+/** FNV-1a — stable across sessions, cheap, good spread on uuids. */
+function fnv1a(input: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+export function divisionHue(divisionId: string): number {
+  return HUES[fnv1a(divisionId) % HUES.length];
+}
+
+/** CSS color for the card border / board lane. Fixed s/l keeps every stop
+ *  distinguishable on the white card without fighting the text for contrast. */
+export function divisionAccent(divisionId: string): string {
+  return `hsl(${divisionHue(divisionId)} 62% 48%)`;
+}

--- a/apps/web/src/lib/feature-copy.ts
+++ b/apps/web/src/lib/feature-copy.ts
@@ -31,7 +31,7 @@ const FEATURE_REASONS: Record<string, string> = {
   realtime: "Live push updates are a Pro feature.",
   // Platform
   "api.access": "API keys are a Pro feature.",
-  "api.write": "Write access via the API needs the Business plan.",
+  "api.write": "Write access via the API needs an upgraded plan — contact us to enable it.",
   exports: "CSV/PDF exports are a Pro feature.",
   "exports.branded": "Branded print templates (club colours, sponsor logos) are a Pro feature.",
   // Clubs & bulk import (Jul3/01 §7)
@@ -65,7 +65,8 @@ export function featureReason(featureKey: string): string {
 
 // Cheapest plan that unlocks each feature (mirrors the plan_entitlements
 // seeds, V112 + V240). Everything not listed here unlocks on Pro — only the
-// Business-tier exceptions need rows.
+// above-Pro exceptions need rows. (`business` is a hidden DB plan key —
+// v3/03 §6 — the UI renders these as a generic "Upgrade".)
 const BUSINESS_FEATURES = new Set(["api.write", "scorers.max"]);
 
 export type PaidPlan = "pro" | "business";

--- a/apps/web/src/lib/help.ts
+++ b/apps/web/src/lib/help.ts
@@ -1,0 +1,9 @@
+// Help-centre link resolver. /help ships in PROMPT-35; until its article
+// registry exists every slug resolves to null and "Learn more" links simply
+// don't render (v3/03 §4 — no dead links). PROMPT-35 replaces the body of
+// this function with a lookup against its article registry.
+
+export function helpUrl(slug: string | undefined): string | null {
+  void slug;
+  return null;
+}

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -1,0 +1,107 @@
+// UI copy layer (v3/11 gap 4): every string v3 surfaces add lives here as a
+// flat key → English string map. No i18n library, no locale routing yet —
+// the point is that when pt-BR lands (v4), translation is a second map, not a
+// rewrite of every component. Later v3 prompts extend this file.
+//
+// Keys are dot-namespaced by surface: `chip.*` status vocabulary,
+// `visibility.*` the picker, `confirm.*` dialogs, `card.*` grids,
+// `tips.*` live in config/tips.ts (same pattern, richer shape).
+
+export const messages = {
+  // ── Status chip vocabulary (v3/03 §1) ──
+  "chip.draft": "Draft",
+  "chip.registration": "Registration open",
+  "chip.live": "Live",
+  "chip.completed": "Completed",
+  "chip.archived": "Archived",
+  "chip.frozen": "Read-only",
+  "chip.scheduled": "Scheduled",
+
+  // ── Card grids (v3/03 §2) ──
+  "card.empty.competitions": "No competitions yet — create one in about two minutes.",
+  "card.empty.competitions.cta": "Create your first competition",
+  "card.empty.divisions":
+    "No divisions yet. A division picks the sport, its variant and format — entrants and fixtures live inside it.",
+  "card.empty.divisions.cta": "Add a division",
+  "card.view.cards": "Cards",
+  "card.view.list": "List",
+  "card.actions": "Actions",
+  "card.next.none": "Nothing scheduled yet",
+  "card.progress.none": "No fixtures yet",
+
+  // ── ConfirmDialog (v3/03 §3) ──
+  "confirm.cancel": "Cancel",
+  "confirm.typed.instruction": "Type {name} to confirm",
+  "confirm.downgrade.title": "Downgrade to Community?",
+  "confirm.downgrade.body":
+    "Pro features become unavailable immediately. Anything over the Community limits is frozen, not deleted.",
+  "confirm.downgrade.label": "Downgrade",
+  "confirm.leaveOrg.title": "Leave this organisation?",
+  "confirm.leaveOrg.body": "You lose access to {name} immediately. An owner can invite you back.",
+  "confirm.leaveOrg.label": "Leave organisation",
+  "confirm.transferOwner.title": "Transfer ownership?",
+  "confirm.transferOwner.body":
+    "You become an admin and cannot undo this yourself — only the new owner can transfer it back.",
+  "confirm.transferOwner.label": "Transfer ownership",
+  "confirm.restoreCheckpoint.title": "Restore this save point?",
+  "confirm.restoreCheckpoint.body":
+    "Schedule edits made after {name} are undone. Results are never touched.",
+  "confirm.restoreCheckpoint.label": "Restore",
+  "confirm.clearSlots.title": "Clear unlocked slots?",
+  "confirm.clearSlots.body":
+    "Every unlocked timetable slot in this division is cleared. Locked slots and results stay.",
+  "confirm.clearSlots.label": "Clear slots",
+  "confirm.deleteClub.title": "Delete this club?",
+  "confirm.deleteClub.body":
+    "{name} is removed. Its teams stay — their badges fall back to no club badge.",
+  "confirm.deleteClub.label": "Delete club",
+  "confirm.withdrawRegistration.title": "Withdraw this registration?",
+  "confirm.withdrawRegistration.body": "The entrant comes off the list and their spot frees up.",
+  "confirm.withdrawRegistration.label": "Withdraw",
+  "confirm.refundRegistration.title": "Refund this registration?",
+  "confirm.refundRegistration.body": "The remaining amount is refunded to the payer.",
+  "confirm.refundRegistration.label": "Refund",
+  "confirm.withdrawOwnRegistration.title": "Withdraw your registration?",
+  "confirm.withdrawOwnRegistration.body": "This frees your spot. You can register again while registration is open.",
+  "confirm.withdrawOwnRegistration.label": "Withdraw",
+  "confirm.revokeKey.title": "Revoke this API key?",
+  "confirm.revokeKey.body": "Integrations using {name} stop working immediately. This cannot be undone.",
+  "confirm.revokeKey.label": "Revoke key",
+  "confirm.deleteStage.title": "Delete this stage?",
+  "confirm.deleteStage.body": "{name} and its fixtures are removed. Completed results in other stages stay.",
+  "confirm.deleteStage.label": "Delete stage",
+
+  // ── Visibility picker (v3/03 §7) ──
+  "visibility.legend": "Who can see this",
+  "visibility.private.label": "Private",
+  "visibility.private.consequence": "Only your team can see it.",
+  "visibility.unlisted.label": "Link only",
+  "visibility.unlisted.consequence":
+    "Anyone with the link can view. Hidden from Google and our directory.",
+  "visibility.public.label": "Public",
+  "visibility.public.consequence":
+    "Anyone can find it — Google, and the Seazn discover page.",
+  "visibility.share.label": "Share link",
+  "visibility.share.copy": "Copy link",
+  "visibility.share.copied": "Copied",
+  "visibility.youth.title": "This competition includes youth divisions",
+  "visibility.youth.body":
+    "Making it visible publishes players' names on the public page. Confirm you hold guardian consent for every under-age player before continuing.",
+  "visibility.youth.confirm": "I hold guardian consent — continue",
+  "visibility.youth.cancel": "Keep it private",
+
+  // ── Mobile primitives (v3/02) ──
+  "sheet.close": "Close",
+  "table.actions": "Actions",
+} as const;
+
+export type MessageKey = keyof typeof messages;
+
+/** Copy lookup with `{placeholder}` interpolation. Never throws. */
+export function msg(key: MessageKey, vars?: Record<string, string | number>): string {
+  const raw: string = messages[key];
+  if (!vars) return raw;
+  return raw.replace(/\{(\w+)\}/g, (m, name) =>
+    Object.prototype.hasOwnProperty.call(vars, name) ? String(vars[name]) : m,
+  );
+}

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -1,0 +1,27 @@
+// Console route builder (v3/01 §6). Every console <Link>/redirect builds its
+// href here, never by string concatenation — so when PROMPT-30 moves the
+// console to slug-based /o/[org]/c/[comp]/d/[div] URLs, only this file's
+// internals change. Until then the builders emit today's id-based routes and
+// deliberately ignore slug arguments some callers already pass.
+
+type Id = string;
+
+export const routes = {
+  dashboard: () => "/dashboard",
+  competitionNew: () => "/competitions/new",
+  competition: (competitionId: Id) => `/competitions/${competitionId}`,
+  competitionSettings: (competitionId: Id) => `/competitions/${competitionId}/settings`,
+  competitionSchedule: (competitionId: Id) => `/competitions/${competitionId}/schedule`,
+  divisionNew: (competitionId: Id) => `/competitions/${competitionId}/divisions/new`,
+  division: (divisionId: Id, tab?: string) =>
+    tab ? `/divisions/${divisionId}?tab=${tab}` : `/divisions/${divisionId}`,
+  divisionSchedule: (divisionId: Id) => `/divisions/${divisionId}/schedule`,
+  divisionRegistrations: (divisionId: Id) => `/divisions/${divisionId}/registrations`,
+  settings: (tab?: string) => (tab ? `/settings?tab=${tab}` : "/settings"),
+  billing: () => "/settings/billing",
+  slideshowCompetition: (competitionId: Id) => `/slideshow/competitions/${competitionId}`,
+  slideshowDivision: (divisionId: Id) => `/slideshow/divisions/${divisionId}`,
+  /** Public dashboard path — already slug-based, unchanged by PROMPT-30. */
+  shared: (orgSlug: string, compSlug?: string, divSlug?: string) =>
+    ["/shared", orgSlug, compSlug, divSlug].filter(Boolean).join("/"),
+} as const;

--- a/apps/web/src/lib/typed-confirm.ts
+++ b/apps/web/src/lib/typed-confirm.ts
@@ -1,0 +1,7 @@
+// Type-to-confirm arming rule (v3/03 §3), shared by the ConfirmDialog
+// provider and the controlled v2 dialog so the contract is tested once:
+// exact match, no trimming, no case folding — the user types the name.
+
+export function isConfirmArmed(typedName: string | undefined, typed: string): boolean {
+  return typedName === undefined || typed === typedName;
+}

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -140,6 +140,8 @@ export const ROUTES: RouteSpec[] = [
   { path: "/teams", method: "get", summary: "List teams with their division entries", tag: "clubs" },
   { path: "/teams/{id}/squad", method: "get", summary: "Get a team's persistent squad", tag: "clubs", errors: [404] },
   { path: "/teams/{id}/squad", method: "put", summary: "Replace a team's squad (auto-seeds entrant rosters on enrollment)", tag: "clubs", request: S.SetTeamSquad, errors: [402, 404] },
+  { path: "/teams/{id}/logo", method: "post", summary: "Set a team badge: multipart `file` (v3/03 §5; overrides the club badge for this team)", tag: "clubs", errors: [404, 422] },
+  { path: "/teams/{id}/logo", method: "delete", summary: "Clear a team badge (falls back to the club badge)", tag: "clubs", errors: [404] },
   { path: "/clubs/logos", method: "post", summary: "Bulk logo assign: multipart `files` + `mapping` JSON + `assign_remaining` (Jul3/01 §5; Pro `logos.bulk` for >1 file)", tag: "clubs", response: z.array(S.LogoAssignment), errors: [402, 422] },
   { path: "/imports", method: "post", summary: "Upload a participants spreadsheet (multipart `file`) → dry-run { importId, plan }; writes nothing (Jul3/01 §6)", tag: "clubs", response: S.ImportPreview, status: 201, errors: [402, 413, 422] },
   { path: "/imports/{id}", method: "get", summary: "Re-preview a stored import against current state", tag: "clubs", response: S.ImportPreview },

--- a/apps/web/src/server/public-site/data.ts
+++ b/apps/web/src/server/public-site/data.ts
@@ -134,6 +134,14 @@ export interface PublicEntrant {
   seed: number | null;
   status: string;
   members: PublicEntrantMember[];
+  /** Effective badge block from team_display_v (team → club fallback);
+   *  null for individual/pair entrants (v3/03 §5). */
+  team_display?: {
+    club_id: string | null;
+    club_name: string | null;
+    logo_path: string | null;
+    colors: unknown;
+  } | null;
 }
 
 export interface PublicPlayer {
@@ -280,7 +288,8 @@ export async function getPublicDivision(
         select stage_id, pool_id, rows, updated_at
         from public_standings_v where division_id = ${division.id}`;
       const entrants = await sql<PublicEntrant[]>`
-        select id, division_id, kind, display_name, seed, status, members
+        select id, division_id, kind, display_name, seed, status, members,
+               team_display
         from public_entrants_v where division_id = ${division.id}
         order by seed nulls last, display_name`;
       return { stages, pools, fixtures, standings, entrants };

--- a/apps/web/src/server/slideshow-data.ts
+++ b/apps/web/src/server/slideshow-data.ts
@@ -6,6 +6,7 @@ import { sql, withTenant } from "@/lib/db";
 import { listStages, getStandings } from "@/server/usecases/stages";
 import { listDivisionFixtures } from "@/server/usecases/fixtures";
 import { listEntrants } from "@/server/usecases/entrants";
+import { listEntrantLogoUrls } from "@/server/usecases/teams";
 import { hasFeature } from "@/lib/entitlements";
 import { resolveLogoUrl } from "@/server/public-site/data";
 import type { AuthCtx } from "@/server/api-v1/auth";
@@ -25,6 +26,10 @@ export interface StandingsSlideRow {
 export interface FixtureSlideItem {
   home: string;
   away: string;
+  /** Team badge URLs (team → club via team_display_v) — the matchup slide is
+   *  the one surface that may show both sides' badges at once (v3/03 §5). */
+  homeLogo: string | null;
+  awayLogo: string | null;
   /** Display-ready score headline from match_states, e.g. "2 – 1" or "21-15, 21-18". */
   line: string | null;
   status: string;
@@ -64,10 +69,11 @@ export async function buildDivisionSlides(
   divisionId: string,
   divisionName: string,
 ): Promise<Slide[]> {
-  const [stages, fixtures, entrants] = await Promise.all([
+  const [stages, fixtures, entrants, logos] = await Promise.all([
     listStages(auth, divisionId),
     listDivisionFixtures(auth, divisionId),
     listEntrants(auth, divisionId),
+    listEntrantLogoUrls(auth, divisionId),
   ]);
   const names = Object.fromEntries(entrants.map((e) => [e.id, e.display_name]));
   const slides: Slide[] = [];
@@ -126,6 +132,8 @@ export async function buildDivisionSlides(
   const item = (f: (typeof fixtures)[number]): FixtureSlideItem => ({
     home: names[f.home_entrant_id ?? ""] ?? "TBD",
     away: names[f.away_entrant_id ?? ""] ?? "TBD",
+    homeLogo: logos[f.home_entrant_id ?? ""] ?? null,
+    awayLogo: logos[f.away_entrant_id ?? ""] ?? null,
     line: lineOf.get(f.id) ?? null,
     status: f.status,
     round: f.round_no,

--- a/apps/web/src/server/usecases/card-stats.ts
+++ b/apps/web/src/server/usecases/card-stats.ts
@@ -1,0 +1,155 @@
+import "server-only";
+// Card-grid aggregates (v3/03 §1–2): the EntityCard's meta / "Next:" /
+// progress lines in one query per list — no N+1 across a 3-column grid.
+// Read-only; RLS scopes everything through withTenant.
+import { withTenant } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+export interface NextFixture {
+  home: string | null;
+  away: string | null;
+  court_label: string | null;
+  scheduled_at: string | null;
+  in_play: boolean;
+}
+
+export interface CompetitionCardStats {
+  competition_id: string;
+  divisions: number;
+  entrants: number;
+  played: number;
+  total: number;
+  next: NextFixture | null;
+}
+
+export interface DivisionCardStats {
+  division_id: string;
+  entrants: number;
+  capacity: number | null;
+  stage_kinds: string[];
+  registration_open: boolean;
+  played: number;
+  total: number;
+  next: NextFixture | null;
+}
+
+// "Played" = a result exists (decided/finalized); denominator excludes
+// cancelled fixtures. Matches how organisers count a matchday.
+const PLAYED = ["decided", "finalized"] as const;
+
+export async function listCompetitionCardStats(
+  auth: AuthCtx,
+): Promise<Map<string, CompetitionCardStats>> {
+  const rows = await withTenant(auth.orgId, (tx) =>
+    tx<(CompetitionCardStats & { next: NextFixture | null })[]>`
+      select c.id as competition_id,
+        (select count(*)::int from divisions d
+          where d.competition_id = c.id and d.archived_at is null) as divisions,
+        (select count(*)::int from entrants e
+          join divisions d on d.id = e.division_id
+          where d.competition_id = c.id and d.archived_at is null
+            and e.status in ('registered','confirmed')) as entrants,
+        (select count(*)::int from fixtures f
+          join divisions d on d.id = f.division_id
+          where d.competition_id = c.id and d.archived_at is null
+            and f.status in ${tx([...PLAYED])}) as played,
+        (select count(*)::int from fixtures f
+          join divisions d on d.id = f.division_id
+          where d.competition_id = c.id and d.archived_at is null
+            and f.status <> 'cancelled') as total,
+        nf.next
+      from competitions c
+      left join lateral (
+        select jsonb_build_object(
+            'home', he.display_name, 'away', ae.display_name,
+            'court_label', f.court_label, 'scheduled_at', f.scheduled_at,
+            'in_play', f.status = 'in_play') as next
+        from fixtures f
+        join divisions d on d.id = f.division_id
+        left join entrants he on he.id = f.home_entrant_id
+        left join entrants ae on ae.id = f.away_entrant_id
+        where d.competition_id = c.id and d.archived_at is null
+          and f.status in ('scheduled','in_play')
+        order by (f.status = 'in_play') desc,
+                 f.scheduled_at asc nulls last, f.round_no, f.seq_in_round
+        limit 1
+      ) nf on true`,
+  );
+  return new Map(rows.map((r) => [r.competition_id, r]));
+}
+
+export async function listDivisionCardStats(
+  auth: AuthCtx,
+  competitionId: string,
+): Promise<Map<string, DivisionCardStats>> {
+  const rows = await withTenant(auth.orgId, (tx) =>
+    tx<DivisionCardStats[]>`
+      select d.id as division_id,
+        (select count(*)::int from entrants e
+          where e.division_id = d.id
+            and e.status in ('registered','confirmed')) as entrants,
+        rs.capacity,
+        coalesce(rs.enabled, false)
+          and (rs.opens_at is null or rs.opens_at <= now())
+          and (rs.closes_at is null or rs.closes_at > now()) as registration_open,
+        coalesce((select array_agg(distinct s.kind order by s.kind)
+          from stages s where s.division_id = d.id), '{}') as stage_kinds,
+        (select count(*)::int from fixtures f
+          where f.division_id = d.id and f.status in ${tx([...PLAYED])}) as played,
+        (select count(*)::int from fixtures f
+          where f.division_id = d.id and f.status <> 'cancelled') as total,
+        nf.next
+      from divisions d
+      left join registration_settings rs on rs.division_id = d.id
+      left join lateral (
+        select jsonb_build_object(
+            'home', he.display_name, 'away', ae.display_name,
+            'court_label', f.court_label, 'scheduled_at', f.scheduled_at,
+            'in_play', f.status = 'in_play') as next
+        from fixtures f
+        left join entrants he on he.id = f.home_entrant_id
+        left join entrants ae on ae.id = f.away_entrant_id
+        where f.division_id = d.id and f.status in ('scheduled','in_play')
+        order by (f.status = 'in_play') desc,
+                 f.scheduled_at asc nulls last, f.round_no, f.seq_in_round
+        limit 1
+      ) nf on true
+      where d.competition_id = ${competitionId} and d.archived_at is null`,
+  );
+  return new Map(rows.map((r) => [r.division_id, r]));
+}
+
+/** "Arun vs Dev · Court 2 · 14:30" — the card's one-line answer to "what's
+ *  next?". Null-safe on every field (TBD entrants, unscheduled fixtures). */
+export function nextLine(next: NextFixture | null): string | null {
+  if (!next) return null;
+  const pair = `${next.home ?? "TBD"} vs ${next.away ?? "TBD"}`;
+  const parts = [pair];
+  if (next.court_label) parts.push(next.court_label);
+  if (next.scheduled_at) {
+    const at = new Date(next.scheduled_at);
+    const sameDay = at.toDateString() === new Date().toDateString();
+    parts.push(
+      at.toLocaleString("en-GB", {
+        ...(sameDay ? {} : { weekday: "short", day: "numeric", month: "short" }),
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    );
+  }
+  return (next.in_play ? "Now: " : "") + parts.join(" · ");
+}
+
+/** "Knockout", "Group + Knockout", "League" — format from real structure. */
+export function formatLabel(kinds: string[]): string | null {
+  if (kinds.length === 0) return null;
+  const label: Record<string, string> = {
+    league: "League",
+    group: "Groups",
+    knockout: "Knockout",
+    swiss: "Swiss",
+    ladder: "Ladder",
+    americano: "Americano",
+  };
+  return kinds.map((k) => label[k] ?? k).join(" + ");
+}

--- a/apps/web/src/server/usecases/teams.ts
+++ b/apps/web/src/server/usecases/teams.ts
@@ -4,10 +4,13 @@ import "server-only";
 // team" flow. Each team carries a persistent squad (team_members) managed in the
 // club directory, used to auto-seed an entrant's roster on enrollment.
 // Reads are ungated; create/edit (Pro club hierarchy) require clubs.hierarchy.
+import { createHash } from "node:crypto";
 import type postgres from "postgres";
 import { withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { requireFeature } from "@/lib/entitlements";
+import { supabaseAdmin } from "@/lib/supabase-admin";
+import { publicStorageUrl } from "@/lib/supabase-storage";
 import type { z } from "zod";
 import type { EntrantMemberInput } from "@/server/api-v1/schemas";
 import type { AuthCtx } from "@/server/api-v1/auth";
@@ -77,6 +80,70 @@ export async function createTeam(
       returning id, name, short_name, club_id`;
     return team!;
   });
+}
+
+// ---------------------------------------------------------------------------
+// Team logo (v3/03 §5): same pipeline as club badges — content-hash path in
+// the public assets bucket, one object per unique bytes. Single-file, so it
+// stays available on Community (like one-at-a-time club logos); teams fall
+// back to their club badge via team_display_v when unset.
+// ---------------------------------------------------------------------------
+
+const LOGO_MAX_BYTES = 2 * 1024 * 1024;
+const LOGO_MIME = new Map([
+  ["image/png", "png"],
+  ["image/jpeg", "jpg"],
+  ["image/webp", "webp"],
+  ["image/svg+xml", "svg"],
+]);
+
+export async function setTeamLogo(
+  auth: AuthCtx,
+  teamId: string,
+  file: { contentType: string; bytes: Buffer },
+): Promise<{ logo_path: string }> {
+  const ext = LOGO_MIME.get(file.contentType);
+  if (!ext) throw new HttpError(422, `unsupported logo type '${file.contentType}'`);
+  if (file.bytes.length > LOGO_MAX_BYTES) throw new HttpError(422, "logo exceeds the 2 MB limit");
+  return withTenant(auth.orgId, async (tx) => {
+    const [team] = await tx`select 1 from teams where id = ${teamId}`;
+    if (!team) throw new HttpError(404, "team not found");
+    const hash = createHash("sha256").update(file.bytes).digest("hex").slice(0, 32);
+    const path = `orgs/${auth.orgId}/teams/${hash}.${ext}`;
+    const { error } = await supabaseAdmin()
+      .storage.from("assets")
+      .upload(path, file.bytes, { contentType: file.contentType, upsert: true });
+    if (error) throw new HttpError(502, `logo upload failed: ${error.message}`);
+    await tx`update teams set logo_path = ${path} where id = ${teamId}`;
+    return { logo_path: path };
+  });
+}
+
+export async function removeTeamLogo(auth: AuthCtx, teamId: string): Promise<void> {
+  await withTenant(auth.orgId, async (tx) => {
+    const [team] = await tx`select 1 from teams where id = ${teamId}`;
+    if (!team) throw new HttpError(404, "team not found");
+    // Objects are content-hash shared across teams — clear the pointer only.
+    await tx`update teams set logo_path = null where id = ${teamId}`;
+  });
+}
+
+/** entrant_id → resolved badge URL for a division (team → club via
+ *  team_display_v; null = fall through to monogram/initials in EntityLogo). */
+export async function listEntrantLogoUrls(
+  auth: AuthCtx,
+  divisionId: string,
+): Promise<Record<string, string | null>> {
+  const rows = await withTenant(auth.orgId, (tx) =>
+    tx<{ entrant_id: string; logo_path: string | null }[]>`
+      select e.id as entrant_id, td.logo_path
+      from entrants e
+      left join team_display_v td on td.team_id = e.team_id and td.org_id = ${auth.orgId}
+      where e.division_id = ${divisionId}`,
+  );
+  return Object.fromEntries(
+    rows.map((r) => [r.entrant_id, r.logo_path ? publicStorageUrl(r.logo_path) : null]),
+  );
 }
 
 /** Load a team's persistent squad (in the CreateEntrant member shape, minus

--- a/design/v3/02-mobile-responsive-overhaul.md
+++ b/design/v3/02-mobile-responsive-overhaul.md
@@ -52,6 +52,13 @@ the work is applying patterns, not inventing breakpoints.
   scroll container; freeze the first column (`position: sticky; left: 0`).
 - Fixtures list: already list-like; enforce patterns 2/5 (score entry = bottom sheet).
 
+> **Implementation note (PROMPT-31, 2026-07-10):** entrants (and the other v2
+> panels) kept their tables inside pattern-4 scroll containers instead of a card
+> rewrite — the rows embed roster editors whose card form is a bigger redesign;
+> `<ResponsiveTable>` exists for the next table that opts in. Score entry stayed
+> on the fixture page (its dialogs now render as bottom sheets via the shared
+> modal); the dedicated score-sheet bottom sheet folds into v3/04's board work.
+
 ### 3.4 Schedule board — deferred to v3/04 (its own redesign; mobile agenda view there).
 
 ### 3.5 Remaining sweep

--- a/design/v3/03-ui-system-refresh.md
+++ b/design/v3/03-ui-system-refresh.md
@@ -68,6 +68,14 @@ Three logo levels exist conceptually; only org + club exist in data (club badge 
 `team_display_v` shipped in Jul3/01). **Add `teams.logo_url`** (upload path mirrors club
 logos; falls back club → org monogram → initials avatar).
 
+> **Implementation note (PROMPT-32, 2026-07-10):** no new migration was needed —
+> `teams.logo_path` has existed since V206 and `team_display_v` already resolves
+> team → club. What shipped: `POST/DELETE /api/v1/teams/{id}/logo` (content-hash
+> upload mirroring club badges), the `<EntityLogo>` chain component, badges on
+> console + public standings rows, slideshow fixture rows (both sides on the
+> matchup surface), and per-team upload in the club detail. XLSX/PDF row chips
+> were not added — exports already carry branded logos via Jul3/06's pipeline.
+
 | Surface | Org logo | Club logo | Team logo |
 |---|---|---|---|
 | Console header / org switcher | ✅ 24px | — | — |

--- a/design/v3/README.md
+++ b/design/v3/README.md
@@ -6,12 +6,21 @@ engine**: mobile, navigation, pricing/packaging, self-serve growth, documentatio
 handful of correctness fixes. Intake: the 9 Jul 2026 organiser/founder list (31 items,
 captured verbatim in [00-intake-backlog.md](00-intake-backlog.md)).
 
-> **Status: designed; PROMPT-38 implemented** (2026-07-10, branch
-> `feat/engine-fixes-prompt-38`) — badminton headline + set-end matrix, cricket
-> undo/status coherence + scoring error boundary, sim-replay v2 (matrix +
-> `sim-report.json` + CI profile), division delete/archive/restore. The rest are
-> designed, not implemented. Prompts numbered PROMPT-30…39 (continuing Jul3's
-> 21–29). Numbering of design docs is independent of `engine/` docs.
+> **Status: designed; PROMPT-38, PROMPT-32 and PROMPT-31 implemented.**
+> PROMPT-38 (2026-07-10, branch `feat/engine-fixes-prompt-38`) — badminton
+> headline + set-end matrix, cricket undo/status coherence + scoring error
+> boundary, sim-replay v2, division delete/archive/restore.
+> PROMPT-32 + PROMPT-31 (2026-07-10, branch `feat/v3-ui-prompt-32-31`) —
+> match-day card system (EntityCard/StatusChip/division hue), promise-based
+> ConfirmDialog provider (all 9 native `confirm()` sites replaced + ESLint
+> ban), Tips framework (12-tip registry), EntityLogo chain + team badges,
+> plan scrub + CI grep gate, visibility radio cards + youth interstitial,
+> `lib/messages.ts` copy layer, `lib/routes.ts` route builder, five mobile
+> patterns applied console-wide, Playwright `mobile-se`/`mobile-14` viewport
+> gate (no-h-scroll + axe serious/critical + Fast-3G LCP). Deviations noted
+> inline in docs 02/03. The rest are designed, not implemented. Prompts
+> numbered PROMPT-30…39 (continuing Jul3's 21–29). Numbering of design docs
+> is independent of `engine/` docs.
 
 ## Theme
 

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -26777,6 +26777,420 @@
         ]
       }
     },
+    "/api/v1/teams/{id}/logo": {
+      "post": {
+        "summary": "Set a team badge: multipart `file` (v3/03 §5; overrides the club badge for this team)",
+        "tags": [
+          "clubs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Clear a team badge (falls back to the club badge)",
+        "tags": [
+          "clubs"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/api/v1/clubs/logos": {
       "post": {
         "summary": "Bulk logo assign: multipart `files` + `mapping` JSON + `assign_remaining` (Jul3/01 §5; Pro `logos.bulk` for >1 file)",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
@@ -131,6 +132,19 @@
         "@apm-js-collab/code-transformer": "^0.15.0",
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/scripts/check-plan-scrub.sh
+++ b/scripts/check-plan-scrub.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# v3/03 §6 regression gate: the retired plan tier must never reappear in UI
+# copy. The word (capitalised, standalone) is forbidden in component/app
+# source; the lowercase `business` DB plan-key literal in lib/server code is
+# deliberately out of scope.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+matches=$(grep -rn --include='*.ts' --include='*.tsx' -w 'Business' \
+  apps/web/src/components apps/web/src/app || true)
+
+if [[ -n "$matches" ]]; then
+  echo "Plan-scrub gate failed — 'Business' found in UI source (v3/03 §6):"
+  echo "$matches"
+  exit 1
+fi
+echo "plan-scrub gate ok"

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -218,10 +218,68 @@ async function main() {
   // free org lifts the divisions quota; archive/restore on the Pro org.
   await divisionLifecycleSuite(admin, org2.id);
 
+  // --- v3 UI system (PROMPT-32): card grid render + visibility flip on both
+  // plans — pro on org2, free on a fresh community owner.
+  await uiSystemSuite(admin, org2.slug);
+
   // --- Growth-wave gaps (device links, scorer seats, discovery, registration,
   // ownership transfer, downgrade freeze) — pro paths on org2, free paths on a
   // fresh community owner. Destructive downgrade runs last.
   await gapSuite(admin, org.id, org2.id);
+}
+
+/** Fetch a page as HTML with the session's cookies (raw() assumes JSON). */
+async function html(s: Session, path: string): Promise<{ status: number; body: string }> {
+  const res = await fetch(BASE + path, {
+    headers: Object.keys(s.cookies).length ? { cookie: cookieHeader(s) } : {},
+  });
+  return { status: res.status, body: await res.text() };
+}
+
+/** PROMPT-32 smoke: match-day cards render server-side and the visibility
+ *  keys flip end-to-end (share page live + noindex) on pro AND free orgs. */
+async function uiSystemSuite(admin: Session, proOrgSlug: string): Promise<void> {
+  // Pro path (admin's active org is the pro org2).
+  const comp = v1data<{ id: string; slug: string }>(
+    await v1(admin, "/api/v1/competitions", "POST", {
+      name: `UI Cards ${tag}`,
+      visibility: "private",
+    }),
+  );
+  const dash = await html(admin, "/dashboard");
+  check("dashboard renders card grid (pro)", dash.status === 200 && dash.body.includes("ecard"));
+  check("card carries status chip", dash.body.includes('data-chip="draft"'));
+
+  const flip = await v1(admin, `/api/v1/competitions/${comp.id}`, "PATCH", {
+    visibility: "unlisted",
+  });
+  check("visibility flips to Link only (pro)", flip.status === 200);
+  const shared = await html(newSession(), `/shared/${proOrgSlug}/${comp.slug}`);
+  check("link-only page serves (pro)", shared.status === 200);
+  check("link-only page keeps noindex", shared.body.includes("noindex"));
+
+  // Free path: fresh community owner, same flow.
+  const free = newSession();
+  const freeVer = await signIn(free, `ui_free_${tag}@example.com`);
+  const freeOrgs = (await call(free, "/api/orgs")) as { id: string; slug: string }[];
+  const freeOrg = freeOrgs.find((o) => o.id === freeVer.org_id)!;
+  const freeComp = v1data<{ id: string; slug: string }>(
+    await v1(free, "/api/v1/competitions", "POST", {
+      name: `UI Cards Free ${tag}`,
+      visibility: "private",
+    }),
+  );
+  const freeDash = await html(free, "/dashboard");
+  check(
+    "dashboard renders card grid (free)",
+    freeDash.status === 200 && freeDash.body.includes("ecard"),
+  );
+  const freeFlip = await v1(free, `/api/v1/competitions/${freeComp.id}`, "PATCH", {
+    visibility: "unlisted",
+  });
+  check("visibility flips to Link only (free)", freeFlip.status === 200);
+  const freeShared = await html(newSession(), `/shared/${freeOrg.slug}/${freeComp.slug}`);
+  check("link-only page serves + noindex (free)", freeShared.status === 200 && freeShared.body.includes("noindex"));
 }
 
 // v1 responses: { ok, data | error: {code, message, …}, requestId }.
@@ -1042,6 +1100,7 @@ async function cleanup(tag: string): Promise<void> {
     `scorer2_${tag}@example.com`,
     `free_${tag}@example.com`,
     `walkin_${tag}@example.com`,
+    `ui_free_${tag}@example.com`,
   ];
   const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
   const sql = postgres(url, {


### PR DESCRIPTION
## PROMPT-32 — UI System Refresh

- **Match-day card system** (v3/03 §1–2): `EntityCard` + `StatusChip` vocabulary (Draft / Registration open / Live / Completed / Archived) + per-division hue (`lib/division-hue.ts`); dashboard and competition pages render card grids with Live-first sort, `⋯` menus, list toggle (localStorage), invitation empty states. Card meta/next/progress lines come from one query per list (`server/usecases/card-stats.ts`).
- **ConfirmDialog** (v3/03 §3): promise-based `useConfirm()` provider in the root layout; bottom sheet under `sm`, `tone: danger` (no Enter-submit), `typedName` challenge. All **9** native `confirm()` call sites replaced; ESLint now bans `confirm`/`alert`.
- **Tips** (v3/03 §4): `config/tips.ts` registry (12 seed tips), `<Tip>` popover + `<TipCallout>` dismissible variant; Learn-more links render only when `/help` resolves (dead until PROMPT-35).
- **Logos** (v3/03 §5): `EntityLogo` fallback chain team→club→org monogram→initials; team badge upload `POST/DELETE /api/v1/teams/{id}/logo` (content-hash, mirrors club pipeline); chips on console + public standings and slideshow fixture rows. *No migration needed — `teams.logo_path` existed since V206 (doc note added).*
- **Plan scrub** (v3/03 §6): retired tier gone from `plan-badge`, `feature-copy`, api-keys copy; `scripts/check-plan-scrub.sh` wired into CI.
- **Visibility picker** (v3/03 §7): Private / Link only / Public radio cards with permanent consequence sentences + share-URL copy row; youth guardian-consent interstitial (v3/11 gap 8); same component in wizard + settings; `noindex` behaviour unchanged.
- **Copy layer** (v3/11 gap 4): every new string via `lib/messages.ts`; console hrefs via `lib/routes.ts` so PROMPT-30's route move touches one file.

## PROMPT-31 — Mobile & Responsive Overhaul

- **Primitives** (v3/02 §2): `ResponsiveTable`, `ActionBar` (safe-area bottom dock), dialog→bottom-sheet (shared `.modal` + ConfirmDialog), global `overflow-x: clip` with `.scroll-x`/`.scroll-x-fade` containers, ≥16px inputs under `sm`.
- **Org settings**: sidebar → sticky scrollable tab row on phones; member rows wrap actions to a full-width line.
- **Billing**: plan comparison stacks under `xs`; embedded Stripe checkout full-bleed at 375px (the reported break).
- **Division console**: scrollable tab bar with edge fade; StatusChip header; standings rank column frozen (`sticky left-0`) inside its scroll container; v2 panel tables in scroll containers; header actions icon-only on mobile (also competition page, per request).
- **Viewport gate** (v3/02 §4 + gaps 11/12/15): Playwright `mobile-se` (375×667) + `mobile-14` (390×844) run `e2e/mobile.spec.ts` — `expectNoHorizontalScroll` on 15 console + 5 public routes, axe WCAG 2.1 AA (serious/critical fail), page smokes (settings save round-trip, plan card), Fast-3G LCP < 2.5s on public dashboard + registration. Wired into `npm run test:e2e` (CI e2e workflow picks it up). The axe gate caught and fixed real issues: low-contrast slate-400/purple-400 text, unnamed icon links, `.label` opacity.

## Acceptance evidence

- `tsc` clean · `eslint` 0 errors · unit **192 passed** (new golden tests: chip states, logo initials, typedName arming, messages, hue, card meta lines)
- e2e: `ui-system.spec.ts` 3/3 (card nav, ConfirmDialog with native-dialog tripwire, visibility flip + copyable URL + noindex) · `mobile-se` 8/8 · `mobile-14` 8/8 · parallel project green (2 spec locators updated for the new Tip affordance)
- `scripts/smoke.ts` **127 passed** incl. new card-grid + visibility-flip checks on pro AND free orgs
- v3/README status updated; deviations noted inline in v3/02 §3.3 and v3/03 §5

🤖 Generated with [Claude Code](https://claude.com/claude-code)