### PR TITLE
PERF-A: monolith tuning — DB config, slug cache, peer ISR revalidate, next/image, CSP, CDN seam, public ISR fix

### DIFF
--- a/apps/web/e2e/public-cache-headers.spec.ts
+++ b/apps/web/e2e/public-cache-headers.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { TAG, apiJson, activeOrg } from "./helpers";
+
+// Guards spec 2026-07-12 P1/P5 (Task 7): the public tree must stay
+// ISR-cacheable — a stray cookies()/nonce read on a /shared page would flip
+// it to `private, no-cache, no-store` and silently detach any CDN sitting in
+// front of it (node_modules/next/dist/docs/01-app/02-guides/cdn-caching.md:
+// "Dynamic pages (no caching): private, no-cache, no-store, max-age=0,
+// must-revalidate"). /shared/[orgSlug]/[competitionSlug]/page.tsx pins
+// `export const revalidate = 30`.
+//
+// Runtime probe, not an environment assumption: this suite's webServer
+// (playwright.config.ts) runs `npm run dev`, i.e. `next dev` — which ALWAYS
+// renders dynamically and never emits `s-maxage`, on every route, regardless
+// of the route's own `revalidate` export. There is no dev-mode way to
+// exercise this guard, and the suite has no prod-build project to opt into
+// instead. Rather than assert nothing meaningful against a server that can
+// never pass, this test probes the live response's own Cache-Control header
+// and skips — loudly, with a reason — the moment the tree doesn't look
+// ISR-cacheable.
+//
+// Deliberately NOT narrowed to "dev mode": manual `next build && next start`
+// verification for this task (task-7-report.md) found this exact route
+// serving `private, no-store` on a REAL production build too, root-caused to
+// a missing `generateStaticParams` — per Next's own docs
+// (api-reference/functions/generate-static-params.md: "You must return an
+// empty array from generateStaticParams ... in order to revalidate (ISR)
+// paths at runtime"), a dynamic segment with no generateStaticParams never
+// gets ISR treatment for its runtime-discovered params, regardless of
+// `revalidate`. (The root layout's AnalyticsBootstrap also independently
+// forces many OTHER routes dynamic whenever PostHog is configured — a
+// separate, also-real finding — but is NOT what's blocking this route.) A
+// probe that only checked NODE_ENV would have missed this entirely; checking
+// the actual header is what makes this guard meaningful once it's fixed.
+test("public competition page emits s-maxage for CDN caching", async ({ page, request }) => {
+  const comp = await apiJson<{ id: string; slug: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Cache Header ${TAG}`,
+    visibility: "public",
+  });
+  expect(comp.status).toBeLessThan(300);
+  const orgSlug = (await activeOrg(page)).slug;
+
+  const res = await request.get(`/shared/${orgSlug}/${comp.data!.slug}`);
+  expect(res.status()).toBe(200);
+  const cc = res.headers()["cache-control"] ?? "";
+  test.skip(
+    !cc.includes("s-maxage"),
+    `server isn't emitting ISR cache headers for this route (got Cache-Control: "${cc}") — ` +
+      "either it's a dev-mode server (next dev always renders dynamically), or the tree is " +
+      "missing generateStaticParams on a real production build (see task-7-report.md for a " +
+      "known instance of the latter, plus a separate PostHog/AnalyticsBootstrap gap). Point " +
+      "PLAYWRIGHT_BASE at a `next build && next start` server with that fixed to actually run " +
+      "this assertion.",
+  );
+  expect(cc).toContain("s-maxage=30");
+  expect(cc).toContain("stale-while-revalidate");
+});

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -76,7 +76,29 @@ const nextConfig = {
       },
     ];
   },
+  // next/image: only Supabase Storage public objects are optimizable —
+  // arbitrary avatar URLs stay on plain <img> (can't enumerate the internet
+  // in remotePatterns). Long minimumCacheTTL: logos change rarely and the
+  // optimizer output is CPU we don't want to respend (spec 2026-07-12 P2).
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: process.env.NEXT_PUBLIC_SUPABASE_URL
+          ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+          : "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+    minimumCacheTTL: 86400,
+  },
 };
