### PR TITLE
docs: v4 AI-scheduling + v5 i18n design corpora (PROMPT-41..47)

### DIFF
--- a/design/v4/00-ai-schedule-architect.md
+++ b/design/v4/00-ai-schedule-architect.md
@@ -1,0 +1,136 @@
+# v4/00 — AI Schedule Architect (normative spec)
+
+Scope: divisions + competitions, timed scheduling only. Replaces the retired
+prose→constraints feature. Implemented by PROMPT-41/42/43.
+
+## §1 Remove the old feature
+
+The first-cut AI (`scheduling.ai` v1) only translated prose into the constraints jsonb and
+its UI was already withdrawn ("endpoint intact, UI withdrawn"). Verdict: not good enough —
+delete it, keep its plumbing. Removal inventory (PROMPT-41):
+
+- `aiConstraintsForDivision` + `parseAiConstraints` + `AiConstraints` zod in
+  `apps/web/src/server/usecases/schedule-plus.ts`
+- Route `apps/web/src/app/api/v1/divisions/[id]/schedule/ai-constraints/route.ts`
+- Its `RouteSpec` row in `apps/web/src/server/api-v1/openapi.ts` ROUTES + schemas
+- Parked prose box + dead handlers in `apps/web/src/components/v2/constraints-panel.tsx`
+- Unit/e2e tests exercising ai-constraints
+
+**Keep and reuse:** entitlement key `scheduling.ai` (V245 — same paid gate, new feature
+behind it), PostHog kill-switch flag `ai-scheduling` (evaluated before the billing gate),
+env `SCHEDULING_AI_MODEL` (default `claude-opus-4-8`), `@anthropic-ai/sdk` dep, error
+conventions: missing `ANTHROPIC_API_KEY` → 503 friendly message; unparseable model output
+after retries → 422.
+
+## §2 Product shape — three modes, one pipeline
+
+| Mode | Trigger | Movable set | Draft given to LLM |
+|------|---------|-------------|--------------------|
+| `generate` | Blank or partial board, organiser writes an instruction | All unpinned `scheduled`-status fixtures in scope | Greedy `slotFixtures` pass |
+| `refine` | Follow-up turn on a proposal ("move finals to Sunday evening") | Same as the prior proposal | The prior proposal |
+| `repair` | Disruption ("Court 2 flooded", "rain washed out Saturday") | Only fixtures matching `scope` (from-date / courts / pools), rest become obstacles | Current persisted schedule |
+
+Every mode is **propose-only**. The endpoint returns a proposal + verifier report + diff;
+nothing persists until the organiser accepts. Accept path reuses the existing
+`applySchedule` use-case (transaction, re-validate, `assertNoBlocking`, advisory lock,
+`schedule_applied` ledger event, `divisions.seq` bump) — the AI feature adds zero new write
+machinery.
+
+Flexible divisions (`scheduling_mode='flexible'`) are rejected 409 `AI_PLAN_UNSUPPORTED`
+(no timestamps to plan). Divisions with >500 movable fixtures are rejected 422 (matches
+the apply limit and bounds the context pack).
+
+## §3 Pipeline
+
+```
+buildContextPack ─→ greedy draft ─→ LLM (structured output) ─→ validateAssignments
+                                            ▲                        │
+                                            └── repair round ≤2 ─────┘ blocking conflicts
+                                                                     │
+                                                          proposal + warnings + diff
+```
+
+1. **Context pack** (`buildSchedulePack`, new module `apps/web/src/server/usecases/schedule-ai.ts`):
+   deterministic JSON — settings (tz, matchMinutes, gapMinutes, courts, sessionWindows,
+   blackouts, `constraints{}`), entrants (+ pool, seed) and the shared-person map from
+   `entrant_members`, movable fixtures (id, ext_key, round_no, seq_in_round, pool, feeds,
+   current slot, pinned/locked-scope flags), obstacles (other stages, sibling divisions via
+   the same query family as `siblingAssignments`), the mode, the draft, the instruction.
+   Sorted keys, stable ordering → snapshot-testable and prompt-cache friendly.
+2. **Draft**: `slotFixtures` output (mode `generate`) — a legal-but-naive baseline. The LLM
+   improves on it instead of inventing time math from scratch.
+3. **LLM call**: see `01-llm-contract.md`. Strict structured output; every movable fixture
+   must appear exactly once in `assignments` or `unschedulable`.
+4. **Verifier**: run engine `validateAssignments` (court/rest/blackout/person_overlap/
+   start_window/order) on the proposal against the same obstacles. Blocking conflicts →
+   one repair round: send the conflict report back, ask for minimal fixes. Max 2 repair
+   rounds, then return the best proposal with residual conflicts marked `blocking:true`
+   (UI disables accept for those fixtures, offers "drop blockers to tray").
+5. **Response**: `{proposal, warnings, blocking, diff:{moved,placed,unscheduled,unchanged},
+   explanations, summary, constraint_suggestions?, usage:{input_tokens,output_tokens,repair_rounds}}`.
+
+## §4 API surface (all registered in ROUTES)
+
+- `POST /api/v1/divisions/{id}/schedule/ai-plan` — body
+  `{instruction: string(3..4000), mode: "generate"|"refine"|"repair" = "generate",
+  scope?: {from?: iso, courts?: string[], pool_ids?: uuid[]},
+  prior?: {instruction: string, assignments: ScheduleAssignment[]}}`.
+  Stateless: the client holds the conversation; `refine` posts the prior proposal back.
+  Auth `requireResourceAuth(division, "write")`; gates §6.
+- `POST /api/v1/competitions/{id}/schedule/ai-plan` (PROMPT-42) — multi-division: movable
+  set spans the competition's timed divisions, court space is shared, response groups
+  assignments per division. Additionally gated `scheduling.multi_division`. Accept applies
+  per division in build order, each under its own advisory lock + checkpoint.
+- Accept = existing `POST /api/v1/stages/{id}/schedule/apply` (division boards) /
+  per-division loop (competition board). Client sends `source:"ai"`.
+- Constraint suggestions accept = existing `PUT /api/v1/divisions/{id}/schedule-settings`
+  (client merges the suggested `constraints{}` delta; no new endpoint).
+
+## §5 Data changes
+
+One migration (V-next): extend `fixtures.schedule_source` check constraint
+`none|auto|manual` → `none|auto|manual|ai`; extend `ApplyScheduleRequest.source` enum to
+match. `schedule_applied` ledger payload already carries `source` — now distinguishes AI
+applies for audit/analytics. No new tables: proposals are ephemeral (client state), the
+applied result is fully captured by the existing ledger + checkpoint machinery.
+Auto-checkpoint named `before-ai` (via `schedule.versioning` checkpoints) is created in the
+accept flow before apply → one-click undo.
+
+## §6 Gating, limits, telemetry
+
+Order of checks in the use-case: auth → PostHog `ai-scheduling` kill-switch (fallback
+`true`) → `requireFeature(orgId, "scheduling.ai")` (+ `scheduling.multi_division` for the
+competition route) → `rateLimit("ai-plan:" + divisionId, {max: 5, windowSeconds: 3600})`
+(429 with friendly copy; competition route keys on competition id, max 3/h) → mode/scope
+validation. `captureServer("ai_plan_run", {mode, fixtures, repair_rounds, input_tokens,
+output_tokens, blocking})` per run and `ai_plan_accepted` / `ai_plan_discarded` from the UI.
+Add `ANTHROPIC_API_KEY` + `SCHEDULING_AI_MODEL` to `apps/web/.env.example` (currently
+missing — known gap).
+
+## §7 Failure modes
+
+| Condition | Response |
+|---|---|
+| No `ANTHROPIC_API_KEY` | 503 "AI scheduling is not configured on this server" |
+| Kill-switch off | 404-style hidden in UI; API 403 `FEATURE_DISABLED` |
+| Free org | 402 `PAYMENT_REQUIRED` + `feature_key` → `UpgradeGate` |
+| Model refusal / unparseable after retry | 422 `AI_PLAN_FAILED` with summary text |
+| >500 movable fixtures | 422 `AI_PLAN_TOO_LARGE` |
+| Flexible division | 409 `AI_PLAN_UNSUPPORTED` |
+| Rate window exceeded | 429 |
+| Board changed since proposal (stale `expected_seq` on apply) | existing 409 `SEQ_CONFLICT` → UI refreshes + offers re-run as `refine` |
+
+## §8 Decisions (binding)
+
+1. **LLM plans, engine referees** — no proposal reaches the DB without passing
+   `validateAssignments` + `assertNoBlocking` in the apply transaction.
+2. **Stateless conversation** — no ai_sessions table; client posts prior proposal back.
+   Revisit only if transcripts must survive reloads.
+3. **Reuse `scheduling.ai` key** — billing matrix untouched; this is a replacement, not a
+   new SKU.
+4. **Sync request** — no queue/streaming in this wave; ≤500 fixtures fits comfortably in
+   one request. If p95 latency hurts, streaming is the follow-up, not a blocker.
+5. **`slotFixtures` stays** — the free/Pro "Auto-schedule" button is unchanged; AI is a
+   layer above it, and its draft feeds the LLM.
+6. **Suggestions are opt-in** — `constraint_suggestions` never auto-write settings; UI
+   shows them as a checked-by-default list applied on accept via the existing PUT.

