### PR TITLE
fix(test): slug suites stop relying on variant-seed race for division config

### DIFF
--- a/apps/web/src/server/__tests__/slug-resolve.test.ts
+++ b/apps/web/src/server/__tests__/slug-resolve.test.ts
@@ -61,7 +61,7 @@ describe.skipIf(!HAS_DB)("slug-resolve (PROMPT-30)", () => {
       name: "Open",
       sport_key: "generic",
       variant_key: "score",
-      config: {},
+      config: GENERIC_CONFIG,
       eligibility: [],
     });
 
@@ -101,7 +101,7 @@ describe.skipIf(!HAS_DB)("slug-resolve (PROMPT-30)", () => {
       name: "Open",
       sport_key: "generic",
       variant_key: "score",
-      config: {},
+      config: GENERIC_CONFIG,
       eligibility: [],
     });
     const [{ id: stageId }] = await sql<{ id: string }[]>`
@@ -136,7 +136,7 @@ describe.skipIf(!HAS_DB)("slug-resolve (PROMPT-30)", () => {
       name: "U16 Boys",
       sport_key: "generic",
       variant_key: "score",
-      config: {},
+      config: GENERIC_CONFIG,
       eligibility: [],
     });
     const names = await breadcrumbNames(auth.orgId);

--- a/apps/web/src/server/__tests__/slug-resolve.test.ts
+++ b/apps/web/src/server/__tests__/slug-resolve.test.ts
@@ -146,5 +146,6 @@ describe.skipIf(!HAS_DB)("slug-resolve (PROMPT-30)", () => {
 });
 
 afterAll(async () => {
+  if (!HAS_DB) return; // DB-less unit job: connecting just to disconnect throws
   await sql.end();
 });

--- a/apps/web/src/server/usecases/__tests__/slug-hygiene.test.ts
+++ b/apps/web/src/server/usecases/__tests__/slug-hygiene.test.ts
@@ -159,5 +159,6 @@ describe.skipIf(!HAS_DB)("slug hygiene (PROMPT-30)", () => {
 });
 
 afterAll(async () => {
+  if (!HAS_DB) return; // DB-less unit job: connecting just to disconnect throws
   await sql.end();
 });

--- a/apps/web/src/server/usecases/__tests__/slug-hygiene.test.ts
+++ b/apps/web/src/server/usecases/__tests__/slug-hygiene.test.ts
@@ -55,7 +55,7 @@ const divInput = (name: string) => ({
   name,
   sport_key: "generic",
   variant_key: "score",
-  config: {},
+  config: GENERIC_CONFIG,
   eligibility: [],
 });
 


### PR DESCRIPTION
Fixes the 5 `invalid generic config` failures on main (run [29114860591](https://github.com/ashokhein/seazn.club/actions/runs/29114860591)).

**Root cause:** `slug-resolve.test.ts` / `slug-hygiene.test.ts` create divisions with `config: {}` and rely on their own `sport_variants` seed for `points`/`progressScore`. All suites seed `generic/score` with `on conflict do nothing` against one shared CI database — whichever suite runs first wins. `team-squad.test.ts` seeds a sparse config (no `progressScore`), and when it wins, `createDivision` rejects the merged config.

**Fix:** pass the full `GENERIC_CONFIG` (already defined in both files, previously unused) in every `createDivision` call — validity no longer depends on suite ordering.

**Verified:** fresh DB + deliberately sparse `generic/score` seed → 5 failures before (identical to CI), 13/13 pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)