### PR TITLE
ci: sync sport catalog on staging deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,15 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
 
+      # Sport catalog rows are GENERATED from the engine registry — new
+      # sports ship as rows, not schema (v6/00). Idempotent upserts keyed by
+      # sport/variant; must land before the app deploys or the division
+      # builder serves a stale sport_variants catalog (known gotcha).
+      - name: Sync sport catalog
+        run: npm run sync:sports
+        env:
+          DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
+
       # Idempotent by design: prices matched by lookup_key, currency_options
       # re-asserted, resulting ids written into `plans` (checkout 503s when
       # unsynced, so this must land before the app). Skips with a notice


### PR DESCRIPTION
Follow-up to #79 — this 9-line ci.yml commit raced the squash-merge and missed main. Adds the "Sync sport catalog" step to deploy-staging (after Flyway migrate, before the Fly deploy) so sport-adding branches never need a manual `sync:sports` on staging. Idempotent upserts against STAGING_DATABASE_URL.

Note: today's deploy ran WITHOUT it — staging is still on the pre-v6 catalog until this merges and the next main push deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)