--- a/design/v4/01-llm-contract.md
+++ b/design/v4/01-llm-contract.md
@@ -1,0 +1,168 @@
+# v4/01 — LLM contract (model, context pack, schema, system prompt)
+
+Normative for PROMPT-41/42. The strings and schemas below ship verbatim (module
+`apps/web/src/server/usecases/schedule-ai-prompt.ts`); edits require updating the golden
+tests in §6.
+
+## §1 Model + call parameters
+
+```ts
+const client = new Anthropic();                       // reads ANTHROPIC_API_KEY
+const model = process.env.SCHEDULING_AI_MODEL ?? "claude-opus-4-8";
+const response = await client.messages.parse({
+  model,
+  max_tokens: 32_000,
+  thinking: { type: "adaptive" },                     // let it plan; depth via effort
+  output_config: { effort: "high", format: zodOutputFormat(AiSchedulePlan) },
+  system: SYSTEM_PROMPT,                              // §4, cached: cache_control ephemeral
+  messages,                                           // §5 protocol
+});
+```
+
+- `system` carries a `cache_control: {type: "ephemeral"}` breakpoint — repair/refine rounds
+  in the same run reuse the prefix.
+- `!response.parsed_output` → one retry with a corrective user turn, then 422.
+- `response.stop_reason === "refusal"` → 422 `AI_PLAN_FAILED` (never read content first).
+- Timeout: SDK default; abort controller at 120s per round, surfaced as 422 with retry hint.
+
+## §2 Context pack (the single user-turn JSON)
+
+Deterministic (sorted keys, fixtures ordered by `round_no, seq_in_round, ext_key`), built by
+`buildSchedulePack`. Shape:
+
+```jsonc
+{
+  "mode": "generate",                       // generate | refine | repair
+  "division": { "id": "…", "name": "Div 1", "sport": "badminton", "tz": "Europe/London",
+                "scheduling_mode": "timed" },
+  "settings": {
+    "matchMinutes": 30, "gapMinutes": 5,
+    "courts": ["Court 1", "Court 2"],       // the ONLY legal court_label values
+    "sessionWindows": [{ "from": "2026-07-18T09:00:00+01:00", "to": "2026-07-18T18:00:00+01:00" }],
+    "blackouts": [{ "court": "Court 2", "from": "…", "to": "…" }],
+    "constraints": { "restMin": 20, "noBackToBack": true, "startWindows": [ … ],
+                     "fieldFairness": "balance", "parallelism": "mixed",
+                     "crossPersonClash": "hard" }
+  },
+  "entrants": [{ "id": "…", "name": "Riverside A", "pool": "A", "seed": 1 }],
+  "people": [{ "person_id": "…", "entrant_ids": ["…", "…"] }],   // shared-player map
+  "fixtures": {
+    "movable":   [{ "id": "…", "ext_key": "rr-r1-c2", "round": 1, "seq": 2, "pool": "A",
+                    "home": "…", "away": "…",
+                    "feeds": { "winner_to": null, "after": ["…fixture ids…"] },
+                    "current": { "at": null, "court": null }, "pinned": false }],
+    "obstacles": [{ "court": "Court 1", "from": "…", "to": "…", "label": "Div 2 · R1" }]
+  },
+  "draft": [{ "fixture_id": "…", "scheduled_at": "…", "court_label": "Court 1" }],
+  "instruction": "Finish by 6pm. Juniors before 2pm. Final last on Court 1.",
+  "prior": null                              // refine/repair: { instruction, assignments }
+}
+```
+
+Budget: pack must stay ≤60K tokens (measure with `count_tokens` in tests on the 500-fixture
+golden pack); above that the route already 422s on fixture count.
+
+## §3 Output schema (zod, strict)
+
+```ts
+export const AiAssignment = z.object({
+  fixture_id: z.string().uuid(),
+  scheduled_at: z.string().datetime({ offset: true }),
+  court_label: z.string().min(1),
+  schedule_locked: z.boolean().optional(),   // only when instruction says "pin/fix this"
+});
+export const AiSchedulePlan = z.object({
+  assignments: z.array(AiAssignment).max(500),
+  unschedulable: z.array(z.object({ fixture_id: z.string().uuid(), reason: z.string().max(200) })),
+  explanations: z.array(z.object({ fixture_id: z.string().uuid(), note: z.string().max(200) })).max(60),
+  constraint_suggestions: AiConstraintDelta.optional(),  // subset of ScheduleConfig.constraints
+  summary: z.string().max(600),
+});
+```
+
+`AiConstraintDelta` = partial of the existing `constraints{}` schema (restMin,
+noBackToBack, startWindows, fieldFairness, parallelism, crossPersonClash) — reuse the
+schema objects from `server/api-v1/schemas.ts`, do not redeclare shapes.
+
+## §4 System prompt (verbatim)
+
+```text
+You are the schedule architect inside league-management software. You assign a start time
+and court to every movable fixture of a sports division, following the organiser's
+instruction as closely as the hard rules allow.
+
+You receive one JSON context pack: settings (timezone, durations, courts, windows,
+blackouts, constraints), entrants, a shared-player map, movable fixtures, fixed obstacles,
+a draft schedule from a greedy solver, and the organiser's instruction. In refine or repair
+mode you also receive the prior proposal and, on repair rounds, a verifier conflict report.
+
+HARD RULES — the server verifier rejects violations, so check your work against each one
+before answering:
+1. court_label must be exactly one of settings.courts. scheduled_at must be ISO-8601 with
+   a UTC offset, expressed in the division timezone. Never invent courts or fixtures; use
+   only the fixture ids given as movable.
+2. A fixture occupies [scheduled_at, scheduled_at + matchMinutes + gapMinutes). Two
+   fixtures on the same court must not overlap in that interval.
+3. Never place any part of a fixture inside a blackout for its court (or a court-less
+   blackout). When sessionWindows exist, every fixture must start and finish inside one.
+4. An entrant — or two entrants sharing a person in the shared-player map — must never
+   play two overlapping fixtures. Keep at least restMin (or perEntrantMinRest) minutes
+   between consecutive fixtures of the same entrant; if noBackToBack is true, an entrant
+   must never play consecutive time slots even when rest is satisfied.
+5. Respect startWindows: a targeted entrant, pool, or division must not start before
+   notBefore or after notAfter.
+6. Order dependencies: a fixture must start only after every fixture listed in
+   feeds.after is scheduled to finish. Rounds generally flow in order; never schedule a
+   final before its semifinals finish.
+7. Never move a fixture marked pinned; never output an id that is not in movable. Treat
+   obstacles as immovable occupied court time.
+
+SOFT GOALS — in this priority order:
+a. The organiser's instruction. It outranks everything except hard rules. If parts of it
+   conflict with hard rules or with each other, satisfy what you can, put the rest in
+   unschedulable or explain the compromise in summary.
+b. Compactness: finish the programme as early as the instruction allows; avoid stranding
+   long idle gaps on a court.
+c. Fairness: spread each entrant's matches out evenly, balance court usage
+   (fieldFairness), avoid one entrant always playing first or last.
+d. Stability: in refine and repair modes move as few fixtures as possible; prefer keeping
+   the prior proposal where it already satisfies the instruction.
+
+METHOD: Before placing anything, work out the capacity maths (courts × windows vs total
+match minutes) and identify the most constrained items — finals and feed chains,
+startWindow targets, entrants sharing people, instruction-critical fixtures. Place those
+first, then fill the rest from the draft, adjusting only where the instruction requires.
+The draft is legal but naive: improve it, don't worship it.
+
+OUTPUT: Only the structured object. Every movable fixture appears exactly once — in
+assignments or in unschedulable with a short honest reason. explanations: one short note
+for each placement the instruction directly shaped (skip routine placements). If the
+instruction implies a durable weekly rule (e.g. "juniors always before 2pm"), express it
+in constraint_suggestions using the constraints schema; otherwise omit the field. summary:
+at most three sentences to the organiser — what you did, any compromises, what to change
+if a wish was impossible.
+```
+
+## §5 Message protocol
+
+- Turn 1 (user): the context pack as a single JSON block.
+- Repair round r (user): `{"verifier_conflicts": [...engine report...], "note": "Fix only
+  these conflicts. Move as few fixtures as possible. Do not reintroduce earlier
+  conflicts."}` — assistant turns are passed back unchanged (thinking blocks included).
+- Refine run: fresh conversation, `mode:"refine"`, `prior` populated; server rebuilds the
+  pack from live DB state (fixtures may have changed since the prior proposal).
+- Max 2 repair rounds per run; after that return best-so-far with `blocking` marked.
+
+## §6 Eval fixtures (golden tests, PROMPT-41)
+
+Committed under `apps/web/src/server/usecases/__tests__/schedule-ai/`:
+1. **Pack snapshot** — seeded 2-court, 8-entrant RR division → `buildSchedulePack` output
+   snapshot (deterministic).
+2. **Legality harness** — mocked Anthropic returning a hand-written plan with one court
+   clash → verifier catches it, repair round message contains the clash, second mock
+   response passes → run succeeds with `repair_rounds:1`.
+3. **Instruction cases** (mocked): "finish by 18:00" (all assignments end ≤18:00),
+   "Court 2 unavailable Saturday" via repair scope (no Saturday/Court 2 placements),
+   pinned fixture untouched in all modes.
+4. **Live smoke (opt-in, `AI_EVAL=1`)** — real API call on the small pack; asserts parse +
+   verifier-clean; excluded from CI.

