### PR TITLE
docs: v8 corpus — player accounts (PROMPT-53) + DB connection budget (PROMPT-54)

### DIFF
--- a/design/v8/README.md
+++ b/design/v8/README.md
@@ -1,0 +1,34 @@
+# v8 — Player Accounts · DB Connection Budget
+
+> **Status (2026-07-13):** not started. PROMPT-53 ⏳ · PROMPT-54 ⏳.
+> Branches (planned): `feat/v8-player-accounts` (worktree), `chore/v8-db-pool`.
+> Migrations: V275 expected in PROMPT-53 (`person_claims` + `fixture_availability`);
+> none in PROMPT-54.
+>
+> **Naming note:** PR #76 ("v8: image-led console cards + division Settings tab")
+> shipped 2026-07-13 without a corpus folder — this folder is the first *recorded*
+> v8 corpus. If the collision bothers anyone, `git mv design/v8 design/v9` before
+> kickoff; prompt numbering (53/54) is global and unaffected.
+
+## Theme
+
+Two unrelated leftovers promoted to a wave:
+
+1. **Player accounts (PROMPT-20c, last tier-1 feature)** — everything so far is
+   organiser-operated; `persons.user_id` has existed since V204 and never been
+   filled. Claim flow (invite + QR), a cross-org player home with fixtures/results,
+   availability RSVP feeding the lineup picker, QR self check-in, and consent
+   ownership moving to the claimed player. Closes out the PROMPT-20 spec.
+2. **DB connection budget** — the `DB_POOL_MAX` knob shipped in PERF-A but nothing
+   sets it, no env has an explicit budget, and the 2026-07-13 stg outage (crash-loop
+   → connection leak → FATAL 53300 on `max_connections=60`) showed the failure mode
+   is leaks, not steady-state load. Explicit per-env values, rotation guardrails,
+   a diagnostics script, and a runbook.
+
+## Prompts
+
+- `prompts/PROMPT-53-player-accounts.md` — claim flow, `/me` player home,
+  `fixture_availability` RSVP + organiser grid, QR self check-in, consent handover.
+- `prompts/PROMPT-54-db-connection-budget.md` — per-env `DB_POOL_MAX`, budget math,
+  `max_lifetime` rotation, `scripts/db-conn-report.ts`, `docs/ops/db-connections.md`
+  runbook with the 53300 incident.

