### PR TITLE
ci: run test gates on pull requests only; main push keeps just the deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# Test gates (test/smoke/security) run on PULL REQUESTS ONLY — a squash-merge
+# lands the exact tree the PR already validated, so re-running them on the
+# main push would test the same code twice. The push:main trigger stays
+# solely to drive the staging deploy, which trusts the PR gates.
 on:
   push:
     branches: [main]
@@ -16,6 +20,7 @@ jobs:
   # -------------------------------------------------------------------------
   test:
     name: Unit + typecheck
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -67,6 +72,7 @@ jobs:
   # -------------------------------------------------------------------------
   security:
     name: Security scan
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -92,6 +98,7 @@ jobs:
   # -------------------------------------------------------------------------
   smoke:
     name: Smoke (Postgres container)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     services:
@@ -209,7 +216,12 @@ jobs:
     name: Deploy (staging)
     runs-on: ubuntu-latest
     needs: [test, smoke, security]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # The gates are PR-only now, so on a main push they report 'skipped' —
+    # always() + no-failure lets the deploy proceed past skipped needs while
+    # still halting if a gate somehow ran and failed.
+    if: >-
+      always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+      && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     concurrency:
       group: deploy-staging
       cancel-in-progress: false


### PR DESCRIPTION
test/smoke/security currently run twice per change — once on the PR, again on the identical squash-merged tree pushed to main. This makes them `pull_request`-only.

- `on: push: branches: [main]` **stays**, but now solely drives `deploy-staging` — removing it would silently kill staging deploys.
- `deploy-staging` keeps its `needs: [test, smoke, security]`; on a main push those report `skipped`, so the condition becomes `always() && push && main && no needs failure/cancelled` — deploy proceeds past skipped gates but still halts if a gate somehow ran and failed.
- e2e.yml untouched (already main-push + manual dispatch).

Effect: one CI battery per change (on the PR), deploys unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)