--- a/design/v4/README.md
+++ b/design/v4/README.md
@@ -1,0 +1,46 @@
+# v4 — AI Schedule Architect
+
+> **Status (2026-07-12):** not started. PROMPT-41 ⏳ · PROMPT-42 ⏳ · PROMPT-43 ⏳.
+> Branch (planned): `feat/v4-ai-schedule`. Migrations: V-next (schedule_source `ai`).
+
+## Theme
+
+Replace the weak first-cut schedule AI (`aiConstraintsForDivision` — prose→constraints only,
+UI already withdrawn) with a full **AI Schedule Architect**: the organiser types an
+instruction in plain language ("finish by 6pm, juniors before 2pm, marquee match last on
+Court 1, keep the Smith brothers apart") and the system produces a complete, legal,
+applicable schedule — then refines it in follow-up turns and repairs it after mid-season
+disruptions. Pro-only (`scheduling.ai`). Token spend is acceptable: a couple of runs per
+division, quality over cost.
+
+**Architecture in one line: solver drafts → AI plans → engine referees.** The LLM is never
+trusted for legality; `validateAssignments` re-checks every proposal server-side and feeds
+conflicts back for repair rounds. Output is the existing `applySchedule` shape, so apply,
+undo, checkpoints, seq-concurrency and the ledger all work unchanged.
+
+## Document index
+
+| # | File | Contents | Prompt |
+|---|------|----------|--------|
+| 00 | `00-ai-schedule-architect.md` | Normative spec: removal of old feature, modes, pipeline, API, data, gating, failure modes, decisions | 41, 42, 43 |
+| 01 | `01-llm-contract.md` | The LLM contract: model/params, context-pack format, output schema, verbatim system prompt, repair/refine protocol, eval fixtures | 41, 42 |
+
+## Prompt index (prompts/)
+
+| Prompt | Delivers | Depends on |
+|--------|----------|------------|
+| PROMPT-41 | Core engine: context pack, Anthropic call, verify/repair loop, `POST /divisions/{id}/schedule/ai-plan`, removal of old ai-constraints feature, `schedule_source='ai'` migration | — |
+| PROMPT-42 | Refine + repair modes, competition-level multi-division planning, constraint-suggestion accept path | PROMPT-41 |
+| PROMPT-43 | Board UX: instruction panel, ghost preview, diff + explanations, accept→apply, follow-up chat | PROMPT-41 (42 for follow-up) |
+
+## Build order (canonical)
+
+41 → 42 → 43. Do not run 42/43 alongside 41 (shared files: `schedule-plus.ts`,
+`openapi.ts`, `constraints-panel.tsx`).
+
+## House rules
+
+PROMPT-00 conventions apply. Every change ships a failing-without-it regression test;
+`scripts/smoke.ts` extended per feature (pro + free paths); `tsc` + unit tests green before
+push; new v1 routes registered in `server/api-v1/openapi.ts` ROUTES (coverage test enforces).
+Read `v3/11-gaps-and-decisions.md` for still-binding cross-cutting defaults.

--- a/design/v4/prompts/PROMPT-41-ai-schedule-engine.md
+++ b/design/v4/prompts/PROMPT-41-ai-schedule-engine.md
@@ -1,0 +1,57 @@
+# PROMPT-41 — AI Schedule Engine: context pack, verify/repair loop, ai-plan endpoint, old-AI removal
+
+**Read first:** `v4/00-ai-schedule-architect.md` (normative), `v4/01-llm-contract.md`
+(model, schemas, system prompt — ship verbatim); `packages/engine/src/scheduling/calendar.ts`
+(`slotFixtures`, `validateAssignments`), `apps/web/src/server/usecases/schedule.ts`
+(`autoSchedule`, `applySchedule`, `siblingAssignments`, `assertFreshSeq`),
+`apps/web/src/server/usecases/schedule-plus.ts` (old feature to remove; keep its gating
+pattern), `apps/web/src/server/api-v1/openapi.ts` (ROUTES coverage test).
+Preamble: PROMPT-00. **Depends:** none. Do not run alongside PROMPT-42/43.
+
+## Task
+
+1. **Remove old AI** (v4/00 §1): delete `aiConstraintsForDivision`, `parseAiConstraints`,
+   `AiConstraints` from `schedule-plus.ts`; delete
+   `app/api/v1/divisions/[id]/schedule/ai-constraints/route.ts`; drop its ROUTES row +
+   request/response schemas; strip the parked prose box + handlers from
+   `components/v2/constraints-panel.tsx`; delete its tests. Keep entitlement key
+   `scheduling.ai`, flag `ai-scheduling`, env `SCHEDULING_AI_MODEL`.
+2. **Migration V-next** (v4/00 §5): widen `fixtures.schedule_source` check to
+   `none|auto|manual|ai`; extend `ApplyScheduleRequest.source` enum + board client types.
+3. **Context pack** (v4/01 §2): new `apps/web/src/server/usecases/schedule-ai.ts` with
+   `buildSchedulePack(auth, divisionId, {mode, scope, prior, instruction})` — settings,
+   entrants, shared-person map (`entrant_members` join), movable fixtures (unpinned,
+   un-scope-locked, status `scheduled`, scope-filtered in repair), obstacles (other stages
+   + sibling divisions, reuse `siblingAssignments` family), greedy draft via `slotFixtures`.
+   Deterministic ordering; reject flexible divisions (409 `AI_PLAN_UNSUPPORTED`) and >500
+   movable (422 `AI_PLAN_TOO_LARGE`).
+4. **LLM runner** (v4/01 §1/§4/§5): `runAiPlan(pack)` — `client.messages.parse`, system
+   prompt + `zodOutputFormat(AiSchedulePlan)` from `schedule-ai-prompt.ts` (verbatim from
+   v4/01), `thinking: adaptive`, `effort: high`, cache_control on system; verifier loop:
+   `validateAssignments` → blocking conflicts → repair message → ≤2 rounds; refusal /
+   parse-fail → 422 `AI_PLAN_FAILED`; missing key → 503.
+5. **Endpoint** (v4/00 §4): `POST /api/v1/divisions/{id}/schedule/ai-plan` — `v1()` +
+   `parseBody` + `requireResourceAuth(division, "write")`; use-case order: kill-switch →
+   `requireFeature("scheduling.ai")` → `rateLimit("ai-plan:"+divisionId,{max:5,windowSeconds:3600})`
+   → pack → run. Response per v4/00 §3 step 5 (proposal, warnings, blocking, diff,
+   explanations, summary, constraint_suggestions, usage). Register in ROUTES + schemas.
+   `mode:"generate"` only in this prompt (42 adds refine/repair bodies — build the schema
+   with all three modes now, 501 `AI_PLAN_MODE_UNAVAILABLE` for refine/repair).
+6. **Telemetry + env** (v4/00 §6): `captureServer("ai_plan_run", …)`; add
+   `ANTHROPIC_API_KEY`, `SCHEDULING_AI_MODEL` to `apps/web/.env.example`.
+7. **Golden tests** (v4/01 §6 items 1–3): pack snapshot, legality/repair harness with
+   mocked SDK (`vi.mock("@anthropic-ai/sdk")`), instruction cases, pinned-untouched.
+
+## Acceptance
+
+- Unit: pack snapshot deterministic across two builds; repair harness shows
+  `repair_rounds:1` and no reintroduced conflicts; flexible → 409; 501-fixture division →
+  422; free org → 402 with `feature_key:"scheduling.ai"`; kill-switch off → 403; no key →
+  503; old route gone → openapi coverage test green with removed row.
+- E2E (mocked Anthropic via env-injected base URL or module mock in test server): pro org
+  posts instruction on seeded 8-entrant RR division → 200 proposal, every movable fixture
+  covered, diff counts consistent; apply proposal via existing apply route with
+  `source:"ai"` → fixtures persisted, `schedule_applied` event payload has `source:"ai"`,
+  undo restores.
+- smoke.ts: pro path runs ai-plan (mock) + applies; free path asserts 402 upgrade shape.
+- `npm test` + `tsc` green; update v4/README status.

--- a/design/v4/prompts/PROMPT-42-ai-refine-and-repair.md
+++ b/design/v4/prompts/PROMPT-42-ai-refine-and-repair.md
@@ -1,0 +1,48 @@
+# PROMPT-42 — AI Refine + Repair + Multi-Division: follow-up turns, disruption reflow, competition scope
+
+**Read first:** `v4/00-ai-schedule-architect.md` §2/§4 (modes, competition endpoint),
+`v4/01-llm-contract.md` §5 (refine/repair protocol); `apps/web/src/server/usecases/schedule.ts`
+(`applySchedule` per-stage, advisory locks), `server/usecases/history.ts` (checkpoints),
+`app/o/[orgSlug]/c/[compSlug]/schedule/page.tsx` (multi-division board, `scheduling.multi_division`).
+Preamble: PROMPT-00. **Depends:** PROMPT-41. Do not run alongside PROMPT-41/43.
+
+## Task
+
+1. **Refine mode** (v4/00 §2): accept `prior:{instruction, assignments}` in ai-plan body;
+   pack rebuilt from live DB (board may have moved — recompute movable/obstacles), prior
+   proposal becomes the draft, prior instruction included so the model preserves earlier
+   intent; soft goal (d) stability applies. Remove the 501 stub from PROMPT-41.
+2. **Repair mode** (v4/00 §2): `scope{from?, courts?, pool_ids?}` selects the movable set;
+   everything outside scope becomes obstacles (including same-stage fixtures). Typical
+   flows to test: "Court 2 gone from Saturday 12:00" (courts+from), "rain washed out day
+   1, replay everything" (from), pool-scoped reflow. Scope validation: unknown court label
+   → 400; empty movable set → 422 `AI_PLAN_EMPTY_SCOPE`.
+3. **Competition-level planning** (v4/00 §4): `POST /api/v1/competitions/{id}/schedule/ai-plan`
+   — gates `scheduling.ai` + `scheduling.multi_division`; movable set = all timed
+   divisions' eligible fixtures, one shared court space (obstacles only external);
+   response groups `divisions:[{division_id, assignments, …}]`; per-division ≤500 and
+   total ≤500 (one LLM call). Register in ROUTES. Rate key
+   `ai-plan:comp:{id}` max 3/h.
+4. **Accept flow (server side)**: division accept unchanged (existing apply). Competition
+   accept = client loops divisions calling apply per stage; before first apply create a
+   `before-ai` checkpoint per division (existing checkpoints route). Document the
+   partial-failure story: apply is per-division transactional; a `SEQ_CONFLICT` mid-loop
+   stops the loop, UI reports which divisions landed (each independently undo-able).
+5. **Constraint suggestions accept path** (v4/00 §8.6): client-side merge of
+   `constraint_suggestions` into current `config.constraints` + existing schedule-settings
+   PUT; server ensures suggestions schema = strict subset of `ScheduleConfig.constraints`
+   (reuse schema objects, no redeclaration).
+6. **Telemetry**: `ai_plan_run` gains `mode`, `scoped_fixtures`, `divisions` fields.
+
+## Acceptance
+
+- Unit: refine keeps ≥N% of prior placements when instruction is narrow (stability
+  assertion on mocked plan); repair never emits an out-of-scope fixture id (verifier +
+  schema test); competition pack spans divisions and marks cross-division court clashes
+  as blocking; suggestion delta rejects keys outside `constraints{}`.
+- E2E (mocked model): seeded 2-division comp — repair "Court 1 out after 14:00" moves only
+  affected fixtures, others byte-identical; competition plan → accept loop → both
+  divisions applied with `source:"ai"`, checkpoints `before-ai` exist, undo per division
+  restores; free org 402 on competition route even when pro on `scheduling.ai` alone.
+- smoke.ts: pro path adds one refine round on the PROMPT-41 proposal.
+- `npm test` + `tsc` green; update v4/README status.

--- a/design/v4/prompts/PROMPT-43-ai-schedule-board-ux.md
+++ b/design/v4/prompts/PROMPT-43-ai-schedule-board-ux.md
@@ -1,0 +1,52 @@
+# PROMPT-43 — AI Schedule Board UX: instruction panel, ghost preview, diff, accept, follow-up
+
+**Read first:** `v4/00-ai-schedule-architect.md` §2/§7 (modes, failure copy),
+`v4/01-llm-contract.md` §3 (plan shape); `components/v2/schedule-board.tsx` + `board/*`
+(tray/panel patterns, `use-board-actions.ts` seq handling), `components/upgrade-gate.tsx`,
+`lib/feature-copy.ts`; memory gotchas: board payload budget (v3/11 gap 15), tap-target
+a11y (PROMPT-31 patterns). Preamble: PROMPT-00. **Depends:** PROMPT-41 (42 for follow-up
+turns + competition board). Do not run alongside PROMPT-41/42.
+
+## Task
+
+1. **AI panel** (board right dock, mobile bottom sheet — same chrome as unscheduled tray):
+   "AI schedule" pro-badged button in board header; panel = instruction textarea
+   (3..4000, placeholder shows two example instructions), mode auto-derived (blank board →
+   generate; proposal open → refine; "Repair" toggle exposes scope pickers: from
+   datetime, courts multi-select, pools). Hidden entirely when kill-switch off; free orgs
+   see `UpgradeGate feature="scheduling.ai"`.
+2. **Run state**: optimistic spinner with stage text ("Packing board… Planning…
+   Verifying…"); errors map v4/00 §7 copy (503/422/429/402) inline in panel, never toast-only.
+3. **Ghost preview**: proposal renders as translucent blocks on the grid (distinct hue +
+   dashed border) alongside current placements; unchanged fixtures dim; conflicts from
+   `blocking` get the existing red corner tick. Diff strip: `moved / placed / unscheduled /
+   unchanged` counts + list view grouped by change type with jump-to-fixture (reuse
+   conflicts-panel jump). Explanations: info dot on ghost block → popover with the model's
+   note; `summary` shown at top of panel.
+4. **Accept / discard**: Accept = create `before-ai` checkpoint → apply (`source:"ai"`,
+   `expected_seq` via existing seqRef) → if `constraint_suggestions` present, checked
+   list "Also save these rules" applied via schedule-settings PUT → board refetch + toast
+   with undo affordance. `SEQ_CONFLICT` → refetch + offer "Re-run as refine". Discard =
+   `ai_plan_discarded` capture. Blocking assignments: accept button disabled until
+   organiser unticks blockers (they drop to unscheduled tray on apply).
+5. **Follow-up turn** (after PROMPT-42): proposal accepted or not, panel keeps a compact
+   history of instructions this session; new instruction with proposal open posts
+   `mode:"refine"` + `prior`. Competition board gets the same panel wired to the
+   competition endpoint, ghosts across division lanes.
+6. **A11y + mobile**: panel fully keyboard operable; ghost blocks focusable with change
+   description in aria-label; 390px: sheet + agenda-mode diff list (no grid ghosts
+   required, list is the preview).
+
+## Acceptance
+
+- E2E (mocked model) on seeded division: type instruction → ghosts + diff counts match
+  payload; accept → board persists, checkpoint `before-ai` listed in history panel, undo
+  restores pre-AI board; suggestion tick writes constraints (settings tab shows them);
+  free org sees UpgradeGate (no network call); 429 renders inline copy; keyboard-only run
+  → accept pass; 390px sheet flow completes.
+- Unit: diff computation (moved/placed/unscheduled/unchanged) against fixture list;
+  blocking-gate on accept button.
+- smoke.ts: pro path drives panel run + accept via UI-level helper; free path asserts
+  gate visible.
+- No board initial-payload regression (gap 15 budget); `npm test` + `tsc` green; update
+  v4/README status.

--- a/design/v5/00-i18n-strategy.md
+++ b/design/v5/00-i18n-strategy.md
@@ -1,0 +1,102 @@
+# v5/00 — i18n strategy (normative spec)
+
+Scope: UI/emails/metadata/OG for en, fr, es, hi, ta, nl. Implemented by PROMPT-44..47.
+Baseline facts (audit 2026-07-12): Next.js 16.2.9 App Router; no i18n lib; `lang="en"`
+hardcoded (`app/layout.tsx:54`); `Accept-Language` only feeds currency guessing
+(`lib/currency.ts:66`); ~900–1,000 React-tree strings; 10 email templates; 31 help docs;
+37 metadata blocks; fonts Latin-only; OG/PDF renderers embed no font; no locale column
+anywhere.
+
+## §1 Library decision: thin in-house layer
+
+No next-intl / i18next. Rationale: the Next 16 guide's own pattern (server-only
+dictionaries + negotiation in `proxy.ts`) covers our needs; our `proxy.ts` already carries
+CSP/CSRF logic and a second middleware framework risks conflicts; 6 locales × ~1.2K keys
+doesn't justify a runtime ICU engine. Rejected alternative recorded: next-intl (heavier,
+own middleware, message-format runtime).
+
+`apps/web/src/lib/i18n.ts` (~100 lines):
+
+- `type Locale = "en"|"fr"|"es"|"hi"|"ta"|"nl"`, `LOCALES`, `DEFAULT_LOCALE = "en"`.
+- `getDictionary(locale)` — `import "server-only"`, lazy `import()` per locale namespace.
+- `t(dict, key, vars?)` — dot-key lookup, `{name}` interpolation, **en fallback** on
+  missing key + dev-mode console.warn (never throws in prod).
+- `plural(dict, key, count, vars?)` — key convention `key.one` / `key.other` (+ locale
+  extras where needed), selected via `Intl.PluralRules(locale)`.
+- Client components receive strings via props from server components, or — for
+  interactive-heavy trees (board, wizard) — a `<I18nProvider slice={...}>` carrying only
+  that surface's namespace slice (bundle discipline: never ship whole dictionaries to the
+  client).
+
+Dictionaries: `apps/web/src/dictionaries/{locale}/{namespace}.json`, namespaces
+`common`, `marketing`, `public`, `console`, `emails`, `errors`, `metadata`. Key style
+`surface.area.slug` (e.g. `console.board.publish`); no dynamically-built keys (grep-able).
+A generated `dictionary-keys.d.ts` from `en` gives typed `t()` keys (build step in 44).
+
+## §2 Locale resolution (no URL restructure in phase 1)
+
+Order, resolved once per request in a server helper `resolveLocale()`:
+
+1. `seazn_locale` cookie (explicit user pick via switcher; 1y, SameSite=Lax)
+2. `users.locale` (signed-in)
+3. **Public league pages only** (`/o/*`, `/shared/*`, `/slideshow/*`, `/embed/*`): owning
+   org's `orgs.default_locale` — a Chennai club's public pages read Tamil for every
+   visitor unless the visitor picked otherwise
+4. `Accept-Language` negotiation in `proxy.ts` per the Next 16 guide
+   (`@formatjs/intl-localematcher` + `negotiator`, new deps) → sets a request header
+   `x-seazn-locale` consumed by `resolveLocale()`
+5. `en`
+
+`<html lang>` becomes dynamic in the root layouts. Switcher UI: footer (public/marketing)
++ account settings (console); writes cookie (+ `users.locale` when signed in) and
+`router.refresh()`.
+
+**Phase 2 (PROMPT-47): URL prefixes for marketing only.** `/{lang}/pricing` etc. via a
+`[lang]` segment over the marketing group + proxy rewrite so unprefixed = en (no redirect
+churn for existing links); hreflang alternates + localized sitemap. Console and slug
+routes (`/o/...`) stay unprefixed permanently — 87 slug-routed pages, low SEO value, high
+risk; decision recorded, revisit only with SEO evidence.
+
+## §3 DB + emails
+
+Migration V-next: `users.locale text` (nullable, checked against locale set),
+`orgs.default_locale text not null default 'en'`. Registrations: public registration form
+captures the resolved locale into the registration row (recipients often have no user
+account); email builders gain a required `locale` param — subject/preheader/title/body
+strings move to the `emails` namespace; the 9 HTML chrome files get token-driven strings
+(footer, "why you got this") via existing `compose.ts` token fill. Fallback en when a
+recipient locale is unknown.
+
+## §4 Fonts (hi/ta hard blocker)
+
+- App shell: add `Noto_Sans_Devanagari` + `Noto_Sans_Tamil` via `next/font/google`,
+  loaded per-locale in the root layout (locale → font-variable class on `<html>`; Latin
+  locales keep Geist/Barlow only — no payload tax).
+- Display face: Barlow Condensed has no hi/ta glyphs — scoreboard/marketing display styles
+  fall back to the Noto face for hi/ta via CSS variable stack (accepting different
+  personality there; recorded as a deliberate compromise).
+- OG images (`server/og/card.tsx` — currently `fontFamily:"sans-serif"`, no embedded
+  font): load Noto TTF subsets from `apps/web/assets/fonts/` and pass via
+  `ImageResponse` `fonts` option, family picked by locale. Poster PDF (pdfkit):
+  `registerFont` same files. Without this, hi/ta share cards render tofu — treated as a
+  release blocker for those locales.
+
+## §5 Formatting
+
+- New `lib/format.ts`: `fmtDate(locale, tz, opts)`, `fmtTime`, `fmtRange`,
+  `fmtNumber` — thin `Intl.*` wrappers taking the resolved locale. Replace the ~31 files
+  hardcoding `"en-GB"`/`"en-CA"`/`"en-US"`/`"en"` (board, billing, api-keys, card-stats,
+  device-links, division-builder, OG image, client-time).
+- `formatMinor()` in `lib/currency.ts` gains a locale param (currency **selection** logic
+  unchanged — set price points, cookie, subscription; only display formatting localizes).
+- Timezones unchanged (competition tz remains authoritative for schedule display).
+- zod/API errors: server keeps stable `code`s (already in the v1 envelope); client maps
+  code → `errors.*` dictionary key, falling back to server `message`. Custom zod messages
+  in `schemas.ts` become codes where user-facing. No server-side translated strings in v1
+  API responses (API consumers get English + codes; documented).
+
+## §6 Out of scope (binding)
+
+User content translation (names, slugs, help-editor bodies), RTL, locale-specific
+currency FX (multi-currency set-prices already shipped), translating the API reference,
+per-locale PWA screenshots. `slugify()` stays ASCII (existing behavior, recorded).

