### PR TITLE
docs: v6 sport-expansion corpus — tennis, ice hockey, field hockey (PROMPT-48..50)

### DIFF
--- a/design/v6/00-sport-expansion-spec.md
+++ b/design/v6/00-sport-expansion-spec.md
@@ -1,0 +1,161 @@
+# v6/00 — Sport expansion spec (normative)
+
+Adds engine modules `tennis`, `icehockey`, `hockey` (field). All numbers come from
+`v6/01-rules-digest.md`. Implemented by PROMPT-48/49/50.
+
+## §1 What we reuse unchanged (audit-confirmed)
+
+- Event-sourced fold (`foldMatch`, void-resolution, monotonic decision), `score_events`
+  hash chain, `match_states` cache, `nextStatus` derived-from-fold.
+- `SportModule` contract (`sport/module.ts`), registry version pinning, DB catalog via
+  `scripts/sync-sports.ts` (rows, not schema — **no migration**).
+- Format generators (fully sport-agnostic — leagues/knockouts/swiss/americano work day
+  one), scheduling board, constraints, AI scheduler (v4) — `match-length.ts` already
+  carries `tennis:90, hockey:70` defaults; add `icehockey`.
+- Standings: `StandingsDelta`, custom `PointsRule`, comparator registry — IIHF chain =
+  `h2h_points → h2h_diff → h2h_for → diff → for → seed` (exists), FIH = standard.
+- Officials system (`officials`, `fixture_officials`, role_keys, auto-assign) — only role
+  presets + `officialLabel` per module are new.
+
+## §2 New pattern A — nested scoring kernel (tennis; future padel)
+
+`packages/engine/src/sports/nested/kernel.ts` — three-level fold with per-level win predicates:
+
+```
+NestedCfg = {
+  bestOf: 3|5,
+  set: { gamesTo: 6|4, winBy: 2, tiebreakAt: 6|4|3|null,   // null = advantage set
+         tiebreakTo: 7|5 },
+  finalSet: "same" | { matchTiebreakTo: 10|7 },             // MTB replaces deciding set
+  game: { noAd: boolean },
+  tiebreak: { winBy: 2 },
+}
+```
+
+State: `{ sets: SetScore[], games: {home,away}, points: GamePoints, phase, serving:
+"home"|"away", tbServeIndex }` where `GamePoints` is a tagged union
+`standard{0|15|30|40, deuce, advantage}` | `tiebreak{n}` | `matchTiebreak{n}`.
+
+- Events (tier 3): `tennis.point {by, meta?{ace|double_fault|winner|ue}}` — the fold
+  advances point→game→set→match including deuce/adv, no-ad deciding point, TB entry at
+  `tiebreakAt`-all, serve rotation (1 then 2-2 in TB; alternating games otherwise; TB
+  first-server receives next set). Tier 0: `tennis.set_summary {home,away,tb?}` typed
+  per set (mirrors SetbasedPad summary mode).
+- `summary.headline`: `setsWon` big score; `perSide.line` speaks tennis: closed sets
+  `6–4 7–6(5)`, live ` · 40–Ad` or `· TB 5–3`, serve dot on the serving side (serve
+  state exposed in `detail` for pads/scorebug).
+- Outcome: win only (`supportsDraws → false`). Metrics: `sets_won/lost`, `games_won/
+  lost`, `points_won` → tiebreakers `set_ratio` (exists) + new `game_ratio` comparator
+  (same cross-multiplied BigInt pattern as `set_ratio`).
+- Variants: `tour` (bo3, TB sets, TB7), `grand-slam` (bo5, final-set TB at 6–6 to 7 —
+  note real slams use 10 at 6–6; preset uses `finalSet:{matchTiebreakTo:10}` semantics
+  at games level — document), `fast4` (gamesTo 4, TB at 3–3 to 5, no-ad),
+  `doubles-noad-mtb10` (no-ad + match TB 10 as deciding set — the ITF doubles norm).
+- **Why not extend the set-based kernel:** its state (`sets[{home,away}]` flat points)
+  and win predicate (`setTo/winBy/cap`) have no game layer; bolting one on would fork
+  every consumer assumption (SetbasedPad, summaries). Separate kernel keeps both simple;
+  squash/pickleball later fit the *existing* set-based kernel, padel fits this one.
+
+## §3 New pattern B — period kernel + primitives (both hockeys; football refactor)
+
+`packages/engine/src/sports/period/kernel.ts` — generalize football's phase machine:
+
+```
+PeriodCfg = {
+  periods: { count: 2|3|4, minutes: number },               // phases P1..Pn + FT
+  overtime: null | { kind: "periods", count, minutes }      // football ET
+           | { kind: "sudden_death", minutes, skaters? },   // IIHF OT
+  shootout: null | { attempts: 5, suddenDeath: true, meta?: {clockSeconds?: 8} },
+  points: { win, draw, loss, otWin?, otLoss?, shootoutWin?, shootoutLoss? },
+  suspensions: SuspensionCfg | null,
+}
+```
+
+- Phase events `period.advance {to}` replace `football.period` (football's `H1/H2/ET/…`
+  become aliases; **football module refactors onto the kernel with byte-identical folds
+  — golden-replay test over existing ledgers is the acceptance gate**).
+- **Shootout primitive** (`period/shootout.ts`): extract football's best-of-5 alternating
+  early-out into a shared parameterized module — reused as football pens, IIHF GWS
+  (sudden-death pairs, penalty-box ineligibility recorded as flag), FIH SO (8 s attempt
+  metadata).
+- **Suspension track** (`period/suspensions.ts`):
+
+```
+SuspensionCfg = { classes: Record<key, {minutes|null, teamShort: boolean, recordOnly?}> }
+icehockey: minor 2, bench_minor 2, double_minor 4, major 5 (teamShort) ·
+           misconduct 10, game_misconduct, match (recordOnly for strength; PIM 10/20/25) ·
+           penalty_shot (event → shootout-attempt fold)
+hockey:    green 2, yellow 5 (teamShort — FIH teams play short on ALL cards) ·
+           red (permanent, teamShort)
+```
+
+  Events `suspension.start {person?, class, clockRef?}` / `suspension.end` (explicit end
+  event — engine has no clock, so expiry is recorded by the scorer/pad "release" action;
+  pads show a countdown hint from `recorded_at` wall time, but the **fold only trusts
+  events**, consistent with the no-clock boundary). Derived: current strength (`5v4`,
+  `10v11`), PIM metric, per-player card/PIM stats, FIH progressive-escalation flag
+  (prior green → suggest yellow).
+- **Goals**: `goal {by, person?, assists?[0..2], kind?: fg|pp|sh|ps|pc|stroke|og,
+  period}` — assists (ice), goal type (FIH corner/stroke; ice PP/SH) feed metrics.
+- **Draws/OT policy**: `supportsDraws` = league-stage AND (`overtime === null` or
+  explicitly allowed) — IIHF preset `iihf` (OT+GWS, 3-2-1-0 via `otWin:2, otLoss:1`),
+  rec preset `recreational` (no OT, draws, 2/1/0); FIH presets `fih-outdoor`
+  (4×15, draws, 3/1/0) and `fih-shootout` (SO after draw + `shootoutWin` bonus point,
+  Pro-League style).
+
+## §4 Modules
+
+| | `tennis` | `icehockey` | `hockey` |
+|---|---|---|---|
+| Kernel | nested | period | period |
+| Variants | tour, grand-slam, fast4, doubles-noad-mtb10 | iihf, recreational | fih-outdoor, fih-shootout, youth (4×10) |
+| supportsDraws | never | rec-league only | league stages |
+| Metrics | sets/games/points ratios | GF/GA/diff, PIM, PP%, player G/A/P | GF/GA/diff, cards, PC conversion |
+| Tiebreak default | points → set_ratio → game_ratio → h2h → seed | points → h2h_points → h2h_diff → h2h_for → diff → for → seed (IIHF §220) | points → diff → for → h2h_points → seed |
+| officialLabel.scorer | "Chair Umpire" | "Scorekeeper" | "Umpire" |
+| Officials preset roles | referee, chair_umpire, line_umpire | referee ×2, linesman ×2, scorekeeper, timekeeper | umpire ×2, technical_officer, reserve_umpire |
+| Fidelity tiers | 0: set summaries · 3: point-by-point | 0: final score · 1: goals-by-period · 3: full events (goals+assists+penalties) | same as ice |
+
+## §5 UI / app wiring
+
+- **TennisPad** (PROMPT-48): rally mode = one tap per point with spoken-score display
+  (15/30/40/Ad, TB numerals), serve dot, set strip `6–4 · 3–2 (40–15)`; summary mode =
+  per-set games (+TB score) typed. Registers in both dispatch points
+  (`fixture-console.tsx`, `device-score-pad.tsx`) — **do not add tennis to `SETBASED`
+  sets**; new `NESTED` set.
+- **PeriodPad** (PROMPT-50): shared by icehockey/hockey (and future football migration):
+  goal button (+scorer/assists/type sub-sheet), penalty/card button (class picker per
+  `SuspensionCfg`, person, release action), period advance, OT/shootout flow (attempt
+  recorder), strength chip (PP 5v4 / 10v11) always visible. Live scorebug + `/live` wall
+  show strength chip + period; headline grammar: ice `2 — 1 · P3` / `(GWS 2–1)`, FIH
+  `1 — 1 · Q4` / `(SO 3–2)`.
+- Maps/config: `SPORT_RULES` entries (tennis: bestOf/set type/final set; hockeys:
+  periods/OT/shootout/points), `PREFERRED_VARIANT` (`tennis:"tour"`, `icehockey:"iihf"`,
+  `hockey:"fih-outdoor"`), `match-length.ts` add `icehockey:75`, `venue.ts` add
+  `icehockey:"rink"` (tennis/hockey rows exist), sync-sports SPORT_NAMES entries.
+- Seed/demo (`scripts/seed-demo.ts`): pro org gains a tennis division (tour bo3) with a
+  TB set + an MTB result, and an icehockey division with an OT game, a GWS game and a
+  5v4 PP goal; community org gains a FIH division with a draw + green/yellow cards
+  (demo-richness house rule).
+
+## §6 Decisions (binding)
+
+1. **No real clock in the engine** — periods/suspensions advance by events only; elapsed
+   displays are UI sugar from `recorded_at`. Keeps determinism gate intact.
+2. **Football refactors onto the period kernel** with golden-replay equivalence as the
+   acceptance bar; its event names and folds must not change (pinned `module_version`
+   stays 1.0.0 if byte-identical, else bump minor and keep legacy fold path — decide by
+   replay result).
+3. **Key naming**: field hockey = `hockey` (matches existing map placeholders), ice
+   hockey = `icehockey`. Rename later only with a catalog migration.
+4. **Penalty-law fidelity**: modules record and derive (strength, PIM, escalation
+   hints); they do **not** adjudicate coincidental/delayed-penalty law — scorer decides,
+   `core.note` for context. Out of scope: full NHL/IIHF situation handbook.
+5. **Shoot-out procedures** (FIH 8 s, 23 m; GWS ice conditions) are attempt metadata,
+   not folded constraints.
+6. **Hockey5s / indoor hockey / padel / basketball**: out of scope; digest pattern +
+   kernels are built so each lands as a module + preset later (basketball = period
+   kernel with quarters + points-per-goal weight — noted, not built).
+7. **i18n**: pad strings follow v5 conventions if v5 has landed (console namespace);
+   otherwise plain strings with a v5 follow-up note. Cross-wave dependency, not a
+   blocker.