--- a/design/v8/prompts/PROMPT-53-player-accounts.md
+++ b/design/v8/prompts/PROMPT-53-player-accounts.md
@@ -1,0 +1,85 @@
+# PROMPT-53 — Player accounts: claim, player home, availability, consent
+
+**Read first:** `design/v2/prompts/PROMPT-20-tier1-features.md` §20c (normative origin)
+and `design/v2/16-future-features.md` §1.3;
+`db/migration/v2-engine/tables/V204__persons.sql` (`persons.user_id` + `consent` jsonb
+ALREADY exist — claim fills them, no persons migration needed),
+`V213__entrant_members.sql` + `V215__lineups.sql` (person ↔ entrant ↔ lineup chain);
+`apps/web/src/server/usecases/persons.ts` (extend, don't fork);
+`apps/web/src/lib/auth.ts` (session/`getCurrentUser`, magic-link login);
+`apps/web/src/app/api/users/me/route.ts` (account surface — player home is NOT this) and
+`api/v1/me/assigned-fixtures/route.ts` (existing cross-org "me" query precedent);
+`apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx`
+(public card whose consent flags flip);
+`apps/web/src/app/(public)/r/[ref]/ticket.png/route.tsx` (QR rendering precedent);
+`apps/web/src/server/api-v1/schemas.ts` + `usecases/registrations.ts` (existing
+DOB/guardian-consent shapes — reuse vocabulary);
+`apps/web/src/lib/email-templates/compose.ts` (invite email on courtside template);
+`apps/web/src/lib/routes.ts` (register every new page — raw hrefs are lint-banned);
+`apps/web/src/lib/messages.ts` (i18n — all new strings through it).
+**Depends:** nothing pending. Migration **V275**.
+
+## Context
+
+Every surface today is organiser-operated; players are `persons` rows with no login.
+`persons.user_id` (V204) is the designed seam and has never been filled. This prompt
+ships the last PROMPT-20 tier-1 feature: a person claims their row, gets a cross-org
+player home, RSVPs availability that organisers see in the lineup picker, self-checks-in
+via QR, and owns their consent flags. Player accounts are **all plans, free included**
+(growth loop — every claimed player is a future organiser).
+
+## Task
+
+1. **Schema V275** (`db/migration/deltas/V275__player_accounts.sql`), house RLS/org
+   pattern:
+   - `person_claims`: id, org_id, person_id FK, email, token (unique, hashed at rest
+     like device links), invited_by, expires_at, claimed_at, revoked_at. Partial unique
+     index: one OPEN claim per person (`where claimed_at is null and revoked_at is null`).
+   - `fixture_availability`: fixture_id FK, person_id FK, status in
+     ('in','out','maybe'), note text, updated_at; unique (fixture_id, person_id).
+2. **Claim flow**:
+   - Organiser console (people page): "Invite to claim" → email via `compose.ts`
+     template + copyable link; QR for the same link on the person's console detail
+     (print-at-the-club path).
+   - `/claim/[token]`: magic-link login if logged out → confirm identity → set
+     `persons.user_id`, stamp `claimed_at`. Token expired/revoked/claimed → clear error
+     states. Staff unlink (sets `user_id` null, revokes claim) — audited via the
+     existing history pattern.
+3. **Player home `/me`** (console shell, NOT org-scoped):
+   - `GET /api/v1/me/fixtures` — all persons where `user_id = me` → `entrant_members`
+     → entrants → upcoming fixtures across orgs; plus recent results and teams.
+     Mirror the `assigned-fixtures` query/auth shape.
+   - RSVP buttons (in/out/maybe + note) writing `fixture_availability`.
+   - Consent card: claimed player edits own `consent` flags (overrides org defaults);
+     save triggers tag revalidation so the public player card flips immediately.
+   - **Guardian gate (decision — confirm with owner at kickoff):** if `dob` says
+     under 16, consent stays read-only for the player; organiser-set values hold.
+     Full guardian-link accounts are out of scope.
+4. **Organiser availability grid**: in the lineup picker, per-person availability chip
+   for the fixture (✓/✗/? + note tooltip); unclaimed persons show "—". No layout
+   rework — chips into the existing picker rows.
+5. **QR self check-in**: fixture-scoped signed token (device-links signing approach) →
+   `/f/[token]/checkin` marks lineup presence for the claimed person; organiser sees it
+   in the lineup picker. Unclaimed person scanning → claim-first interstitial.
+6. **Closing pass (mandatory)**: `content/help/*.md` (player-accounts page + organiser
+   invite section), `scripts/smoke.ts` extended (pro + free: invite → claim → RSVP →
+   grid shows it), i18n keys via `messages.ts`, new pages in `routes.ts`.
+
+## Acceptance
+
+- E2E (Playwright, magic-link `login_url` trick): invite → claim → RSVP → organiser
+  grid shows chip → QR check-in marks presence. Second claim attempt on a claimed
+  person fails clean.
+- Consent flip by player revalidates the public card (assert name/photo appears and
+  disappears); **unclaimed persons unaffected everywhere** (public card, exports,
+  lineup picker) — regression-tested.
+- Unit: claim token lifecycle (expire/revoke/reuse), one-open-claim index, cross-org
+  `/me/fixtures` isolation (user A never sees user B's persons), guardian gate by dob.
+- `npx tsc --noEmit` + unit suite green BEFORE push; screenshots desktop + 390px for
+  `/me` and the grid.
+
+## Out of scope
+
+Guardian-link accounts (full sub-account flows), player-to-player messaging, push
+notifications, profile merging across orgs, per-org PWA manifest (parked follow-up —
+see memory), availability-aware auto-scheduling (feeds PROMPT-41 later).

--- a/design/v8/prompts/PROMPT-54-db-connection-budget.md
+++ b/design/v8/prompts/PROMPT-54-db-connection-budget.md
@@ -1,0 +1,68 @@
+# PROMPT-54 — DB connection budget: explicit DB_POOL_MAX, rotation, runbook
+
+**Read first:** `apps/web/src/lib/db.ts` (`connectionOptions()` — the `DB_POOL_MAX`
+knob EXISTS since PERF-A: 1..50, default 5, `prepare` off only on `:6543`; this prompt
+sets values and adds guardrails, it does NOT add the knob),
+`docs/superpowers/specs/2026-07-12-architecture-performance-design.md` §7 (ops
+checklist this closes), `fly.toml` + `fly.stg.toml` (machine counts × pool = the
+budget), `.github/workflows/ci.yml` ~L210 (stale "session pooler 5432" comment —
+contradicts the direct-only decision).
+**Depends:** nothing. **No migrations.**
+
+## Context
+
+Remote Supabase is DIRECT connection only (user decision 2026-07-13 — never suggest
+the Supavisor pooler). `max_connections=60` on the current instance. Live measurement
+2026-07-13: 13/60 used — ~12 is Supabase baseline (pg_cron, postgres_exporter, pg_net,
+PostgREST, background workers), app contribution at idle is 0 (`idle_timeout: 20`
+closes pool connections). Steady state is nowhere near exhaustion: 2 machines × 5
+default = 10 worst case on top of the baseline.
+
+The real failure mode is the 2026-07-13 stg outage: crash-looping machines leaked dead
+direct connections until FATAL 53300 ("remaining connection slots are reserved for
+SUPERUSER"), which caused more crashes. Self-healed when flapping stopped. So: budget
+explicitly, rotate connections so leaks age out, and give ops a one-command diagnosis.
+
+## Task
+
+1. **Explicit per-env values** in `fly.stg.toml` and `fly.toml` `[env]`:
+   `DB_POOL_MAX=5` (stg) / `DB_POOL_MAX=8` (prod) with a comment carrying the formula:
+   `machines × DB_POOL_MAX + Flyway(1) + ops headroom(3) + Supabase baseline(~12)
+   ≤ max_connections − superuser_reserved`. Assert both envs pass it in a comment
+   table (stg: 2×5+16=26 ≤ ~55 ✓).
+2. **Rotation guardrail** in `db.ts`: add `max_lifetime: 60 * 30` to the `postgres()`
+   options so stale/leaked connections age out within 30 min, and surface it through
+   `connectionOptions()` (env-tunable `DB_MAX_LIFETIME`, same clamp style as
+   `DB_POOL_MAX`) so tests can pin it. Keep `idle_timeout: 20` as is.
+3. **Diagnosis script** `scripts/db-conn-report.ts` (runs with whatever `DATABASE_URL`
+   it's given, read-only): prints max_connections, total/active/idle,
+   rollup by `usename`+`application_name`, and `pg_prepared_statements` count
+   (>0 proves the direct/session connection keeps prepared statements — `:6543`
+   silently disables them). npm script `db:conn-report`.
+4. **Runbook** `docs/ops/db-connections.md`: the budget formula + current table, the
+   53300 incident (symptom chain: crash loop → leak → 53300 → more crashes;
+   resolution: stop flapping, wait for `max_lifetime`/server timeout to reap), the
+   verification queries from the script, and the escalation ladder (bump machine size
+   / `max_connections` BEFORE reaching for the pooler — direct-only is a standing
+   decision).
+5. **Comment hygiene**: fix the `ci.yml` ~L210 stale pooler comment to state
+   direct-only + the IPv6 constraint (GH runners are IPv4-only — migrate step needs
+   IPv4 add-on or Fly-side execution; do not silently re-point at the pooler).
+
+## Acceptance
+
+- `connectionOptions()` unit tests extended: `max_lifetime` default + clamp +
+  override, existing `DB_POOL_MAX` clamps still pinned.
+- `npm run db:conn-report` against the local dev DB prints all four sections;
+  against stg (via `REMOTE_DATABASE_URL` or Supabase MCP query equivalents) shows
+  prepared statements > 0.
+- fly.toml diffs reviewed against the budget table; `npx tsc --noEmit` + unit green.
+- Runbook exists and is linked from the PERF-A spec §7 checklist (mark the
+  `DB_POOL_MAX` item done).
+
+## Out of scope
+
+Supavisor/pgbouncer (standing decision: direct only), Supabase IPv4 add-on purchase
+(separate ops decision), Approach B worker/queue, connection-level metrics shipping
+(PostHog/exporter dashboards), fixing the fly.toml app-name mismatch (separate ops
+item — verify with `fly apps list` before any deploy).

--- a/design/v8/prompts/PROMPT-54-db-connection-budget.md
+++ b/design/v8/prompts/PROMPT-54-db-connection-budget.md
@@ -18,10 +18,13 @@ PostgREST, background workers), app contribution at idle is 0 (`idle_timeout: 20
 closes pool connections). Steady state is nowhere near exhaustion: 2 machines × 5
 default = 10 worst case on top of the baseline.
 
-The real failure mode is the 2026-07-13 stg outage: crash-looping machines leaked dead
-direct connections until FATAL 53300 ("remaining connection slots are reserved for
-SUPERUSER"), which caused more crashes. Self-healed when flapping stopped. So: budget
-explicitly, rotate connections so leaks age out, and give ops a one-command diagnosis.
+**Root cause found + fixed after this prompt was written** (PR #80,
+`fix/db-client-singleton`): production builds never cached the postgres client —
+`getClient()` constructed a fresh pool per sql-proxy access, so ONE page render held
+25+ connections; the 2026-07-13 stg FATAL 53300 outage was this bug, with crash-loops
+as the symptom. The tasks below remain valid as defense-in-depth (budget the pool
+explicitly, rotate so any future leak ages out, one-command diagnosis) — verify PR #80
+is merged/deployed first, and re-measure with `db-conn-report` before choosing values.
 
 ## Task
 


### PR DESCRIPTION
## What

Design corpus for the next wave — docs only, no code, no migrations.

- `design/v8/README.md` — wave overview, planned branches, v8 naming-collision note (PR #76 called itself v8 without a corpus folder)
- `design/v8/prompts/PROMPT-53-player-accounts.md` — closes out PROMPT-20c: claim flow filling `persons.user_id` (exists since V204), V275 `person_claims` + `fixture_availability`, cross-org `/me` player home, RSVP → organiser lineup grid, QR self check-in, consent handover with bounded under-16 guardian gate
- `design/v8/prompts/PROMPT-54-db-connection-budget.md` — sets the existing `DB_POOL_MAX` knob explicitly per env with budget math (stg live-measured 13/60 conns, ~12 Supabase baseline), `max_lifetime` rotation so crash-loop leaks age out (July 13 53300 incident), `scripts/db-conn-report.ts`, ops runbook

## Why now

Both were the remaining items after the v7/v8 feature waves: 20c is the last tier-1 feature, and the PERF-A §7 ops checklist still has `DB_POOL_MAX` unset everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)