+
+// Pre-wrap config, re-exported by name: withSentryConfig's returned object
+// isn't guaranteed to expose `images` in a stable, typed shape, so tests (and
+// anything else needing the raw Next config) should import this instead of
+// the default export.
+export { nextConfig };
 
 export default withSentryConfig(nextConfig, {
   // Source map upload — set SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT in CI

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
+    "sharp": "^0.34.5",
     "stripe": "^22.3.0",
     "tiptap-markdown": "^0.9.0",
     "unified": "^11.0.5",

--- a/apps/web/src/__tests__/proxy-csp.test.ts
+++ b/apps/web/src/__tests__/proxy-csp.test.ts
@@ -9,10 +9,12 @@ const page = (path: string) => new NextRequest(`http://localhost:3000${path}`);
 describe("CSP vs cacheable public routes", () => {
   it("classifies the cacheable public tree", () => {
     expect(isCacheablePublicPath("/shared/riverside/summer-league")).toBe(true);
+    expect(isCacheablePublicPath("/shared")).toBe(true);
     expect(isCacheablePublicPath("/embed/divisions/x/standings")).toBe(true);
-    expect(isCacheablePublicPath("/r/AB12CD")).toBe(true);
     expect(isCacheablePublicPath("/dashboard")).toBe(false);
-    expect(isCacheablePublicPath("/register")).toBe(false); // /r prefix must not over-match
+    expect(isCacheablePublicPath("/r/AB12CD")).toBe(false); // force-dynamic registration-ref tree excluded
+    expect(isCacheablePublicPath("/register")).toBe(false);
+    expect(isCacheablePublicPath("/reset-password")).toBe(false);
   });
 
   it("keeps report-only CSP on cacheable public pages even in enforce mode", () => {
@@ -26,5 +28,26 @@ describe("CSP vs cacheable public routes", () => {
     vi.stubEnv("CSP_MODE", "enforce");
     const res = proxy(page("/dashboard"));
     expect(res.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+  });
+
+  it("skips nonce request headers on cacheable public paths to preserve ISR", () => {
+    vi.stubEnv("CSP_MODE", "enforce");
+    const res = proxy(page("/shared/riverside/summer-league"));
+    // x-middleware-override-headers should be null or not contain x-nonce
+    const overrideHeaders = res.headers.get("x-middleware-override-headers");
+    if (overrideHeaders) {
+      expect(overrideHeaders).not.toContain("x-nonce");
+    }
+    // x-middleware-request-x-nonce should not be forwarded
+    expect(res.headers.get("x-middleware-request-x-nonce")).toBeNull();
+  });
+
+  it("forwards nonce request headers on app pages for per-request CSP stamping", () => {
+    vi.stubEnv("CSP_MODE", "enforce");
+    const res = proxy(page("/dashboard"));
+    // x-middleware-request-x-nonce should be forwarded (non-empty string)
+    const nonceHeader = res.headers.get("x-middleware-request-x-nonce");
+    expect(nonceHeader).toBeTruthy();
+    expect(typeof nonceHeader).toBe("string");
   });
 });

--- a/apps/web/src/__tests__/proxy-csp.test.ts
+++ b/apps/web/src/__tests__/proxy-csp.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy, isCacheablePublicPath } from "@/proxy";
+
+afterEach(() => vi.unstubAllEnvs());
+
+const page = (path: string) => new NextRequest(`http://localhost:3000${path}`);
+
+describe("CSP vs cacheable public routes", () => {
+  it("classifies the cacheable public tree", () => {
+    expect(isCacheablePublicPath("/shared/riverside/summer-league")).toBe(true);
+    expect(isCacheablePublicPath("/embed/divisions/x/standings")).toBe(true);
+    expect(isCacheablePublicPath("/r/AB12CD")).toBe(true);
+    expect(isCacheablePublicPath("/dashboard")).toBe(false);
+    expect(isCacheablePublicPath("/register")).toBe(false); // /r prefix must not over-match
+  });
+
+  it("keeps report-only CSP on cacheable public pages even in enforce mode", () => {
+    vi.stubEnv("CSP_MODE", "enforce");
+    const res = proxy(page("/shared/riverside/summer-league"));
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("Content-Security-Policy-Report-Only")).toContain("default-src 'self'");
+  });
+
+  it("enforces on app pages when CSP_MODE=enforce", () => {
+    vi.stubEnv("CSP_MODE", "enforce");
+    const res = proxy(page("/dashboard"));
+    expect(res.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+  });
+});

--- a/apps/web/src/app/(public)/r/[ref]/ticket.png/route.tsx
+++ b/apps/web/src/app/(public)/r/[ref]/ticket.png/route.tsx
@@ -109,6 +109,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ ref: str
                 {stamp.label}
               </div>
             </div>
+            {/* next/og ImageResponse (satori) renderer — the next/image component
+                isn't supported inside it, stays <img> */}
             {/* eslint-disable-next-line @next/next/no-img-element -- OG renderer */}
             <img src={qr} alt="" width={180} height={180} style={{ borderRadius: 12 }} />
           </div>

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx
@@ -12,6 +12,12 @@ import { ShareButton } from "@/components/share-button";
 
 export const revalidate = 30;
 
+// ISR (task-8): empty-array generateStaticParams is required for on-demand
+// ISR on a dynamic segment in this Next version — see generate-static-params.md.
+export async function generateStaticParams() {
+  return [];
+}
+
 type Props = {
   params: Promise<{
     orgSlug: string;

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
@@ -21,6 +21,12 @@ import type { MetricSpecLike } from "@/lib/public-site";
 
 export const revalidate = 30;
 
+// ISR (task-8): empty-array generateStaticParams is required for on-demand
+// ISR on a dynamic segment in this Next version — see generate-static-params.md.
+export async function generateStaticParams() {
+  return [];
+}
+
 type Props = {
   params: Promise<{ orgSlug: string; competitionSlug: string; divisionSlug: string }>;
 };

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
@@ -3,6 +3,7 @@
 // render with noindex; private ones never reach here (the view 404s them).
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
+import Image from "next/image";
 import type { Metadata } from "next";
 import { ChevronRight } from "lucide-react";
 import { getPublicCompetition } from "@/server/public-site/data";
@@ -82,6 +83,10 @@ export default async function CompetitionHomePage({ params }: Props) {
       <section className="relative mb-6 overflow-hidden rounded-2xl bg-court text-court-ink shadow-lg">
         {branding.banner ? (
           <>
+            {/* competition branding.banner — raw jsonb (z.record(string, unknown)),
+                not routed through resolveLogoUrl and has no upload UI today, so it
+                isn't provably a storage URL; stays <img> until that's confirmed
+                (task-4 report: skipped-ambiguous-source) */}
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={branding.banner}
@@ -103,6 +108,8 @@ export default async function CompetitionHomePage({ params }: Props) {
         <div className="relative flex flex-col gap-5 p-6 sm:p-8">
           <div className="flex flex-wrap items-start gap-4">
             {branding.logo ? (
+              // competition branding.logo — same unconstrained jsonb / no-upload-UI
+              // situation as branding.banner above; skipped-ambiguous-source.
               // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={branding.logo}
@@ -247,8 +254,8 @@ export default async function CompetitionHomePage({ params }: Props) {
               const inner = (
                 <span className="flex items-center gap-2 rounded-lg border border-zinc-200/80 bg-surface px-3 py-2 text-sm text-zinc-600 shadow-sm">
                   {s.logo ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={s.logo} alt="" className="h-6 w-6 object-contain" />
+                    // sponsor logo — uploaded via content-upload, always a storage URL.
+                    <Image src={s.logo} alt="" width={24} height={24} className="h-6 w-6 object-contain" />
                   ) : null}
                   {s.name}
                 </span>

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
@@ -16,6 +16,12 @@ import { CompetitionProse } from "@/components/public-site/competition-prose";
 
 export const revalidate = 30;
 
+// ISR (task-8): empty-array generateStaticParams is required for on-demand
+// ISR on a dynamic segment in this Next version — see generate-static-params.md.
+export async function generateStaticParams() {
+  return [];
+}
+
 type Props = { params: Promise<{ orgSlug: string; competitionSlug: string }> };
 
 interface Branding {

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
@@ -42,6 +42,7 @@ export default async function PlayerCardPage({ params }: Props) {
       </nav>
       <div className="flex items-start gap-4">
         {player.photo ? (
+          // arbitrary-host avatar — not in remotePatterns, stays <img>
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={player.photo}

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
@@ -8,6 +8,13 @@ import { getPublicPlayer } from "@/server/public-site/data";
 
 export const revalidate = 300; // doc 09 §3: entrant/player pages revalidate 300
 
+// ISR (task-8): empty-array generateStaticParams is required for on-demand
+// ISR on a dynamic segment in this Next version — see generate-static-params.md.
+// REVALIDATE_SLOW (300) above is unchanged, just gaining ISR eligibility.
+export async function generateStaticParams() {
+  return [];
+}
+
 type Props = {
   params: Promise<{ orgSlug: string; competitionSlug: string; personId: string }>;
 };

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx
@@ -37,6 +37,8 @@ export default async function PosterPage({ params }: Props) {
         <div aria-hidden className="h-1 bg-accent" />
         <div className="flex flex-col items-center gap-5 px-8 py-8">
           <div className="rounded-2xl border border-zinc-200 p-3 shadow-sm">
+            {/* data: URI QR code — generated in-memory, not storage-served; next/image
+                optimizer doesn't apply, stays <img> */}
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={qr} alt={`QR code for ${url}`} className="h-72 w-72" />
           </div>

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx
@@ -8,6 +8,12 @@ import { PrintButton } from "@/components/print-button";
 
 export const revalidate = 300;
 
+// ISR (task-8): empty-array generateStaticParams is required for on-demand
+// ISR on a dynamic segment in this Next version — see generate-static-params.md.
+export async function generateStaticParams() {
+  return [];
+}
+
 type Props = { params: Promise<{ orgSlug: string; competitionSlug: string }> };
 
 export const metadata: Metadata = {

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/page.tsx
@@ -4,6 +4,7 @@ export const dynamic = "force-dynamic";
 // confirmation. Uncached — remaining capacity is live.
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import Image from "next/image";
 import type { Metadata } from "next";
 import { publicRegistrationInfo } from "@/server/usecases/registrations";
 import { getPublicOrg } from "@/server/public-site/data";
@@ -52,8 +53,8 @@ export default async function RegisterPage({ params }: Props) {
           {sponsors.slice(0, 5).map((s) => (
             <span key={s.name} className="inline-flex items-center gap-1.5">
               {s.logo ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={s.logo} alt="" className="h-4 w-4 rounded-sm object-contain" />
+                // sponsor logo — uploaded via content-upload, always a storage URL.
+                <Image src={s.logo} alt="" width={16} height={16} className="h-4 w-4 rounded-sm object-contain" />
               ) : null}
               {s.name}
             </span>

--- a/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
@@ -8,6 +8,7 @@
 // can re-brand the whole surface later without touching components.
 import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
+import Image from "next/image";
 import { Barlow_Condensed } from "next/font/google";
 import { isReservedSlug } from "@/lib/public-site";
 import { publicThemeStyle } from "@/lib/public-theme";
@@ -60,10 +61,12 @@ export default async function PublicOrgLayout({
       <header className="sticky top-0 z-40 bg-court text-court-ink shadow-md">
         <div className="mx-auto flex h-[52px] max-w-5xl items-center gap-3 px-4">
           {org.logo ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
+            // resolveLogoUrl(...) output — storage-served, covered by remotePatterns.
+            <Image
               src={org.logo}
               alt=""
+              width={32}
+              height={32}
               className="h-8 w-8 shrink-0 rounded-md bg-white/10 object-cover"
             />
           ) : (

--- a/apps/web/src/app/(public)/shared/[orgSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/page.tsx
@@ -11,6 +11,15 @@ import { CompetitionProse } from "@/components/public-site/competition-prose";
 
 export const revalidate = 30;
 
+// ISR (task-8): a dynamic-param route with no generateStaticParams never
+// gets ISR treatment in this Next version, regardless of `revalidate` above
+// — empty array + default dynamicParams=true still enables on-demand ISR
+// (first request renders + caches; docs: api-reference/functions/
+// generate-static-params.md).
+export async function generateStaticParams() {
+  return [];
+}
+
 type Props = { params: Promise<{ orgSlug: string }> };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/apps/web/src/app/api/internal/revalidate/route.test.ts
+++ b/apps/web/src/app/api/internal/revalidate/route.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+afterEach(() => vi.unstubAllEnvs());
+
+const req = (body: unknown, secret?: string) =>
+  new NextRequest("http://localhost:3000/api/internal/revalidate", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(secret ? { "x-cron-secret": secret } : {}) },
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/internal/revalidate", () => {
+  it("401s without the shared secret (and when none is configured)", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+    expect((await POST(req({ tags: ["t"], mode: "swr" }))).status).toBe(401);
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    expect((await POST(req({ tags: ["t"], mode: "swr" }, "wrong"))).status).toBe(401);
+  });
+
+  it("400s on malformed bodies", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    expect((await POST(req({ tags: "not-an-array", mode: "swr" }, "s3cret"))).status).toBe(400);
+    expect((await POST(req({ tags: ["t"], mode: "purge-everything" }, "s3cret"))).status).toBe(400);
+    expect((await POST(req({ tags: Array(21).fill("t"), mode: "swr" }, "s3cret"))).status).toBe(400);
+  });
+
+  it("applies each tag locally and reports ok", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    const res = await POST(req({ tags: ["division:d1", "discovery"], mode: "swr" }, "s3cret"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, applied: 2 });
+  });
+});

--- a/apps/web/src/app/api/internal/revalidate/route.test.ts
+++ b/apps/web/src/app/api/internal/revalidate/route.test.ts
@@ -30,6 +30,6 @@ describe("POST /api/internal/revalidate", () => {
     vi.stubEnv("CRON_SECRET", "s3cret");
     const res = await POST(req({ tags: ["division:d1", "discovery"], mode: "swr" }, "s3cret"));
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true, applied: 2 });
+    expect(await res.json()).toEqual({ ok: true });
   });
 });

--- a/apps/web/src/app/api/internal/revalidate/route.ts
+++ b/apps/web/src/app/api/internal/revalidate/route.ts
@@ -26,6 +26,10 @@ export async function POST(req: NextRequest) {
   const parsed = Body.safeParse(await req.json().catch(() => null));
   if (!parsed.success) return NextResponse.json({ ok: false }, { status: 400 });
   const { tags, mode } = parsed.data;
+  // Per-tag failures are swallowed (same fail-open contract as fire*Revalidate
+  // in server/public-site/revalidate.ts — staleness is bounded by the 30s ISR
+  // window), so the response below deliberately reports acceptance, not
+  // per-tag success. Callers (lib/peer-revalidate.ts) ignore the body.
   for (const tag of tags) {
     // Same Next 16 semantics as server/public-site/revalidate.ts: 'max' =
     // stale-while-revalidate for scoring pages; expire:0 = read-your-writes
@@ -37,5 +41,5 @@ export async function POST(req: NextRequest) {
       // outside a Next request scope (tests, scripts) — nothing to invalidate
     }
   }
-  return NextResponse.json({ ok: true, applied: tags.length });
+  return NextResponse.json({ ok: true });
 }

--- a/apps/web/src/app/api/internal/revalidate/route.ts
+++ b/apps/web/src/app/api/internal/revalidate/route.ts
@@ -1,0 +1,41 @@
+import { timingSafeEqual } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { z } from "zod";
+
+// Peer endpoint for multi-machine ISR coherence (lib/peer-revalidate). Applies
+// tags LOCALLY only — it never re-broadcasts, so fan-out cannot loop. Guarded
+// by the same CRON_SECRET the GHA cron endpoints use.
+const Body = z.object({
+  tags: z.array(z.string().min(1).max(200)).min(1).max(20),
+  mode: z.enum(["swr", "expire"]),
+});
+
+function secretOk(header: string | null): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || !header) return false;
+  const a = Buffer.from(header);
+  const b = Buffer.from(secret);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function POST(req: NextRequest) {
+  if (!secretOk(req.headers.get("x-cron-secret"))) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+  const parsed = Body.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ ok: false }, { status: 400 });
+  const { tags, mode } = parsed.data;
+  for (const tag of tags) {
+    // Same Next 16 semantics as server/public-site/revalidate.ts: 'max' =
+    // stale-while-revalidate for scoring pages; expire:0 = read-your-writes
+    // for org chrome edits.
+    try {
+      if (mode === "expire") revalidateTag(tag, { expire: 0 });
+      else revalidateTag(tag, "max");
+    } catch {
+      // outside a Next request scope (tests, scripts) — nothing to invalidate
+    }
+  }
+  return NextResponse.json({ ok: true, applied: tags.length });
+}

--- a/apps/web/src/app/api/orgs/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[id]/__tests__/route.test.ts
@@ -1,0 +1,86 @@
+// Org PATCH invalidation call-site coverage (Task 2 review finding 3): a
+// rename must call invalidateSlugCache with the old+new slug; a non-rename
+// patch (e.g. logo) must not. requireOrgRole is stubbed to skip real
+// cookie/JWT auth — everything else this route touches (generateOrgSlug,
+// invalidateUserOrgs, the DB writes) runs for real against the migrated
+// test Postgres, same DB-backed convention as slug-hygiene.test.ts.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import type { User } from "@/lib/types";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const fakeUser: User = {
+  id: randomUUID(),
+  display_name: "Route Test",
+  email: "route-test@test.local",
+  avatar_url: null,
+};
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    requireOrgRole: vi.fn(async () => ({ user: fakeUser, role: "owner" as const })),
+  };
+});
+
+vi.mock("@/server/slug-resolve", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/slug-resolve")>();
+  return { ...actual, invalidateSlugCache: vi.fn(actual.invalidateSlugCache) };
+});
+
+import { invalidateSlugCache } from "@/server/slug-resolve";
+import { PATCH } from "../route";
+
+async function seedOrg(): Promise<{ id: string; slug: string }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [org] = await sql<{ id: string; slug: string }[]>`
+    insert into organizations (name, slug)
+    values (${"Route Org " + suffix}, ${"route-org-" + suffix})
+    returning id, slug`;
+  return org!;
+}
+
+function patchReq(body: unknown): Request {
+  return new Request("http://localhost/api/orgs/x", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe.skipIf(!HAS_DB)("PATCH /api/orgs/[id] slug cache invalidation", () => {
+  it("renaming the org calls invalidateSlugCache once with the old and new slug", async () => {
+    const org = await seedOrg();
+    const suffix = randomUUID().slice(0, 8);
+    const res = await PATCH(patchReq({ name: `Riverside United ${suffix}` }), {
+      params: Promise.resolve({ id: org.id }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; data: { slug: string } };
+    expect(json.ok).toBe(true);
+    expect(json.data.slug).not.toBe(org.slug);
+    expect(invalidateSlugCache).toHaveBeenCalledTimes(1);
+    expect(invalidateSlugCache).toHaveBeenCalledWith("org", null, org.slug, json.data.slug);
+  });
+
+  it("a non-rename patch (logo) never invalidates the slug cache", async () => {
+    const org = await seedOrg();
+    const res = await PATCH(patchReq({ logo_storage_path: "orgs/logo.png" }), {
+      params: Promise.resolve({ id: org.id }),
+    });
+    expect(res.status).toBe(200);
+    expect(invalidateSlugCache).not.toHaveBeenCalled();
+  });
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return; // DB-less unit job: connecting just to disconnect throws
+  await sql.end();
+});

--- a/apps/web/src/app/api/orgs/[id]/route.ts
+++ b/apps/web/src/app/api/orgs/[id]/route.ts
@@ -1,6 +1,7 @@
 import { sql } from "@/lib/db";
 import { requireOrgRole, invalidateUserOrgs, generateOrgSlug } from "@/lib/auth";
 import { recordSlugHistory } from "@/server/usecases/slugs";
+import { invalidateSlugCache } from "@/server/slug-resolve";
 import { fireOrgRevalidate } from "@/server/public-site/revalidate";
 import { handler } from "@/lib/http";
 import { HttpError } from "@/lib/errors";
@@ -102,6 +103,7 @@ export async function PATCH(
     // A rename busts the OLD slug's tree too (its pages now redirect).
     fireOrgRevalidate(org.slug);
     if (previousSlug) fireOrgRevalidate(previousSlug);
+    if (previousSlug) await invalidateSlugCache("org", null, previousSlug, org.slug);
 
     return org;
   });

--- a/apps/web/src/app/api/users/me/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/me/__tests__/route.test.ts
@@ -60,41 +60,55 @@ beforeEach(() => {
   resolveActiveOrgMock.mockReset();
 });
 
+// Identity endpoints must never be cacheable — an intermediary caching a 200
+// would leak one user's identity to another, and a cached 401 would blind the
+// post-login identify (task-8 review F3). Explicit on EVERY status, not left
+// to framework defaults + external CDN rules.
+const NO_STORE = "private, no-store";
+
 describe.skipIf(!HAS_DB)("GET /api/users/me", () => {
-  it("401s when not authenticated", async () => {
+  it("401s when not authenticated, with Cache-Control: private, no-store", async () => {
     requireUserMock.mockRejectedValueOnce(new AuthError("Not authenticated"));
     const res = await GET();
     expect(res.status).toBe(401);
+    expect(res.headers.get("cache-control")).toBe(NO_STORE);
     const json = (await res.json()) as { ok: boolean };
     expect(json.ok).toBe(false);
   });
 
-  it("200s with { id, email, org } for an authenticated user with an active org", async () => {
+  it("200s with the minimized { id, org } payload — no email — and no-store", async () => {
     const org = await seedOrgWithPlan("pro");
     requireUserMock.mockResolvedValueOnce(fakeUser);
     resolveActiveOrgMock.mockResolvedValueOnce(org);
 
     const res = await GET();
     expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe(NO_STORE);
     const json = (await res.json()) as {
       ok: boolean;
-      data: { id: string; email: string; org: { id: string; name: string; plan: string } | null };
+      data: { id: string; org: { id: string; name: string; plan: string } | null };
     };
     expect(json.ok).toBe(true);
     expect(json.data.id).toBe(fakeUser.id);
-    expect(json.data.email).toBe(fakeUser.email);
     expect(json.data.org).toEqual({ id: org.id, name: org.name, plan: "pro" });
+    // Data minimization (task-8 review F3): nothing consumes email — the
+    // identify payload is {userId, orgId, orgName, plan} — so it must not
+    // ride along on an endpoint fetched on every anonymous navigation.
+    expect(json.data).not.toHaveProperty("email");
+    expect(Object.keys(json.data).sort()).toEqual(["id", "org"]);
   });
 
-  it("200s with org: null when the user belongs to no org", async () => {
+  it("200s with org: null (and no email) when the user belongs to no org", async () => {
     requireUserMock.mockResolvedValueOnce(fakeUser);
     resolveActiveOrgMock.mockResolvedValueOnce(null);
 
     const res = await GET();
     expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe(NO_STORE);
     const json = (await res.json()) as { ok: boolean; data: { org: unknown } };
     expect(json.ok).toBe(true);
     expect(json.data.org).toBeNull();
+    expect(json.data).not.toHaveProperty("email");
   });
 });
 

--- a/apps/web/src/app/api/users/me/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/me/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+// GET /api/users/me (task-8): a whoami endpoint the client-side analytics
+// bootstrap fetches instead of the root layout reading cookies() directly
+// (see analytics-bootstrap.tsx / task-8-report.md). requireUser and
+// resolveActiveOrg are stubbed — real cookie/JWT auth skipped, same
+// convention as app/api/orgs/[id]/__tests__/route.test.ts; the plan_key
+// lookup runs for real against the migrated test Postgres via a seeded
+// subscriptions row.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { AuthError } from "@/lib/errors";
+import type { OrgMembership, User } from "@/lib/types";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const fakeUser: User = {
+  id: randomUUID(),
+  display_name: "Me Route Test",
+  email: "me-route-test@test.local",
+  avatar_url: null,
+};
+
+const requireUserMock = vi.fn<() => Promise<User>>();
+const resolveActiveOrgMock = vi.fn<(user: User) => Promise<OrgMembership | null>>();
+
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    requireUser: () => requireUserMock(),
+    resolveActiveOrg: (user: User) => resolveActiveOrgMock(user),
+  };
+});
+
+import { GET } from "../route";
+
+async function seedOrgWithPlan(plan: string): Promise<OrgMembership> {
+  const suffix = randomUUID().slice(0, 8);
+  const [org] = await sql<
+    { id: string; name: string; slug: string; created_by: string | null; created_at: string }[]
+  >`
+    insert into organizations (name, slug)
+    values (${"Me Route Org " + suffix}, ${"me-route-org-" + suffix})
+    returning id, name, slug, created_by, created_at`;
+  await sql`
+    insert into subscriptions (org_id, plan_key, status)
+    values (${org!.id}, ${plan}, 'active')`;
+  return {
+    ...org!,
+    logo_url: null,
+    logo_storage_path: null,
+    payment_instructions: null,
+    branding: null,
+    role: "owner",
+  };
+}
+
+beforeEach(() => {
+  requireUserMock.mockReset();
+  resolveActiveOrgMock.mockReset();
+});
+
+describe.skipIf(!HAS_DB)("GET /api/users/me", () => {
+  it("401s when not authenticated", async () => {
+    requireUserMock.mockRejectedValueOnce(new AuthError("Not authenticated"));
+    const res = await GET();
+    expect(res.status).toBe(401);
+    const json = (await res.json()) as { ok: boolean };
+    expect(json.ok).toBe(false);
+  });
+
+  it("200s with { id, email, org } for an authenticated user with an active org", async () => {
+    const org = await seedOrgWithPlan("pro");
+    requireUserMock.mockResolvedValueOnce(fakeUser);
+    resolveActiveOrgMock.mockResolvedValueOnce(org);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      ok: boolean;
+      data: { id: string; email: string; org: { id: string; name: string; plan: string } | null };
+    };
+    expect(json.ok).toBe(true);
+    expect(json.data.id).toBe(fakeUser.id);
+    expect(json.data.email).toBe(fakeUser.email);
+    expect(json.data.org).toEqual({ id: org.id, name: org.name, plan: "pro" });
+  });
+
+  it("200s with org: null when the user belongs to no org", async () => {
+    requireUserMock.mockResolvedValueOnce(fakeUser);
+    resolveActiveOrgMock.mockResolvedValueOnce(null);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; data: { org: unknown } };
+    expect(json.ok).toBe(true);
+    expect(json.data.org).toBeNull();
+  });
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return; // DB-less unit job: connecting just to disconnect throws
+  await sql.end();
+});

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -15,24 +15,30 @@ import { sendAccountDeletionEmail } from "@/lib/email";
  * via getCurrentUser()/cookies() directly in the ROOT layout — moved here so
  * that read no longer forces every route rendered through the root layout to
  * go dynamic whenever NEXT_PUBLIC_POSTHOG_KEY is set. The client-side
- * analytics bootstrap fetches this once (sessionStorage-memoized) instead.
- * 401 for anonymous callers; org is null for a user with no org membership.
+ * analytics bootstrap (lib/analytics-identity) fetches this per navigation
+ * until identified (sessionStorage-memoized). 401 for anonymous callers; org
+ * is null for a user with no org membership. Payload is minimized to what
+ * the identify call consumes — no email (task-8 review F3).
  */
 export async function GET() {
-  return handler(async () => {
+  const res = await handler(async () => {
     const user = await requireUser();
     const org = await resolveActiveOrg(user);
-    if (!org) return { id: user.id, email: user.email, org: null };
+    if (!org) return { id: user.id, org: null };
 
     const [sub] = await sql<{ plan_key: string | null }[]>`
       select coalesce(plan_key, 'community') as plan_key
       from subscriptions where org_id = ${org.id}`;
     return {
       id: user.id,
-      email: user.email,
       org: { id: org.id, name: org.name, plan: sub?.plan_key ?? "community" },
     };
   });
+  // Identity endpoints must never be cacheable — set explicitly on EVERY
+  // status (200 and 401 alike), not left to framework defaults + external
+  // CDN rules (task-8 review F3).
+  res.headers.set("Cache-Control", "private, no-store");
+  return res;
 }
 
 /** Update the authenticated user's profile (currently just the display name). */

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -1,8 +1,39 @@
 import { sql } from "@/lib/db";
-import { requireUser, destroySession, invalidateUser, invalidateUserOrgs } from "@/lib/auth";
+import {
+  requireUser,
+  resolveActiveOrg,
+  destroySession,
+  invalidateUser,
+  invalidateUserOrgs,
+} from "@/lib/auth";
 import { handler, HttpError } from "@/lib/http";
 import { deleteAccountSchema, updateProfileSchema } from "@/lib/types";
 import { sendAccountDeletionEmail } from "@/lib/email";
+
+/**
+ * Whoami (task-8): resolves the same identity AnalyticsBootstrap used to read
+ * via getCurrentUser()/cookies() directly in the ROOT layout — moved here so
+ * that read no longer forces every route rendered through the root layout to
+ * go dynamic whenever NEXT_PUBLIC_POSTHOG_KEY is set. The client-side
+ * analytics bootstrap fetches this once (sessionStorage-memoized) instead.
+ * 401 for anonymous callers; org is null for a user with no org membership.
+ */
+export async function GET() {
+  return handler(async () => {
+    const user = await requireUser();
+    const org = await resolveActiveOrg(user);
+    if (!org) return { id: user.id, email: user.email, org: null };
+
+    const [sub] = await sql<{ plan_key: string | null }[]>`
+      select coalesce(plan_key, 'community') as plan_key
+      from subscriptions where org_id = ${org.id}`;
+    return {
+      id: user.id,
+      email: user.email,
+      org: { id: org.id, name: org.name, plan: sub?.plan_key ?? "community" },
+    };
+  });
+}
 
 /** Update the authenticated user's profile (currently just the display name). */
 export async function PATCH(req: Request) {

--- a/apps/web/src/app/embed/divisions/[id]/[widget]/page.tsx
+++ b/apps/web/src/app/embed/divisions/[id]/[widget]/page.tsx
@@ -15,6 +15,13 @@ import type { StandingsRow } from "@seazn/engine/competition";
 
 export const revalidate = 30;
 
+// ISR (task-8): same fix as the /shared tree — empty-array generateStaticParams
+// is required for on-demand ISR on a dynamic segment in this Next version
+// (docs: api-reference/functions/generate-static-params.md).
+export async function generateStaticParams() {
+  return [];
+}
+
 const WIDGETS = new Set(["standings", "schedule", "bracket"]);
 const BRACKET_KINDS = new Set(["knockout", "double_elim", "stepladder"]);
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AnalyticsBootstrap } from "@/components/analytics-bootstrap";
@@ -59,10 +58,10 @@ export default function RootLayout({
             trees both have destructive actions. */}
         <ConfirmProvider>{children}</ConfirmProvider>
         {/* Identifies the logged-in user for PostHog; a no-op for anon traffic.
-            Suspense keeps its DB reads off the page's render-blocking path. */}
-        <Suspense fallback={null}>
-          <AnalyticsBootstrap />
-        </Suspense>
+            Client-mounted (task-8): fetches identity from /api/users/me
+            instead of reading cookies() here, so this layout's RSC tree stays
+            static/ISR-eligible (see analytics-bootstrap.tsx). */}
+        <AnalyticsBootstrap />
         {/* Global consent banner — analytics stays opted out until Accept. */}
         <CookieConsent />
       </body>

--- a/apps/web/src/components/analytics-bootstrap.tsx
+++ b/apps/web/src/components/analytics-bootstrap.tsx
@@ -1,86 +1,87 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 import posthog from "posthog-js";
 import { AnalyticsIdentify } from "@/components/analytics-identify";
-
-interface Identity {
-  userId: string;
-  orgId: string;
-  orgName: string;
-  plan: string;
-}
-
-interface MeResponse {
-  data: {
-    id: string;
-    org: { id: string; name: string; plan: string } | null;
-  };
-}
-
-const IDENTITY_CACHE_KEY = "seazn_analytics_identity";
+import {
+  hasIdentifiedThisTab,
+  markIdentifiedThisTab,
+  resolveIdentity,
+  type AnalyticsIdentity,
+} from "@/lib/analytics-identity";
 
 /**
  * Client-mounted (task-8: make the public tree actually ISR in production).
  * The old version was a server component that called getCurrentUser() (->
- * cookies()) directly from the ROOT layout — that forces EVERY route
- * rendered through it (/, /clubs, /people, /players, /_not-found, and would
- * re-dynamicize /shared once R1's generateStaticParams fix landed) to render
- * dynamically the moment NEXT_PUBLIC_POSTHOG_KEY is set (task-7's audited
- * finding). This version resolves the exact same identity
- * (userId/orgId/orgName/plan) via a fetch to GET /api/users/me instead,
- * keeping the root layout's RSC tree cookie-free. Memoized in sessionStorage
- * so a browser tab only pays for the round trip once; a failed/401 fetch
- * (anonymous visitor) leaves identity null and renders nothing, same as the
- * old `if (user && org)` gate. AnalyticsIdentify (the actual
+ * cookies()) directly from the ROOT layout — that forces EVERY route rendered
+ * through it to render dynamically the moment NEXT_PUBLIC_POSTHOG_KEY is set
+ * (task-7's audited finding). This version resolves the same identity
+ * (userId/orgId/orgName/plan) via lib/analytics-identity (a fetch to
+ * GET /api/users/me, sessionStorage-memoized) instead, keeping the root
+ * layout's RSC tree cookie-free. AnalyticsIdentify (the actual
  * posthog.identify/group call) is unchanged.
+ *
+ * Lifecycle (task-8 review fix, Critical finding): the effect is keyed on the
+ * pathname, not run-once — logins here are SOFT navigations (magic-link.tsx
+ * does router.push + refresh), so an empty-dep effect would never identify a
+ * user who signed in after first paint. Conversely, logout-button calls
+ * clearAnalyticsIdentity() + posthog.reset() before ITS soft navigation,
+ * resetting the identified-this-tab flag and the cache, so this effect
+ * re-resolves (and 401s → stays anonymous) instead of carrying a stale
+ * identity into the next session.
  */
 export function AnalyticsBootstrap() {
-  const [identity, setIdentity] = useState<Identity | null>(null);
+  // seq bumps per fresh resolution so AnalyticsIdentify REMOUNTS (key below)
+  // even when the payload values are identical — e.g. the same user logging
+  // back in after a logout: posthog.reset() rotated the distinct id, but
+  // AnalyticsIdentify's primitive effect deps wouldn't change, so without the
+  // remount it would never re-identify.
+  const [resolved, setResolved] = useState<{
+    identity: AnalyticsIdentity;
+    seq: number;
+  } | null>(null);
+  const pathname = usePathname();
 
+  // Effect-only on purpose (SSR-safe: the server render and the first client
+  // paint both yield null; sessionStorage/fetch happen strictly post-mount) —
+  // the react-hooks/set-state-in-effect warning on this pattern remains a
+  // deliberate, accepted exception (task-8 report, Concern 2).
   useEffect(() => {
     if (!posthog.__loaded) return; // no key configured, or impersonation-suppressed
+    if (hasIdentifiedThisTab()) return; // done this tab — until a logout clears the flag
 
-    const cached = sessionStorage.getItem(IDENTITY_CACHE_KEY);
-    if (cached) {
-      try {
-        setIdentity(JSON.parse(cached) as Identity);
-      } catch {
-        sessionStorage.removeItem(IDENTITY_CACHE_KEY);
-      }
-      return;
-    }
-
+    // Anonymous-visitor cost trade (task-8 review F2): anonymous results are
+    // never cached (a sentinel would block identify-after-login), so an anon
+    // visitor pays at most ONE light fetch per soft navigation + one per hard
+    // load — and /api/users/me 401s via requireUser() before any DB call when
+    // there's no session cookie. Comparable to the old per-request RSC
+    // getCurrentUser() cost. Identified visitors pay one fetch per tab, then
+    // the flag above short-circuits every later navigation.
     let cancelled = false;
-    fetch("/api/users/me")
-      .then((res) => (res.ok ? (res.json() as Promise<MeResponse>) : null))
-      .then((body) => {
-        if (cancelled || !body?.data.org) return;
-        const next: Identity = {
-          userId: body.data.id,
-          orgId: body.data.org.id,
-          orgName: body.data.org.name,
-          plan: body.data.org.plan,
-        };
-        sessionStorage.setItem(IDENTITY_CACHE_KEY, JSON.stringify(next));
-        setIdentity(next);
+    resolveIdentity()
+      .then((identity) => {
+        if (cancelled || !identity) return;
+        markIdentifiedThisTab();
+        setResolved((prev) => ({ identity, seq: (prev?.seq ?? 0) + 1 }));
       })
       .catch(() => {
-        // Analytics must never break the app — swallow fetch failures.
+        // resolveIdentity is total; belt-and-braces — analytics must never
+        // break the app.
       });
-
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [pathname]);
 
-  if (!identity) return null;
+  if (!resolved) return null;
   return (
     <AnalyticsIdentify
-      userId={identity.userId}
-      orgId={identity.orgId}
-      orgName={identity.orgName}
-      plan={identity.plan}
+      key={resolved.seq}
+      userId={resolved.identity.userId}
+      orgId={resolved.identity.orgId}
+      orgName={resolved.identity.orgName}
+      plan={resolved.identity.plan}
     />
   );
 }

--- a/apps/web/src/components/analytics-bootstrap.tsx
+++ b/apps/web/src/components/analytics-bootstrap.tsx
@@ -1,41 +1,78 @@
-import "server-only";
-import { getCurrentUser, resolveActiveOrg } from "@/lib/auth";
-import { sql } from "@/lib/db";
+"use client";
+
+import { useEffect, useState } from "react";
+import posthog from "posthog-js";
 import { AnalyticsIdentify } from "@/components/analytics-identify";
 
-/**
- * Server component mounted once in the root layout. For logged-in users it
- * resolves the active org + plan and hands them to the client identifier.
- *
- * Cheap for anonymous traffic: getCurrentUser only reads the session cookie
- * (no DB) when it's absent, so marketing pages pay nothing here. Wrapped in a
- * best-effort try/catch — analytics identity must never break page render.
- */
-export async function AnalyticsBootstrap() {
-  // Skip entirely when PostHog isn't configured.
-  if (!process.env.NEXT_PUBLIC_POSTHOG_KEY) return null;
+interface Identity {
+  userId: string;
+  orgId: string;
+  orgName: string;
+  plan: string;
+}
 
-  // Resolve identity defensively — a failure here must not break page render.
-  // (JSX is built outside the try/catch: React defers rendering, so catch
-  // wouldn't see render-time errors anyway.)
-  let identity: { userId: string; orgId: string; orgName: string; plan: string } | null = null;
-  try {
-    const user = await getCurrentUser();
-    const org = user ? await resolveActiveOrg(user) : null;
-    if (user && org) {
-      const [sub] = await sql<{ plan_key: string | null }[]>`
-        select coalesce(plan_key, 'community') as plan_key
-        from subscriptions where org_id = ${org.id}`;
-      identity = {
-        userId: user.id,
-        orgId: org.id,
-        orgName: org.name,
-        plan: sub?.plan_key ?? "community",
-      };
+interface MeResponse {
+  data: {
+    id: string;
+    org: { id: string; name: string; plan: string } | null;
+  };
+}
+
+const IDENTITY_CACHE_KEY = "seazn_analytics_identity";
+
+/**
+ * Client-mounted (task-8: make the public tree actually ISR in production).
+ * The old version was a server component that called getCurrentUser() (->
+ * cookies()) directly from the ROOT layout — that forces EVERY route
+ * rendered through it (/, /clubs, /people, /players, /_not-found, and would
+ * re-dynamicize /shared once R1's generateStaticParams fix landed) to render
+ * dynamically the moment NEXT_PUBLIC_POSTHOG_KEY is set (task-7's audited
+ * finding). This version resolves the exact same identity
+ * (userId/orgId/orgName/plan) via a fetch to GET /api/users/me instead,
+ * keeping the root layout's RSC tree cookie-free. Memoized in sessionStorage
+ * so a browser tab only pays for the round trip once; a failed/401 fetch
+ * (anonymous visitor) leaves identity null and renders nothing, same as the
+ * old `if (user && org)` gate. AnalyticsIdentify (the actual
+ * posthog.identify/group call) is unchanged.
+ */
+export function AnalyticsBootstrap() {
+  const [identity, setIdentity] = useState<Identity | null>(null);
+
+  useEffect(() => {
+    if (!posthog.__loaded) return; // no key configured, or impersonation-suppressed
+
+    const cached = sessionStorage.getItem(IDENTITY_CACHE_KEY);
+    if (cached) {
+      try {
+        setIdentity(JSON.parse(cached) as Identity);
+      } catch {
+        sessionStorage.removeItem(IDENTITY_CACHE_KEY);
+      }
+      return;
     }
-  } catch {
-    return null;
-  }
+
+    let cancelled = false;
+    fetch("/api/users/me")
+      .then((res) => (res.ok ? (res.json() as Promise<MeResponse>) : null))
+      .then((body) => {
+        if (cancelled || !body?.data.org) return;
+        const next: Identity = {
+          userId: body.data.id,
+          orgId: body.data.org.id,
+          orgName: body.data.org.name,
+          plan: body.data.org.plan,
+        };
+        sessionStorage.setItem(IDENTITY_CACHE_KEY, JSON.stringify(next));
+        setIdentity(next);
+      })
+      .catch(() => {
+        // Analytics must never break the app — swallow fetch failures.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   if (!identity) return null;
   return (

--- a/apps/web/src/components/logout-button.tsx
+++ b/apps/web/src/components/logout-button.tsx
@@ -2,7 +2,9 @@
 
 import { LogOut } from "lucide-react";
 import { useRouter } from "next/navigation";
+import posthog from "posthog-js";
 import { api } from "@/lib/client";
+import { clearAnalyticsIdentity } from "@/lib/analytics-identity";
 
 export function LogoutButton() {
   const router = useRouter();
@@ -10,6 +12,16 @@ export function LogoutButton() {
     <button
       onClick={async () => {
         await api("/api/auth/logout", { method: "POST" });
+        // Kill the analytics identity BEFORE the (soft) navigation — the
+        // cached identify payload and posthog distinct id would otherwise
+        // outlive the session and misattribute the next user in this tab
+        // (task-8 review, Critical). Guarded: must never block logout.
+        try {
+          clearAnalyticsIdentity();
+          if (posthog.__loaded) posthog.reset();
+        } catch {
+          /* analytics teardown is best-effort */
+        }
         router.push("/login");
         router.refresh();
       }}

--- a/apps/web/src/components/public-site/register-form.tsx
+++ b/apps/web/src/components/public-site/register-form.tsx
@@ -8,6 +8,7 @@
 // Youth divisions (v3/11 gap 8) always include the guardian-consent preset.
 import { useMemo, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import Image from "next/image";
 import { apiV1 } from "@/lib/client-v1";
 import { msg } from "@/lib/messages";
 import { Tip } from "@/components/ui/tip";
@@ -391,8 +392,8 @@ export function RegisterForm({
       <header className="overflow-hidden rounded-2xl border border-zinc-200 bg-surface">
         <div className="flex items-center gap-4 px-5 py-4">
           {org.logo_url ? (
-            /* eslint-disable-next-line @next/next/no-img-element -- org asset */
-            <img
+            // resolveLogoUrl(...) output — storage-served, covered by remotePatterns.
+            <Image
               src={org.logo_url}
               alt=""
               width={48}

--- a/apps/web/src/components/public-site/ticket.tsx
+++ b/apps/web/src/components/public-site/ticket.tsx
@@ -102,6 +102,8 @@ export function TearOffTicket({
             <p className="mt-2 max-w-md text-xs text-ink-muted">{msg("register.ticket.keep")}</p>
           </div>
           {qrDataUrl && (
+            /* data: URI QR code — generated in-memory, not storage-served; next/image
+               optimizer doesn't apply, stays <img> */
             /* eslint-disable-next-line @next/next/no-img-element -- data URL QR */
             <img
               src={qrDataUrl}

--- a/apps/web/src/lib/__tests__/analytics-bootstrap-contract.test.ts
+++ b/apps/web/src/lib/__tests__/analytics-bootstrap-contract.test.ts
@@ -1,0 +1,60 @@
+// Source contract for task-8 R2: the root layout's RSC tree must not read
+// cookies()/getCurrentUser for analytics identity. The OLD AnalyticsBootstrap
+// was a server component that called getCurrentUser() (-> cookies()) from
+// the ROOT layout, forcing every route rendered through it (/, /clubs,
+// /people, /players, /_not-found, and — once R1's generateStaticParams
+// fix lands — /shared too) to render dynamically whenever
+// NEXT_PUBLIC_POSTHOG_KEY was set (task-7-report.md's audited finding). The
+// replacement resolves the same identity client-side via a fetch to
+// GET /api/users/me instead — anchored here on the real identifiers so a
+// regression (someone adding cookies()/getCurrentUser back to this file, or
+// to the root layout) fails loudly.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const BOOTSTRAP = join(__dirname, "..", "..", "components/analytics-bootstrap.tsx");
+const LAYOUT = join(__dirname, "..", "..", "app/layout.tsx");
+const ME_ROUTE = join(__dirname, "..", "..", "app/api/users/me/route.ts");
+
+/** Strip comments before checking for real imports/usages — this file's own
+ *  explanatory comments legitimately mention "getCurrentUser"/"cookies()" by
+ *  name (describing what the OLD version did), which must not trip the
+ *  contract meant to catch a real reintroduced dependency. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+describe("analytics-bootstrap contract (task-8): root layout stays cookie-free", () => {
+  it("analytics-bootstrap.tsx is a client component, not a server component", () => {
+    const source = readFileSync(BOOTSTRAP, "utf8");
+    expect(source).toMatch(/^"use client";/m);
+  });
+
+  it("analytics-bootstrap.tsx does not import server-only, next/headers, or getCurrentUser", () => {
+    const source = stripComments(readFileSync(BOOTSTRAP, "utf8"));
+    expect(source).not.toMatch(/import\s+["']server-only["']/);
+    expect(source).not.toMatch(/next\/headers/);
+    expect(source).not.toMatch(/getCurrentUser/);
+  });
+
+  it("analytics-bootstrap.tsx resolves identity via a fetch to /api/users/me", () => {
+    const source = readFileSync(BOOTSTRAP, "utf8");
+    expect(source).toMatch(/fetch\(\s*["']\/api\/users\/me["']/);
+  });
+
+  it("root layout mounts AnalyticsBootstrap without reading cookies/getCurrentUser itself", () => {
+    const raw = readFileSync(LAYOUT, "utf8");
+    expect(raw).toMatch(/<AnalyticsBootstrap\s*\/>/);
+    const source = stripComments(raw);
+    expect(source).not.toMatch(/getCurrentUser/);
+    expect(source).not.toMatch(/next\/headers/);
+    expect(source).not.toMatch(/cookies\(\)/);
+  });
+
+  it("GET /api/users/me exists and requires auth", () => {
+    const source = readFileSync(ME_ROUTE, "utf8");
+    expect(source).toMatch(/export\s+async function\s+GET\s*\(/);
+    expect(source).toMatch(/requireUser\s*\(/);
+  });
+});

--- a/apps/web/src/lib/__tests__/analytics-bootstrap-contract.test.ts
+++ b/apps/web/src/lib/__tests__/analytics-bootstrap-contract.test.ts
@@ -1,26 +1,35 @@
-// Source contract for task-8 R2: the root layout's RSC tree must not read
-// cookies()/getCurrentUser for analytics identity. The OLD AnalyticsBootstrap
-// was a server component that called getCurrentUser() (-> cookies()) from
-// the ROOT layout, forcing every route rendered through it (/, /clubs,
-// /people, /players, /_not-found, and — once R1's generateStaticParams
-// fix lands — /shared too) to render dynamically whenever
-// NEXT_PUBLIC_POSTHOG_KEY was set (task-7-report.md's audited finding). The
-// replacement resolves the same identity client-side via a fetch to
-// GET /api/users/me instead — anchored here on the real identifiers so a
-// regression (someone adding cookies()/getCurrentUser back to this file, or
-// to the root layout) fails loudly.
+// Source contract for task-8 R2 (+ review fix): the root layout's RSC tree
+// must not read cookies()/getCurrentUser for analytics identity. The OLD
+// AnalyticsBootstrap was a server component that called getCurrentUser() (->
+// cookies()) from the ROOT layout, forcing every route rendered through it
+// (/, /clubs, /people, /players, /_not-found, and — once R1's
+// generateStaticParams fix lands — /shared too) to render dynamically
+// whenever NEXT_PUBLIC_POSTHOG_KEY was set (task-7-report.md's audited
+// finding). The replacement resolves the same identity client-side via
+// lib/analytics-identity (which owns the GET /api/users/me fetch),
+// re-resolving per navigation (usePathname) so an in-tab login identifies,
+// and logout-button clears the cache + resets posthog so an in-tab logout
+// can't misattribute — anchored here on the real identifiers so a regression
+// (someone adding cookies()/getCurrentUser back, or dropping the logout
+// clear) fails loudly.
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const BOOTSTRAP = join(__dirname, "..", "..", "components/analytics-bootstrap.tsx");
+const IDENTITY = join(__dirname, "..", "analytics-identity.ts");
+const LOGOUT = join(__dirname, "..", "..", "components/logout-button.tsx");
 const LAYOUT = join(__dirname, "..", "..", "app/layout.tsx");
 const ME_ROUTE = join(__dirname, "..", "..", "app/api/users/me/route.ts");
 
 /** Strip comments before checking for real imports/usages — this file's own
  *  explanatory comments legitimately mention "getCurrentUser"/"cookies()" by
  *  name (describing what the OLD version did), which must not trip the
- *  contract meant to catch a real reintroduced dependency. */
+ *  contract meant to catch a real reintroduced dependency.
+ *  Known limitation (task-8 review F4): not string-literal-aware — a comment
+ *  opener INSIDE a string (e.g. the "//" in "https://…") eats the rest of
+ *  that line, which could hide a banned identifier appearing after it.
+ *  Accepted for these small, string-light source files. */
 function stripComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
 }
@@ -38,9 +47,25 @@ describe("analytics-bootstrap contract (task-8): root layout stays cookie-free",
     expect(source).not.toMatch(/getCurrentUser/);
   });
 
-  it("analytics-bootstrap.tsx resolves identity via a fetch to /api/users/me", () => {
-    const source = readFileSync(BOOTSTRAP, "utf8");
-    expect(source).toMatch(/fetch\(\s*["']\/api\/users\/me["']/);
+  it("analytics-bootstrap.tsx resolves via lib/analytics-identity, re-keyed per navigation (usePathname)", () => {
+    const source = stripComments(readFileSync(BOOTSTRAP, "utf8"));
+    expect(source).toMatch(/@\/lib\/analytics-identity/);
+    expect(source).toMatch(/usePathname/);
+  });
+
+  it("lib/analytics-identity.ts owns the /api/users/me fetch and stays client-safe", () => {
+    const raw = readFileSync(IDENTITY, "utf8");
+    expect(raw).toMatch(/["']\/api\/users\/me["']/);
+    const source = stripComments(raw);
+    expect(source).not.toMatch(/import\s+["']server-only["']/);
+    expect(source).not.toMatch(/next\/headers/);
+    expect(source).not.toMatch(/getCurrentUser/);
+  });
+
+  it("logout-button clears the cached identity and resets posthog before navigating (review Critical)", () => {
+    const source = stripComments(readFileSync(LOGOUT, "utf8"));
+    expect(source).toMatch(/clearAnalyticsIdentity\s*\(/);
+    expect(source).toMatch(/posthog\.reset\s*\(/);
   });
 
   it("root layout mounts AnalyticsBootstrap without reading cookies/getCurrentUser itself", () => {

--- a/apps/web/src/lib/__tests__/analytics-identity.test.ts
+++ b/apps/web/src/lib/__tests__/analytics-identity.test.ts
@@ -1,0 +1,147 @@
+// Unit tests for the analytics identity lifecycle (task-8 review fix,
+// Critical finding): identify must start working after an IN-TAB login
+// (magic-link.tsx soft-navigates — router.push + refresh, no reload) and must
+// stop immediately after an IN-TAB logout (logout-button.tsx soft-navigates
+// too). The old analytics-bootstrap effect ran once per hard load with a
+// never-invalidated sessionStorage cache, so it missed both transitions.
+// Mocked fetch + in-memory storage stub — no jsdom, no network, no DB.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  IDENTITY_CACHE_KEY,
+  clearAnalyticsIdentity,
+  hasIdentifiedThisTab,
+  markIdentifiedThisTab,
+  resolveIdentity,
+  type AnalyticsIdentity,
+} from "@/lib/analytics-identity";
+
+type StorageStub = Pick<Storage, "getItem" | "setItem" | "removeItem"> & {
+  dump(): Record<string, string>;
+};
+
+function memoryStorage(): StorageStub {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+    dump: () => Object.fromEntries(map),
+  };
+}
+
+const IDENTITY: AnalyticsIdentity = {
+  userId: "u1",
+  orgId: "o1",
+  orgName: "Riverside",
+  plan: "pro",
+};
+
+const ok200 = () =>
+  new Response(
+    JSON.stringify({
+      ok: true,
+      data: { id: "u1", org: { id: "o1", name: "Riverside", plan: "pro" } },
+    }),
+    { status: 200 },
+  );
+const noOrg200 = () =>
+  new Response(JSON.stringify({ ok: true, data: { id: "u1", org: null } }), { status: 200 });
+const anon401 = () =>
+  new Response(JSON.stringify({ ok: false, error: "Not authenticated" }), { status: 401 });
+
+beforeEach(() => {
+  // Reset the module-level identified-this-tab flag between tests.
+  clearAnalyticsIdentity({ storage: memoryStorage() });
+});
+
+describe("resolveIdentity", () => {
+  it("login transition: anonymous 401 resolves null WITHOUT caching, then the same tab identifies on the next resolve once the session exists", async () => {
+    const storage = memoryStorage();
+    // First navigation: no session yet — the magic link hasn't been consumed.
+    const fetchFn = vi.fn(async () => anon401());
+    expect(await resolveIdentity({ fetchFn, storage })).toBeNull();
+    expect(storage.dump()).toEqual({}); // anonymous result must never be cached
+    // The user logs in (session cookie now set); the post-login redirect is a
+    // navigation, which triggers the next resolve — it must retry the fetch.
+    fetchFn.mockImplementation(async () => ok200());
+    expect(await resolveIdentity({ fetchFn, storage })).toEqual(IDENTITY);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(storage.dump()[IDENTITY_CACHE_KEY]!)).toEqual(IDENTITY);
+  });
+
+  it("logout transition: clearAnalyticsIdentity drops the cache so the next resolve refetches and comes back anonymous", async () => {
+    const storage = memoryStorage();
+    const fetchFn = vi.fn(async () => ok200());
+    expect(await resolveIdentity({ fetchFn, storage })).toEqual(IDENTITY);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    clearAnalyticsIdentity({ storage });
+    expect(storage.dump()).toEqual({});
+
+    // Session cookie destroyed by POST /api/auth/logout — the endpoint 401s.
+    fetchFn.mockImplementation(async () => anon401());
+    expect(await resolveIdentity({ fetchFn, storage })).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(2); // refetch happened (no stale cache hit)
+    expect(storage.dump()).toEqual({});
+  });
+
+  it("cache hit returns the identified payload without fetching", async () => {
+    const storage = memoryStorage();
+    storage.setItem(IDENTITY_CACHE_KEY, JSON.stringify(IDENTITY));
+    const fetchFn = vi.fn(async () => ok200());
+    expect(await resolveIdentity({ fetchFn, storage })).toEqual(IDENTITY);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("200 with no active org resolves null and is not cached (retries next navigation)", async () => {
+    const storage = memoryStorage();
+    const fetchFn = vi.fn(async () => noOrg200());
+    expect(await resolveIdentity({ fetchFn, storage })).toBeNull();
+    expect(storage.dump()).toEqual({});
+    expect(await resolveIdentity({ fetchFn, storage })).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(2); // no anonymous sentinel blocked the retry
+  });
+
+  it("network error resolves null, caches nothing, and the next resolve retries", async () => {
+    const storage = memoryStorage();
+    const fetchFn = vi
+      .fn(async () => ok200())
+      .mockRejectedValueOnce(new Error("offline"));
+    expect(await resolveIdentity({ fetchFn, storage })).toBeNull();
+    expect(storage.dump()).toEqual({});
+    expect(await resolveIdentity({ fetchFn, storage })).toEqual(IDENTITY);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("malformed cached JSON is dropped and resolution falls through to a fetch", async () => {
+    const storage = memoryStorage();
+    storage.setItem(IDENTITY_CACHE_KEY, "{not json");
+    const fetchFn = vi.fn(async () => ok200());
+    expect(await resolveIdentity({ fetchFn, storage })).toEqual(IDENTITY);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(storage.dump()[IDENTITY_CACHE_KEY]!)).toEqual(IDENTITY);
+  });
+
+  it("a resolution in flight when clearAnalyticsIdentity runs is discarded, not cached (logout race)", async () => {
+    const storage = memoryStorage();
+    let release!: (res: Response) => void;
+    const gate = new Promise<Response>((r) => (release = r));
+    const fetchFn = vi.fn(() => gate);
+    const inFlight = resolveIdentity({ fetchFn, storage });
+    // User clicks logout while the identity fetch is still in flight.
+    clearAnalyticsIdentity({ storage });
+    release(ok200()); // the request raced the logout and still 200'd
+    expect(await inFlight).toBeNull();
+    expect(storage.dump()).toEqual({}); // stale identity must NOT be re-cached
+  });
+});
+
+describe("identified-this-tab flag", () => {
+  it("clearAnalyticsIdentity resets the flag so a post-logout login re-identifies in the same tab", () => {
+    expect(hasIdentifiedThisTab()).toBe(false);
+    markIdentifiedThisTab();
+    expect(hasIdentifiedThisTab()).toBe(true);
+    clearAnalyticsIdentity({ storage: memoryStorage() });
+    expect(hasIdentifiedThisTab()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/cdn-purge.test.ts
+++ b/apps/web/src/lib/__tests__/cdn-purge.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { purgeCdn, __resetPurgeDebounceForTests } from "@/lib/cdn-purge";
+
+beforeEach(() => __resetPurgeDebounceForTests());
+afterEach(() => vi.unstubAllEnvs());
+
+function arm() {
+  vi.stubEnv("CDN_PURGE_URL", "https://api.cloudflare.com/client/v4/zones/z1/purge_cache");
+  vi.stubEnv("CDN_PURGE_TOKEN", "tok");
+}
+
+describe("purgeCdn", () => {
+  it("no-ops without CDN env", async () => {
+    const fetchFn = vi.fn();
+    await purgeCdn({ fetchFn });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("POSTs purge_everything with the bearer token", async () => {
+    arm();
+    const fetchFn = vi.fn(async () => new Response("{}"));
+    await purgeCdn({ fetchFn });
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [
+      string,
+      { headers: Record<string, string>; body: string },
+    ];
+    expect(String(url)).toContain("/purge_cache");
+    expect(init.headers.authorization).toBe("Bearer tok");
+    expect(JSON.parse(init.body)).toEqual({ purge_everything: true });
+  });
+
+  it("debounces to one purge per 30s window", async () => {
+    arm();
+    const fetchFn = vi.fn(async () => new Response("{}"));
+    let t = 1_000_000;
+    const now = () => t;
+    await purgeCdn({ fetchFn, now });
+    await purgeCdn({ fetchFn, now }); // same instant — skipped
+    t += 31_000;
+    await purgeCdn({ fetchFn, now });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows network failures (fail-open)", async () => {
+    arm();
+    await expect(
+      purgeCdn({ fetchFn: vi.fn(async () => Promise.reject(new Error("down"))) }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/__tests__/db-options.test.ts
+++ b/apps/web/src/lib/__tests__/db-options.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { connectionOptions } from "@/lib/db";
+
+describe("connectionOptions", () => {
+  const remote = "postgresql://u:p@aws-0-eu-west-2.pooler.supabase.com";
+
+  it("disables prepared statements on the transaction pooler (:6543)", () => {
+    expect(connectionOptions(`${remote}:6543/postgres`, {}).prepare).toBe(false);
+  });
+
+  it("enables prepared statements on the session pooler (:5432)", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).prepare).toBe(true);
+  });
+
+  it("requires SSL for remote hosts, none for localhost", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).ssl).toBe("require");
+    expect(connectionOptions("postgresql://u:p@localhost:5432/seazn", {}).ssl).toBe(false);
+  });
+
+  it("honors DATABASE_SSL override", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, { DATABASE_SSL: "disable" }).ssl).toBe(false);
+    expect(connectionOptions("postgresql://u:p@localhost:5432/x", { DATABASE_SSL: "require" }).ssl).toBe("require");
+  });
+
+  it("defaults pool max to 5, accepts DB_POOL_MAX within 1..50, rejects garbage", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).max).toBe(5);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "10" }).max).toBe(10);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "0" }).max).toBe(5);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "banana" }).max).toBe(5);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "999" }).max).toBe(5);
+  });
+
+  it("defaults schema to seazn_club, honors DB_SCHEMA", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).schema).toBe("seazn_club");
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_SCHEMA: "public" }).schema).toBe("public");
+  });
+});

--- a/apps/web/src/lib/__tests__/deferred.test.ts
+++ b/apps/web/src/lib/__tests__/deferred.test.ts
@@ -1,4 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
+
+// `after` is wrapped (not replaced) so the two request-scope-less tests below
+// keep exercising the REAL next/server after() throwing outside a request
+// scope (the actual behavior this helper's fallback branch depends on) — only
+// the regression test overrides it, per-call, via mockImplementationOnce.
+vi.mock("next/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/server")>();
+  return { ...actual, after: vi.fn(actual.after) };
+});
+
+import { after } from "next/server";
 import { deferred } from "@/lib/deferred";
 
 describe("deferred", () => {
@@ -14,5 +25,49 @@ describe("deferred", () => {
     });
     expect(() => deferred(fn)).not.toThrow();
     await vi.waitFor(() => expect(fn).toHaveBeenCalled());
+  });
+
+  // Task 6 review finding 1 (CRITICAL) / finding 4: `run` used to be
+  // non-async and returned undefined, so after(run) hands Next's after()
+  // nothing to wait on — the after-window can close (Redis invalidation +
+  // revalidateTag racing the response) even though `run` is still mid-flight.
+  // Simulates being inside a request scope (after() registers instead of
+  // throwing) and proves the registered callback's OWN returned promise
+  // tracks fn's completion, not just fn's synchronous kickoff.
+  it("hands after() a callback whose promise stays pending until fn settles", async () => {
+    let captured: (() => unknown) | undefined;
+    vi.mocked(after).mockImplementationOnce((task) => {
+      captured = task as () => unknown;
+    });
+
+    let flag = false;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    deferred(async () => {
+      await gate;
+      flag = true;
+    });
+
+    expect(captured).toBeTypeOf("function");
+
+    let settled = false;
+    const returned = Promise.resolve(captured!()).then(() => {
+      settled = true;
+    });
+
+    // Drain microtasks AND a macrotask tick without releasing the gate — a
+    // non-async `run` (the bug) resolves `captured()` immediately regardless,
+    // so this is where the unfixed helper fails.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(settled).toBe(false);
+    expect(flag).toBe(false);
+
+    release();
+    await returned;
+
+    expect(settled).toBe(true);
+    expect(flag).toBe(true);
   });
 });

--- a/apps/web/src/lib/__tests__/deferred.test.ts
+++ b/apps/web/src/lib/__tests__/deferred.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { deferred } from "@/lib/deferred";
+
+describe("deferred", () => {
+  it("runs the callback inline when outside a Next request scope", async () => {
+    const fn = vi.fn(async () => {});
+    deferred(fn);
+    await vi.waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+  });
+
+  it("swallows callback rejections", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    expect(() => deferred(fn)).not.toThrow();
+    await vi.waitFor(() => expect(fn).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/lib/__tests__/image-config.test.ts
+++ b/apps/web/src/lib/__tests__/image-config.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+// next.config.js is wrapped in withSentryConfig for the default export; the
+// pre-wrap object is re-exported by name so this test (and anything else that
+// needs the raw Next config) doesn't depend on Sentry's wrapper shape.
+import { nextConfig } from "../../../next.config.js";
+
+describe("next/image remotePatterns", () => {
+  it("allows the Supabase storage public-object path and nothing broader", () => {
+    const patterns =
+      (nextConfig as { images?: { remotePatterns?: unknown[] } }).images?.remotePatterns ?? [];
+    expect(patterns).toContainEqual(
+      expect.objectContaining({
+        protocol: "https",
+        hostname: expect.stringContaining("supabase.co"),
+        pathname: "/storage/v1/object/public/**",
+      }),
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/image-config.test.ts
+++ b/apps/web/src/lib/__tests__/image-config.test.ts
@@ -8,6 +8,9 @@ describe("next/image remotePatterns", () => {
   it("allows the Supabase storage public-object path and nothing broader", () => {
     const patterns =
       (nextConfig as { images?: { remotePatterns?: unknown[] } }).images?.remotePatterns ?? [];
+    // Exactly one entry — "nothing broader" only holds if broadening (a second
+    // pattern, or widening this one) can't sneak in unnoticed (review finding 2).
+    expect(patterns).toHaveLength(1);
     expect(patterns).toContainEqual(
       expect.objectContaining({
         protocol: "https",

--- a/apps/web/src/lib/__tests__/peer-revalidate.test.ts
+++ b/apps/web/src/lib/__tests__/peer-revalidate.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { broadcastRevalidate } from "@/lib/peer-revalidate";
+
+afterEach(() => vi.unstubAllEnvs());
+
+function arm() {
+  vi.stubEnv("PEER_REVALIDATE", "1");
+  vi.stubEnv("FLY_APP_NAME", "seazn-club-prod");
+  vi.stubEnv("CRON_SECRET", "s3cret");
+  vi.stubEnv("FLY_PRIVATE_IP", "fdaa::3");
+}
+
+describe("broadcastRevalidate", () => {
+  it("no-ops when PEER_REVALIDATE is not enabled", async () => {
+    const fetchFn = vi.fn();
+    await broadcastRevalidate(["division:d1"], "swr", { fetchFn });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("POSTs tags to every peer except itself, with the secret header", async () => {
+    arm();
+    const fetchFn = vi.fn(async () => new Response("{}"));
+    await broadcastRevalidate(["division:d1", "competition:c1"], "swr", {
+      resolveIps: async () => ["fdaa::3", "fdaa::4", "fdaa::5"],
+      fetchFn,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchFn.mock.calls[0] as unknown as [
+      string,
+      { headers: Record<string, string>; body: string },
+    ];
+    expect(String(url)).toBe("http://[fdaa::4]:3000/api/internal/revalidate");
+    expect(init.headers["x-cron-secret"]).toBe("s3cret");
+    expect(JSON.parse(init.body)).toEqual({ tags: ["division:d1", "competition:c1"], mode: "swr" });
+  });
+
+  it("swallows resolver and fetch failures (fail-open)", async () => {
+    arm();
+    await expect(
+      broadcastRevalidate(["division:d1"], "swr", {
+        resolveIps: async () => {
+          throw new Error("dns down");
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/__tests__/public-image-contract.test.ts
+++ b/apps/web/src/lib/__tests__/public-image-contract.test.ts
@@ -1,0 +1,85 @@
+// Source contract for the four public-surface `<img>` → `next/image`
+// conversions (task-4-report.md §3, review finding 1). The repo deliberately
+// has no component-render test machinery (no jsdom/RTL) — so this can't
+// render the JSX and check what actually paints. Instead it locks the source
+// text of each converted call site: still imports Image from "next/image",
+// still carries the exact width/height pair it was converted with (dimension
+// drift silently reintroduces CLS — next/image's whole point), and hasn't
+// quietly reverted to a plain <img> for the same value. e2e owns visual
+// verification; this test only guards against silent regression in source.
+//
+// Assertions are deliberately narrow per file (matched on the specific `src`
+// identifier actually used at each converted site), not a file-wide `<img`
+// ban — apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
+// still has two *deliberate* `<img>` (competition branding.banner/logo,
+// skipped as ambiguous-source per the report §4) that must keep working.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC_ROOT = join(__dirname, "..", "..");
+
+interface Case {
+  name: string;
+  file: string;
+  /** The exact `src={...}` expression at the converted call site. */
+  srcExpr: string;
+  width: number;
+  height: number;
+}
+
+const CASES: Case[] = [
+  {
+    name: "register-form.tsx org logo",
+    file: join(SRC_ROOT, "components/public-site/register-form.tsx"),
+    srcExpr: "org.logo_url",
+    width: 48,
+    height: 48,
+  },
+  {
+    name: "[competitionSlug]/register/page.tsx sponsor logo",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/[competitionSlug]/register/page.tsx"),
+    srcExpr: "s.logo",
+    width: 16,
+    height: 16,
+  },
+  {
+    name: "[competitionSlug]/page.tsx sponsor logo",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx"),
+    srcExpr: "s.logo",
+    width: 24,
+    height: 24,
+  },
+  {
+    name: "[orgSlug]/layout.tsx org logo",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/layout.tsx"),
+    srcExpr: "org.logo",
+    width: 32,
+    height: 32,
+  },
+];
+
+describe("public next/image conversions (source contract)", () => {
+  it.each(CASES)("$name: imports Image from next/image", ({ file }) => {
+    const source = readFileSync(file, "utf8");
+    expect(source).toMatch(/import\s+Image\s+from\s+["']next\/image["']/);
+  });
+
+  it.each(CASES)("$name: converted element keeps its width/height pair", ({ file, srcExpr, width, height }) => {
+    const source = readFileSync(file, "utf8");
+    const tagMatch = source.match(/<Image\b[\s\S]*?\/>/);
+    expect(tagMatch, `expected an <Image ... /> element in ${file}`).not.toBeNull();
+    const tag = (tagMatch as RegExpMatchArray)[0];
+    expect(tag).toContain(`src={${srcExpr}}`);
+    expect(tag).toContain(`width={${width}}`);
+    expect(tag).toContain(`height={${height}}`);
+  });
+
+  it.each(CASES)("$name: has not reverted to a plain <img> for the same source", ({ file, srcExpr }) => {
+    const source = readFileSync(file, "utf8");
+    const imgTags = source.match(/<img\b[\s\S]*?\/>/g) ?? [];
+    for (const tag of imgTags) {
+      expect(tag).not.toContain(`src={${srcExpr}}`);
+    }
+  });
+});

--- a/apps/web/src/lib/__tests__/public-isr-contract.test.ts
+++ b/apps/web/src/lib/__tests__/public-isr-contract.test.ts
@@ -1,0 +1,88 @@
+// Source contract for task-8 (make the public tree actually ISR in
+// production): every enumerated cacheable public/embed page must export
+// BOTH `revalidate` (already present pre-task-8) AND `generateStaticParams`
+// — in this Next version a dynamic-param route with no generateStaticParams
+// never gets ISR treatment, regardless of `revalidate`
+// (node_modules/next/dist/docs/01-app/03-api-reference/04-functions/
+// generate-static-params.md: "You must return an empty array from
+// generateStaticParams ... in order to revalidate (ISR) paths at runtime.").
+// task-7-report.md audited this empirically (temporarily adding the export
+// flipped the competition page from `ƒ` to ISR with a real curl showing
+// `s-maxage=30`). No render harness exists here (see
+// public-image-contract.test.ts) — this locks the source text instead.
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC_ROOT = join(__dirname, "..", "..");
+
+interface Case {
+  name: string;
+  file: string;
+  revalidate: number;
+}
+
+const CASES: Case[] = [
+  {
+    name: "org landing",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/page.tsx"),
+    revalidate: 30,
+  },
+  {
+    name: "competition home",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx"),
+    revalidate: 30,
+  },
+  {
+    name: "division home",
+    file: join(
+      SRC_ROOT,
+      "app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx",
+    ),
+    revalidate: 30,
+  },
+  {
+    name: "fixture page",
+    file: join(
+      SRC_ROOT,
+      "app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/fixtures/[fixtureId]/page.tsx",
+    ),
+    revalidate: 30,
+  },
+  {
+    name: "player card",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx"),
+    revalidate: 300, // REVALIDATE_SLOW — keep the value, just add generateStaticParams
+  },
+  {
+    name: "poster page",
+    file: join(SRC_ROOT, "app/(public)/shared/[orgSlug]/[competitionSlug]/poster/page.tsx"),
+    revalidate: 300,
+  },
+  {
+    name: "embed widget page",
+    file: join(SRC_ROOT, "app/embed/divisions/[id]/[widget]/page.tsx"),
+    revalidate: 30,
+  },
+];
+
+describe("public/embed ISR contract (task-8)", () => {
+  it.each(CASES)("$name: still exports revalidate = $revalidate", ({ file, revalidate }) => {
+    const source = readFileSync(file, "utf8");
+    expect(source).toMatch(new RegExp(`export const revalidate = ${revalidate};`));
+  });
+
+  it.each(CASES)("$name: exports generateStaticParams returning an empty array", ({ file }) => {
+    const source = readFileSync(file, "utf8");
+    expect(source).toMatch(/export\s+async function\s+generateStaticParams\s*\(\s*\)\s*{/);
+    expect(source).toMatch(/generateStaticParams[\s\S]*?return\s*\[\s*\]\s*;/);
+  });
+
+  it.each(CASES)(
+    "$name: dynamicParams is not disabled (on-demand fill must stay on)",
+    ({ file }) => {
+      const source = readFileSync(file, "utf8");
+      expect(source).not.toMatch(/dynamicParams\s*=\s*false/);
+    },
+  );
+});

--- a/apps/web/src/lib/analytics-identity.ts
+++ b/apps/web/src/lib/analytics-identity.ts
@@ -1,0 +1,131 @@
+// Analytics identity lifecycle (task-8 review fix, Critical finding).
+// Client-safe module — no server imports, no posthog dependency — so it can be
+// unit-tested with a mocked fetch + in-memory storage and imported from any
+// client component (analytics-bootstrap resolves, logout-button clears).
+//
+// Semantics (the review-approved design):
+//  - sessionStorage caches ONLY an identified payload — never an anonymous
+//    sentinel. A cache hit returns without fetching.
+//  - A miss fetches GET /api/users/me. 200-with-org → cache + return.
+//    401 / no-org / network error → null WITHOUT caching, so the next
+//    navigation retries. That retry is what restores identify-after-login:
+//    the post-login redirect (magic-link.tsx router.push) is itself a
+//    navigation, and the effect in analytics-bootstrap is keyed on pathname.
+//  - clearAnalyticsIdentity (called by logout-button BEFORE its router.push)
+//    drops the cache, resets the identified-this-tab flag, and invalidates any
+//    resolution still in flight so a request that raced the logout can't
+//    re-cache the stale identity.
+
+export interface AnalyticsIdentity {
+  userId: string;
+  orgId: string;
+  orgName: string;
+  plan: string;
+}
+
+/** sessionStorage key holding the identified payload for this tab. */
+export const IDENTITY_CACHE_KEY = "seazn_analytics_identity";
+
+type IdentityStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export interface ResolveIdentityDeps {
+  fetchFn?: typeof fetch;
+  storage?: IdentityStorage;
+}
+
+interface MeResponse {
+  data: {
+    id: string;
+    org: { id: string; name: string; plan: string } | null;
+  };
+}
+
+// Bumped by clearAnalyticsIdentity: a resolution that started under an older
+// generation discards its result instead of caching it (logout race guard).
+let generation = 0;
+
+// "Identified already this tab" — set by analytics-bootstrap after a
+// successful identify so the pathname-keyed effect stops doing work; reset by
+// clearAnalyticsIdentity so a post-logout login in the SAME tab re-identifies.
+let identifiedThisTab = false;
+
+export function hasIdentifiedThisTab(): boolean {
+  return identifiedThisTab;
+}
+
+export function markIdentifiedThisTab(): void {
+  identifiedThisTab = true;
+}
+
+function defaultStorage(): IdentityStorage | null {
+  try {
+    // Guarded: absent during SSR/tests; access can throw in some privacy modes.
+    return typeof sessionStorage === "undefined" ? null : sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the identify payload for the current session, or null for an
+ * anonymous visitor. Total: never throws (analytics must never break the app).
+ */
+export async function resolveIdentity(
+  deps: ResolveIdentityDeps = {},
+): Promise<AnalyticsIdentity | null> {
+  const storage = deps.storage ?? defaultStorage();
+
+  if (storage) {
+    try {
+      const cached = storage.getItem(IDENTITY_CACHE_KEY);
+      if (cached) return JSON.parse(cached) as AnalyticsIdentity;
+    } catch {
+      // Malformed entry — drop it and fall through to a fresh fetch.
+      try {
+        storage.removeItem(IDENTITY_CACHE_KEY);
+      } catch {
+        /* storage gone mid-flight — nothing to clean */
+      }
+    }
+  }
+
+  const startedGeneration = generation;
+  const fetchFn = deps.fetchFn ?? fetch;
+  try {
+    const res = await fetchFn("/api/users/me");
+    if (!res.ok) return null; // 401 anonymous — never cached
+    const body = (await res.json()) as MeResponse;
+    if (!body?.data?.org) return null; // logged in but org-less — never cached
+    const identity: AnalyticsIdentity = {
+      userId: body.data.id,
+      orgId: body.data.org.id,
+      orgName: body.data.org.name,
+      plan: body.data.org.plan,
+    };
+    // A logout landed while this request was in flight — discard, don't cache.
+    if (startedGeneration !== generation) return null;
+    try {
+      storage?.setItem(IDENTITY_CACHE_KEY, JSON.stringify(identity));
+    } catch {
+      /* quota/privacy-mode write failure — identify still proceeds uncached */
+    }
+    return identity;
+  } catch {
+    return null; // network error — never cached; next navigation retries
+  }
+}
+
+/**
+ * Kill the cached identity NOW (logout). Callers pair this with
+ * posthog.reset() so the device's distinct id rotates too.
+ */
+export function clearAnalyticsIdentity(deps: { storage?: IdentityStorage } = {}): void {
+  generation += 1;
+  identifiedThisTab = false;
+  const storage = deps.storage ?? defaultStorage();
+  try {
+    storage?.removeItem(IDENTITY_CACHE_KEY);
+  } catch {
+    /* storage unavailable — nothing cached to clear */
+  }
+}

--- a/apps/web/src/lib/cdn-purge.ts
+++ b/apps/web/src/lib/cdn-purge.ts
@@ -1,0 +1,35 @@
+import "server-only";
+
+// CDN purge hook (spec 2026-07-12 §3 A-step 1). Fail-open + debounced
+// purge_everything: at this site's size a full purge every ≤30s window is
+// cheaper-simpler than tag→URL mapping, and CDN staleness stays bounded by
+// s-maxage even when a purge is missed. Targeted per-URL purge is a later
+// refinement at this same seam. Multi-machine: each machine debounces
+// independently — worst case N purges per window, still idempotent.
+const PURGE_DEBOUNCE_MS = 30_000;
+let lastPurgeAt = 0;
+
+export function __resetPurgeDebounceForTests(): void {
+  lastPurgeAt = 0;
+}
+
+export async function purgeCdn(
+  deps: { fetchFn?: typeof fetch; now?: () => number } = {},
+): Promise<void> {
+  const url = process.env.CDN_PURGE_URL;
+  const token = process.env.CDN_PURGE_TOKEN;
+  if (!url || !token) return;
+  const now = deps.now ?? Date.now;
+  if (now() - lastPurgeAt < PURGE_DEBOUNCE_MS) return;
+  lastPurgeAt = now();
+  try {
+    await (deps.fetchFn ?? fetch)(url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ purge_everything: true }),
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch {
+    // fail open — s-maxage bounds staleness
+  }
+}

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -22,6 +22,34 @@ export function statementCount(): number {
   return globalForDb._queryCount ?? 0;
 }
 
+export interface DbConnectionOptions {
+  ssl: false | "require";
+  prepare: boolean;
+  max: number;
+  schema: string;
+}
+
+/**
+ * Pure derivation of postgres.js options from the URL + env. Session pooler
+ * (:5432) / direct connections keep prepared statements; Supabase's
+ * transaction pooler (:6543) does not support them. Pool size is env-tunable
+ * (DB_POOL_MAX, 1..50) so a machine-size bump doesn't need a code change.
+ */
+export function connectionOptions(
+  url: string,
+  env: Record<string, string | undefined> = process.env,
+): DbConnectionOptions {
+  const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
+  const sslEnv = env.DATABASE_SSL;
+  const ssl: false | "require" =
+    sslEnv === "disable" ? false : sslEnv === "require" ? "require" : isLocal ? false : "require";
+  const prepare = !url.includes(":6543");
+  const rawMax = Number(env.DB_POOL_MAX);
+  const max = Number.isInteger(rawMax) && rawMax >= 1 && rawMax <= 50 ? rawMax : 5;
+  const schema = env.DB_SCHEMA ?? "seazn_club";
+  return { ssl, prepare, max, schema };
+}
+
 function getClient(): Sql {
   if (globalForDb._sql) return globalForDb._sql;
   const url = process.env.DATABASE_URL;
@@ -30,32 +58,12 @@ function getClient(): Sql {
       "DATABASE_URL is not set. Copy .env.example to .env.local and add your Supabase connection string.",
     );
   }
-  // Supabase requires SSL; a local Postgres rejects it. Auto-detect, with an
-  // optional override via DATABASE_SSL=require|disable.
-  const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
-  const sslEnv = process.env.DATABASE_SSL;
-  const ssl =
-    sslEnv === "disable"
-      ? false
-      : sslEnv === "require"
-        ? "require"
-        : isLocal
-          ? false
-          : "require";
-
-  // Supabase's transaction pooler (port 6543) does not support prepared
-  // statements; disable them in that case.
-  const prepare = !url.includes(":6543");
-
-  // The app lives in a dedicated schema (see db/flyway.toml). Pin it on the
-  // connection startup packet so every query — including `withTenant`'s
-  // `set local role app_user` transactions — resolves unqualified names there.
-  const schema = process.env.DB_SCHEMA ?? "seazn_club";
+  const { ssl, prepare, max, schema } = connectionOptions(url);
 
   const client = postgres(url, {
     ssl,
     prepare,
-    max: 5,
+    max,
     idle_timeout: 20,
     connect_timeout: 15,
     connection: { search_path: schema },

--- a/apps/web/src/lib/deferred.ts
+++ b/apps/web/src/lib/deferred.ts
@@ -1,0 +1,23 @@
+import "server-only";
+import { after } from "next/server";
+
+/**
+ * Run non-critical tail work AFTER the response streams (Next `after()`),
+ * falling back to inline fire-and-forget outside a request scope (vitest,
+ * scripts) — same contract as fire*Revalidate's try/catch. Never throws,
+ * never delays the caller.
+ */
+export function deferred(fn: () => Promise<unknown> | unknown): void {
+  const run = () => {
+    try {
+      void Promise.resolve(fn()).catch((err) => console.warn("[deferred] task failed:", err));
+    } catch (err) {
+      console.warn("[deferred] task failed:", err);
+    }
+  };
+  try {
+    after(run);
+  } catch {
+    run(); // outside a request scope
+  }
+}

--- a/apps/web/src/lib/deferred.ts
+++ b/apps/web/src/lib/deferred.ts
@@ -2,15 +2,18 @@ import "server-only";
 import { after } from "next/server";
 
 /**
- * Run non-critical tail work AFTER the response streams (Next `after()`),
- * falling back to inline fire-and-forget outside a request scope (vitest,
- * scripts) — same contract as fire*Revalidate's try/catch. Never throws,
- * never delays the caller.
+ * Register non-critical tail work. Registration itself never delays the
+ * caller: in a Next request scope, `after()` receives the real work promise
+ * and awaits it in its after-window (so it genuinely finishes before the
+ * window closes, even on error/redirect/notFound); outside a request scope
+ * (vitest, scripts) it falls back to inline fire-and-forget. Either way the
+ * work's own errors are swallowed, not thrown — same contract as
+ * fire*Revalidate's try/catch.
  */
 export function deferred(fn: () => Promise<unknown> | unknown): void {
-  const run = () => {
+  const run = async () => {
     try {
-      void Promise.resolve(fn()).catch((err) => console.warn("[deferred] task failed:", err));
+      await fn();
     } catch (err) {
       console.warn("[deferred] task failed:", err);
     }
@@ -18,6 +21,6 @@ export function deferred(fn: () => Promise<unknown> | unknown): void {
   try {
     after(run);
   } catch {
-    run(); // outside a request scope
+    void run(); // outside a request scope
   }
 }

--- a/apps/web/src/lib/peer-revalidate.ts
+++ b/apps/web/src/lib/peer-revalidate.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+// Fan revalidateTag out to sibling Fly machines (spec 2026-07-12 §3 A-step 5).
+// Fly's 6PN DNS: `global.<app>.internal` AAAA-resolves to every machine's
+// private IPv6. Fail-open by design: a lost broadcast is bounded by the 30s
+// public ISR window (REVALIDATE_FAST). This module is the transport seam —
+// a Cloud Run move swaps DNS fan-out for Redis pub/sub here, nothing else.
+export interface BroadcastDeps {
+  resolveIps?: () => Promise<string[]>;
+  fetchFn?: typeof fetch;
+}
+
+async function flyPeerIps(appName: string): Promise<string[]> {
+  const { resolve6 } = await import("node:dns/promises");
+  return resolve6(`global.${appName}.internal`);
+}
+
+export async function broadcastRevalidate(
+  tags: string[],
+  mode: "swr" | "expire",
+  deps: BroadcastDeps = {},
+): Promise<void> {
+  const appName = process.env.FLY_APP_NAME;
+  const secret = process.env.CRON_SECRET;
+  if (process.env.PEER_REVALIDATE !== "1" || !appName || !secret || tags.length === 0) return;
+  try {
+    const ips = await (deps.resolveIps ?? (() => flyPeerIps(appName)))();
+    const self = process.env.FLY_PRIVATE_IP;
+    const fetchFn = deps.fetchFn ?? fetch;
+    await Promise.allSettled(
+      ips
+        .filter((ip) => ip !== self)
+        .map((ip) =>
+          fetchFn(`http://[${ip}]:3000/api/internal/revalidate`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-cron-secret": secret },
+            body: JSON.stringify({ tags, mode }),
+            signal: AbortSignal.timeout(2000),
+          }),
+        ),
+    );
+  } catch {
+    // fail open — peers converge within REVALIDATE_FAST
+  }
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,9 +5,11 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 // ISR/CDN-cacheable public surfaces (spec 2026-07-12 P5): nonce CSP forces
 // dynamic rendering, so these trees stay Report-Only permanently — flipping
 // CSP_MODE=enforce hardens the app surface without un-caching spectator pages.
-// /r is the registration-ref tree (/r/[ref]); keep the segment boundary so
-// e.g. /reset-password never matches.
-const CACHEABLE_PUBLIC = /^\/(shared|embed|r)(\/|$)/;
+// Cacheable trees: /shared and /embed. /r (registration-ref tree, /r/[ref]) is
+// deliberately excluded because it is force-dynamic and processes self-withdraw
+// tokens; excluding it from the carve-out costs no caching but keeps enforce
+// active on a token-bearing page.
+const CACHEABLE_PUBLIC = /^\/(shared|embed)(\/|$)/;
 
 export function isCacheablePublicPath(pathname: string): boolean {
   return CACHEABLE_PUBLIC.test(pathname);

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -2,6 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
+// ISR/CDN-cacheable public surfaces (spec 2026-07-12 P5): nonce CSP forces
+// dynamic rendering, so these trees stay Report-Only permanently — flipping
+// CSP_MODE=enforce hardens the app surface without un-caching spectator pages.
+// /r is the registration-ref tree (/r/[ref]); keep the segment boundary so
+// e.g. /reset-password never matches.
+const CACHEABLE_PUBLIC = /^\/(shared|embed|r)(\/|$)/;
+
+export function isCacheablePublicPath(pathname: string): boolean {
+  return CACHEABLE_PUBLIC.test(pathname);
+}
+
 /**
  * Build the Content-Security-Policy for a page request (doc 04 §5).
  *
@@ -16,9 +27,9 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
  * browser console on staging) to switch to blocking. Enforcing nonce CSP forces
  * dynamic rendering (no static/CDN caching), which is why it is opt-in.
  */
-function cspHeader(nonce: string): { name: string; value: string } {
+function cspHeader(nonce: string, opts: { forceReportOnly?: boolean } = {}): { name: string; value: string } {
   const isDev = process.env.NODE_ENV === "development";
-  const enforce = process.env.CSP_MODE === "enforce";
+  const enforce = process.env.CSP_MODE === "enforce" && !opts.forceReportOnly;
   const value = [
     `default-src 'self'`,
     // Stripe.js is loaded from js.stripe.com for Embedded Checkout.
@@ -99,13 +110,17 @@ export function proxy(request: NextRequest) {
   }
 
   // Page requests: attach a per-request nonce + CSP.
+  const cacheable = isCacheablePublicPath(request.nextUrl.pathname);
   const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
-  const csp = cspHeader(nonce);
+  const csp = cspHeader(nonce, { forceReportOnly: cacheable });
 
   const requestHeaders = new Headers(request.headers);
-  requestHeaders.set("x-nonce", nonce);
-  // Next reads the enforcing CSP header on the request to stamp script nonces.
-  requestHeaders.set(csp.name, csp.value);
+  if (!cacheable) {
+    // Nonce request headers make Next stamp scripts per-request; cacheable
+    // trees skip them so the HTML stays byte-stable for ISR/CDN.
+    requestHeaders.set("x-nonce", nonce);
+    requestHeaders.set(csp.name, csp.value);
+  }
 
   const response = NextResponse.next({ request: { headers: requestHeaders } });
   response.headers.set(csp.name, csp.value);

--- a/apps/web/src/server/__tests__/slug-cache.test.ts
+++ b/apps/web/src/server/__tests__/slug-cache.test.ts
@@ -19,7 +19,12 @@ vi.mock("@/lib/db", () => ({
   sql: vi.fn(() => Promise.resolve(results.shift() ?? [])),
 }));
 
-import { orgBySlugUncached, invalidateSlugCache } from "@/server/slug-resolve";
+import {
+  orgBySlugUncached,
+  compBySlugUncached,
+  divBySlugUncached,
+  invalidateSlugCache,
+} from "@/server/slug-resolve";
 import { cacheSet, cacheDelPattern } from "@/lib/cache";
 import { sql } from "@/lib/db";
 
@@ -48,9 +53,84 @@ describe("slug resolution cache", () => {
     expect(cacheSet).not.toHaveBeenCalled();
   });
 
-  it("invalidateSlugCache deletes old and new slug keys", async () => {
+  // Review finding 2: the test above only ever drove the plain double-miss
+  // (live miss + history miss -> null) — the actual `{ renamedTo }` branch
+  // (live miss -> history HIT -> target HIT) was never exercised, so a
+  // regression that started caching that branch would have gone undetected.
+  it("never caches a renamedTo fallback", async () => {
+    results.push([], [{ entity_id: "org-2" }], [{ slug: "riverside-new" }]);
+    expect(await orgBySlugUncached("riverside-old")).toEqual({ renamedTo: "riverside-new" });
+    expect(sql).toHaveBeenCalledTimes(3); // live miss, slug_history hit, target lookup
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("invalidateSlugCache deletes old and new slug keys for org, competition and division", async () => {
     await invalidateSlugCache("org", null, "riverside", "riverside-united");
     expect(cacheDelPattern).toHaveBeenCalledWith("slug:org:riverside");
     expect(cacheDelPattern).toHaveBeenCalledWith("slug:org:riverside-united");
+
+    await invalidateSlugCache("competition", "org-1", "spring-open", "autumn-open");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:comp:org-1:spring-open");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:comp:org-1:autumn-open");
+
+    await invalidateSlugCache("division", "comp-1", "u16-boys", "u18-boys");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:div:comp-1:u16-boys");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:div:comp-1:u18-boys");
+  });
+});
+
+describe("slug resolution cache — competition", () => {
+  const live = { id: "comp-1", name: "Summer Smash", slug: "summer-smash" };
+  const orgId = "org-1";
+
+  it("caches a live resolution and serves the repeat from Redis", async () => {
+    results.push([live]); // first call: DB answers
+    expect(await compBySlugUncached(orgId, "summer-smash")).toEqual(live);
+    expect(cacheSet).toHaveBeenCalledWith(`slug:comp:${orgId}:summer-smash`, live, 60);
+
+    // second call: no DB result queued — must come from cache
+    expect(await compBySlugUncached(orgId, "summer-smash")).toEqual(live);
+    expect(sql).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches a miss", async () => {
+    results.push([], []); // live miss, history miss
+    expect(await compBySlugUncached(orgId, "ghost")).toBeNull();
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("never caches a renamedTo fallback", async () => {
+    results.push([], [{ entity_id: "comp-2" }], [{ slug: "autumn-open" }]);
+    expect(await compBySlugUncached(orgId, "spring-open")).toEqual({ renamedTo: "autumn-open" });
+    expect(sql).toHaveBeenCalledTimes(3);
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("slug resolution cache — division", () => {
+  const live = { id: "div-1", name: "U16 Boys", slug: "u16-boys" };
+  const compId = "comp-1";
+
+  it("caches a live resolution and serves the repeat from Redis", async () => {
+    results.push([live]); // first call: DB answers
+    expect(await divBySlugUncached(compId, "u16-boys")).toEqual(live);
+    expect(cacheSet).toHaveBeenCalledWith(`slug:div:${compId}:u16-boys`, live, 60);
+
+    // second call: no DB result queued — must come from cache
+    expect(await divBySlugUncached(compId, "u16-boys")).toEqual(live);
+    expect(sql).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches a miss", async () => {
+    results.push([], []); // live miss, history miss
+    expect(await divBySlugUncached(compId, "ghost")).toBeNull();
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("never caches a renamedTo fallback", async () => {
+    results.push([], [{ entity_id: "div-2" }], [{ slug: "u18-boys" }]);
+    expect(await divBySlugUncached(compId, "u16-boys-old")).toEqual({ renamedTo: "u18-boys" });
+    expect(sql).toHaveBeenCalledTimes(3);
+    expect(cacheSet).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/server/__tests__/slug-cache.test.ts
+++ b/apps/web/src/server/__tests__/slug-cache.test.ts
@@ -1,0 +1,56 @@
+// Redis read-through cache for slug resolution (v3 perf wave, Task 2).
+// React cache() memoizes per request; in vitest that would make a second
+// `orgBySlug` call in the same test skip our code entirely and pass
+// vacuously, so these tests exercise the uncached inner export instead —
+// the public `orgBySlug` stays cache()-wrapped for real request dedupe.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const store = new Map<string, unknown>();
+vi.mock("@/lib/cache", () => ({
+  cacheGet: vi.fn(async (k: string) => store.get(k) ?? null),
+  cacheSet: vi.fn(async (k: string, v: unknown) => void store.set(k, v)),
+  cacheDelPattern: vi.fn(async (p: string) => void store.delete(p)),
+}));
+
+// Each sql`` call resolves to the next queued result — enough to script
+// live-hit vs miss sequences without a database.
+const results: unknown[][] = [];
+vi.mock("@/lib/db", () => ({
+  sql: vi.fn(() => Promise.resolve(results.shift() ?? [])),
+}));
+
+import { orgBySlugUncached, invalidateSlugCache } from "@/server/slug-resolve";
+import { cacheSet, cacheDelPattern } from "@/lib/cache";
+import { sql } from "@/lib/db";
+
+beforeEach(() => {
+  store.clear();
+  results.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("slug resolution cache", () => {
+  const live = { id: "org-1", name: "Riverside", slug: "riverside" };
+
+  it("caches a live resolution and serves the repeat from Redis", async () => {
+    results.push([live]); // first call: DB answers
+    expect(await orgBySlugUncached("riverside")).toEqual(live);
+    expect(cacheSet).toHaveBeenCalledWith("slug:org:riverside", live, 60);
+
+    // second call: no DB result queued — must come from cache
+    expect(await orgBySlugUncached("riverside")).toEqual(live);
+    expect(sql).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches a miss or a rename fallback", async () => {
+    results.push([], []); // live miss, history miss
+    expect(await orgBySlugUncached("ghost")).toBeNull();
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("invalidateSlugCache deletes old and new slug keys", async () => {
+    await invalidateSlugCache("org", null, "riverside", "riverside-united");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:org:riverside");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:org:riverside-united");
+  });
+});

--- a/apps/web/src/server/public-site/__tests__/revalidate.test.ts
+++ b/apps/web/src/server/public-site/__tests__/revalidate.test.ts
@@ -15,6 +15,8 @@ vi.mock("@/server/public-site/data", () => ({
   orgTag: (slug: string) => `org-public:${slug}`,
   DISCOVERY_TAG: "discovery",
 }));
+const broadcastRevalidate = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("@/lib/peer-revalidate", () => ({ broadcastRevalidate }));
 
 import {
   fireDivisionRevalidate,
@@ -22,7 +24,10 @@ import {
   fireDiscoveryRevalidate,
 } from "../revalidate";
 
-beforeEach(() => revalidateTag.mockClear());
+beforeEach(() => {
+  revalidateTag.mockClear();
+  broadcastRevalidate.mockClear();
+});
 
 describe("public-site revalidation profiles", () => {
   it("org chrome expires immediately (read-your-writes)", () => {
@@ -30,15 +35,27 @@ describe("public-site revalidation profiles", () => {
     expect(revalidateTag).toHaveBeenCalledWith("org-public:my-org", { expire: 0 });
   });
 
+  it("org chrome broadcast fans out with expire mode", () => {
+    fireOrgRevalidate("riverside");
+    expect(broadcastRevalidate).toHaveBeenCalledWith(["org-public:riverside"], "expire");
+  });
+
   it("division/competition tags keep stale-while-revalidate", () => {
     fireDivisionRevalidate("d1", "c1");
     expect(revalidateTag).toHaveBeenCalledWith("division:d1", "max");
     expect(revalidateTag).toHaveBeenCalledWith("competition:c1", "max");
+    expect(broadcastRevalidate).toHaveBeenCalledWith(["division:d1", "competition:c1"], "swr");
+  });
+
+  it("division-only broadcast omits the competition tag when none is passed", () => {
+    fireDivisionRevalidate("d1");
+    expect(broadcastRevalidate).toHaveBeenCalledWith(["division:d1"], "swr");
   });
 
   it("discovery tag keeps stale-while-revalidate", () => {
     fireDiscoveryRevalidate();
     expect(revalidateTag).toHaveBeenCalledWith("discovery", "max");
+    expect(broadcastRevalidate).toHaveBeenCalledWith(["discovery"], "swr");
   });
 
   it("swallows revalidateTag throwing outside a request scope", () => {
@@ -46,5 +63,8 @@ describe("public-site revalidation profiles", () => {
       throw new Error("static generation store missing");
     });
     expect(() => fireOrgRevalidate("my-org")).not.toThrow();
+    // Broadcast is unconditional — it must still fire even though the local
+    // revalidateTag call above threw (outside-request-scope path).
+    expect(broadcastRevalidate).toHaveBeenCalledWith(["org-public:my-org"], "expire");
   });
 });

--- a/apps/web/src/server/public-site/__tests__/revalidate.test.ts
+++ b/apps/web/src/server/public-site/__tests__/revalidate.test.ts
@@ -17,6 +17,11 @@ vi.mock("@/server/public-site/data", () => ({
 }));
 const broadcastRevalidate = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("@/lib/peer-revalidate", () => ({ broadcastRevalidate }));
+// Task 7: CDN purge fires alongside the peer broadcast at the same seam —
+// mocked here purely to assert the wiring, not purgeCdn's own behavior
+// (that's cdn-purge.test.ts's job).
+const purgeCdn = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("@/lib/cdn-purge", () => ({ purgeCdn }));
 
 import {
   fireDivisionRevalidate,
@@ -27,6 +32,7 @@ import {
 beforeEach(() => {
   revalidateTag.mockClear();
   broadcastRevalidate.mockClear();
+  purgeCdn.mockClear();
 });
 
 describe("public-site revalidation profiles", () => {
@@ -66,5 +72,27 @@ describe("public-site revalidation profiles", () => {
     // Broadcast is unconditional — it must still fire even though the local
     // revalidateTag call above threw (outside-request-scope path).
     expect(broadcastRevalidate).toHaveBeenCalledWith(["org-public:my-org"], "expire");
+  });
+});
+
+// Task 7 (spec 2026-07-12 §3 A-step 1): a CDN purge must fire alongside the
+// peer broadcast at every revalidation seam — otherwise a stray rendering
+// change can go un-cached (or a purge can silently stop happening) with no
+// test ever catching it. This is a pure wiring check: purgeCdn's own
+// behavior (debounce, fail-open, env-gating) is covered by cdn-purge.test.ts.
+describe("CDN purge fires alongside peer broadcast (Task 7)", () => {
+  it("fireDivisionRevalidate calls purgeCdn", () => {
+    fireDivisionRevalidate("d1", "c1");
+    expect(purgeCdn).toHaveBeenCalledTimes(1);
+  });
+
+  it("fireOrgRevalidate calls purgeCdn", () => {
+    fireOrgRevalidate("riverside");
+    expect(purgeCdn).toHaveBeenCalledTimes(1);
+  });
+
+  it("fireDiscoveryRevalidate calls purgeCdn", () => {
+    fireDiscoveryRevalidate();
+    expect(purgeCdn).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/server/public-site/revalidate.ts
+++ b/apps/web/src/server/public-site/revalidate.ts
@@ -6,6 +6,7 @@ import "server-only";
 import { revalidateTag } from "next/cache";
 import { cacheDelPattern } from "@/lib/cache";
 import { broadcastRevalidate } from "@/lib/peer-revalidate";
+import { purgeCdn } from "@/lib/cdn-purge";
 import { divisionTag, competitionTag, orgTag, DISCOVERY_TAG } from "./data";
 
 export { DISCOVERY_TAG };
@@ -21,6 +22,7 @@ export function fireDivisionRevalidate(divisionId: string, competitionId?: strin
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }
   void broadcastRevalidate(tags, "swr");
+  void purgeCdn();
 }
 
 /** Org chrome changes (name, logo, brand color) show on every page of the
@@ -36,6 +38,7 @@ export function fireOrgRevalidate(orgSlug: string): void {
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }
   void broadcastRevalidate([orgTag(orgSlug)], "expire");
+  void purgeCdn();
 }
 
 /** Fire the shared discovery ISR tag (doc 15, PROMPT-19): home strips,
@@ -48,6 +51,7 @@ export function fireDiscoveryRevalidate(): void {
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }
   void broadcastRevalidate([DISCOVERY_TAG], "swr");
+  void purgeCdn();
 }
 
 /** Redis layer in front of GET /api/v1/public/discovery (doc 15 §4). */

--- a/apps/web/src/server/public-site/revalidate.ts
+++ b/apps/web/src/server/public-site/revalidate.ts
@@ -5,19 +5,22 @@ import "server-only";
 // call use-cases outside a request scope where revalidateTag would throw.
 import { revalidateTag } from "next/cache";
 import { cacheDelPattern } from "@/lib/cache";
+import { broadcastRevalidate } from "@/lib/peer-revalidate";
 import { divisionTag, competitionTag, orgTag, DISCOVERY_TAG } from "./data";
 
 export { DISCOVERY_TAG };
 
 export function fireDivisionRevalidate(divisionId: string, competitionId?: string): void {
+  const tags = [divisionTag(divisionId), ...(competitionId ? [competitionTag(competitionId)] : [])];
   try {
     // Next 16 signature: second arg = stale-while-revalidate window ('max' =
     // serve stale while fresh regenerates — right for spectator pages).
-    revalidateTag(divisionTag(divisionId), "max");
+    revalidateTag(tags[0], "max");
     if (competitionId) revalidateTag(competitionTag(competitionId), "max");
   } catch {
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }
+  void broadcastRevalidate(tags, "swr");
 }
 
 /** Org chrome changes (name, logo, brand color) show on every page of the
@@ -32,6 +35,7 @@ export function fireOrgRevalidate(orgSlug: string): void {
   } catch {
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }
+  void broadcastRevalidate([orgTag(orgSlug)], "expire");
 }
 
 /** Fire the shared discovery ISR tag (doc 15, PROMPT-19): home strips,
@@ -43,6 +47,7 @@ export function fireDiscoveryRevalidate(): void {
   } catch {
     // outside a Next request scope (tests, scripts) — nothing to invalidate
   }
+  void broadcastRevalidate([DISCOVERY_TAG], "swr");
 }
 
 /** Redis layer in front of GET /api/v1/public/discovery (doc 15 §4). */

--- a/apps/web/src/server/slug-resolve.ts
+++ b/apps/web/src/server/slug-resolve.ts
@@ -10,6 +10,30 @@ import "server-only";
 import { cache } from "react";
 import { sql } from "@/lib/db";
 import { routes } from "@/lib/routes";
+import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
+
+// Read-through cache for LIVE slug rows only (v3 perf wave). Renames and
+// misses always hit Postgres: they're rare, and the slug_history fallback is
+// correctness-critical. TTL bounds staleness if an invalidation is missed;
+// rename paths call invalidateSlugCache explicitly.
+const SLUG_TTL_SECONDS = 60;
+const slugKey = (
+  kind: "org" | "competition" | "division",
+  parentId: string | null,
+  slug: string,
+): string =>
+  kind === "org" ? `slug:org:${slug}` : `slug:${kind === "competition" ? "comp" : "div"}:${parentId}:${slug}`;
+
+/** Drop cached resolutions for the given slugs (old + new after a rename). */
+export async function invalidateSlugCache(
+  kind: "org" | "competition" | "division",
+  parentId: string | null,
+  ...slugs: (string | null | undefined)[]
+): Promise<void> {
+  await Promise.all(
+    slugs.filter((s): s is string => Boolean(s)).map((s) => cacheDelPattern(slugKey(kind, parentId, s))),
+  );
+}
 
 export interface ResolvedEntity {
   id: string;
@@ -19,10 +43,20 @@ export interface ResolvedEntity {
 
 export type Resolution = ResolvedEntity | { renamedTo: string } | null;
 
-export const orgBySlug = cache(async (slug: string): Promise<Resolution> => {
+// Each `xxxUncached` function holds the actual cache-aside + fallback logic
+// and is exported so tests can assert it directly — React's cache() (below)
+// memoizes per request, which would make a second same-args call in one test
+// skip the body (and the Redis cache we're testing) entirely.
+export async function orgBySlugUncached(slug: string): Promise<Resolution> {
+  const key = slugKey("org", null, slug);
+  const hit = await cacheGet<ResolvedEntity>(key);
+  if (hit) return hit;
   const [live] = await sql<ResolvedEntity[]>`
     select id, name, slug from organizations where slug = ${slug}`;
-  if (live) return live;
+  if (live) {
+    await cacheSet(key, live, SLUG_TTL_SECONDS);
+    return live;
+  }
   const [hist] = await sql<{ entity_id: string }[]>`
     select entity_id from slug_history
     where entity_type = 'org' and parent_id is null and old_slug = ${slug}`;
@@ -30,40 +64,51 @@ export const orgBySlug = cache(async (slug: string): Promise<Resolution> => {
   const [target] = await sql<{ slug: string }[]>`
     select slug from organizations where id = ${hist.entity_id}`;
   return target ? { renamedTo: target.slug } : null;
-});
+}
+export const orgBySlug = cache(orgBySlugUncached);
 
-export const compBySlug = cache(
-  async (orgId: string, slug: string): Promise<Resolution> => {
-    const [live] = await sql<ResolvedEntity[]>`
-      select id, name, slug from competitions
-      where org_id = ${orgId} and slug = ${slug}`;
-    if (live) return live;
-    const [hist] = await sql<{ entity_id: string }[]>`
-      select entity_id from slug_history
-      where entity_type = 'competition' and parent_id = ${orgId} and old_slug = ${slug}`;
-    if (!hist) return null;
-    const [target] = await sql<{ slug: string }[]>`
-      select slug from competitions where id = ${hist.entity_id} and org_id = ${orgId}`;
-    return target ? { renamedTo: target.slug } : null;
-  },
-);
+export async function compBySlugUncached(orgId: string, slug: string): Promise<Resolution> {
+  const key = slugKey("competition", orgId, slug);
+  const hit = await cacheGet<ResolvedEntity>(key);
+  if (hit) return hit;
+  const [live] = await sql<ResolvedEntity[]>`
+    select id, name, slug from competitions
+    where org_id = ${orgId} and slug = ${slug}`;
+  if (live) {
+    await cacheSet(key, live, SLUG_TTL_SECONDS);
+    return live;
+  }
+  const [hist] = await sql<{ entity_id: string }[]>`
+    select entity_id from slug_history
+    where entity_type = 'competition' and parent_id = ${orgId} and old_slug = ${slug}`;
+  if (!hist) return null;
+  const [target] = await sql<{ slug: string }[]>`
+    select slug from competitions where id = ${hist.entity_id} and org_id = ${orgId}`;
+  return target ? { renamedTo: target.slug } : null;
+}
+export const compBySlug = cache(compBySlugUncached);
 
-export const divBySlug = cache(
-  async (competitionId: string, slug: string): Promise<Resolution> => {
-    const [live] = await sql<ResolvedEntity[]>`
-      select id, name, slug from divisions
-      where competition_id = ${competitionId} and slug = ${slug}`;
-    if (live) return live;
-    const [hist] = await sql<{ entity_id: string }[]>`
-      select entity_id from slug_history
-      where entity_type = 'division' and parent_id = ${competitionId} and old_slug = ${slug}`;
-    if (!hist) return null;
-    const [target] = await sql<{ slug: string }[]>`
-      select slug from divisions
-      where id = ${hist.entity_id} and competition_id = ${competitionId}`;
-    return target ? { renamedTo: target.slug } : null;
-  },
-);
+export async function divBySlugUncached(competitionId: string, slug: string): Promise<Resolution> {
+  const key = slugKey("division", competitionId, slug);
+  const hit = await cacheGet<ResolvedEntity>(key);
+  if (hit) return hit;
+  const [live] = await sql<ResolvedEntity[]>`
+    select id, name, slug from divisions
+    where competition_id = ${competitionId} and slug = ${slug}`;
+  if (live) {
+    await cacheSet(key, live, SLUG_TTL_SECONDS);
+    return live;
+  }
+  const [hist] = await sql<{ entity_id: string }[]>`
+    select entity_id from slug_history
+    where entity_type = 'division' and parent_id = ${competitionId} and old_slug = ${slug}`;
+  if (!hist) return null;
+  const [target] = await sql<{ slug: string }[]>`
+    select slug from divisions
+    where id = ${hist.entity_id} and competition_id = ${competitionId}`;
+  return target ? { renamedTo: target.slug } : null;
+}
+export const divBySlug = cache(divBySlugUncached);
 
 export const fixtureByNo = cache(
   async (divisionId: string, no: number): Promise<{ id: string } | null> => {

--- a/apps/web/src/server/usecases/__tests__/scoring-deferred.test.ts
+++ b/apps/web/src/server/usecases/__tests__/scoring-deferred.test.ts
@@ -1,0 +1,159 @@
+// Task 6 review finding 3: nothing failed if the deferred(...) wrapper
+// around discovery invalidation in invalidatePublicCache (scoring.ts) were
+// dropped or reordered — Redis pub:v1:discovery:* + the ISR discovery tag
+// would then run inline on the scoring hot path again (dropped), or race
+// each other (reordered). `@/lib/deferred` is replaced with a capture (NOT
+// auto-executed, so the test controls when the tail work runs) and
+// `@/server/public-site/revalidate`'s two discovery functions are
+// order-instrumented. A single core.start event is the smallest write that
+// flips movesDiscovery = true (scoring.ts's scoreEvent), so it reaches the
+// guarded branch without a full decide+finalize sequence. Real Postgres
+// required; skipped without DATABASE_URL — scoring has no DB-free path (see
+// scorers.test.ts).
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+const capture = vi.hoisted(() => ({ fns: [] as Array<() => unknown> }));
+vi.mock("@/lib/deferred", () => ({
+  deferred: vi.fn((fn: () => unknown) => {
+    capture.fns.push(fn);
+  }),
+}));
+
+const order = vi.hoisted(() => ({ log: [] as string[] }));
+vi.mock("@/server/public-site/revalidate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/public-site/revalidate")>();
+  return {
+    ...actual,
+    // A microtask hop on invalidate: if the real code ever drops its `await`
+    // before fireDiscoveryRevalidate, the (synchronous) revalidate push wins
+    // the race and order.log comes out ["revalidate", "invalidate"].
+    invalidateDiscoveryCache: vi.fn(async () => {
+      await Promise.resolve();
+      order.log.push("invalidate");
+    }),
+    fireDiscoveryRevalidate: vi.fn(() => {
+      order.log.push("revalidate");
+    }),
+  };
+});
+
+import { sql } from "@/lib/db";
+import { deferred } from "@/lib/deferred";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition, patchCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages, generateStageFixtures } from "../stages";
+import { startDivision } from "../schedule";
+import { scoreEvent } from "../scoring";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const VARIANT_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+async function seedOrg(): Promise<{ auth: AuthCtx }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Deferred " + suffix}, ${"deferred-" + suffix})
+    returning id`;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(VARIANT_CONFIG)}, true)
+    on conflict do nothing`;
+  return { auth: { orgId, via: "session", userId: null, role: "owner", keyId: null } };
+}
+
+/** Discoverable competition with one startable fixture — the smallest rig
+ *  that reaches invalidatePublicCache's `movesDiscovery && row.discoverable`
+ *  branch. */
+async function discoverableFixtureRig(auth: AuthCtx): Promise<string> {
+  const competition = await createCompetition(auth, {
+    name: "Deferred Cup " + randomUUID().slice(0, 6),
+    visibility: "public",
+    branding: {},
+  });
+  const division = await createDivision(auth, competition.id, {
+    name: "Open",
+    sport_key: "generic",
+    variant_key: "score",
+    config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    eligibility: [],
+  });
+  await createEntrants(
+    auth,
+    division.id,
+    ["A", "B"].map((n, i) => ({
+      kind: "individual" as const,
+      display_name: n,
+      seed: i + 1,
+      members: [],
+    })),
+  );
+  const [stage] = await createStages(auth, division.id, {
+    seq: 1,
+    kind: "league",
+    name: "L",
+    config: {},
+  });
+  const { fixtures } = await generateStageFixtures(auth, stage.id);
+  await startDivision(auth, division.id);
+  await patchCompetition(auth, competition.id, { discoverable: true });
+  return fixtures[0]!.id;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("scoring -> deferred discovery wiring (Task 6 review finding 3)", () => {
+  it("wraps discovery invalidation in deferred(), and invalidateDiscoveryCache resolves before fireDiscoveryRevalidate fires", async () => {
+    const { auth } = await seedOrg();
+    const fixtureId = await discoverableFixtureRig(auth);
+
+    // Rig setup's patchCompetition(discoverable: true) opt-in calls the
+    // discovery functions directly (not through deferred) — isolate the
+    // assertions below to just the scoring write under test.
+    order.log.length = 0;
+    capture.fns.length = 0;
+    vi.mocked(deferred).mockClear();
+
+    // core.start alone flips movesDiscovery = true (scoring.ts) — the
+    // smallest write that reaches the guarded branch, no decide/finalize
+    // sequence needed.
+    await scoreEvent(auth, fixtureId, { expected_seq: 0, type: "core.start", payload: {} });
+
+    // invalidatePublicCache runs fire-and-forget off scoreEvent (`void
+    // invalidatePublicCache(...)`) — poll for the deferred registration the
+    // same way deferred.test.ts polls for the helper's own callback.
+    await vi.waitFor(() => expect(deferred).toHaveBeenCalledTimes(1));
+
+    // If the deferred(...) wrapper were ever dropped, `deferred` (fully
+    // replaced here, not a passthrough spy) would never be called and the
+    // waitFor above times out and fails — that's the regression signal for
+    // "dropped". Nothing has actually run the discovery calls yet.
+    expect(capture.fns).toHaveLength(1);
+    expect(order.log).toEqual([]);
+
+    await capture.fns[0]!();
+
+    // If the wrapper were reordered (or the await before
+    // fireDiscoveryRevalidate dropped), this would read
+    // ["revalidate", "invalidate"] instead — that's the regression signal
+    // for "reordered".
+    expect(order.log).toEqual(["invalidate", "revalidate"]);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/slug-invalidation.test.ts
+++ b/apps/web/src/server/usecases/__tests__/slug-invalidation.test.ts
@@ -1,0 +1,117 @@
+// Slug-cache invalidation call-site coverage (Task 2 review finding 3):
+// slug-hygiene.test.ts proves renames regenerate the slug and record
+// slug_history, but nothing asserted that patchCompetition/patchDivision
+// actually CALL invalidateSlugCache — a caller could record history and
+// still leave the stale Redis entry live for up to the 60s TTL. `@/server/
+// slug-resolve` is partially mocked so invalidateSlugCache still runs for
+// real (it's inert without REDIS_URL) but as a spy we can assert on.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+vi.mock("@/server/slug-resolve", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/slug-resolve")>();
+  return { ...actual, invalidateSlugCache: vi.fn(actual.invalidateSlugCache) };
+});
+
+import { invalidateSlugCache } from "@/server/slug-resolve";
+import { createCompetition, patchCompetition } from "@/server/usecases/competitions";
+import { createDivision, patchDivision } from "@/server/usecases/divisions";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+async function seedOrg(): Promise<{ auth: AuthCtx }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Slug " + suffix}, ${"slug-" + suffix})
+    returning id`;
+  await sql`
+    insert into subscriptions (org_id, plan_key, status)
+    values (${orgId}, 'pro', 'active')
+    on conflict (org_id) do update set plan_key = 'pro'`;
+  await invalidateOrgEntitlements(orgId);
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(GENERIC_CONFIG)}, true)
+    on conflict do nothing`;
+  return { auth: { orgId, via: "session", userId: null, role: "owner", keyId: null } };
+}
+
+const compInput = (name: string) => ({
+  name,
+  visibility: "private" as const,
+  branding: {},
+});
+
+const divInput = (name: string) => ({
+  name,
+  sport_key: "generic",
+  variant_key: "score",
+  config: GENERIC_CONFIG,
+  eligibility: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe.skipIf(!HAS_DB)("slug cache invalidation call sites (Task 2 review finding 3)", () => {
+  it("competition rename calls invalidateSlugCache once with the old and new slug", async () => {
+    const { auth } = await seedOrg();
+    const c = await createCompetition(auth, compInput("Spring Open"));
+    const renamed = await patchCompetition(auth, c.id, { name: "Autumn Open" });
+    expect(renamed.slug).toBe("autumn-open");
+    expect(invalidateSlugCache).toHaveBeenCalledTimes(1);
+    expect(invalidateSlugCache).toHaveBeenCalledWith(
+      "competition",
+      auth.orgId,
+      "spring-open",
+      "autumn-open",
+    );
+  });
+
+  it("a competition patch that doesn't touch the name never invalidates the slug cache", async () => {
+    const { auth } = await seedOrg();
+    const c = await createCompetition(auth, compInput("Steady Cup"));
+    const patched = await patchCompetition(auth, c.id, { description: "Now with a blurb" });
+    expect(patched.slug).toBe("steady-cup");
+    expect(invalidateSlugCache).not.toHaveBeenCalled();
+  });
+
+  it("division rename calls invalidateSlugCache once with the competition as parent", async () => {
+    const { auth } = await seedOrg();
+    const c = await createCompetition(auth, compInput("Host Cup"));
+    const d = await createDivision(auth, c.id, divInput("U16 Boys"));
+    const renamed = await patchDivision(auth, d.id, { name: "U18 Boys" });
+    expect(renamed.slug).toBe("u18-boys");
+    expect(invalidateSlugCache).toHaveBeenCalledTimes(1);
+    expect(invalidateSlugCache).toHaveBeenCalledWith("division", c.id, "u16-boys", "u18-boys");
+  });
+
+  it("a division patch that doesn't touch the name never invalidates the slug cache", async () => {
+    const { auth } = await seedOrg();
+    const c = await createCompetition(auth, compInput("Quiet Cup"));
+    const d = await createDivision(auth, c.id, divInput("Open"));
+    const patched = await patchDivision(auth, d.id, { officials_hide_names: true });
+    expect(patched.slug).toBe("open");
+    expect(invalidateSlugCache).not.toHaveBeenCalled();
+  });
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return; // DB-less unit job: connecting just to disconnect throws
+  await sql.end();
+});

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -11,6 +11,7 @@ import type { AuthCtx } from "@/server/api-v1/auth";
 import { page, type ListQuery, type Page } from "@/server/api-v1/http";
 import type { CreateCompetition, PatchCompetition } from "@/server/api-v1/schemas";
 import { fireDiscoveryRevalidate, invalidateDiscoveryCache } from "@/server/public-site/revalidate";
+import { invalidateSlugCache } from "@/server/slug-resolve";
 import {
   ACTIVE_COMPETITION_STATUSES,
   assertCompetitionNotFrozen,
@@ -193,6 +194,7 @@ export async function patchCompetition(
     await requireFeature(auth.orgId, "discovery.branding");
   }
   let statusChangedTo: string | null = null;
+  let previousSlug: string | null = null;
   const { row, discoveryTouched } = await withTenant(auth.orgId, async (tx) => {
     if (patch.slug) {
       if (RESERVED_ENTITY_SLUGS.has(patch.slug)) {
@@ -222,6 +224,7 @@ export async function patchCompetition(
     }
     if (effective.slug && effective.slug !== before.slug) {
       await recordSlugHistory(tx, "competition", auth.orgId, before.slug, id);
+      previousSlug = before.slug;
     }
     const nextVisibility = patch.visibility ?? before.visibility;
     // Hard coupling (doc 15 §1): never leak a non-public competition to
@@ -269,6 +272,9 @@ export async function patchCompetition(
     await invalidateDiscoveryCache();
     fireDiscoveryRevalidate();
   }
+  // A rename busts the cached slug resolution (old + new key) — outside the
+  // tx, same reasoning as the discovery invalidation above.
+  if (previousSlug) await invalidateSlugCache("competition", auth.orgId, previousSlug, row.slug);
   // Lifecycle events (feature 1): tournament start/finish. `active` = play is on;
   // `complete` = it's wrapped up.
   if (statusChangedTo === "active" || statusChangedTo === "complete") {

--- a/apps/web/src/server/usecases/divisions.ts
+++ b/apps/web/src/server/usecases/divisions.ts
@@ -14,6 +14,7 @@ import { captureServer } from "@/lib/posthog-server";
 import { EVENTS } from "@/lib/analytics-events";
 import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { slugify, uniqueSlug, recordSlugHistory, RESERVED_ENTITY_SLUGS } from "./slugs";
+import { invalidateSlugCache } from "@/server/slug-resolve";
 
 export interface DivisionRow {
   id: string;
@@ -356,7 +357,9 @@ export async function patchDivision(
       select competition_id from divisions where id = ${id}`;
     await requireFeature(auth.orgId, "formats.advanced", d?.competition_id);
   }
-  return withTenant(auth.orgId, async (tx) => {
+  let previousSlug: string | null = null;
+  let previousCompetitionId: string | null = null;
+  const row = await withTenant(auth.orgId, async (tx) => {
     const effective: Record<string, unknown> = { ...patch };
     // Eligibility edits re-derive the youth flag unless the same patch sets
     // it explicitly (v3/11 gap 8 — auto with organiser override).
@@ -378,6 +381,8 @@ export async function patchDivision(
         if (regenerated !== before.slug) {
           effective.slug = regenerated;
           await recordSlugHistory(tx, "division", before.competition_id, before.slug, id);
+          previousSlug = before.slug;
+          previousCompetitionId = before.competition_id;
         }
       }
     }
@@ -393,4 +398,10 @@ export async function patchDivision(
     if (!row) throw new HttpError(404, "division not found");
     return row;
   });
+  // A rename busts the cached slug resolution (old + new key) — outside the
+  // tx, matching the pattern in patchCompetition.
+  if (previousSlug) {
+    await invalidateSlugCache("division", previousCompetitionId, previousSlug, row.slug);
+  }
+  return row;
 }

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -9,6 +9,7 @@ import { HttpError } from "@/lib/errors";
 import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
 import { rateLimit } from "@/lib/rate-limit";
 import { requireFeature } from "@/lib/entitlements";
+import { deferred } from "@/lib/deferred";
 import { EngineError } from "@seazn/engine/core";
 import { appendEvent, resolveModule } from "@/server/engine-db";
 import { recomputeStandings } from "@/server/engine-db";
@@ -369,8 +370,10 @@ async function invalidatePublicCache(
     // Cheap by design (doc 15 §2 / PROMPT-19 item 4): the `discovery` tag
     // fires only for discoverable competitions.
     if (movesDiscovery && row.discoverable) {
-      await invalidateDiscoveryCache();
-      fireDiscoveryRevalidate();
+      deferred(async () => {
+        await invalidateDiscoveryCache();
+        fireDiscoveryRevalidate();
+      });
     }
   }
 }

--- a/docs/superpowers/plans/2026-07-12-perf-approach-a.md
+++ b/docs/superpowers/plans/2026-07-12-perf-approach-a.md
@@ -1,0 +1,1116 @@
+# Approach A — Monolith Tuning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make page + backend performance materially better without new services: session-pooler-ready DB config, Redis slug cache, multi-machine-safe ISR revalidation, `next/image` on public surfaces, CSP that never kills caching, a trimmed scoring tail, and a CDN purge seam.
+
+**Architecture:** Everything stays in the `apps/web` monolith. Each task is an independent, reversible slice with its own regression test. No schema migrations in this wave. The revalidation-broadcast + CDN-purge work concentrates at one seam (`server/public-site/revalidate.ts`) so a later Cloud Run move only swaps transports there.
+
+**Tech Stack:** Next 16 App Router, postgres.js, ioredis/Upstash (fail-open via `lib/cache`), Fly.io machines, vitest, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-architecture-performance-design.md`
+
+## Global Constraints
+
+- Branch: `feat/perf-a-monolith-tuning`; PR to `main` at the end.
+- **No DB schema changes** in this wave (no Flyway migration files).
+- Every code change ships with a regression test that fails without it (repo rule).
+- Before any push: `npm run typecheck --workspace apps/web && npm run test` (repo rule — unit tests alone have missed tsc breaks).
+- Public ISR contract unchanged: `REVALIDATE_FAST = 30`, `REVALIDATE_SLOW = 300` (`server/public-site/data.ts`).
+- Redis is always **fail-open** (matching `lib/cache.ts` philosophy): no Redis ⇒ behavior identical to today.
+- This Next version has breaking changes vs training data — before touching any Next API, read the relevant guide under `node_modules/next/dist/docs/` (repo AGENTS.md rule).
+- `npm run build --workspace apps/web` (standalone output) must stay green — Docker deploy depends on it.
+- Vitest DB-backed suites use the ephemeral local Postgres on :54329 (see repo memory/README recipe); pure-unit tests must not require a DB.
+
+---
+
+### Task 1: Session-pooler-ready DB config (`connectionOptions`)
+
+The app is an always-on Fly machine, not serverless. Moving `DATABASE_URL` from the transaction pooler (`:6543`) to the session pooler (`:5432`) re-enables prepared statements — `lib/db.ts` already derives `prepare` from the URL, but the option derivation is untestable (buried in `getClient`) and pool size is hard-coded at 5. Extract a pure function, make pool size env-tunable, document the URL swap.
+
+**Files:**
+- Modify: `apps/web/src/lib/db.ts`
+- Test: `apps/web/src/lib/__tests__/db-options.test.ts` (new)
+- Modify: `fly.toml` (secrets comment block only)
+
+**Interfaces:**
+- Produces: `connectionOptions(url: string, env?: Record<string, string | undefined>): { ssl: false | "require"; prepare: boolean; max: number; schema: string }` exported from `@/lib/db`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/lib/__tests__/db-options.test.ts
+import { describe, expect, it } from "vitest";
+import { connectionOptions } from "@/lib/db";
+
+describe("connectionOptions", () => {
+  const remote = "postgresql://u:p@aws-0-eu-west-2.pooler.supabase.com";
+
+  it("disables prepared statements on the transaction pooler (:6543)", () => {
+    expect(connectionOptions(`${remote}:6543/postgres`, {}).prepare).toBe(false);
+  });
+
+  it("enables prepared statements on the session pooler (:5432)", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).prepare).toBe(true);
+  });
+
+  it("requires SSL for remote hosts, none for localhost", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).ssl).toBe("require");
+    expect(connectionOptions("postgresql://u:p@localhost:5432/seazn", {}).ssl).toBe(false);
+  });
+
+  it("honors DATABASE_SSL override", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, { DATABASE_SSL: "disable" }).ssl).toBe(false);
+    expect(connectionOptions("postgresql://u:p@localhost:5432/x", { DATABASE_SSL: "require" }).ssl).toBe("require");
+  });
+
+  it("defaults pool max to 5, accepts DB_POOL_MAX within 1..50, rejects garbage", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).max).toBe(5);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "10" }).max).toBe(10);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "0" }).max).toBe(5);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "banana" }).max).toBe(5);
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_POOL_MAX: "999" }).max).toBe(5);
+  });
+
+  it("defaults schema to seazn_club, honors DB_SCHEMA", () => {
+    expect(connectionOptions(`${remote}:5432/postgres`, {}).schema).toBe("seazn_club");
+    expect(connectionOptions(`${remote}:5432/postgres`, { DB_SCHEMA: "public" }).schema).toBe("public");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/db-options.test.ts`
+Expected: FAIL — `connectionOptions` is not exported.
+
+- [ ] **Step 3: Implement — extract the pure function in `lib/db.ts`**
+
+Insert above `getClient` and rewire `getClient` to use it (delete the inline `isLocal`/`sslEnv`/`ssl`/`prepare`/`schema` lines):
+
+```ts
+export interface DbConnectionOptions {
+  ssl: false | "require";
+  prepare: boolean;
+  max: number;
+  schema: string;
+}
+
+/**
+ * Pure derivation of postgres.js options from the URL + env. Session pooler
+ * (:5432) / direct connections keep prepared statements; Supabase's
+ * transaction pooler (:6543) does not support them. Pool size is env-tunable
+ * (DB_POOL_MAX, 1..50) so a machine-size bump doesn't need a code change.
+ */
+export function connectionOptions(
+  url: string,
+  env: Record<string, string | undefined> = process.env,
+): DbConnectionOptions {
+  const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
+  const sslEnv = env.DATABASE_SSL;
+  const ssl: false | "require" =
+    sslEnv === "disable" ? false : sslEnv === "require" ? "require" : isLocal ? false : "require";
+  const prepare = !url.includes(":6543");
+  const rawMax = Number(env.DB_POOL_MAX);
+  const max = Number.isInteger(rawMax) && rawMax >= 1 && rawMax <= 50 ? rawMax : 5;
+  const schema = env.DB_SCHEMA ?? "seazn_club";
+  return { ssl, prepare, max, schema };
+}
+```
+
+In `getClient`, replace the derivation block with:
+
+```ts
+  const { ssl, prepare, max, schema } = connectionOptions(url);
+```
+
+and pass `max` instead of the literal `5` in the `postgres(url, { … })` call. Keep the `debug` counter, `types`, `idle_timeout`, `connect_timeout` untouched.
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/db-options.test.ts && npm run typecheck --workspace apps/web`
+Expected: PASS. Also run the full unit suite once (`npm run test --workspace apps/web`) — the statement-count budget tests (`statementCount()`) must be unaffected.
+
+- [ ] **Step 5: Document the pooler swap in `fly.toml`**
+
+In the secrets comment block, change the `DATABASE_URL` line to:
+
+```toml
+# DATABASE_URL             — Supabase SESSION pooler URL (port 5432, Supavisor).
+#                            The app is an always-on server: session mode keeps
+#                            prepared statements (transaction pooler :6543
+#                            disables them — lib/db.ts auto-detects either).
+# DB_POOL_MAX              — optional, default 5; raise with machine size.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/db.ts apps/web/src/lib/__tests__/db-options.test.ts fly.toml
+git commit -m "perf: extract connectionOptions, env-tunable pool, session-pooler docs"
+```
+
+Ops note (post-merge, not in this repo): `fly secrets set DATABASE_URL=<session-pooler-url>` then verify `select count(*) from pg_prepared_statements` grows under load.
+
+---
+
+### Task 2: Redis read-through cache for slug resolution
+
+`server/slug-resolve.ts` hits Postgres 2–4× on every authenticated navigation (org → comp → div chain) with only per-request `React.cache()` dedupe. Add a fail-open Redis layer: **positive live-row resolutions only** (renames/misses always go to the DB — they're rare and correctness-critical), 60s TTL, explicit invalidation at the three rename sites.
+
+**Files:**
+- Modify: `apps/web/src/server/slug-resolve.ts`
+- Modify: `apps/web/src/server/usecases/competitions.ts` (~line 224 caller)
+- Modify: `apps/web/src/server/usecases/divisions.ts` (~line 380 caller)
+- Modify: `apps/web/src/app/api/orgs/[id]/route.ts` (~line 93 caller)
+- Test: `apps/web/src/server/__tests__/slug-cache.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `cacheGet`, `cacheSet`, `cacheDelPattern` from `@/lib/cache` (fail-open, no-ops without REDIS_URL).
+- Produces: `invalidateSlugCache(kind: "org" | "competition" | "division", parentId: string | null, ...slugs: (string | null | undefined)[]): Promise<void>` exported from `@/server/slug-resolve`.
+
+- [ ] **Step 1: Write the failing test (mocked cache backend)**
+
+Follow the `lib/__tests__/entitlements-cache.test.ts` pattern — mock `@/lib/cache` with a Map-backed fake, mock `@/lib/db` for the resolver's SQL:
+
+```ts
+// apps/web/src/server/__tests__/slug-cache.test.ts
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const store = new Map<string, unknown>();
+vi.mock("@/lib/cache", () => ({
+  cacheGet: vi.fn(async (k: string) => store.get(k) ?? null),
+  cacheSet: vi.fn(async (k: string, v: unknown) => void store.set(k, v)),
+  cacheDelPattern: vi.fn(async (p: string) => void store.delete(p)),
+}));
+
+// Each sql`` call resolves to the next queued result — enough to script
+// live-hit vs miss sequences without a database.
+const results: unknown[][] = [];
+vi.mock("@/lib/db", () => ({
+  sql: vi.fn(() => Promise.resolve(results.shift() ?? [])),
+}));
+
+import { orgBySlug, invalidateSlugCache } from "@/server/slug-resolve";
+import { cacheSet, cacheDelPattern } from "@/lib/cache";
+import { sql } from "@/lib/db";
+
+beforeEach(() => {
+  store.clear();
+  results.length = 0;
+  vi.clearAllMocks();
+});
+
+describe("slug resolution cache", () => {
+  const live = { id: "org-1", name: "Riverside", slug: "riverside" };
+
+  it("caches a live resolution and serves the repeat from Redis", async () => {
+    results.push([live]); // first call: DB answers
+    expect(await orgBySlug("riverside")).toEqual(live);
+    expect(cacheSet).toHaveBeenCalledWith("slug:org:riverside", live, 60);
+
+    // second call: no DB result queued — must come from cache
+    expect(await orgBySlug("riverside")).toEqual(live);
+    expect(sql).toHaveBeenCalledTimes(1);
+  });
+
+  it("never caches a miss or a rename fallback", async () => {
+    results.push([], []); // live miss, history miss
+    expect(await orgBySlug("ghost")).toBeNull();
+    expect(cacheSet).not.toHaveBeenCalled();
+  });
+
+  it("invalidateSlugCache deletes old and new slug keys", async () => {
+    await invalidateSlugCache("org", null, "riverside", "riverside-united");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:org:riverside");
+    expect(cacheDelPattern).toHaveBeenCalledWith("slug:org:riverside-united");
+  });
+});
+```
+
+> `React.cache()` dedupes per request; in vitest each `orgBySlug` call shares one module instance, so the test calls the un-deduped inner path — if `cache()` memoization makes call 2 skip the mock entirely, export the inner uncached function for the test (name it `orgBySlugUncached`) and keep the public API wrapped.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/server/__tests__/slug-cache.test.ts`
+Expected: FAIL — `invalidateSlugCache` not exported; no `cacheSet` calls.
+
+- [ ] **Step 3: Implement in `server/slug-resolve.ts`**
+
+Add at the top (after existing imports):
+
+```ts
+import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
+
+// Read-through cache for LIVE slug rows only (v3 perf wave). Renames and
+// misses always hit Postgres: they're rare, and the slug_history fallback is
+// correctness-critical. TTL bounds staleness if an invalidation is missed;
+// rename paths call invalidateSlugCache explicitly.
+const SLUG_TTL_SECONDS = 60;
+const slugKey = (
+  kind: "org" | "competition" | "division",
+  parentId: string | null,
+  slug: string,
+): string =>
+  kind === "org" ? `slug:org:${slug}` : `slug:${kind === "competition" ? "comp" : "div"}:${parentId}:${slug}`;
+
+/** Drop cached resolutions for the given slugs (old + new after a rename). */
+export async function invalidateSlugCache(
+  kind: "org" | "competition" | "division",
+  parentId: string | null,
+  ...slugs: (string | null | undefined)[]
+): Promise<void> {
+  await Promise.all(
+    slugs.filter((s): s is string => Boolean(s)).map((s) => cacheDelPattern(slugKey(kind, parentId, s))),
+  );
+}
+```
+
+Rework each resolver so the live-row path is cache-aside. `orgBySlug` becomes:
+
+```ts
+export const orgBySlug = cache(async (slug: string): Promise<Resolution> => {
+  const key = slugKey("org", null, slug);
+  const hit = await cacheGet<ResolvedEntity>(key);
+  if (hit) return hit;
+  const [live] = await sql<ResolvedEntity[]>`
+    select id, name, slug from organizations where slug = ${slug}`;
+  if (live) {
+    await cacheSet(key, live, SLUG_TTL_SECONDS);
+    return live;
+  }
+  const [hist] = await sql<{ entity_id: string }[]>`
+    select entity_id from slug_history
+    where entity_type = 'org' and parent_id is null and old_slug = ${slug}`;
+  if (!hist) return null;
+  const [target] = await sql<{ slug: string }[]>`
+    select slug from organizations where id = ${hist.entity_id}`;
+  return target ? { renamedTo: target.slug } : null;
+});
+```
+
+Apply the same shape to `compBySlug` (key `slugKey("competition", orgId, slug)`) and `divBySlug` (key `slugKey("division", competitionId, slug)`). `fixtureByNo` stays uncached (single indexed lookup, high write churn). If the React `cache()` wrapper defeats the test's second-call assertion, export the inner functions as `orgBySlugUncached` etc. and wrap: `export const orgBySlug = cache(orgBySlugUncached);`.
+
+- [ ] **Step 4: Wire invalidation at the three rename sites**
+
+Each call goes **after the transaction commits** (cache delete inside a tx could be undone by a rollback yet stay deleted — harmless — but a commit after a failed delete would leave stale cache; ordering after commit + TTL bounds both):
+
+1. `apps/web/src/app/api/orgs/[id]/route.ts` — after the tx block, next to the existing `fireOrgRevalidate(org.slug)` (~line 103):
+
+```ts
+    if (previousSlug) await invalidateSlugCache("org", null, previousSlug, org.slug);
+```
+
+2. `apps/web/src/server/usecases/competitions.ts` — the usecase containing line 224 (`recordSlugHistory(tx, "competition", auth.orgId, before.slug, id)`): after its `withTenant`/tx completes and the new slug is known:
+
+```ts
+  await invalidateSlugCache("competition", auth.orgId, before.slug, updated.slug);
+```
+
+3. `apps/web/src/server/usecases/divisions.ts` — same pattern around line 380, parent is the competition id:
+
+```ts
+  await invalidateSlugCache("division", before.competition_id, before.slug, updated.slug);
+```
+
+Adjust local variable names to what those functions actually use (`before`/`updated` per surrounding code); import `invalidateSlugCache` from `@/server/slug-resolve`.
+
+- [ ] **Step 5: Run tests + full suite**
+
+Run: `npm run test --workspace apps/web -- run src/server/__tests__/slug-cache.test.ts`
+Expected: PASS.
+Run: `npm run test --workspace apps/web && npm run typecheck --workspace apps/web`
+Expected: PASS — in particular the existing DB-backed `server/__tests__/slug-resolve.test.ts` must still pass unchanged (cache is inert without REDIS_URL).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/server/slug-resolve.ts apps/web/src/server/__tests__/slug-cache.test.ts \
+  apps/web/src/server/usecases/competitions.ts apps/web/src/server/usecases/divisions.ts \
+  "apps/web/src/app/api/orgs/[id]/route.ts"
+git commit -m "perf: redis read-through cache for slug resolution with rename invalidation"
+```
+
+---
+
+### Task 3: Multi-machine ISR revalidation broadcast + machine right-size
+
+`revalidateTag` only invalidates the machine that handled the write. With `min_machines_running = 2` (this task) the other machine would serve stale ISR for up to 30s and the "instant refresh after a score" contract breaks. Fix: every `fire*Revalidate` also POSTs the tags to peer machines over Fly's private 6PN network; peers apply them locally. Fail-open — a missed broadcast is bounded by the 30s ISR window.
+
+**Files:**
+- Create: `apps/web/src/lib/peer-revalidate.ts`
+- Create: `apps/web/src/app/api/internal/revalidate/route.ts`
+- Modify: `apps/web/src/server/public-site/revalidate.ts`
+- Test: `apps/web/src/lib/__tests__/peer-revalidate.test.ts` (new)
+- Test: `apps/web/src/app/api/internal/revalidate/route.test.ts` (new — same convention as `app/api/auth/change-email/confirm/route.test.ts`)
+- Modify: `fly.toml` (vm memory, min machines)
+
+**Interfaces:**
+- Produces: `broadcastRevalidate(tags: string[], mode: "swr" | "expire"): Promise<void>` from `@/lib/peer-revalidate` — resolves peer IPs via `global.${FLY_APP_NAME}.internal` AAAA lookup, skips `FLY_PRIVATE_IP` (self), POSTs `{ tags, mode }` with `x-cron-secret` header; no-op unless `PEER_REVALIDATE === "1"` and `FLY_APP_NAME` + `CRON_SECRET` set. Accepts an optional third arg `deps?: { resolveIps?: () => Promise<string[]>; fetchFn?: typeof fetch }` for tests.
+- Produces: `POST /api/internal/revalidate` — body `{ tags: string[] (≤20), mode: "swr" | "expire" }`, guarded by constant-time `x-cron-secret` check; applies tags locally only (never re-broadcasts — loop prevention).
+- Modifies: `fireDivisionRevalidate` / `fireOrgRevalidate` / `fireDiscoveryRevalidate` each gain a trailing `void broadcastRevalidate([...tags], mode)`.
+
+- [ ] **Step 1: Write the failing unit test for the broadcaster**
+
+```ts
+// apps/web/src/lib/__tests__/peer-revalidate.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { broadcastRevalidate } from "@/lib/peer-revalidate";
+
+afterEach(() => vi.unstubAllEnvs());
+
+function arm() {
+  vi.stubEnv("PEER_REVALIDATE", "1");
+  vi.stubEnv("FLY_APP_NAME", "seazn-club-prod");
+  vi.stubEnv("CRON_SECRET", "s3cret");
+  vi.stubEnv("FLY_PRIVATE_IP", "fdaa::3");
+}
+
+describe("broadcastRevalidate", () => {
+  it("no-ops when PEER_REVALIDATE is not enabled", async () => {
+    const fetchFn = vi.fn();
+    await broadcastRevalidate(["division:d1"], "swr", { fetchFn });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("POSTs tags to every peer except itself, with the secret header", async () => {
+    arm();
+    const fetchFn = vi.fn(async () => new Response("{}"));
+    await broadcastRevalidate(["division:d1", "competition:c1"], "swr", {
+      resolveIps: async () => ["fdaa::3", "fdaa::4", "fdaa::5"],
+      fetchFn,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(String(url)).toBe("http://[fdaa::4]:3000/api/internal/revalidate");
+    expect(init.headers["x-cron-secret"]).toBe("s3cret");
+    expect(JSON.parse(init.body)).toEqual({ tags: ["division:d1", "competition:c1"], mode: "swr" });
+  });
+
+  it("swallows resolver and fetch failures (fail-open)", async () => {
+    arm();
+    await expect(
+      broadcastRevalidate(["division:d1"], "swr", {
+        resolveIps: async () => {
+          throw new Error("dns down");
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/peer-revalidate.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `lib/peer-revalidate.ts`**
+
+```ts
+import "server-only";
+
+// Fan revalidateTag out to sibling Fly machines (spec 2026-07-12 §3 A-step 5).
+// Fly's 6PN DNS: `global.<app>.internal` AAAA-resolves to every machine's
+// private IPv6. Fail-open by design: a lost broadcast is bounded by the 30s
+// public ISR window (REVALIDATE_FAST). This module is the transport seam —
+// a Cloud Run move swaps DNS fan-out for Redis pub/sub here, nothing else.
+export interface BroadcastDeps {
+  resolveIps?: () => Promise<string[]>;
+  fetchFn?: typeof fetch;
+}
+
+async function flyPeerIps(appName: string): Promise<string[]> {
+  const { resolve6 } = await import("node:dns/promises");
+  return resolve6(`global.${appName}.internal`);
+}
+
+export async function broadcastRevalidate(
+  tags: string[],
+  mode: "swr" | "expire",
+  deps: BroadcastDeps = {},
+): Promise<void> {
+  const appName = process.env.FLY_APP_NAME;
+  const secret = process.env.CRON_SECRET;
+  if (process.env.PEER_REVALIDATE !== "1" || !appName || !secret || tags.length === 0) return;
+  try {
+    const ips = await (deps.resolveIps ?? (() => flyPeerIps(appName)))();
+    const self = process.env.FLY_PRIVATE_IP;
+    const fetchFn = deps.fetchFn ?? fetch;
+    await Promise.allSettled(
+      ips
+        .filter((ip) => ip !== self)
+        .map((ip) =>
+          fetchFn(`http://[${ip}]:3000/api/internal/revalidate`, {
+            method: "POST",
+            headers: { "content-type": "application/json", "x-cron-secret": secret },
+            body: JSON.stringify({ tags, mode }),
+            signal: AbortSignal.timeout(2000),
+          }),
+        ),
+    );
+  } catch {
+    // fail open — peers converge within REVALIDATE_FAST
+  }
+}
+```
+
+- [ ] **Step 4: Run unit test to verify it passes**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/peer-revalidate.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing route test**
+
+```ts
+// apps/web/src/app/api/internal/revalidate/route.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "./route";
+
+afterEach(() => vi.unstubAllEnvs());
+
+const req = (body: unknown, secret?: string) =>
+  new NextRequest("http://localhost:3000/api/internal/revalidate", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(secret ? { "x-cron-secret": secret } : {}) },
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/internal/revalidate", () => {
+  it("401s without the shared secret (and when none is configured)", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+    expect((await POST(req({ tags: ["t"], mode: "swr" }))).status).toBe(401);
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    expect((await POST(req({ tags: ["t"], mode: "swr" }, "wrong"))).status).toBe(401);
+  });
+
+  it("400s on malformed bodies", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    expect((await POST(req({ tags: "not-an-array", mode: "swr" }, "s3cret"))).status).toBe(400);
+    expect((await POST(req({ tags: ["t"], mode: "purge-everything" }, "s3cret"))).status).toBe(400);
+    expect((await POST(req({ tags: Array(21).fill("t"), mode: "swr" }, "s3cret"))).status).toBe(400);
+  });
+
+  it("applies each tag locally and reports ok", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    const res = await POST(req({ tags: ["division:d1", "discovery"], mode: "swr" }, "s3cret"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, applied: 2 });
+  });
+});
+```
+
+- [ ] **Step 6: Run route test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run "src/app/api/internal/revalidate/route.test.ts"`
+Expected: FAIL — route module missing.
+
+- [ ] **Step 7: Implement the route**
+
+```ts
+// apps/web/src/app/api/internal/revalidate/route.ts
+import { timingSafeEqual } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+import { z } from "zod";
+
+// Peer endpoint for multi-machine ISR coherence (lib/peer-revalidate). Applies
+// tags LOCALLY only — it never re-broadcasts, so fan-out cannot loop. Guarded
+// by the same CRON_SECRET the GHA cron endpoints use.
+const Body = z.object({
+  tags: z.array(z.string().min(1).max(200)).min(1).max(20),
+  mode: z.enum(["swr", "expire"]),
+});
+
+function secretOk(header: string | null): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || !header) return false;
+  const a = Buffer.from(header);
+  const b = Buffer.from(secret);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export async function POST(req: NextRequest) {
+  if (!secretOk(req.headers.get("x-cron-secret"))) {
+    return NextResponse.json({ ok: false }, { status: 401 });
+  }
+  const parsed = Body.safeParse(await req.json().catch(() => null));
+  if (!parsed.success) return NextResponse.json({ ok: false }, { status: 400 });
+  const { tags, mode } = parsed.data;
+  for (const tag of tags) {
+    // Same Next 16 semantics as server/public-site/revalidate.ts: 'max' =
+    // stale-while-revalidate for scoring pages; expire:0 = read-your-writes
+    // for org chrome edits.
+    if (mode === "expire") revalidateTag(tag, { expire: 0 });
+    else revalidateTag(tag, "max");
+  }
+  return NextResponse.json({ ok: true, applied: tags.length });
+}
+```
+
+> Verify the `revalidateTag` second-argument forms against `node_modules/next/dist/docs` before relying on them — `server/public-site/revalidate.ts:16` documents the `'max'` form this Next version uses. If `revalidateTag` throws when the route is invoked in vitest (outside a full request scope), wrap the loop body in the same try/catch used by `fire*Revalidate`.
+
+- [ ] **Step 8: Wire broadcasts into `server/public-site/revalidate.ts`**
+
+Add import and one line per fire-function (after the local `revalidateTag` calls, outside the try/catch so a local failure still broadcasts is NOT wanted — keep it **inside** the function but after the try/catch block, unconditional):
+
+```ts
+import { broadcastRevalidate } from "@/lib/peer-revalidate";
+```
+
+```ts
+export function fireDivisionRevalidate(divisionId: string, competitionId?: string): void {
+  const tags = [divisionTag(divisionId), ...(competitionId ? [competitionTag(competitionId)] : [])];
+  try {
+    revalidateTag(tags[0], "max");
+    if (competitionId) revalidateTag(competitionTag(competitionId), "max");
+  } catch {
+    // outside a Next request scope (tests, scripts) — nothing to invalidate
+  }
+  void broadcastRevalidate(tags, "swr");
+}
+```
+
+`fireOrgRevalidate`: `void broadcastRevalidate([orgTag(orgSlug)], "expire");`
+`fireDiscoveryRevalidate`: `void broadcastRevalidate([DISCOVERY_TAG], "swr");`
+
+- [ ] **Step 9: fly.toml sizing**
+
+```toml
+[http_service]
+  min_machines_running = 2          # deploy overlap + matchday headroom; peers
+                                    # stay ISR-coherent via /api/internal/revalidate
+
+[[vm]]
+  size   = "shared-cpu-1x"
+  memory = "1gb"
+```
+
+Also append to the secrets comment block: `# PEER_REVALIDATE=1 — enable multi-machine tag fan-out (requires CRON_SECRET)`.
+
+- [ ] **Step 10: Full verification + commit**
+
+Run: `npm run test --workspace apps/web && npm run typecheck --workspace apps/web`
+Expected: PASS (route + broadcaster tests green, nothing else regressed).
+
+```bash
+git add apps/web/src/lib/peer-revalidate.ts apps/web/src/lib/__tests__/peer-revalidate.test.ts \
+  apps/web/src/app/api/internal/revalidate apps/web/src/server/public-site/revalidate.ts fly.toml
+git commit -m "perf: peer ISR revalidation broadcast; 2 machines / 1gb"
+```
+
+---
+
+### Task 4: `next/image` for public-surface logos and badges
+
+Zero `next/image` today — Supabase Storage originals ship raw to mobile spectators. Convert the **public-site** storage-served images (org logos, team badges) to `next/image`; leave arbitrary-URL avatars (OAuth etc.) as `<img>` since `remotePatterns` can't safely enumerate the whole https universe.
+
+**Files:**
+- Modify: `apps/web/next.config.mjs`
+- Modify: `apps/web/package.json` (add `sharp`)
+- Modify: the storage-image call sites under `apps/web/src/components/public-site/` and `apps/web/src/app/(public)/` — enumerate with `grep -rn "<img" apps/web/src/components/public-site "apps/web/src/app/(public)"` and convert those whose `src` comes from `resolveLogoUrl(...)` or `/storage/v1/object/public/`
+- Test: `apps/web/src/lib/__tests__/image-config.test.ts` (new)
+
+**Interfaces:**
+- Consumes: `resolveLogoUrl` from `@/server/public-site/data` (unchanged).
+- Produces: `images.remotePatterns` in next.config covering the Supabase storage host; converted components render `<Image>` with explicit `width`/`height` (or `fill` + `sizes`).
+
+- [ ] **Step 1: Write the failing config test**
+
+```ts
+// apps/web/src/lib/__tests__/image-config.test.ts
+import { describe, expect, it } from "vitest";
+import config from "../../../next.config.mjs";
+
+describe("next/image remotePatterns", () => {
+  it("allows the Supabase storage public-object path and nothing broader", () => {
+    const patterns = (config as { images?: { remotePatterns?: unknown[] } }).images?.remotePatterns ?? [];
+    expect(patterns).toContainEqual(
+      expect.objectContaining({
+        protocol: "https",
+        hostname: expect.stringContaining("supabase.co"),
+        pathname: "/storage/v1/object/public/**",
+      }),
+    );
+  });
+});
+```
+
+> `next.config.mjs` is wrapped by `withSentryConfig` — if the wrapper hides `images`, assert on the pre-wrap object: export the inner `nextConfig` as a named export (`export { nextConfig };`) and import that in the test instead.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/image-config.test.ts`
+Expected: FAIL — no `images` key.
+
+- [ ] **Step 3: Config + dependency**
+
+```bash
+npm install sharp --workspace apps/web
+```
+
+In `next.config.mjs`, inside `nextConfig`:
+
+```js
+  // next/image: only Supabase Storage public objects are optimizable —
+  // arbitrary avatar URLs stay on plain <img> (can't enumerate the internet
+  // in remotePatterns). Long minimumCacheTTL: logos change rarely and the
+  // optimizer output is CPU we don't want to respend (spec 2026-07-12 P2).
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: process.env.NEXT_PUBLIC_SUPABASE_URL
+          ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+          : "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+    minimumCacheTTL: 86400,
+  },
+```
+
+- [ ] **Step 4: Convert the public-site call sites**
+
+Enumerate: `grep -rn "<img" apps/web/src/components/public-site "apps/web/src/app/(public)"`. For each hit whose `src` is a storage/logo URL (from `resolveLogoUrl`, `entrantLogos`, `org.logo`), convert following this pattern:
+
+```tsx
+import Image from "next/image";
+
+// before
+<img src={logo} alt={`${org.name} logo`} className="h-10 w-10 rounded object-cover" />
+
+// after — explicit dimensions match the rendered box; next/image serves
+// resized webp/avif and lazy-loads below the fold by default
+<Image src={logo} alt={`${org.name} logo`} width={40} height={40} className="h-10 w-10 rounded object-cover" />
+```
+
+Rules: dimensions = the Tailwind box the class already imposes (h-10 w-10 → 40×40); hero/full-width images use `fill` + `sizes="(max-width: 768px) 100vw, 768px"` inside a `relative` container; anything above the fold on the division page gets `priority`. Leave non-storage `src` values (OAuth avatar URLs, `photo` fields that can be arbitrary hosts) as `<img>` — add a one-line comment `{/* arbitrary-host avatar — not in remotePatterns, stays <img> */}` at each skipped site.
+
+- [ ] **Step 5: Verify — tests, typecheck, build, visual**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/image-config.test.ts && npm run typecheck --workspace apps/web`
+Expected: PASS.
+Run: `npm run build --workspace apps/web`
+Expected: builds clean; confirm `apps/web/.next/standalone` contains `sharp` (`ls apps/web/.next/standalone/node_modules | grep sharp` — if missing, add `"sharp"` to `serverExternalPackages` in next.config and rebuild).
+Then start the dev server, load a public division page of the demo org (Riverside — see seeded demo accounts), and confirm logos render via `/_next/image?url=…` in the network tab.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/next.config.mjs apps/web/package.json package-lock.json \
+  apps/web/src/components/public-site "apps/web/src/app/(public)" \
+  apps/web/src/lib/__tests__/image-config.test.ts
+git commit -m "perf: next/image for storage-served public logos and badges"
+```
+
+---
+
+### Task 5: CSP enforcement must never disable caching on public routes
+
+`proxy.ts` stamps a per-request nonce CSP on every page. Today it's report-only; the day `CSP_MODE=enforce` flips, nonce CSP forces dynamic rendering and silently kills ISR (and any CDN) for `/shared`, `/embed`, `/r` (spec P5). Make cacheable public routes permanently report-only + nonce-free, so enforcement of the app surface can proceed safely.
+
+**Files:**
+- Modify: `apps/web/src/proxy.ts`
+- Test: `apps/web/src/__tests__/proxy-csp.test.ts` (new)
+
+**Interfaces:**
+- Produces: exported `isCacheablePublicPath(pathname: string): boolean` from `@/proxy` (used by the test; keep it pure).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/__tests__/proxy-csp.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy, isCacheablePublicPath } from "@/proxy";
+
+afterEach(() => vi.unstubAllEnvs());
+
+const page = (path: string) => new NextRequest(`http://localhost:3000${path}`);
+
+describe("CSP vs cacheable public routes", () => {
+  it("classifies the cacheable public tree", () => {
+    expect(isCacheablePublicPath("/shared/riverside/summer-league")).toBe(true);
+    expect(isCacheablePublicPath("/embed/divisions/x/standings")).toBe(true);
+    expect(isCacheablePublicPath("/r/AB12CD")).toBe(true);
+    expect(isCacheablePublicPath("/dashboard")).toBe(false);
+    expect(isCacheablePublicPath("/register")).toBe(false); // /r prefix must not over-match
+  });
+
+  it("keeps report-only CSP on cacheable public pages even in enforce mode", () => {
+    vi.stubEnv("CSP_MODE", "enforce");
+    const res = proxy(page("/shared/riverside/summer-league"));
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("Content-Security-Policy-Report-Only")).toContain("default-src 'self'");
+  });
+
+  it("enforces on app pages when CSP_MODE=enforce", () => {
+    vi.stubEnv("CSP_MODE", "enforce");
+    const res = proxy(page("/dashboard"));
+    expect(res.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/__tests__/proxy-csp.test.ts`
+Expected: FAIL — `isCacheablePublicPath` not exported; enforce mode currently applies everywhere.
+
+- [ ] **Step 3: Implement in `proxy.ts`**
+
+Add above `cspHeader`:
+
+```ts
+// ISR/CDN-cacheable public surfaces (spec 2026-07-12 P5): nonce CSP forces
+// dynamic rendering, so these trees stay Report-Only permanently — flipping
+// CSP_MODE=enforce hardens the app surface without un-caching spectator pages.
+// /r is the registration-ref tree (/r/[ref]); keep the segment boundary so
+// e.g. /reset-password never matches.
+const CACHEABLE_PUBLIC = /^\/(shared|embed|r)(\/|$)/;
+
+export function isCacheablePublicPath(pathname: string): boolean {
+  return CACHEABLE_PUBLIC.test(pathname);
+}
+```
+
+Change `cspHeader(nonce: string)` to `cspHeader(nonce: string, opts: { forceReportOnly?: boolean } = {})` and the name line to:
+
+```ts
+  const enforce = process.env.CSP_MODE === "enforce" && !opts.forceReportOnly;
+```
+
+In `proxy()`, replace the page-request block's CSP wiring:
+
+```ts
+  const cacheable = isCacheablePublicPath(request.nextUrl.pathname);
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = cspHeader(nonce, { forceReportOnly: cacheable });
+
+  const requestHeaders = new Headers(request.headers);
+  if (!cacheable) {
+    // Nonce request headers make Next stamp scripts per-request; cacheable
+    // trees skip them so the HTML stays byte-stable for ISR/CDN.
+    requestHeaders.set("x-nonce", nonce);
+    requestHeaders.set(csp.name, csp.value);
+  }
+```
+
+(Keep setting `csp.name`/`csp.value` on the **response** for both cases.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test --workspace apps/web -- run src/__tests__/proxy-csp.test.ts && npm run typecheck --workspace apps/web`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/proxy.ts apps/web/src/__tests__/proxy-csp.test.ts
+git commit -m "perf: cacheable public routes keep report-only nonce-free CSP under enforce mode"
+```
+
+---
+
+### Task 6: Take awaited non-critical work off the scoring hot path
+
+`scoreEvent`'s realtime publishes are already fire-and-forget (`void publish…`, `scoring.ts:93-97`), but the discovery invalidation is awaited in-request (`scoring.ts:372`). Add a `deferred()` helper on Next's `after()` (runs post-response; inline fallback outside a request scope so vitest/scripts keep working) and move the discovery tail onto it.
+
+**Files:**
+- Create: `apps/web/src/lib/deferred.ts`
+- Modify: `apps/web/src/server/usecases/scoring.ts` (~lines 370-374)
+- Test: `apps/web/src/lib/__tests__/deferred.test.ts` (new)
+
+**Interfaces:**
+- Produces: `deferred(fn: () => Promise<unknown> | unknown): void` from `@/lib/deferred`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/lib/__tests__/deferred.test.ts
+import { describe, expect, it, vi } from "vitest";
+import { deferred } from "@/lib/deferred";
+
+describe("deferred", () => {
+  it("runs the callback inline when outside a Next request scope", async () => {
+    const fn = vi.fn(async () => {});
+    deferred(fn);
+    await vi.waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+  });
+
+  it("swallows callback rejections", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    expect(() => deferred(fn)).not.toThrow();
+    await vi.waitFor(() => expect(fn).toHaveBeenCalled());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/deferred.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `lib/deferred.ts`**
+
+First read `node_modules/next/dist/docs` for the `after` API in this Next version (search: `grep -rn "after" node_modules/next/dist/docs/01-app/03-api-reference/04-functions/after.md | head`). Then:
+
+```ts
+import "server-only";
+import { after } from "next/server";
+
+/**
+ * Run non-critical tail work AFTER the response streams (Next `after()`),
+ * falling back to inline fire-and-forget outside a request scope (vitest,
+ * scripts) — same contract as fire*Revalidate's try/catch. Never throws,
+ * never delays the caller.
+ */
+export function deferred(fn: () => Promise<unknown> | unknown): void {
+  const run = () => {
+    try {
+      void Promise.resolve(fn()).catch((err) => console.warn("[deferred] task failed:", err));
+    } catch (err) {
+      console.warn("[deferred] task failed:", err);
+    }
+  };
+  try {
+    after(run);
+  } catch {
+    run(); // outside a request scope
+  }
+}
+```
+
+- [ ] **Step 4: Apply in `scoring.ts`**
+
+Replace (around lines 370-374, inside the discovery-relevant branch):
+
+```ts
+      await invalidateDiscoveryCache();
+      fireDiscoveryRevalidate();
+```
+
+with:
+
+```ts
+      deferred(async () => {
+        await invalidateDiscoveryCache();
+        fireDiscoveryRevalidate();
+      });
+```
+
+Import `deferred` from `@/lib/deferred`. Do **not** touch line 291's `await recomputeStandings(...)` — standings must be committed before the response — nor line 368's `fireDivisionRevalidate` (already sync-cheap + broadcast is void).
+
+- [ ] **Step 5: Run scoring + full suites**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/deferred.test.ts src/server/usecases/__tests__`
+Expected: PASS. If a scoring/discovery test asserted the cache was invalidated synchronously after `scoreEvent` resolved, wrap the assertion in `vi.waitFor` (the inline fallback resolves on the microtask queue).
+Run: `npm run typecheck --workspace apps/web`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/lib/deferred.ts apps/web/src/lib/__tests__/deferred.test.ts \
+  apps/web/src/server/usecases/scoring.ts
+git commit -m "perf: defer discovery invalidation off the scoring hot path"
+```
+
+---
+
+### Task 7: CDN purge seam + cache-header e2e guard + ops checklist
+
+Next already emits `s-maxage`/`stale-while-revalidate` on ISR responses (`node_modules/next/dist/docs/01-app/02-guides/cdn-caching.md`). Add the app-side purge hook (fail-open, debounced `purge_everything` — right-sized for a site this small; targeted purge is a later refinement), call it from the same revalidation seam, and pin the header contract with an e2e test so a rendering change can't silently un-cache the public tree.
+
+**Files:**
+- Create: `apps/web/src/lib/cdn-purge.ts`
+- Modify: `apps/web/src/server/public-site/revalidate.ts`
+- Test: `apps/web/src/lib/__tests__/cdn-purge.test.ts` (new)
+- Test: `apps/web/e2e/public-cache-headers.spec.ts` (new — follow existing e2e conventions in `apps/web/e2e/`)
+- Modify: `docs/superpowers/specs/2026-07-12-architecture-performance-design.md` (append ops checklist)
+
+**Interfaces:**
+- Consumes: called from `fireDivisionRevalidate` / `fireOrgRevalidate` / `fireDiscoveryRevalidate` (Task 3's shapes).
+- Produces: `purgeCdn(deps?: { fetchFn?: typeof fetch; now?: () => number }): Promise<void>` from `@/lib/cdn-purge`; env contract `CDN_PURGE_URL` (full purge endpoint, e.g. `https://api.cloudflare.com/client/v4/zones/<zone-id>/purge_cache`) + `CDN_PURGE_TOKEN`; also exports `__resetPurgeDebounceForTests(): void`.
+
+- [ ] **Step 1: Write the failing unit test**
+
+```ts
+// apps/web/src/lib/__tests__/cdn-purge.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { purgeCdn, __resetPurgeDebounceForTests } from "@/lib/cdn-purge";
+
+beforeEach(() => __resetPurgeDebounceForTests());
+afterEach(() => vi.unstubAllEnvs());
+
+function arm() {
+  vi.stubEnv("CDN_PURGE_URL", "https://api.cloudflare.com/client/v4/zones/z1/purge_cache");
+  vi.stubEnv("CDN_PURGE_TOKEN", "tok");
+}
+
+describe("purgeCdn", () => {
+  it("no-ops without CDN env", async () => {
+    const fetchFn = vi.fn();
+    await purgeCdn({ fetchFn });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("POSTs purge_everything with the bearer token", async () => {
+    arm();
+    const fetchFn = vi.fn(async () => new Response("{}"));
+    await purgeCdn({ fetchFn });
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(String(url)).toContain("/purge_cache");
+    expect(init.headers.authorization).toBe("Bearer tok");
+    expect(JSON.parse(init.body)).toEqual({ purge_everything: true });
+  });
+
+  it("debounces to one purge per 30s window", async () => {
+    arm();
+    const fetchFn = vi.fn(async () => new Response("{}"));
+    let t = 1_000_000;
+    const now = () => t;
+    await purgeCdn({ fetchFn, now });
+    await purgeCdn({ fetchFn, now }); // same instant — skipped
+    t += 31_000;
+    await purgeCdn({ fetchFn, now });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows network failures (fail-open)", async () => {
+    arm();
+    await expect(
+      purgeCdn({ fetchFn: vi.fn(async () => Promise.reject(new Error("down"))) }),
+    ).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/cdn-purge.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `lib/cdn-purge.ts`**
+
+```ts
+import "server-only";
+
+// CDN purge hook (spec 2026-07-12 §3 A-step 1). Fail-open + debounced
+// purge_everything: at this site's size a full purge every ≤30s window is
+// cheaper-simpler than tag→URL mapping, and CDN staleness stays bounded by
+// s-maxage even when a purge is missed. Targeted per-URL purge is a later
+// refinement at this same seam. Multi-machine: each machine debounces
+// independently — worst case N purges per window, still idempotent.
+const PURGE_DEBOUNCE_MS = 30_000;
+let lastPurgeAt = 0;
+
+export function __resetPurgeDebounceForTests(): void {
+  lastPurgeAt = 0;
+}
+
+export async function purgeCdn(
+  deps: { fetchFn?: typeof fetch; now?: () => number } = {},
+): Promise<void> {
+  const url = process.env.CDN_PURGE_URL;
+  const token = process.env.CDN_PURGE_TOKEN;
+  if (!url || !token) return;
+  const now = deps.now ?? Date.now;
+  if (now() - lastPurgeAt < PURGE_DEBOUNCE_MS) return;
+  lastPurgeAt = now();
+  try {
+    await (deps.fetchFn ?? fetch)(url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}`, "content-type": "application/json" },
+      body: JSON.stringify({ purge_everything: true }),
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch {
+    // fail open — s-maxage bounds staleness
+  }
+}
+```
+
+- [ ] **Step 4: Wire into the revalidation seam**
+
+In `server/public-site/revalidate.ts`, add `import { purgeCdn } from "@/lib/cdn-purge";` and append `void purgeCdn();` as the last line of `fireDivisionRevalidate`, `fireOrgRevalidate`, and `fireDiscoveryRevalidate` (after the Task 3 `broadcastRevalidate` lines).
+
+- [ ] **Step 5: Run unit tests**
+
+Run: `npm run test --workspace apps/web -- run src/lib/__tests__/cdn-purge.test.ts && npm run typecheck --workspace apps/web`
+Expected: PASS.
+
+- [ ] **Step 6: Pin the ISR header contract with e2e**
+
+First check how existing specs boot/authenticate (`ls apps/web/e2e`, read one public-page spec). ISR `Cache-Control` headers only appear on production builds — `next dev` serves everything dynamic. Follow whichever pattern the e2e suite uses for prod-build assertions; if the suite only runs against dev, gate on it:
+
+```ts
+// apps/web/e2e/public-cache-headers.spec.ts
+import { expect, test } from "@playwright/test";
+
+// Guards spec 2026-07-12 P1/P5: the public tree must stay ISR-cacheable —
+// a stray cookies()/nonce read would flip it to private,no-store and
+// silently detach any CDN. Prod-build servers only (dev is always dynamic).
+test("public division page emits s-maxage for CDN caching", async ({ request, baseURL }) => {
+  const probe = await request.get(`${baseURL}/`);
+  test.skip(probe.headers()["cache-control"]?.includes("no-store") === undefined && process.env.CI !== "true", "requires prod build");
+
+  const res = await request.get(`${baseURL}/shared/riverside/summer-league`);
+  expect(res.status()).toBe(200);
+  const cc = res.headers()["cache-control"] ?? "";
+  expect(cc).toContain("s-maxage=30");
+  expect(cc).toContain("stale-while-revalidate");
+});
+```
+
+> The seeded demo org/competition slugs come from the e2e fixtures — reuse whatever `/shared/...` URL an existing public e2e spec visits instead of the literal above. If the suite has no prod-build project, mark the test `test.fixme` with a comment pointing at the CI smoke job and assert there instead — do not ship a green-but-vacuous test.
+
+Run: `npx playwright test e2e/public-cache-headers.spec.ts --project=parallel` (from `apps/web`)
+Expected: PASS on prod build, or documented skip on dev.
+
+- [ ] **Step 7: Append the ops checklist to the spec doc**
+
+Append to `docs/superpowers/specs/2026-07-12-architecture-performance-design.md`:
+
+```markdown
+## 7. Ops checklist (post-merge, no code)
+
+1. Custom domain → Cloudflare DNS (proxied). fly.dev cannot sit behind a CDN.
+2. Cloudflare cache rules: cache `/shared/*`, `/embed/*`, `/r/*`, `/_next/static/*`,
+   `/_next/image*`; **respect origin Cache-Control**; include the `_rsc` query
+   param in the cache key (bundled guide: cdn-caching.md); never cache `/api/*`,
+   `/o/*`, `/dashboard`.
+3. Secrets: `fly secrets set DATABASE_URL=<session-pooler :5432 URL> DB_POOL_MAX=10
+   PEER_REVALIDATE=1 CDN_PURGE_URL=<cloudflare purge endpoint> CDN_PURGE_TOKEN=<token>`.
+4. `fly deploy` picks up min 2 machines / 1gb from fly.toml.
+5. Baseline + after: Sentry p50/p75/p95 TTFB for `/shared|/embed` vs `/o/…` vs
+   `/api/v1`; Fly CPU/memory high-water on a matchday; Cloudflare cache-hit ratio.
+6. Verify prepared statements active: `select count(*) from pg_prepared_statements`
+   on the session pooler while browsing the console.
+```
+
+- [ ] **Step 8: Full-suite verification + commit + PR**
+
+Run: `npm run typecheck --workspace apps/web && npm run test && npm run build --workspace apps/web`
+Expected: all green.
+
+```bash
+git add apps/web/src/lib/cdn-purge.ts apps/web/src/lib/__tests__/cdn-purge.test.ts \
+  apps/web/src/server/public-site/revalidate.ts apps/web/e2e/public-cache-headers.spec.ts \
+  docs/superpowers/specs/2026-07-12-architecture-performance-design.md
+git commit -m "perf: CDN purge seam, public cache-header guard, ops checklist"
+```
+
+Then push the branch and open a PR titled `perf: Approach A — monolith tuning (spec 2026-07-12)`; body lists the seven slices + ops checklist pointer, ends with the repo's standard generated-with footer.
+
+---
+
+## Plan self-review notes
+
+- **Spec coverage:** A1 CDN → Task 7 (+ops checklist); A2 pooler → Task 1; A3 slug cache → Task 2; A4 images → Task 4; A5 machines (+the multi-instance coherence gap found in review) → Task 3; A6 CSP → Task 5; A7 scoring tail → Task 6. Baseline metrics → Task 7 ops checklist §5. Full coverage.
+- **Known judgment calls:** peer-broadcast over Redis `cacheHandler` (30s-ISR contract makes bounded staleness acceptable; the seam is documented for a Cloud Run swap); `purge_everything` over tag→URL mapping (site size); positive-only slug caching (rename correctness).
+- **Smoke/demo rule:** no new user-facing feature in this wave — `scripts/smoke.ts` needs no extension, but must pass in CI as-is.

--- a/docs/superpowers/specs/2026-07-12-architecture-performance-design.md
+++ b/docs/superpowers/specs/2026-07-12-architecture-performance-design.md
@@ -189,3 +189,20 @@ rename, CDN purge on revalidate, pooler-mode statement budgets).
 2. Is global (non-EU) spectator traffic actually expected soon? Decides how
    hard to push P1 vs pure backend tuning.
 3. Budget appetite for a second Fly machine (~$5–10/mo) now vs later?
+
+## 7. Ops checklist (post-merge, no code)
+
+1. Custom domain → Cloudflare DNS (proxied). fly.dev cannot sit behind a CDN.
+2. Cloudflare cache rules: cache `/shared/*`, `/embed/*`, `/_next/static/*`,
+   `/_next/image*`; **respect origin Cache-Control**; include the `_rsc` query
+   param in the cache key (bundled guide: cdn-caching.md); never cache `/api/*`,
+   `/o/*`, `/dashboard`. `/r/*` is deliberately left out of the cacheable set —
+   it's `force-dynamic` and processes self-withdraw tokens (Task 5), so it must
+   stay off any CDN cache even though the path looks "public".
+3. Secrets: `fly secrets set DATABASE_URL=<session-pooler :5432 URL> DB_POOL_MAX=10
+   PEER_REVALIDATE=1 CDN_PURGE_URL=<cloudflare purge endpoint> CDN_PURGE_TOKEN=<token>`.
+4. `fly deploy` picks up min 2 machines / 1gb from fly.toml.
+5. Baseline + after: Sentry p50/p75/p95 TTFB for `/shared|/embed` vs `/o/…` vs
+   `/api/v1`; Fly CPU/memory high-water on a matchday; Cloudflare cache-hit ratio.
+6. Verify prepared statements active: `select count(*) from pg_prepared_statements`
+   on the session pooler while browsing the console.

--- a/docs/superpowers/specs/2026-07-12-architecture-performance-design.md
+++ b/docs/superpowers/specs/2026-07-12-architecture-performance-design.md
@@ -1,0 +1,191 @@
+# Architecture & Performance Assessment — 2026-07-12
+
+Scope: page performance, backend performance, and whether/how to separate services.
+Status: **assessment + proposed approaches — nothing implemented yet.**
+
+## 1. Current architecture (as found)
+
+```
+Browser ──► Fly.io (lhr, 1× shared-cpu-1x / 512MB, min 1 warm)
+              └─ Next 16 standalone monolith
+                  ├─ 87 pages, 163 API routes, proxy.ts (CSP nonce + CSRF)
+                  ├─ packages/engine  (pure TS, in-process)
+                  ├─ pdfkit / exceljs exports, satori OG images (in-process)
+                  └─ posthog reverse proxy (/ingest rewrites)
+       Supabase Postgres ◄─ postgres.js, transaction pooler :6543, max 5 conns,
+                            RLS via withTenant (BEGIN + set_config + set role)
+       Upstash Redis     ◄─ cache-aside fail-open: auth (300s/120s),
+                            entitlements (300s), idempotency, rate limits
+       Supabase Realtime ◄─ broadcast-only fan-out (already off-box ✔)
+       Supabase Storage  ◄─ logos/avatars (raw <img>, no optimizer)
+       GitHub Actions    ◄─ cron via HTTP + CRON_SECRET (hourly funnel sweep)
+```
+
+What is already right (keep):
+
+- **Public read model**: consent-filtered `public_*_v` views + `unstable_cache`
+  with tags + ISR 30s (`REVALIDATE_FAST`), `revalidateTag` fired from the same
+  write paths that publish realtime (`server/public-site/data.ts`,
+  `server/usecases/scoring.ts`). Standings are **precomputed snapshots** on
+  write under a per-division advisory lock — reads never fold events.
+- **Engine as a pure package** — deterministic, zero I/O; the most important
+  "service boundary" already exists as a library boundary.
+- **Realtime fan-out is already a separate service** (Supabase broadcast);
+  the app never holds spectator websockets.
+- Deliberate perf indexes (V254), statement-count budget tests, Redis
+  fail-open discipline, `Promise.all` on the heavy organiser pages.
+
+## 2. Findings
+
+### Page performance
+
+| # | Finding | Where | Impact |
+|---|---------|-------|--------|
+| P1 | No CDN. ISR pages are cached **in the box**, so every spectator request — the spiky, anonymous majority — still terminates in lhr. Next already emits `s-maxage`/`stale-while-revalidate` for ISR routes; nothing consumes them. | fly.toml, `next.config.mjs` | Global TTFB = RTT to London; box eats all spectator load |
+| P2 | Zero `next/image`; 22 raw `<img>` sites serve Supabase Storage originals — no resize, no modern formats, no lazy hints. | app/, components/ | Mobile spectator pages pay full-size logo/avatar bytes |
+| P3 | Slug resolution (`orgBySlug`/`compBySlug`/`divBySlug`) is React-`cache()` deduped per request but hits Postgres 2–4× on **every** authenticated navigation; no Redis layer, unlike auth. | `server/slug-resolve.ts` | Adds serial round-trips before any page data loads |
+| P4 | `requireFixturePage` / `requireDivisionPage` chains are serial: user → org slug → memberships → comp slug → div slug → fixture (5–6 awaited queries) before page queries start. | `server/page-auth.ts` | Deep-link TTFB stacks pooler round-trips |
+| P5 | Enforcing CSP (`CSP_MODE=enforce`) uses per-request nonces, which forces dynamic rendering and would silently kill ISR + any CDN caching for public pages. Currently report-only, so latent. | `src/proxy.ts` | Future security flip conflicts with the perf strategy |
+| P6 | PostHog is reverse-proxied through the app origin — every analytics event is an extra request through the 512MB box. | next.config rewrites | Matchday event bursts compete with page serving |
+
+### Backend performance
+
+| # | Finding | Where | Impact |
+|---|---------|-------|--------|
+| B1 | One shared CPU core serves everything: requests, bcrypt logins, satori OG renders, pdfkit posters, exceljs workbooks, engine folds. 512MB + exceljs on a big division is an OOM candidate. | fly.toml, exports/OG routes | Tail latency spikes; single machine = no isolation, deploys briefly 1→0 |
+| B2 | Transaction pooler (:6543) disables prepared statements, and `withTenant` spends 2 extra round-trips per write tx (`set_config` + `set local role`). But the app is a **persistent server**, not serverless — the pooler is solving a problem this app doesn't have. | `lib/db.ts` | Every query re-parses; writes pay +2 RTT; 5-conn cap under 500-conn HTTP concurrency |
+| B3 | Scoring write path is fully synchronous in-request: idempotency check → rate limit → tx (advisory lock, gapless seq via `max(seq)+1`, fold, snapshot write) → realtime publish (HTTP) → revalidateTag → discovery invalidation. | `server/usecases/scoring.ts` | Courtside score-entry latency stacks every hop; realtime/revalidate could trail the response |
+| B4 | No job runner. Cron = GitHub Actions hitting endpoints (imprecise, ≥ hourly practical). Exports/imports/digest-emails all live in request lifecycles. | `.github/workflows/funnel-reminders.yml` | Long work ties up request workers; planned digest email has no home |
+| B5 | `min_machines_running = 1`, single machine: a deploy or crash-restart is a visible blip; no headroom for matchday concurrency. | fly.toml | Availability + burst capacity |
+
+### Service separation — verdict
+
+**Do not microservice by domain.** At this scale (single region, modest team,
+one DB) a domain split buys distributed-systems tax and no throughput. The
+monolith is modular in the right places already (engine package, usecase layer,
+views-only public reads). The separations that pay are **by workload class**:
+
+1. **Spectator reads → edge (CDN)** — anonymous, cacheable, spiky. This is the
+   real "service extraction": the audience never needs to reach the box.
+2. **CPU-heavy render (PDF/Excel/OG/imports) → worker process** — same image,
+   second Fly process group, fed by a queue. Protects interactive latency.
+3. **Scheduled work → real scheduler** — replace GHA-cron-over-HTTP as jobs grow
+   (digest emails are already planned).
+
+Realtime is already separated. The engine should stay in-process (pure, fast,
+deterministic; a network hop would only add failure modes).
+
+## 3. Approaches
+
+### Approach A — Tune the monolith (recommended first)
+
+No new services. Ordered by leverage:
+
+1. **CDN in front of public + embed routes** (Cloudflare in front of Fly, or
+   Fly's edge + `Cache-Control` respected by a proxy): honor the ISR
+   `s-maxage`/`stale-while-revalidate` headers Next already sends; include the
+   `_rsc` search param in the cache key (bundled Next guide:
+   `02-guides/cdn-caching.md`); purge CDN keys alongside `revalidateTag` in
+   `server/public-site/revalidate.ts`. Scope it to `/shared`, `/embed`, `/o/…`
+   stays dynamic. Resolves P1; halves B1's traffic at the same time.
+2. **DB connection mode**: point the always-on server at the **session pooler
+   (Supavisor :5432) or direct connections**, re-enable prepared statements,
+   keep `max: 5` (raise to ~10 if pool-wait metrics say so). Measure with the
+   existing statement-count tests + a pgbench-style before/after. Resolves B2.
+3. **Redis read-through for slug resolution** (`slug:{org}`,
+   `slug:{org}:{comp}`, …, invalidated on rename — renames already write
+   `slug_history`). Collapses P3; P4 shrinks to the user/org lookups that are
+   already Redis-cached.
+4. **Image handling**: adopt `next/image` (or Supabase image transforms) for
+   logos/avatars with explicit sizes. Resolves P2. (Next's optimizer costs box
+   CPU — with the CDN from step 1 caching `/_next/image`, that cost amortizes.)
+5. **Machine right-size**: bump to 1GB / dedicated core *after* measuring; add
+   a second machine (min 2) for deploy overlap + burst. Cheap, reversible.
+6. **CSP decision**: for public routes prefer hash/`strict-dynamic` without
+   per-request nonces (or keep report-only there) so enforcement never forces
+   dynamic rendering. Locks in P5 before it bites.
+7. **Async tail on scoring**: keep the tx synchronous, but fire realtime
+   publish + revalidate + discovery invalidation with `after()` (Next 16) so
+   the scorer's 201 returns at commit. Trims B3 latency with zero semantics
+   change.
+
+- **Cost**: days, not weeks; no new deployables. CDN purge wiring is the only
+  genuinely new moving part.
+- **Risk**: low; every step reversible and independently measurable.
+
+### Approach B — Workload split on Fly (second wave)
+
+Same codebase, same image — add a `worker` **process group** and a queue:
+
+- Queue choice: **pg-boss** (Postgres-backed, zero new infra, transactional
+  enqueue with the domain write) vs **Upstash QStash** (HTTP push, wakes
+  auto-stop machines, no poller). pg-boss fits better: jobs enqueue inside the
+  same DB tx as the triggering write, and a worker machine can stay tiny.
+- Move: PDF posters, Excel exports, bulk imports, digest emails, funnel sweeps
+  (replaces GHA cron), OG pre-render on write (optional).
+- Web machines keep serving; worker machine absorbs CPU spikes. Resolves B1's
+  isolation half, B4 entirely.
+- **Cost**: ~a week including job UI/status plumbing for exports (they become
+  "generate → notify/download" instead of request-blocking).
+- **Risk**: moderate — introduces job lifecycle states users can see.
+
+### Approach C — Bigger levers (defer until triggered)
+
+- **Multi-region Fly + read replicas, `fly-replay` for writes** — trigger:
+  sustained non-EU audience with p75 TTFB > ~600ms *after* CDN.
+- **`cacheComponents` migration** (`use cache`/`cacheLife` replaces segment
+  configs; PPR-style static shells with streamed dynamic holes) — trigger:
+  after A, if organiser-page TTFB still hurts; touches UI-state behavior
+  (`<Activity>` preservation) so it's a deliberate wave, not a drive-by.
+- **Domain service extraction** (scoring API, registration service…) — trigger:
+  team growth / independent scaling needs. Not before.
+
+**Recommendation: A now; B when exports/digest emails next get touched; C on
+triggers only.**
+
+## 4. Out-of-the-box ideas (kept honest)
+
+1. **Push the read model to storage**: standings/schedule snapshots are already
+   JSON — publish per-division blobs to Supabase Storage (CDN-fronted) on every
+   score write; embeds + live pages fetch the blob and use the existing
+   realtime broadcast as the refetch signal. Spectator load on the box → ~zero,
+   even without the full CDN story. Natural fit: `writeSnapshot` already owns
+   the moment of truth.
+2. **Calendar-aware capacity**: fixtures carry `scheduled_at` — a cron can
+   scale Fly machines up before scheduled match windows and back down after
+   (machines API), sized by fixtures-per-hour. A sports platform can *predict*
+   its own load; almost nobody exploits that.
+3. **OG images as write-time artifacts**: pre-render division/fixture OG PNGs
+   to storage on result writes (they change only then), serve statically;
+   satori leaves the request path.
+4. **Session claims**: embed an org-memberships hash in the session JWT to skip
+   the per-request membership lookup, verifying against DB only on writes.
+   Staleness window equals what Redis already accepts (120s). Idea only —
+   security-sensitive, needs its own design.
+5. **Matchday mode**: when any division has an `in_play` fixture, drop that
+   division's ISR window to 5s / raise otherwise. Tag-driven, tiny change,
+   makes "live" feel live while quiet weeks cost nothing.
+
+## 5. Measure first / prove after
+
+Before A lands, capture a baseline week in Sentry (already wired):
+
+- p50/p75/p95 TTFB split three ways: `/shared|/embed` (public), `/o/…`
+  (organiser), `/api/v1` (writes).
+- postgres.js pool wait time + statement counts on the scoring path (the
+  `statementCount()` budget tests give the harness).
+- Fly machine CPU steal + memory high-water during a matchday.
+- Core Web Vitals (LCP/INP) for a public division page on mobile.
+
+Each A-step then gets a before/after against the same panel. Regression tests
+per repo convention accompany any code change (slug-cache invalidation on
+rename, CDN purge on revalidate, pooler-mode statement budgets).
+
+## 6. Open questions for the user
+
+1. CDN preference: Cloudflare in front of Fly (free tier works, needs DNS move)
+   vs staying Fly-only (skip P1's global win, keep step 2–7)? A custom domain
+   is a prerequisite — fly.dev can't take a CDN in front cleanly.
+2. Is global (non-EU) spectator traffic actually expected soon? Decides how
+   hard to push P1 vs pure backend tuning.
+3. Budget appetite for a second Fly machine (~$5–10/mo) now vs later?

--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,8 @@ primary_region = "lhr"
   force_https         = true
   auto_stop_machines  = "stop"
   auto_start_machines = true
-  min_machines_running = 1          # keep one warm; avoids cold-start for users
+  min_machines_running = 2          # deploy overlap + matchday headroom; peers
+                                    # stay ISR-coherent via /api/internal/revalidate
 
   [http_service.concurrency]
     type       = "connections"
@@ -32,7 +33,7 @@ primary_region = "lhr"
 
 [[vm]]
   size   = "shared-cpu-1x"
-  memory = "512mb"
+  memory = "1gb"
 
 # ── Secrets (set via `fly secrets set KEY=value`) ─────────────────────────────
 # DATABASE_URL             — Supabase SESSION pooler URL (port 5432, Supavisor).
@@ -47,3 +48,4 @@ primary_region = "lhr"
 # STRIPE_WEBHOOK_SECRET
 # RESEND_API_KEY
 # SENTRY_AUTH_TOKEN        — only needed if uploading source maps in CI
+# PEER_REVALIDATE=1 — enable multi-machine tag fan-out (requires CRON_SECRET)

--- a/fly.toml
+++ b/fly.toml
@@ -35,7 +35,11 @@ primary_region = "lhr"
   memory = "512mb"
 
 # ── Secrets (set via `fly secrets set KEY=value`) ─────────────────────────────
-# DATABASE_URL             — Supabase transaction pooler URL (port 6543)
+# DATABASE_URL             — Supabase SESSION pooler URL (port 5432, Supavisor).
+#                            The app is an always-on server: session mode keeps
+#                            prepared statements (transaction pooler :6543
+#                            disables them — lib/db.ts auto-detects either).
+# DB_POOL_MAX              — optional, default 5; raise with machine size.
 # AUTH_SECRET              — random 32-byte hex; `openssl rand -hex 32`
 # SUPABASE_SERVICE_ROLE_KEY
 # SUPABASE_JWT_SECRET

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
+        "sharp": "^0.34.5",
         "stripe": "^22.3.0",
         "tiptap-markdown": "^0.9.0",
         "unified": "^11.0.5",
@@ -998,7 +999,6 @@
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -7401,7 +7401,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -13974,7 +13973,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -14018,7 +14016,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },


### PR DESCRIPTION
Approach A of the performance/architecture assessment (`docs/superpowers/specs/2026-07-12-architecture-performance-design.md`): tune the monolith on Fly, keep every change portable at the revalidation seam. Eight independently-reviewed slices, no schema migrations.

## What's in here

1. **DB config** — `connectionOptions()` extracted from `lib/db.ts`, pool size env-tunable via `DB_POOL_MAX`; prepared statements auto-enable off the transaction pooler (URL-derived, works with any `DATABASE_URL`).
2. **Redis slug cache** — read-through cache for org/comp/div slug resolution (positive live rows only, 60s TTL), invalidated at all three rename sites. Cuts 2–4 DB round-trips from every authenticated navigation.
3. **Peer ISR revalidation + 2×1GB machines** — `revalidateTag` now fans out to sibling Fly machines over 6PN (`/api/internal/revalidate`, CRON_SECRET-guarded, loop-free, fail-open). Enables `min_machines_running = 2` without stale-page splits.
4. **next/image** — storage-served public logos/badges optimized (sharp in standalone build, remotePatterns pinned to the Supabase storage path); arbitrary-host avatars deliberately stay `<img>`.
5. **CSP vs caching** — `/shared` + `/embed` permanently report-only and nonce-free so `CSP_MODE=enforce` can ship without silently killing ISR/CDN; `/r` deliberately excluded (force-dynamic, token flows — keeps the enforce path).
6. **Scoring tail** — discovery invalidation moved to Next `after()` via `deferred()` (completion-tracked; inline fallback outside request scope).
7. **CDN purge seam** — fail-open, debounced `purge_everything` hook wired into the same fire*Revalidate seam; e2e guard pins `s-maxage=30, stale-while-revalidate` on the public tree.
8. **Public tree actually ISR (follow-up)** — production `/shared`/`/embed` pages served `private, no-store`: fixed by adding `generateStaticParams` (ISR eligibility in this Next version) and removing the root-layout `cookies()` read (analytics identity now resolves client-side via a minimized, `no-store` `GET /api/users/me`, with correct login/logout lifecycle). Marketing/clubs/people/players flip back to static as a bonus. Verified on a real prod build: `Cache-Control: s-maxage=30, stale-while-revalidate=…`, MISS→HIT.

## Verification

- Every task TDD'd with RED→GREEN evidence; per-task spec+quality reviews with fix loops (findings and dispositions in `.superpowers/sdd/progress.md`, local).
- Full suite at tip: 103 files / 767 tests passing (DB-backed suites against a migrated ephemeral Postgres), typecheck clean, standalone build green with sharp verified in the trace.
- Prod-build header checks: public page `s-maxage=30` (ISR MISS→HIT), identity endpoint `private, no-store`.

## Deploy notes (ops, post-merge)

Spec doc §7 has the full checklist. Short version: set `PEER_REVALIDATE=1` (+ existing `CRON_SECRET`) to activate cross-machine revalidation; `DB_POOL_MAX` optional; CDN (Cloudflare in front of a custom domain) is optional and gated on `CDN_PURGE_URL`/`CDN_PURGE_TOKEN` — everything ships inert without those secrets. `fly.toml` app name may be stale vs the real deployment — review before `fly deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