--- a/design/v6/01-rules-digest.md
+++ b/design/v6/01-rules-digest.md
@@ -1,0 +1,105 @@
+# v6/01 — Official rules digest (normative source for module numbers)
+
+Digested 2026-07-12 from the governing bodies' current documents. Every scoring constant
+in the v6 modules traces to a row here. Keep this file updated when rulebooks revise.
+
+Sources:
+- **ITF Rules of Tennis 2026** (itftennis.com, `2026-rules-of-tennis-english.pdf`) — Rules
+  5–7, Appendix VI (alternative scoring), Appendix VII (court officials).
+- **IIHF Official Rule Book 2025/26** (blob.iihf.com, `2025-26_iihf_rulebook_30062025-v1.pdf`)
+  — Rules 16–28 (penalties), 77 (game timing), 84 (overtime/shootout).
+- **IIHF 2026 World Championship Event Code** (`2026_iihf_event_code_-_iihf_world_championship_1.pdf`)
+  — §219 allocation of points, §220 tie-breaking.
+- **FIH Rules of Hockey, effective 1 March 2026** (fih.hockey, `fih-Rules-of-hockey-2026-final.pdf`)
+  — Rule 5 (match & result), personal penalties; **FIH General Tournament Regulations
+  (Jan 2025), Appendix 12** — shoot-out competition.
+
+## §1 Tennis (ITF)
+
+**Game (Rule 5a):** points called Love/15/30/40; at 40–40 "Deuce"; then "Advantage";
+two consecutive points after deuce win the game.
+**No-Ad (App VI):** at deuce a single deciding point; **receiver chooses service side**
+(doubles: receiving team may not change positions).
+**Tie-break game (Rule 5b):** numeric scoring; first to **7, win by 2**, open-ended.
+Serve rotation: 1 point by the due server, then alternating **2 points each**; ends change
+every 6 points; the player who served first in the TB **receives** first next set.
+**Set (Rule 6):** "Advantage Set" first to 6 games win-by-2 open-ended; "Tie-break Set"
+first to 6 win-by-2 with tie-break game at **6–6**. Must be announced in advance,
+including the final-set method.
+**Match (Rule 7):** best of 3 or best of 5 sets.
+**Alternative scoring (App VI):** Short sets — to 4 games, TB at 4–4 (or 3–3 at
+sanctioning body's discretion); Short-set tie-break to **5** (deciding point at 4–4);
+**Match tie-break 7 or 10** — played at one set all (or 2–2 in bo5) **replacing the
+deciding set**, first to 7/10 win by 2; original service order continues, doubles may
+reorder within team.
+**Officials (App VII):** referee = final authority on tennis law; chair umpire = final
+authority on questions of fact; line/net umpires call their line, chair may overrule a
+clear mistake; unsighted call → point replayed.
+**Standings conventions:** no draws; typical league scoring is per-match points with
+`set_ratio`/game ratio tiebreaks (existing comparator registry covers set/point ratios).
+
+## §2 Ice hockey (IIHF)
+
+**Game (Rule 77):** **3 × 20-minute periods** of actual (stop-clock) play, intermissions
+between periods.
+**Overtime (Rule 84.1/84.3):** round-robin/preliminary — tie after 60' → **sudden-death
+OT, max 5 minutes, 3 skaters + goalkeeper per side**, first goal wins; teams may pull the
+goalie for an extra attacker (84.2); carried-over penalties adjust to 4-on-3 / 3-on-3
+equivalents at next stoppage. (Playoff/medal rounds use longer OT — 10'/20' — per event
+regulations; keep OT length + skater count config.)
+**Shootout (Rule 84.4, "GWS"):** if OT scoreless — **5 shooters per team, alternating**;
+shooters need not be pre-named; players with uncompleted penalties ineligible; if tied
+after 5, **sudden-death pairs** (any eligible player, may repeat) until decided.
+**Penalties (Rules 16–28):** minor **2'**, bench minor **2'**, double-minor **4'**,
+major **5'**, misconduct **10'** (player off, team NOT short-handed), game misconduct
+(off for game, 20' recorded), match penalty (off, 25' recorded, team short 5'), penalty
+shot (Rule 24), awarded goal (Rule 25). Short-handed goal does not end a major; minor
+ends on PP goal (delayed-penalty and coincidental rules 15/19 exist — module records
+events, does not adjudicate edge law).
+**Standings (Event Code §219):** **3** regulation win · **2** OT/GWS win · **1** OT/GWS
+loss · **0** regulation loss (wire format: 1 point each at 60' tie + 1 extra to the
+OT/GWS winner).
+**Tie-break (§220):** H2H sub-group points → H2H goal difference → H2H goals for →
+result vs closest best-ranked outside team → (sportive criteria/seeding). Maps directly
+onto existing `h2h_points/h2h_diff/h2h_for` → `diff` → `for` → `seed` comparators.
+**Officials:** 4-official system — 2 referees + 2 linesmen (3-official variant: 1+2);
+off-ice crew (game timekeeper, penalty bench, scorekeeper).
+**Recording conventions:** goals carry scorer + up to 2 assists; PIM per player/team.
+
+## §3 Field hockey (FIH — key `hockey`)
+
+**Match (Rule 5.1):** **4 × 15-minute quarters**; 2' intervals after Q1 and Q3, **10'
+half-time** after Q2 (2026 change: half-time fixed at 10'). Other durations may be agreed
+— keep configurable.
+**Result (Rule 5.2):** most goals wins; **equal goals (incl. 0–0) = draw** — draws are a
+first-class league result. Goals arise from field goals, **penalty corners**, **penalty
+strokes** (record goal type for stats; corner/stroke procedure is not folded).
+**Shoot-out (Tournament Regs App 12, only when regulations require a winner):**
+**5 players per team**, one-on-one vs goalkeeper from the **23 m line, 8 seconds** per
+attempt, alternating; tied after 5 → **sudden death** (same pool, order may change;
+non-starting team starts SD).
+**Personal penalties (Rule 14):** caution → **green card = 2' suspension**, **yellow
+card = minimum 5' suspension**, **red card = permanent exclusion**; during green/yellow
+suspensions **the team plays with one fewer player** (unlike football yellows). Repeat
+offence escalation (green → yellow on subsequent offence); throwing equipment above knee
+= mandatory yellow, deliberate at person → red. Extra-players-on-field materially
+affecting play → **captain receives yellow** (2026 change).
+**Officials:** 2 field umpires (diagonal control), plus technical table/reserve umpire at
+tournament level.
+**Standings conventions:** FIH leagues 3/1/0 (win/draw/loss); shoot-out points variants
+exist in some competitions (Pro League: SO bonus point) — keep `shootoutWin/shootoutLoss`
+points config like football's.
+
+## §4 Cross-sport pattern summary (what the engine must newly support)
+
+| Need | Tennis | Ice hockey | Field hockey | Exists today? |
+|---|---|---|---|---|
+| Nested point→game→set fold, deuce/adv, TB games, match TB | ✅ | — | — | ❌ (set-based kernel is flat) |
+| N timed periods (3, 4) as phase machine | — | 3 | 4 | ❌ (football literal 2 halves) |
+| Sudden-death OT with skater-count semantics | — | ✅ | — | ❌ (football ET = 2 fixed periods) |
+| Shootout best-of-5 + sudden death | — | GWS | SO (8 s / 23 m) | ⚠️ football pens only (private) |
+| Timed suspensions → team strength + PIM | — | 2/4/5/10/GM/MP | green 2' / yellow ≥5' | ❌ (football cards = off, no timer) |
+| OT-aware standings points (3-2-1-0) | — | ✅ | optional SO bonus | ❌ (points map is W/D/L + shootoutWin) |
+| Draws as league result | never | only if OT disabled (rec leagues) | ✅ | ✅ (`supportsDraws`) |
+| H2H-first tie-break chain | — | ✅ | ✅ | ✅ (comparators exist) |
+| Serve/possession indicator in summary | ✅ | — | — | ⚠️ (headline free-form; no serve state) |

--- a/design/v6/README.md
+++ b/design/v6/README.md
@@ -1,0 +1,59 @@
+# v6 — Sport Expansion: Tennis · Ice Hockey · Field Hockey
+
+> **Status (2026-07-12):** not started. PROMPT-48 ⏳ · PROMPT-49 ⏳ · PROMPT-50 ⏳.
+> Branch (planned): `feat/v6-sports`. Migrations: none expected (sports are catalog rows
+> via `scripts/sync-sports.ts`, not schema).
+
+## Theme
+
+Add three sports as first-class engine modules: **tennis** (ITF), **ice hockey** (IIHF),
+**field hockey** (FIH — key `hockey`, matching the existing `match-length.ts`/`venue.ts`
+placeholders). Rules, scoring, officiating and standings conventions are digested from the
+official rulebooks in `01-rules-digest.md` — that digest is the normative source for every
+number in the modules.
+
+**The audit verdict: two new engine patterns are required.**
+
+1. **Nested scoring kernel** (tennis): the existing set-based kernel folds points straight
+   into sets (`setTo/winBy/cap`) — tennis is points→games→sets with deuce/advantage,
+   tie-break games, match tie-breaks and no-ad variants. New `nested/` kernel, reused
+   later by padel.
+2. **Period kernel + suspension & shootout primitives** (both hockeys): football is the
+   only timed-period module and hardcodes `halves: z.literal(2)`, with cards buried in its
+   private event union. Extract a generalized period phase machine (n periods, overtime
+   policy), a **timed-suspension track** (power-play strength, PIM, progressive cards)
+   and a **parameterized shootout primitive** (football pens, IIHF GWS, FIH SO are one
+   shape: best-of-5 alternating + sudden death).
+
+Everything else reuses the existing machinery: event-sourced fold, `MatchOutcome`,
+`StandingsDelta` + points config, tiebreaker comparator registry (h2h chain already
+matches IIHF), officials roles, format generators (fully sport-agnostic — no new formats
+needed; Americano/Swiss/knockout all work day one for the new sports).
+
+## Document index
+
+| # | File | Contents | Prompt |
+|---|------|----------|--------|
+| 00 | `00-sport-expansion-spec.md` | Normative spec: module designs, kernels, suspension/shootout primitives, pads, standings, decisions | 48–50 |
+| 01 | `01-rules-digest.md` | Official-rules digests with citations (ITF 2026, IIHF 2025/26 + Event Code 2026, FIH 2026 + Tournament Regs) | 48–50 |
+
+## Prompt index (prompts/)
+
+| Prompt | Delivers | Depends on |
+|--------|----------|------------|
+| PROMPT-48 | Tennis: nested kernel, `tennis` module (variants: tour-bo3, grand-slam-bo5, fast4, no-ad+MTB10), TennisPad, dispatch + catalog wiring | — |
+| PROMPT-49 | Period kernel extraction, suspension + shootout primitives, `icehockey` + `hockey` modules (engine only), football refactored onto the kernel unchanged | — |
+| PROMPT-50 | Hockey UX + ops: PeriodPad (goals/penalties/cards/period controls), strength on live scorebug, PIM/discipline stats, officials presets, seed + smoke | PROMPT-49 |
+
+## Build order (canonical)
+
+48 ∥ 49 (disjoint engine areas) → 50. PROMPT-49 refactors `football.ts`; nothing else may
+touch it concurrently.
+
+## House rules
+
+PROMPT-00 conventions apply. Every change ships a failing-without-it regression test;
+`scripts/smoke.ts` extended (pro + free paths); `tsc` + unit green before push. New sports
+require `scripts/sync-sports.ts` re-run against every environment DB (stale
+`sport_variants` gotcha — the division builder reads the DB catalog, not the engine
+registry). Engine determinism gate: no `Date.now()` inside modules.

--- a/design/v6/prompts/PROMPT-48-tennis-module.md
+++ b/design/v6/prompts/PROMPT-48-tennis-module.md
@@ -1,0 +1,59 @@
+# PROMPT-48 — Tennis: nested kernel, module, TennisPad, catalog wiring
+
+**Read first:** `v6/00-sport-expansion-spec.md` §2/§4/§5 (normative), `v6/01-rules-digest.md`
+§1 (every constant); `packages/engine/src/sports/setbased/kernel.ts` (style/patterns to mirror —
+do NOT extend it), `packages/engine/src/sport/module.ts` (contract),
+`packages/engine/src/sports/index.ts` (builtinModules), `scripts/sync-sports.ts` (+ its
+SPORT_NAMES map), `components/v2/pads/setbased-pad.tsx` + `fixture-console.tsx` +
+`device-score-pad.tsx` (dispatch points), `competition/tiebreakers.ts` (`set_ratio`
+pattern for the new `game_ratio`). Preamble: PROMPT-00. **Depends:** none. May run
+parallel to PROMPT-49 (disjoint engine areas).
+
+## Task
+
+1. **Nested kernel** (`packages/engine/src/sports/nested/kernel.ts`, v6/00 §2): `NestedCfg`,
+   tagged `GamePoints` state, fold for `point` events — deuce/advantage, no-ad deciding
+   point, tie-break entry at `tiebreakAt`-all (to `tiebreakTo`, win by 2), advantage
+   sets (`tiebreakAt:null`), final-set `matchTiebreakTo` replacing the deciding set,
+   serve tracking (game alternation; TB 1-then-2-2; TB first-server receives next set).
+   Monotonic decision at `ceil(bestOf/2)` sets. Tier-0 `set_summary` events accepted as
+   in setbased summary mode.
+2. **`tennis` module** (`packages/engine/src/sports/tennis/tennis.ts`): configSchema
+   (zod, defaults = `tour`), eventSchema `tennis.point{by, meta?}` +
+   `tennis.set_summary`, variants `tour / grand-slam / fast4 / doubles-noad-mtb10`
+   (constants from digest §1), `supportsDraws → false`, metrics
+   `sets_won/sets_lost/games_won/games_lost/points_won`, defaultTiebreakers
+   `[points, set_ratio, game_ratio, h2h_points, seed]`, fidelityTiers (0 summary /
+   3 point-by-point), `officialLabel.scorer:"Chair Umpire"`, positions catalog minimal
+   (singles/doubles slots), headline grammar per v6/00 §2 (`6–4 7–6(5) · 40–Ad`, serve
+   in `detail.serving`).
+3. **`game_ratio` comparator** in `competition/tiebreakers.ts` — cross-multiplied BigInt
+   like `set_ratio`; register + `validateCascade` coverage.
+4. **Register + catalog**: add to `builtinModules`; SPORT_NAMES `tennis:"Tennis"`;
+   document + run `scripts/sync-sports.ts` (dev DB) — note in PR that staging/prod need
+   the same run (stale sport_variants gotcha).
+5. **TennisPad** (`components/v2/pads/tennis-pad.tsx`): rally mode — big point buttons
+   per side, spoken-score display (Love/15/30/40/Ad; TB numerals), serve dot, set strip,
+   undo-own-events; summary mode — per-set games + optional TB points. Register in a new
+   `NESTED` set in **both** `fixture-console.tsx` and `device-score-pad.tsx` dispatches
+   (do not touch `SETBASED`).
+6. **Builder wiring**: `SPORT_RULES` tennis block (bestOf, set type incl. fast4 preset
+   fields, final-set method), `PREFERRED_VARIANT tennis:"tour"`; `match-length.ts` /
+   `venue.ts` rows already exist — assert via test.
+7. **Docs/demo**: seed-demo pro org tennis division (tour) with one TB set + one MTB
+   match (v6/00 §5); help doc stub per help-content conventions.
+
+## Acceptance
+
+- Unit (engine): golden fold sequences — standard game incl. deuce loop; no-ad deciding
+  point (receiver-choice recorded as meta); TB at 6–6 with serve-rotation assertion and
+  next-set receiver flip; advantage set past 6–6; fast4 (TB at 3–3 to 5); MTB10 deciding
+  set at 1–1; ALREADY_DECIDED after match point; void of match point reopens fold and
+  `nextStatus` returns to `in_play` (regression for the v3/09 class of bug).
+- Unit (standings): `game_ratio` ordering + cascade validation rejects it for sports
+  lacking game metrics.
+- E2E: create tennis division via builder (variant visible from synced catalog), score a
+  bo3 with TB on the device pad at 390px, headline shows `7–6(5)` form, undo restores
+  live point; console summary-mode entry produces identical standings.
+- smoke.ts: pro path scores one tennis set rally-mode; free path unaffected.
+- `npm test` + `tsc` green; update v6/README status.

--- a/design/v6/prompts/PROMPT-49-period-kernel-hockeys.md
+++ b/design/v6/prompts/PROMPT-49-period-kernel-hockeys.md
@@ -1,0 +1,64 @@
+# PROMPT-49 — Period Kernel + Hockeys: kernel extraction, suspensions, shootout primitive, icehockey + hockey modules
+
+**Read first:** `v6/00-sport-expansion-spec.md` §3/§4/§6 (normative), `v6/01-rules-digest.md`
+§2/§3 (every constant); `packages/engine/src/sports/football/football.ts` (phase machine +
+pens to extract; refactor target), `core/events.ts` (fold kernel, postDecisionTypes),
+`core/types.ts` (MatchOutcome/StandingsDelta), `competition/tiebreakers.ts` (h2h chain),
+`scripts/sync-sports.ts`. Preamble: PROMPT-00. **Depends:** none. May run parallel to
+PROMPT-48. **Exclusive lock on `football.ts`.**
+
+## Task
+
+1. **Period kernel** (`packages/engine/src/sports/period/kernel.ts`, v6/00 §3): `PeriodCfg`
+   (periods count/minutes, overtime `periods|sudden_death|null`, shootout, points map
+   incl. `otWin/otLoss/shootoutWin/shootoutLoss`, suspensions), phase state machine
+   `P1..Pn → [OT…] → [SHOOTOUT] → FT`, goal events with `assists[0..2]` + `kind`,
+   decision on phase completion or sudden-death goal.
+2. **Shootout primitive** (`period/shootout.ts`): extract football's best-of-5
+   alternating early-out; parameterize sudden-death pairs + attempt metadata
+   (ineligibility flag, FIH 8 s). Football pens keep identical behavior through it.
+3. **Suspension track** (`period/suspensions.ts`): `SuspensionCfg` classes per v6/00 §3;
+   `suspension.start/end` events; derived current strength (`5v4`, `10v11`), team/player
+   PIM + card metrics, FIH progressive-escalation hint (green on record → yellow
+   suggested), misconduct = not short-handed, match/game-misconduct PIM values (10/20/25)
+   per digest §2.
+4. **Football refactor onto kernel** (v6/00 §6.2): event names, config schema and folds
+   unchanged; **golden-replay test**: fold every football fixture ledger in the test
+   corpus pre/post refactor → byte-identical `state/summary/outcome/StandingsDelta`.
+   Keep `module_version` 1.0.0 if identical, else stop and surface (decision gate).
+5. **`icehockey` module**: 3×20, OT sudden-death 5' 3v3 (config), GWS 5+SD; suspensions
+   per digest §2; points `3/–/0 + otWin:2, otLoss:1` (draws only in `recreational`
+   variant: no OT, 2/1/0); metrics GF/GA/diff/PIM/PP-goals + player G/A/P;
+   defaultTiebreakers `[points, h2h_points, h2h_diff, h2h_for, diff, for, seed]`;
+   fidelityTiers 0/1/3 (final · by-period · full events); `officialLabel.scorer:
+   "Scorekeeper"`; variants `iihf`, `recreational`.
+6. **`hockey` module** (field): 4×15 quarters, draws first-class, SO per digest §3
+   (5 attempts, SD, 8 s metadata), suspensions green 2'/yellow 5'/red permanent — all
+   `teamShort:true`; goal kinds `fg|pc|stroke` + PC-conversion metric; points 3/1/0
+   (variant `fih-shootout` adds SO bonus); variants `fih-outdoor`, `fih-shootout`,
+   `youth` (4×10); `officialLabel.scorer:"Umpire"`.
+7. **Catalog + officials presets**: builtinModules + SPORT_NAMES (`icehockey:"Ice
+   Hockey"`, `hockey:"Hockey"`), sync-sports run note (all envs); officials role presets
+   per v6/00 §4 table (module `positions`/roles + seed role_keys); `match-length.ts`
+   `icehockey:75`, `venue.ts` `icehockey:"rink"`.
+
+Engine-only prompt: **no pads/UI** (PROMPT-50). Pads-less scoring still possible via
+GenericPad fallback? — No: dispatch untouched means unknown keys fall to GenericPad;
+acceptable interim, note in v6/README status.
+
+## Acceptance
+
+- Unit (kernel): phase progression 3-period and 4-quarter folds; sudden-death OT goal
+  decides immediately; shootout early-out + sudden-death pairs; suspension strength math
+  (two minors → 5v3; misconduct keeps 5v5; FIH yellow → 10v11), PIM totals; OT-aware
+  points: reg win 3 / OT win 2 / OT loss 1 / reg loss 0 asserted through StandingsDelta;
+  FIH draw yields 1/1.
+- Unit (football): golden-replay corpus byte-identical (the gate); pens still fold via
+  shootout primitive.
+- Unit (tiebreak): icehockey default cascade validates; H2H sub-group ordering matches a
+  hand-computed IIHF §220 example (3-team tie).
+- E2E: create icehockey (iihf) + hockey (fih-outdoor) divisions from synced catalog;
+  post raw events via API to decide one OT game and one drawn FIH game; standings show
+  3-2-1-0 and draw rows correctly.
+- smoke.ts: seed-path extended with one icehockey OT result asserted in standings.
+- `npm test` + `tsc` green; update v6/README status.

--- a/design/v6/prompts/PROMPT-50-hockey-pads-and-stats.md
+++ b/design/v6/prompts/PROMPT-50-hockey-pads-and-stats.md
@@ -1,0 +1,56 @@
+# PROMPT-50 — Hockey UX + Ops: PeriodPad, strength on live surfaces, discipline stats, seed
+
+**Read first:** `v6/00-sport-expansion-spec.md` §5 (normative), `v6/01-rules-digest.md`
+§2/§3; `components/v2/pads/football-pad.tsx` (closest pad — mine its patterns, then
+prefer the shared kernel shapes), `fixture-console.tsx` + `device-score-pad.tsx`
+(dispatch), `components/public-site/live-score.tsx` + `/live` wall + slideshow (scorebug
+surfaces), `scripts/seed-demo.ts`, demo-richness + smoke house rules. Preamble: PROMPT-00. **Depends:** PROMPT-49.
+
+## Task
+
+1. **PeriodPad** (`components/v2/pads/period-pad.tsx`), shared `icehockey`/`hockey`
+   driven by module config (no sport-key branching inside the pad):
+   - Goal flow: side tap → optional sub-sheet (scorer, assists ×2 for ice, goal kind:
+     PP/SH/PS for ice, FG/PC/stroke for FIH) — sub-sheet skippable (fidelity tiers).
+   - Penalty/card flow: class picker from `SuspensionCfg` (2/4/5/10/GM/MP vs
+     green/yellow/red), person picker, active-suspension list with release action +
+     wall-clock countdown hint (display only — fold trusts events).
+   - Period controls: advance (P1→P2→…, quarter labels for FIH), OT entry, shootout
+     recorder (alternating attempts, early-out indicator, sudden-death pairs).
+   - Strength chip (5v4 / 5v3 / 10v11) always visible while suspensions active.
+   - Register both dispatch points under a `PERIOD` set (football stays on FootballPad
+     this wave; migration noted as follow-up).
+2. **Live surfaces**: scorebug rows + `/live` wall + slideshow render period/phase
+   (`P3`, `Q4`, `OT`, `GWS/SO`) and strength chip from `summary.detail`; headline
+   grammar per v6/00 §5 (`2 — 1 · P3`, `(GWS 2–1)`, `(SO 3–2)`); public fixture page
+   shows goals-by-period table + discipline list.
+3. **Stats & reports**: player stats surfaces gain G/A/P + PIM (ice) and cards (FIH)
+   from module metrics; division "discipline" report tab (PIM leaderboard / card list,
+   FIH escalation flags) on the existing report patterns; PC-conversion stat on FIH
+   division stats.
+4. **Officials UX**: role presets from PROMPT-49 appear in officials panel defaults for
+   the new sports (referee×2+linesman×2 / umpire×2); assignment flows unchanged.
+5. **Seed + demo** (v6/00 §5): pro org — icehockey division with OT game, GWS game, 5v4
+   PP goal; tennis already seeded by 48; community org — FIH division with a draw and
+   green+yellow cards. Demo-richness rule: individual/team entrants + fixtures +
+   results present.
+6. **i18n note** (v6/00 §6.7): strings via v5 `console`/`public` namespaces if landed,
+   else inline with `// v5-i18n` markers for the ratchet.
+
+## Acceptance
+
+- E2E (390px device pad + console): score an icehockey game — two minors overlapping
+  shows 5v3 chip, PP goal recorded with assists, minor released early on PP goal
+  (scorer-driven release), OT sudden-death goal ends game, GWS flow records 5+SD
+  attempts; FIH game — quarter advances, green then yellow on same player shows
+  escalation hint, team-short chip 10v11, drawn game finalizes as draw in standings.
+- E2E (public): live scorebug shows `· P3` + strength chip while suspension active;
+  fixture page renders goals-by-period + discipline list; slideshow unaffected at
+  1080p.
+- Unit: pad-level strength/countdown derivation from suspension events; headline
+  grammar snapshots for all phases; discipline report aggregation.
+- smoke.ts: pro path drives one PP goal + release via pad helper; free path views live
+  scorebug with strength chip.
+- axe pass on PeriodPad (keyboard: goal, penalty, release all operable); no board
+  payload regression; `npm test` + `tsc` green; update v6/README status — wave
+  complete.


### PR DESCRIPTION
## Summary

Design corpus for three new sports as first-class engine modules: **tennis**, **icehockey**, **hockey** (field — key matches existing `match-length.ts`/`venue.ts` placeholders). Docs only; implementation happens by executing PROMPT-48..50. Numbering continues from v5's PROMPT-47.

Every scoring constant traces to official sources, digested in `design/v6/01-rules-digest.md`:
- **ITF Rules of Tennis 2026** (Rules 5–7, Appendix VI alternative scoring, Appendix VII officials)
- **IIHF Official Rule Book 2025/26** (Rules 16–28 penalties, 77 timing, 84 OT/GWS) + **2026 WC Event Code** (§219 points 3-2-1-0, §220 tie-breaking)
- **FIH Rules of Hockey eff. 1 Mar 2026** + **General Tournament Regulations Jan 2025 App 12** (shoot-out: 5 players, 23 m, 8 s, sudden death)

### The audit verdict: two new engine patterns

1. **Nested scoring kernel** (`sports/nested/`) — the set-based kernel folds points flat into sets; tennis needs points→games→sets with deuce/advantage, no-ad, tie-break games (serve rotation), and match tie-breaks replacing the deciding set. Variants: tour bo3, grand-slam bo5, Fast4, doubles no-ad+MTB10. Padel reuses it later.
2. **Period kernel + primitives** (`sports/period/`) — football hardcodes 2 halves. Generalized phase machine (3×20 / 4×15), OT policies (IIHF 5' 3-on-3 sudden death), a **timed-suspension track** (power-play strength, PIM, FIH progressive cards where the team plays short), and one **shared shootout primitive** (football pens ≡ IIHF GWS ≡ FIH SO). Football refactors onto the kernel **gated by golden-replay byte-equality** over existing ledgers. Engine stays clock-free: suspensions expire via scorer release events.

Reused unchanged: format generators (sport-agnostic), standings comparators (IIHF H2H chain already exists), officials system, event-sourced fold. Standings gain an OT-aware points config (3-2-1-0); FIH draws are first-class.

### Prompts

- **PROMPT-48** — tennis: nested kernel, module, `game_ratio` comparator, TennisPad (spoken score, serve dot), catalog wiring
- **PROMPT-49** — period kernel extraction, suspension + shootout primitives, `icehockey` + `hockey` modules, football golden-replay refactor (engine only)
- **PROMPT-50** — PeriodPad (goals/assists/penalties/cards/period/shootout flows), strength chip on live scorebug + /live wall, PIM/discipline reports, officials presets, seed + smoke

## Test plan

- [x] Corpus follows v3 conventions (README + NN docs + prompts/); `Preamble: PROMPT-00` present in all 3 prompts
- [x] All quoted engine paths verified against repo (`sports/setbased/kernel.ts`, `sports/football/football.ts`, `scripts/sync-sports.ts`, pads, dispatch points)
- [x] Rules digest cross-checked against official PDFs (converted + grepped locally)
- [x] Docs only — no code/migrations; tsc/tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)