### PR TITLE
perf: V275 advisor indexes — FK covering indexes + slug_history PK

### DIFF
--- a/db/migration/deltas/V275__advisor_indexes.sql
+++ b/db/migration/deltas/V275__advisor_indexes.sql
@@ -1,0 +1,74 @@
+-- V275: covering indexes for foreign keys + slug_history PK
+-- (Supabase index-advisor pass, 2026-07-13.)
+--
+-- Tier 1: FKs joined or filtered on request paths. Partial (`where … is not
+-- null`) where the column is mostly null, so the index stays tiny and writes
+-- on null rows cost nothing.
+-- Tier 2: audit/attribution FKs to users/orgs — only hit on user deletion or
+-- org purges, where an unindexed FK forces a full child-table scan per row.
+-- Deliberately NOT indexed: score_events.recorded_by / device_link_id (the
+-- hottest write path; admin scans there are rare enough to eat), and the
+-- sport_key/plan_key/pass_key FKs (tiny lookup parents that are never
+-- deleted). platform_settings is a one-row table.
+
+-- ── Tier 1 ────────────────────────────────────────────────────────────────
+create index if not exists persons_user_idx
+  on persons (user_id) where user_id is not null;
+create index if not exists fixtures_pool_idx
+  on fixtures (pool_id) where pool_id is not null;
+create index if not exists fixtures_winner_to_idx
+  on fixtures (winner_to_fixture) where winner_to_fixture is not null;
+create index if not exists fixtures_loser_to_idx
+  on fixtures (loser_to_fixture) where loser_to_fixture is not null;
+create index if not exists registrations_entrant_idx
+  on registrations (entrant_id) where entrant_id is not null;
+create index if not exists team_members_person_idx
+  on team_members (person_id);
+create index if not exists player_stat_snapshots_person_idx
+  on player_stat_snapshots (person_id);
+create index if not exists officials_person_idx
+  on officials (person_id) where person_id is not null;
+create index if not exists officials_entrant_idx
+  on officials (entrant_id) where entrant_id is not null;
+create index if not exists officials_home_pool_idx
+  on officials (home_pool_id) where home_pool_id is not null;
+create index if not exists score_events_voids_idx
+  on score_events (voids_event_id) where voids_event_id is not null;
+
+-- ── Tier 2 ────────────────────────────────────────────────────────────────
+create index if not exists api_keys_org_idx on api_keys (org_id);
+create index if not exists api_keys_created_by_idx on api_keys (created_by);
+create index if not exists competition_events_actor_idx
+  on competition_events (actor_id) where actor_id is not null;
+create index if not exists competitions_created_by_idx
+  on competitions (created_by) where created_by is not null;
+create index if not exists device_links_org_idx on device_links (org_id);
+create index if not exists device_links_issued_by_idx
+  on device_links (issued_by);
+create index if not exists division_checkpoints_created_by_idx
+  on division_checkpoints (created_by) where created_by is not null;
+create index if not exists division_events_actor_idx
+  on division_events (actor_id) where actor_id is not null;
+create index if not exists imports_created_by_idx
+  on imports (created_by) where created_by is not null;
+create index if not exists imports_pin_division_idx
+  on imports (pin_division_id) where pin_division_id is not null;
+create index if not exists org_invites_created_by_idx
+  on org_invites (created_by) where created_by is not null;
+create index if not exists organizations_created_by_idx
+  on organizations (created_by) where created_by is not null;
+create index if not exists impersonation_sessions_target_idx
+  on impersonation_sessions (target_id);
+create index if not exists scorer_assignments_created_by_idx
+  on scorer_assignments (created_by) where created_by is not null;
+create index if not exists registrations_offline_paid_by_idx
+  on registrations (offline_marked_paid_by) where offline_marked_paid_by is not null;
+create index if not exists sport_variants_org_idx
+  on sport_variants (org_id) where org_id is not null;
+
+-- ── slug_history primary key ──────────────────────────────────────────────
+-- V263 gave it a unique lookup index but no PK (advisor: no_primary_key;
+-- replication/dedupe hazard). Surrogate id — the natural key is an
+-- expression (coalesce on nullable parent_id), which can't back a PK.
+alter table slug_history
+  add column if not exists id uuid primary key default gen_random_uuid();

--- a/design/v8/prompts/PROMPT-53-player-accounts.md
+++ b/design/v8/prompts/PROMPT-53-player-accounts.md
@@ -17,7 +17,7 @@ DOB/guardian-consent shapes — reuse vocabulary);
 `apps/web/src/lib/email-templates/compose.ts` (invite email on courtside template);
 `apps/web/src/lib/routes.ts` (register every new page — raw hrefs are lint-banned);
 `apps/web/src/lib/messages.ts` (i18n — all new strings through it).
-**Depends:** nothing pending. Migration **V275**.
+**Depends:** nothing pending. Migration **V276** (V275 = advisor indexes).
 
 ## Context
 
@@ -30,7 +30,7 @@ via QR, and owns their consent flags. Player accounts are **all plans, free incl
 
 ## Task
 
-1. **Schema V275** (`db/migration/deltas/V275__player_accounts.sql`), house RLS/org
+1. **Schema V276** (`db/migration/deltas/V276__player_accounts.sql`), house RLS/org
    pattern:
    - `person_claims`: id, org_id, person_id FK, email, token (unique, hashed at rest
      like device links), invited_by, expires_at, claimed_at, revoked_at. Partial unique


### PR DESCRIPTION
## What

One migration from the Supabase index-advisor pass (project `hoksroegadfdfwererzu`, 2026-07-13):

- **Tier 1 — request-path FKs**: `persons.user_id` (lands before PROMPT-53 player accounts queries it per /me request), `fixtures.pool_id` + bracket progression (`winner_to_fixture`/`loser_to_fixture`), `registrations.entrant_id`, `officials.*`, `team_members.person_id`, `player_stat_snapshots.person_id`, partial `score_events.voids_event_id`.
- **Tier 2 — audit/attribution FKs** (`created_by`/`actor_id`/…): only hit on user deletion/org purges, where unindexed FKs force full child-table scans. Partial indexes where the column is mostly null.
- **`slug_history` PK**: V263 shipped it with a unique lookup index but no primary key (advisor `no_primary_key`); natural key is an expression, so surrogate `id uuid`.

**Deliberately not indexed** (commented in the migration): `score_events.recorded_by`/`device_link_id` (hottest write path — per-event index maintenance costs more than rare admin scans), `sport_key`/`plan_key`/`pass_key` lookups (parents never deleted), one-row `platform_settings`.

~60 of the advisor's 96 lints were noise: the stale `public` schema copy and "unused index" flags that are meaningless on near-zero-traffic stg.

## Verification

- Every (table, column) pair validated against the live catalog before writing (caught one: `device_links.issued_by` is NOT NULL → full index, not partial).
- `db:apply` (Flyway) on local dev DB: schema now v275; all indexes + `slug_history_pkey` confirmed in `pg_indexes`/`pg_constraint`.
- No behavior change → no unit test; CI smoke exercises the migration in the Postgres container.

PROMPT-53 doc bumped to V276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)