--- a/design/v5/01-translation-pipeline.md
+++ b/design/v5/01-translation-pipeline.md
@@ -1,0 +1,69 @@
+# v5/01 — Translation pipeline (en → fr/es/hi/ta/nl)
+
+Normative for PROMPT-44..47. **en dictionaries are the single source of truth**; the other
+five locales are generated artifacts that humans review — never hand-edit en and a target
+in the same PR without regenerating.
+
+## §1 en.json authoring conventions
+
+- Keys `surface.area.slug`, full sentences per key (no string concatenation across keys).
+- Variables `{name}`, `{count}` — ICU-lite; plurals as sibling keys `x.one` / `x.other`
+  (target locales may add forms the script requests per `Intl.PluralRules` categories —
+  none of the six needs beyond one/other except future-proofing).
+- No markup in values except `<b>`/`<i>` pass-through where the component renders rich
+  text via a tiny `<T>` helper; links stay in JSX, split copy around them.
+- Protected terms never translated: `seazn.club`, plan names (`Pro`, `Community`,
+  `Event Pass`), sport format names where they are proper nouns (`Americano`,
+  `Mexicano`, `Swiss`), `API`.
+
+## §2 Machine translation — `scripts/translate-dictionaries.ts`
+
+Anthropic **Batches API** (50% token price; latency irrelevant offline):
+
+- Chunk en namespace files into ≤200-key JSON objects; one batch request per
+  (chunk × target locale), `custom_id = {locale}:{namespace}:{chunk}`.
+- Model `claude-opus-4-8`. System prompt per locale: translator persona for sports-league
+  software; glossary table (protected terms + preferred sport vocabulary per locale, e.g.
+  fixture→fr «rencontre», standings→es «clasificación», court→ta «மைதானம்» vs
+  transliteration choices — glossary file `scripts/i18n-glossary.json` is reviewable);
+  rules: preserve `{placeholders}` exactly, preserve `<b>`/`<i>`, match register
+  (UI = concise informal-polite; emails = warmer), length discipline for button keys
+  (flagged `#btn` comment in en source → "≤24 chars where possible").
+- Structured output: same-shaped JSON object (strict schema built from the chunk's keys)
+  → drop-in namespace files.
+- Idempotent + incremental: script hashes each en value into
+  `dictionaries/.hashes.json`; only changed/new keys are re-sent (cost control, stable
+  reviewed translations don't churn).
+
+## §3 Review workflow
+
+Generated locales land as a PR with per-locale diff; review checklist in the PR template:
+placeholders intact (CI-checked), spot-check 20 random keys per locale, native-speaker
+pass for hi/ta before first release (fr/es/nl acceptable at MT-quality launch, flagged).
+`// REVIEWED` markers not used — review state lives in git history; regenerations only
+touch keys whose en source changed (§2 hashing).
+
+## §4 CI guards (vitest, PROMPT-44)
+
+1. **Key parity**: every locale has exactly en's key set per namespace (missing/extra →
+   fail with key list).
+2. **Placeholder parity**: `{vars}` set per key identical across locales.
+3. **Drift**: en value hash ≠ `.hashes.json` entry while target unchanged → fail
+   ("stale translation — run translate script").
+4. **No hardcoded-string regression** (ratchet): lint rule / test greps the extracted
+   surfaces (per-prompt allowlist shrinks as 45/46 land) for JSX literal text outside
+   `t()` — new violations fail; existing files burn down via allowlist file.
+
+## §5 Pseudo-locale QA
+
+Dev-only locale `en-XA` (accented-expanded pseudotranslation generated locally, not
+committed): lengthens strings ~35% and brackets them — layout-overflow QA for 45/46
+e2e runs at 390px. Enabled via `SEAZN_PSEUDO_LOCALE=1` in dev/proxy only.
+
+## §6 Help docs (PROMPT-47 scope)
+
+31 en markdown docs stay canonical. Translate the top 8 by help-page traffic per locale
+into `content/help/{locale}/{slug}.md` via the same batch script (markdown-aware prompt:
+preserve headings/anchors/frontmatter, don't translate code/paths). Untranslated docs
+render en body + dictionary-driven "This article is in English" notice. Help search stays
+en-index + per-locale title index.

--- a/design/v5/README.md
+++ b/design/v5/README.md
@@ -1,0 +1,58 @@
+# v5 — Internationalization (en · fr · es · hi · ta · nl)
+
+> **Status (2026-07-12):** not started. PROMPT-44 ⏳ · PROMPT-45 ⏳ · PROMPT-46 ⏳ ·
+> PROMPT-47 ⏳. Branch (planned): `feat/v5-i18n`. Migrations: V-next (`users.locale`,
+> `orgs.default_locale`).
+
+## Theme
+
+Take the product from hardcoded English (`lang="en"` in the root layout, ~1,000 inline UI
+strings, English-only emails/OG/help) to six locales: **en (primary/fallback), fr, es, hi,
+ta, nl**. Audit findings: zero i18n infra today; `Accept-Language` only used to guess
+currency; fonts are Latin-only so Hindi/Tamil are hard-blocked in both the app shell and
+the OG/poster image pipeline until fonts land.
+
+Strategy in one line: **thin in-house dictionary layer (per the Next 16 guide), server-side
+locale resolution without URL restructure, Claude-Batches translation pipeline with en.json
+as source of truth, URL prefixes only where SEO pays (marketing).**
+
+## Locale set
+
+| Code | Language | Script | Notes |
+|------|----------|--------|-------|
+| en | English | Latin | primary, fallback, source of truth |
+| fr | French | Latin | |
+| es | Spanish | Latin | |
+| hi | Hindi | Devanagari | needs Noto Sans Devanagari (app + OG/PDF) |
+| ta | Tamil | Tamil | needs Noto Sans Tamil (app + OG/PDF) |
+| nl | Dutch | Latin | |
+
+No RTL locale in scope. User content (org/competition/division names, slugs, help-editor
+bodies) is never machine-translated.
+
+## Document index
+
+| # | File | Contents | Prompt |
+|---|------|----------|--------|
+| 00 | `00-i18n-strategy.md` | Normative spec: locale resolution, dictionary system, routing decision, DB, fonts, formatting | 44–47 |
+| 01 | `01-translation-pipeline.md` | en.json conventions, Claude Batches machine translation, glossary, review, CI parity + drift checks | 44–47 |
+
+## Prompt index (prompts/)
+
+| Prompt | Delivers | Depends on |
+|--------|----------|------------|
+| PROMPT-44 | Foundation: `lib/i18n` + dictionaries, proxy negotiation + cookie, `<html lang>`, switcher, locale DB columns, Noto fonts incl. OG/PDF embedding, translate script + CI checks | — |
+| PROMPT-45 | Public surface extraction: marketing, public league/courtside/slideshow/embeds, metadata + manifest → 6 dictionaries | PROMPT-44 |
+| PROMPT-46 | Console + emails + formatting: console UI extraction, per-locale email templates, zod/API error mapping, kill hardcoded `"en-GB"`/`"en"` Intl calls | PROMPT-44 |
+| PROMPT-47 | SEO + content: `/[lang]` prefix for marketing, hreflang/sitemap, help-docs translation strategy, localized OG/poster taglines | PROMPT-44, 45 |
+
+## Build order (canonical)
+
+44 → 45 → 46 → 47. 45 and 46 touch disjoint surfaces and may run in parallel **after 44
+lands**; 47 last (needs 45's marketing dictionaries).
+
+## House rules
+
+PROMPT-00 conventions apply. Every change ships a failing-without-it regression test;
+`scripts/smoke.ts` extended per feature (pro + free paths); `tsc` + unit green before push.
+New v1 routes (none expected this wave) must register in openapi ROUTES.

--- a/design/v5/prompts/PROMPT-44-i18n-foundation.md
+++ b/design/v5/prompts/PROMPT-44-i18n-foundation.md
@@ -1,0 +1,52 @@
+# PROMPT-44 — i18n Foundation: dictionary layer, locale resolution, fonts, pipeline + CI
+
+**Read first:** `v5/00-i18n-strategy.md` (normative — §1 library, §2 resolution, §3 DB,
+§4 fonts), `v5/01-translation-pipeline.md` (§2 script, §4 CI guards);
+`node_modules/next/dist/docs/01-app/02-guides/internationalization.md` (this repo's Next
+version — proxy negotiation + dictionaries pattern), `apps/web/src/proxy.ts` (existing
+CSP/CSRF — extend, don't replace), `app/layout.tsx` (hardcoded `lang="en"`, fonts),
+`server/og/card.tsx` (no embedded font). Preamble: PROMPT-00. **Depends:** none.
+
+## Task
+
+1. **`lib/i18n.ts`** (v5/00 §1): `Locale`/`LOCALES`/`DEFAULT_LOCALE`, server-only
+   `getDictionary(locale, namespace)`, `t()` with `{var}` interpolation + en fallback +
+   dev warn, `plural()` via `Intl.PluralRules`, client `<I18nProvider slice>` +
+   `useT()`. Dictionaries scaffold `src/dictionaries/{locale}/{common,…}.json` — seed
+   `common` (nav, actions, empty/error states) + move root-layout metadata strings.
+   Typed keys: build step generating `dictionary-keys.d.ts` from en.
+2. **Resolution** (v5/00 §2): `resolveLocale()` server helper implementing the 5-step
+   chain; `proxy.ts` gains `Accept-Language` negotiation (`@formatjs/intl-localematcher`
+   + `negotiator`) setting `x-seazn-locale` — CSP/CSRF behavior byte-identical (regression
+   test); `seazn_locale` cookie; dynamic `<html lang>` in root + public layouts; locale
+   switcher component (footer variant + account-settings variant) writing cookie +
+   `users.locale`.
+3. **Migration V-next** (v5/00 §3): `users.locale text` (check in locale set),
+   `orgs.default_locale text not null default 'en'`; org settings UI field; expose on
+   settings API route schemas.
+4. **Fonts** (v5/00 §4): `Noto_Sans_Devanagari` + `Noto_Sans_Tamil` via `next/font`
+   per-locale in root layout (CSS variable stack so Latin locales pay zero bytes); Barlow
+   display stack falls back to Noto for hi/ta; vendor TTF subsets into
+   `apps/web/assets/fonts/`; `ImageResponse` OG renderer (`server/og/card.tsx`) +
+   pdfkit poster get locale-selected embedded fonts (tofu = blocker).
+5. **Pipeline + CI** (v5/01): `scripts/translate-dictionaries.ts` (Batches API, glossary
+   file, hash-incremental), `scripts/i18n-glossary.json`, vitest guards — key parity,
+   placeholder parity, drift, hardcoded-string ratchet with allowlist; pseudo-locale
+   `en-XA` dev switch.
+6. **Env/docs**: `ANTHROPIC_API_KEY` already added by PROMPT-41 — reference it; document
+   the pipeline commands in `design/v5/README` status + repo docs.
+
+## Acceptance
+
+- Unit: resolution chain (cookie > user > org-default-on-public-routes > header > en) —
+  table-driven; `t()` fallback + interpolation + plural; parity/drift/placeholder CI
+  tests fail on seeded bad fixture and pass on real dictionaries; proxy CSP/CSRF
+  regression test green.
+- E2E: `Accept-Language: fr` visitor sees `<html lang="fr">` + fr common strings on home;
+  switcher to ta persists cookie across reload and swaps to Noto Tamil font (assert
+  computed font-family); signed-in switch writes `users.locale`; org with
+  `default_locale='ta'` serves ta on its public page to a fresh visitor.
+- OG: snapshot test renders card with Tamil org name — no tofu (compare glyph bounding
+  boxes or golden image); poster PDF contains embedded Noto font (parse font table).
+- smoke.ts: pro + free paths assert locale switcher present and fr round-trip.
+- `npm test` + `tsc` green; update v5/README status.

--- a/design/v5/prompts/PROMPT-45-public-surface-strings.md
+++ b/design/v5/prompts/PROMPT-45-public-surface-strings.md
@@ -1,0 +1,39 @@
+# PROMPT-45 — Public Surface Strings: marketing + league pages + metadata → 6 locales
+
+**Read first:** `v5/00-i18n-strategy.md` §1/§2, `v5/01-translation-pipeline.md` §1/§2;
+surfaces: `app/page.tsx` (home, AUDIENCES array), `app/pricing/page.tsx` (FAQ + plan
+tables — note hardcoded `$39`/`$20` inside description copy: split price out of the
+sentence, price stays currency-system-driven), `app/scheduling/page.tsx`, `app/start/*`,
+`components/marketing/*`, public league pages `app/o/[orgSlug]/**` + `app/(public)/shared/**`,
+`app/slideshow/**`, `app/embed/**`, `public/site.webmanifest`. Preamble: PROMPT-00.
+**Depends:** PROMPT-44. May run parallel to PROMPT-46 (disjoint files).
+
+## Task
+
+1. **Marketing extraction** → `marketing` namespace: home, pricing (FAQ arrays, plan
+   cards, comparison table), /scheduling, /start funnel + claim, marketing shell/nav/
+   footer, use-cases. Copy stays sentence-per-key; audience/FAQ arrays become keyed lists.
+2. **Public league + courtside** → `public` namespace: org/comp/division/fixture pages,
+   standings/scorebug labels, registration form (field labels/validation copy), shared
+   pages, slideshow (TV) status strings, embed widgets. Competition-page rendering locale
+   = org `default_locale` chain (44) — verify scorebug density unaffected by longer fr/ta
+   strings at 390px (pseudo-locale run).
+3. **Metadata + manifest** (v5/00 §2): per-page `generateMetadata` reads dictionary
+   (title/description/OG text) via `resolveLocale()`; `site.webmanifest` → dynamic
+   `manifest.ts` serving localized name/description (org-PWA idea stays parked).
+4. **Generate translations**: run pipeline for fr/es/hi/ta/nl over `marketing`+`public`+
+   `metadata`; commit generated files + review-checklist PR notes (v5/01 §3).
+5. **Ratchet**: remove extracted files from the hardcoded-string allowlist.
+
+## Acceptance
+
+- E2E: home + pricing in all 6 locales render translated H1/CTA (snapshot per locale);
+  fr pricing FAQ expands correctly; ta public competition page shows Tamil UI chrome with
+  English org-content untouched; embed widget honors org locale; metadata: `og:title`
+  localized on shared comp page (fetch head).
+- Pseudo-locale 390px pass on home, pricing, register form, scorebug — no overflow/
+  clipped CTAs.
+- Unit: parity tests green for new namespaces; allowlist shrank (ratchet asserts count).
+- smoke.ts: free path loads es home + registers on es public form; pro path checks ta
+  courtside page.
+- `npm test` + `tsc` green; update v5/README status.

--- a/design/v5/prompts/PROMPT-46-console-and-emails.md
+++ b/design/v5/prompts/PROMPT-46-console-and-emails.md
@@ -1,0 +1,45 @@
+# PROMPT-46 — Console + Emails + Formatting: app extraction, per-locale email, Intl plumbing
+
+**Read first:** `v5/00-i18n-strategy.md` §1/§3/§5, `v5/01-translation-pipeline.md`;
+surfaces: `components/v2/**` (board, division-builder wizard, panels), console pages
+`app/o/[orgSlug]/**` (settings/billing/admin), `lib/email-templates/*` + `html/*` +
+`compose.ts` (9 builders + funnel), zod messages in `server/api-v1/schemas.ts`, hardcoded
+`Intl` locales (~31 files: `"en-GB"` in billing/api-keys/card-stats, `"en-CA"`/`"en-US"`
+in device-links, `"en"` in division-builder + `lib/currency.ts:54` `formatMinor`).
+Preamble: PROMPT-00. **Depends:** PROMPT-44. May run parallel to PROMPT-45 (disjoint files).
+
+## Task
+
+1. **Console extraction** → `console` namespace: board + panels (conflicts, tray,
+   settings, move, history), division wizard (steps, format recommender copy), entrants/
+   registration admin, settings/billing/admin pages, api-keys/developers. Interactive
+   trees use `<I18nProvider slice>` (bundle: only the surface's slice ships client-side —
+   assert via bundle test ≤ +10KB gz per route).
+2. **Emails** (v5/00 §3) → `emails` namespace: 9 builders + funnel gain required
+   `locale` param; subjects/preheaders/bodies keyed; HTML chrome strings token-filled via
+   `compose.ts`; plain-text variants localized. Locale source: recipient user's
+   `users.locale` → registration-row locale (add column capture in public registration
+   POST) → org default → en. Registration/payment-reminder flows pass it through
+   (`server/usecases/registrations.ts`, `fixtures.ts`, `lib/billing.ts`, auth mails).
+3. **Errors** (v5/00 §5): client error mapper `errors.*` keyed by envelope `code`
+   (+`feature_key` for 402 copy via `feature-copy.ts` — localize that table); promote
+   user-facing custom zod messages in `schemas.ts` to codes; server responses stay
+   English+code (documented for API consumers).
+4. **Formatting** (v5/00 §5): `lib/format.ts` (`fmtDate/fmtTime/fmtRange/fmtNumber`
+   taking locale + tz); sweep all hardcoded-locale `Intl` call sites onto it;
+   `formatMinor(minor, currency, locale)`; competition-tz semantics unchanged
+   (regression: schedule page still renders competition tz, caption localized).
+5. **Generate translations** for `console`+`emails`+`errors`; ratchet allowlist shrink.
+
+## Acceptance
+
+- Unit: email builder snapshot per locale (registration confirm in fr + ta — subject,
+  body, plain-text; placeholders intact); locale-source chain for a no-account registrant;
+  `formatMinor` renders `1 234,56 €` (fr) vs `€ 1.234,56` (nl) vs `₹1,234.56` (hi/inr);
+  error mapper falls back to server message on unknown code.
+- E2E: hi-locale organiser drives wizard → board → publish entirely in Hindi (Noto
+  rendering, no layout break at 390px via pseudo-locale complement); billing page dates
+  no longer `en-GB`-forced (assert locale-formatted); registration in es sends es email
+  (mailbox capture assert).
+- Bundle guard test green; ratchet count shrinks; `npm test` + `tsc` green; update
+  v5/README status.

--- a/design/v5/prompts/PROMPT-47-seo-and-content.md
+++ b/design/v5/prompts/PROMPT-47-seo-and-content.md
@@ -1,0 +1,41 @@
+# PROMPT-47 — SEO + Content: /[lang] marketing prefix, hreflang, help translation, localized share assets
+
+**Read first:** `v5/00-i18n-strategy.md` §2 phase-2 (routing decision + rationale),
+`v5/01-translation-pipeline.md` §6 (help docs); `lib/routes.ts` (central route builder),
+`app/sitemap.ts` / robots if present, `content/help/` + `server/help-content.ts` +
+`lib/help.ts`, OG consumers (`opengraph-image.tsx` ×3, `ticket.png`, `poster.pdf` —
+fonts already embedded by PROMPT-44). Preamble: PROMPT-00. **Depends:** PROMPT-44, 45.
+
+## Task
+
+1. **Marketing `[lang]` prefix** (v5/00 §2 phase 2): `[lang]` segment over the marketing
+   group only (home, pricing, scheduling, use-cases, start); `generateStaticParams` for
+   the 6 locales; proxy rewrite: unprefixed = en canonical (no redirect), `/fr/pricing`
+   etc. serve prefixed; `lib/routes.ts` gains locale-aware marketing builders (console +
+   slug routes untouched — assert). Locale switcher on marketing navigates to prefixed
+   URL (cookie still set for the rest of the product).
+2. **hreflang + sitemap**: `alternates.languages` in marketing `generateMetadata`
+   (self-referencing + x-default=en); sitemap emits all locale variants; robots
+   unchanged. Canonicals: en = unprefixed.
+3. **Help content** (v5/01 §6): `content/help/{locale}/` structure + loader fallback
+   chain (locale file → en file + localized "in English" notice); translate top-8 docs
+   per locale via markdown-aware pipeline (headings/anchors/frontmatter/code preserved);
+   help index + search: per-locale titles, en body index.
+4. **Localized share assets**: OG card static strings (tagline
+   "Live scores · fixtures · standings", labels) from `metadata` namespace by locale of
+   the org; ticket + poster strings likewise; QR/urls unchanged.
+5. **Generate translations** for help top-8 + remaining `metadata` keys; ratchet final
+   shrink — allowlist empty for public+marketing surfaces.
+
+## Acceptance
+
+- E2E: `/fr/pricing` 200 with fr copy + `<html lang="fr">`; `/pricing` stays en with
+  hreflang set listing all 6 (parse head); sitemap contains `/ta/scheduling`; console
+  and `/o/...` URLs unaffected (route-builder unit test); switcher on `/es/` home →
+  `/hi/` home keeps path.
+- Help: ta visitor opens translated doc (Tamil body); untranslated doc shows en body +
+  ta notice; anchors intact post-translation (link-check test).
+- OG snapshot: shared comp page for a ta-default org renders Tamil tagline, no tofu;
+  poster PDF idem.
+- Lighthouse SEO pass on `/fr/` home ≥ current en score; `npm test` + `tsc` green;
+  update v5/README status — wave complete.


### PR DESCRIPTION
## Summary

Two new design-prompt corpora in the established `design/vN/` format (docs only — no product code). Numbering continues from v3's PROMPT-40.

### design/v4 — AI Schedule Architect (PROMPT-41..43)

Replaces the weak first-cut schedule AI (`aiConstraintsForDivision`, prose→constraints, UI already withdrawn) with a full planner. **Architecture: solver drafts → AI plans → engine referees** — greedy `slotFixtures` draft feeds `claude-opus-4-8` (strict structured output), server re-verifies every proposal with `validateAssignments`, ≤2 repair rounds; apply reuses existing `applySchedule` (checkpoints/undo/seq for free).

- `00-ai-schedule-architect.md` — normative spec: generate/refine/repair modes, removal inventory for the old feature (keeps `scheduling.ai` key, kill-switch, model env), API surface, `schedule_source='ai'` migration, gating/limits/failure modes
- `01-llm-contract.md` — verbatim system prompt, context-pack format, zod output schema, repair/refine protocol, golden-test spec
- PROMPT-41 engine + endpoint + old-AI removal · PROMPT-42 refine/repair + competition-level multi-division · PROMPT-43 board UX (ghost preview, diff, explanations, accept→apply)

### design/v5 — i18n: en · fr · es · hi · ta · nl (PROMPT-44..47)

Audit found zero i18n infra (`lang="en"` hardcoded, ~1,000 inline strings, Latin-only fonts, no locale columns).

- `00-i18n-strategy.md` — thin in-house dictionary layer per the Next 16 guide (no next-intl), locale chain cookie → `users.locale` → org `default_locale` → `Accept-Language` in proxy.ts → en; `[lang]` URL prefix for marketing only; Noto Devanagari/Tamil incl. OG/PDF embedding (hi/ta hard blocker)
- `01-translation-pipeline.md` — en.json source of truth, Claude Batches machine translation with glossary + hash-incremental regen, CI parity/drift/ratchet guards, pseudo-locale QA
- PROMPT-44 foundation · PROMPT-45 public surfaces · PROMPT-46 console/emails/formatting · PROMPT-47 SEO + help content

## Test plan

- [x] Corpus structure matches v3 conventions (README index + NN docs + prompts/), verified `Preamble: PROMPT-00` in all 7 prompts
- [x] All repo paths quoted in the docs exist (spot-checked schedule-plus.ts, calendar.ts, openapi.ts, card.tsx, proxy.ts, routes.ts)
- [x] Docs only — no code, migrations, or config touched; tsc/tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)