### PR TITLE
feat: player accounts — claim, /me home, availability, QR check-in (PROMPT-53)

### DIFF
--- a/apps/web/content/help/players/claim-your-profile.md
+++ b/apps/web/content/help/players/claim-your-profile.md
@@ -8,9 +8,9 @@ Organisers add players to their club directory; claiming links that entry to you
 
 ## How claiming works
 
-An organiser sends you a **claim invite** — an email with a link, or a QR code they show you at the club. Open it, sign in (a magic link to your email, no password), and tap **This is me**. The link works for 14 days and for one profile.
+An organiser sends you a **claim invite** by email. Open the link, sign in with **that same email address** (a magic link, no password), and tap **This is me**. The link works for 14 days and for one profile.
 
-If the link says *expired*, *withdrawn* or *already claimed*, ask the organiser for a fresh invite — your profile and history are unaffected.
+Signed in with a different address? The page will tell you — sign out and sign in with the invited one. If the organiser used the wrong address, ask them to re-send the invite. If the link says *expired*, *withdrawn* or *already claimed*, a fresh invite fixes it — your profile and history are unaffected.
 
 ## Your player home
 

--- a/apps/web/content/help/players/claim-your-profile.md
+++ b/apps/web/content/help/players/claim-your-profile.md
@@ -1,0 +1,31 @@
+---
+title: Claim your player profile
+description: Turn the entry an organiser made for you into your own login — see your matches, RSVP availability, check in by QR and control what's public.
+order: 1
+---
+
+Organisers add players to their club directory; claiming links that entry to your own login. It's free on every plan — you don't need to belong to the organisation, and one login can hold profiles at several clubs.
+
+## How claiming works
+
+An organiser sends you a **claim invite** — an email with a link, or a QR code they show you at the club. Open it, sign in (a magic link to your email, no password), and tap **This is me**. The link works for 14 days and for one profile.
+
+If the link says *expired*, *withdrawn* or *already claimed*, ask the organiser for a fresh invite — your profile and history are unaffected.
+
+## Your player home
+
+Once claimed, **/me** is your player home across every club:
+
+- **Next match and everything coming up** — with the competition, venue and time.
+- **RSVP availability** — tap **In**, **Maybe** or **Out** on any upcoming match, with an optional note ("away that weekend"). Organisers see your answer right where they pick lineups.
+- **Recent results and your teams** — across all your clubs in one list.
+
+## Check in at the venue
+
+Some organisers pin up a **check-in QR** on match day. Scan it, tap once, and you're marked as *at the venue* in their lineup view. Checking in also counts as an "In" RSVP unless you'd already answered differently.
+
+## What's public about you
+
+Claiming puts your consent switches in your hands: **show my name publicly** and **show my photo publicly**, per club. Flip one and your public player card updates immediately — including disappearing entirely when you turn your name off.
+
+**Under 16?** An organiser manages these settings until your 16th birthday (they'll usually have a guardian's consent on file). Everything else on your player home works the same.

--- a/apps/web/content/help/players/invite-to-claim.md
+++ b/apps/web/content/help/players/invite-to-claim.md
@@ -1,6 +1,6 @@
 ---
 title: Inviting players to claim their profiles
-description: Send claim invites from the Directory, hand out QR codes at the club, read the availability grid, and unlink an account when needed.
+description: Email claim invites from the Directory, read the availability grid, run match-day QR check-in, and unlink an account when needed.
 order: 2
 ---
 
@@ -8,12 +8,9 @@ A claimed player sees their own matches, RSVPs availability you can act on, and 
 
 ## Send an invite
 
-In **Directory → Players**, choose **invite to claim…** next to a player and enter their email. Two things happen:
+In **Directory → Players**, choose **Invite to claim…** next to a player and enter their email. They get the claim link by email, and **only an account signed in with that exact address can accept it** — a forwarded link doesn't move the profile to someone else. Invites last 14 days.
 
-- They get an email with the claim link.
-- You get the same link as a **QR code and copyable URL** — shown once, so print it or let them scan it on the spot. It's valid for 14 days.
-
-One open invite per player: sending a new one quietly withdraws the previous link. A pending invite shows as **Invite pending** with a *withdraw* action.
+Typo in the address? Just invite again with the right one — one open invite per player, and sending a new one quietly withdraws the previous link. A pending invite shows as **Invite pending** with a *Withdraw invite* action.
 
 ## Availability in the lineup picker
 
@@ -21,7 +18,7 @@ Once players RSVP from their player home, the fixture's lineup picker shows a ch
 
 ## Match-day check-in QR
 
-On a fixture page, **Check-in QR** mints a code you can pin up at the venue. Claimed players scan it and mark themselves present; the dot appears in your lineup picker. The code stops working at midnight local time. A player who hasn't claimed yet is pointed to ask you for a claim invite — nothing breaks.
+At the top of a fixture page (until the match starts), **Check-in QR** mints a code you can pin up at the venue. Claimed players scan it and mark themselves present; the dot appears in your lineup picker. The code stops working at midnight local time. A player who hasn't claimed yet is pointed to ask you for a claim invite — nothing breaks.
 
 ## Unlinking
 

--- a/apps/web/content/help/players/invite-to-claim.md
+++ b/apps/web/content/help/players/invite-to-claim.md
@@ -1,0 +1,33 @@
+---
+title: Inviting players to claim their profiles
+description: Send claim invites from the Directory, hand out QR codes at the club, read the availability grid, and unlink an account when needed.
+order: 2
+---
+
+A claimed player sees their own matches, RSVPs availability you can act on, and manages their own consent flags. Every claimed player is one less person messaging you "when do I play?". Available on all plans.
+
+## Send an invite
+
+In **Directory → Players**, choose **invite to claim…** next to a player and enter their email. Two things happen:
+
+- They get an email with the claim link.
+- You get the same link as a **QR code and copyable URL** — shown once, so print it or let them scan it on the spot. It's valid for 14 days.
+
+One open invite per player: sending a new one quietly withdraws the previous link. A pending invite shows as **Invite pending** with a *withdraw* action.
+
+## Availability in the lineup picker
+
+Once players RSVP from their player home, the fixture's lineup picker shows a chip next to each name: **✓** in, **✗** out, **?** maybe — hover for their note. A dash (**—**) means no answer yet, or a player who hasn't claimed. A lime dot means they've **checked in at the venue** today.
+
+## Match-day check-in QR
+
+On a fixture page, **Check-in QR** mints a code you can pin up at the venue. Claimed players scan it and mark themselves present; the dot appears in your lineup picker. The code stops working at midnight local time. A player who hasn't claimed yet is pointed to ask you for a claim invite — nothing breaks.
+
+## Unlinking
+
+**Unlink** (next to a claimed player in the Directory) detaches their login: they lose the profile on their player home, but every roster, result and lineup stays. The claim history is kept for your records, and you can invite them to claim again later.
+
+## What claiming never changes
+
+- Date of birth stays organiser-side only — it is never shown to anyone, including on the player's own home (it only drives the under-16 consent rule).
+- Unclaimed players are completely unaffected: no public card without consent, no availability chip, nothing new.

--- a/apps/web/e2e/player-accounts.spec.ts
+++ b/apps/web/e2e/player-accounts.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect, type Page } from "@playwright/test";
+import { TAG, apiJson, activeOrg, loginUi } from "./helpers";
+
+// PROMPT-53 acceptance: invite → claim → RSVP on /me → organiser sees the
+// chip in the lineup picker → QR self-check-in marks presence. Consent flip
+// by the player revalidates the public card immediately; unclaimed persons
+// stay invisible everywhere; a second claim attempt fails clean.
+//
+// Serial: creates a player user (magic-link budget) and leans on the shared
+// Pro org.
+
+const playerEmail = `e2e-player-${TAG}@example.com`;
+
+interface Person {
+  id: string;
+  full_name: string;
+  user_id: string | null;
+}
+interface MyFixtureOut {
+  id: string;
+  fixture_no: number;
+  availability: { status: string; note: string | null } | null;
+  checked_in_at: string | null;
+}
+
+test.describe("player accounts (PROMPT-53)", () => {
+  test.describe.configure({ mode: "serial" });
+  test.slow();
+
+  let orgSlug: string;
+  let compSlug: string;
+  let divSlug: string;
+  let compId: string;
+  let divisionId: string;
+  let ada: Person; // claimed by the player
+  let ben: Person; // stays unclaimed — the regression control
+  let claimUrl: string;
+  let playerPage: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    playerPage = await (await browser.newContext()).newPage();
+  });
+  test.afterAll(async () => {
+    await playerPage.context().close();
+  });
+
+  test("organiser: roster persons, generate fixtures, invite Ada to claim", async ({
+    page,
+    request,
+  }) => {
+    const org = await activeOrg(page);
+    orgSlug = org.slug;
+
+    const comp = await apiJson<{ id: string; slug: string }>(request, "/api/v1/competitions", "POST", {
+      name: `Players ${TAG}`,
+      visibility: "public",
+    });
+    compId = comp.data!.id;
+    compSlug = comp.data!.slug;
+    const div = await apiJson<{ id: string; slug: string }>(
+      request,
+      `/api/v1/competitions/${compId}/divisions`,
+      "POST",
+      {
+        name: "Open",
+        sport_key: "generic",
+        variant_key: "score",
+        config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+      },
+    );
+    divisionId = div.data!.id;
+    divSlug = div.data!.slug;
+
+    const mk = async (name: string) =>
+      (
+        await apiJson<Person>(request, "/api/v1/persons", "POST", {
+          full_name: `${name} ${TAG}`,
+          consent: {},
+        })
+      ).data!;
+    ada = await mk("Ada");
+    ben = await mk("Ben");
+
+    await apiJson(request, `/api/v1/divisions/${divisionId}/entrants`, "POST", [
+      { kind: "individual", display_name: ada.full_name, seed: 1, members: [{ person_id: ada.id }] },
+      { kind: "individual", display_name: ben.full_name, seed: 2, members: [{ person_id: ben.id }] },
+    ]);
+    const stage = await apiJson<{ id: string }>(
+      request,
+      `/api/v1/divisions/${divisionId}/stages`,
+      "POST",
+      { seq: 1, kind: "league", name: "League" },
+    );
+    await apiJson(request, `/api/v1/stages/${stage.data!.id}/generate`, "POST");
+    await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+
+    // Invite Ada — the claim_url embeds the one-time secret (e2e token trick).
+    const invite = await apiJson<{ claim_url: string }>(
+      request,
+      `/api/v1/persons/${ada.id}/claim-invites`,
+      "POST",
+      { email: playerEmail },
+    );
+    expect(invite.status).toBe(201);
+    claimUrl = invite.data!.claim_url;
+    expect(claimUrl).toContain("/claim/pc_");
+  });
+
+  test("player: claim via magic link and land on /me", async () => {
+    await loginUi(playerPage, playerEmail);
+    await playerPage.goto(claimUrl);
+    await playerPage.getByRole("button", { name: /This is me/ }).click();
+    await playerPage.waitForURL(/\/me\?claimed=1/);
+    await expect(playerPage.getByText("Profile claimed")).toBeVisible();
+    // The claimed fixture list shows the league match against Ben.
+    await expect(playerPage.getByText(ben.full_name).first()).toBeVisible();
+  });
+
+  test("player: RSVP Out with a note from the /me hero", async () => {
+    await playerPage.goto("/me");
+    // Hero = next match; Ada has exactly one fixture (vs Ben). exact: true —
+    // substring matching would hit the header's "Sign out" button.
+    await playerPage.getByRole("button", { name: "Out", exact: true }).first().click();
+    await expect(playerPage.getByText("Saved").first()).toBeVisible();
+    const note = playerPage
+      .getByPlaceholder("Add a note for the organiser (optional)")
+      .first();
+    await note.fill("away that weekend");
+    await note.blur();
+    await expect(playerPage.getByText("Saved").first()).toBeVisible();
+
+    const mine = await apiJson<{ upcoming: MyFixtureOut[] }>(
+      playerPage.request,
+      "/api/v1/me/fixtures",
+    );
+    const rsvpd = mine.data!.upcoming.find((f) => f.availability?.status === "out");
+    expect(rsvpd, "RSVP persisted to the API read").toBeTruthy();
+    expect(rsvpd!.availability!.note).toBe("away that weekend");
+  });
+
+  test("organiser: lineup picker shows Ada's ✗ chip and Ben's — chip", async ({
+    page,
+    request,
+  }) => {
+    const mine = await apiJson<{ upcoming: MyFixtureOut[] }>(playerPage.request, "/api/v1/me/fixtures");
+    const fixture = mine.data!.upcoming[0]!;
+    await page.goto(`/o/${orgSlug}/c/${compSlug}/d/${divSlug}/f/${fixture.fixture_no}`);
+
+    // Ada RSVP'd out → ✗ with the note as tooltip; Ben never claimed → "—".
+    const adaChip = page.getByLabel(`${ada.full_name}: unavailable — away that weekend`);
+    await expect(adaChip.first()).toBeVisible({ timeout: 20_000 });
+    const benChip = page.getByLabel(`${ben.full_name}: no availability answer`);
+    await expect(benChip.first()).toBeVisible();
+
+    // Mint the check-in QR from the console (editor session).
+    const link = await apiJson<{ url: string }>(
+      request,
+      `/api/v1/fixtures/${fixture.id}/checkin-link`,
+      "POST",
+    );
+    expect(link.status).toBe(201);
+    process.env.E2E_CHECKIN_URL = link.data!.url;
+  });
+
+  test("player: QR check-in marks presence; organiser sees the venue dot", async ({ page }) => {
+    await playerPage.goto(process.env.E2E_CHECKIN_URL!);
+    await playerPage.getByRole("button", { name: /check in/i }).click();
+    await expect(playerPage.getByTestId("checkin-done")).toBeVisible();
+
+    const mine = await apiJson<{ upcoming: MyFixtureOut[] }>(playerPage.request, "/api/v1/me/fixtures");
+    const fixture = mine.data!.upcoming[0]!;
+    expect(fixture.checked_in_at).toBeTruthy();
+    // Check-in never clobbers an explicit RSVP: Ada stays "out".
+    expect(fixture.availability?.status).toBe("out");
+
+    await page.goto(`/o/${orgSlug}/c/${compSlug}/d/${divSlug}/f/${fixture.fixture_no}`);
+    await expect(
+      page.getByLabel(`${ada.full_name}: checked in at the venue`).first(),
+    ).toBeVisible({ timeout: 20_000 });
+  });
+
+  test("second claim fails clean: 409 re-invite, dead link, unclaimed regression", async ({
+    request,
+  }) => {
+    // Re-inviting a claimed person is a clean 409.
+    const again = await apiJson(request, `/api/v1/persons/${ada.id}/claim-invites`, "POST", {
+      email: "someone-else@example.com",
+    });
+    expect(again.status).toBe(409);
+    expect(again.error?.message).toContain("already claimed");
+
+    // The used link is a dead end with its own copy, not a crash.
+    await playerPage.goto(claimUrl);
+    await expect(playerPage.getByText("Already claimed")).toBeVisible();
+
+    // Ben (unclaimed) is untouched by all of the above.
+    const persons = await apiJson<Person[]>(request, "/api/v1/persons?limit=200");
+    const benRow = persons.data && "items" in (persons.data as object)
+      ? (persons.data as unknown as { items: Person[] }).items.find((p) => p.id === ben.id)
+      : undefined;
+    expect(benRow?.user_id ?? null).toBeNull();
+  });
+
+  test("consent flip by the player revalidates the public card; unclaimed stays 404", async ({
+    request,
+  }) => {
+    const cardUrl = (personId: string) =>
+      `/shared/${orgSlug}/${compSlug}/players/${personId}`;
+
+    // Before consent: both cards 404 (public_players_v is consent-gated).
+    expect((await request.get(cardUrl(ada.id))).status()).toBe(404);
+    expect((await request.get(cardUrl(ben.id))).status()).toBe(404);
+
+    // Player flips public_name ON from /me.
+    await playerPage.goto("/me");
+    await playerPage.getByLabel("Show my name publicly").check();
+    await expect
+      .poll(async () => (await request.get(cardUrl(ada.id))).status(), {
+        message: "public card appears after consent ON",
+        timeout: 15_000,
+      })
+      .toBe(200);
+    const body = await (await request.get(cardUrl(ada.id))).text();
+    expect(body).toContain(ada.full_name);
+
+    // …and OFF again: the card disappears just as fast.
+    await playerPage.getByLabel("Show my name publicly").uncheck();
+    await expect
+      .poll(async () => (await request.get(cardUrl(ada.id))).status(), {
+        message: "public card disappears after consent OFF",
+        timeout: 15_000,
+      })
+      .toBe(404);
+
+    // The unclaimed control never appeared at any point.
+    expect((await request.get(cardUrl(ben.id))).status()).toBe(404);
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -20,7 +20,7 @@ const BASE = process.env.PLAYWRIGHT_BASE ?? "http://localhost:3000";
 const AUTH_STATE = "e2e/.auth/pro.json";
 
 const SERIAL_SPECS =
-  /(journey-pro|journey-community|org-management|billing|billing-states|members-roles|scorer|device-links|division-delete|pricing-v3)\.spec\.ts/;
+  /(journey-pro|journey-community|org-management|billing|billing-states|members-roles|scorer|device-links|division-delete|pricing-v3|player-accounts)\.spec\.ts/;
 
 export default defineConfig({
   testDir: "./e2e",

--- a/apps/web/src/app/api/checkin/[token]/route.ts
+++ b/apps/web/src/app/api/checkin/[token]/route.ts
@@ -1,0 +1,20 @@
+import { handler } from "@/lib/http";
+import { requireUser } from "@/lib/auth";
+import { verifyCheckinToken } from "@/server/usecases/checkin-token";
+import { checkInToFixture } from "@/server/usecases/me";
+
+type Ctx = { params: Promise<{ token: string }> };
+
+/** QR self-check-in (PROMPT-53): stamp presence for the caller's claimed
+ *  person on the fixture. No claimed person → needs_claim (the page shows
+ *  the claim-first interstitial, never an error). */
+export async function POST(_req: Request, { params }: Ctx) {
+  return handler(async () => {
+    const user = await requireUser();
+    const { token } = await params;
+    const fixtureId = await verifyCheckinToken(token);
+    const row = await checkInToFixture(user.id, fixtureId);
+    if (!row) return { needs_claim: true as const };
+    return { checked_in: true as const, status: row.status, checked_in_at: row.checked_in_at };
+  });
+}

--- a/apps/web/src/app/api/claims/[token]/accept/route.ts
+++ b/apps/web/src/app/api/claims/[token]/accept/route.ts
@@ -1,0 +1,20 @@
+import { handler } from "@/lib/http";
+import { requireUser } from "@/lib/auth";
+import { claimPerson } from "@/server/usecases/person-claims";
+
+type Ctx = { params: Promise<{ token: string }> };
+
+/** Accept a claim (PROMPT-53): link persons.user_id to the logged-in caller.
+ *  Racing accepts are resolved in the usecase — exactly one wins. */
+export async function POST(_req: Request, { params }: Ctx) {
+  return handler(async () => {
+    const user = await requireUser();
+    const { token } = await params;
+    const claim = await claimPerson(token, user.id);
+    return {
+      person_id: claim.person_id,
+      person_name: claim.person_name,
+      org_name: claim.org_name,
+    };
+  });
+}

--- a/apps/web/src/app/api/claims/[token]/accept/route.ts
+++ b/apps/web/src/app/api/claims/[token]/accept/route.ts
@@ -10,7 +10,7 @@ export async function POST(_req: Request, { params }: Ctx) {
   return handler(async () => {
     const user = await requireUser();
     const { token } = await params;
-    const claim = await claimPerson(token, user.id);
+    const claim = await claimPerson(token, user.id, user.email);
     return {
       person_id: claim.person_id,
       person_name: claim.person_name,

--- a/apps/web/src/app/api/claims/[token]/route.ts
+++ b/apps/web/src/app/api/claims/[token]/route.ts
@@ -1,0 +1,19 @@
+import { handler } from "@/lib/http";
+import { resolveClaimToken } from "@/server/usecases/person-claims";
+
+type Ctx = { params: Promise<{ token: string }> };
+
+/** Claim status view (PROMPT-53): the token IS the auth — mirrors
+ *  /api/invites. Distinct error codes (CLAIM_INVALID/REVOKED/EXPIRED/CLAIMED)
+ *  drive the /claim page's dead-end states. */
+export async function GET(_req: Request, { params }: Ctx) {
+  return handler(async () => {
+    const { token } = await params;
+    const claim = await resolveClaimToken(token);
+    return {
+      person_name: claim.person_name,
+      org_name: claim.org_name,
+      email: claim.email,
+    };
+  });
+}

--- a/apps/web/src/app/api/v1/fixtures/[id]/checkin-link/route.ts
+++ b/apps/web/src/app/api/v1/fixtures/[id]/checkin-link/route.ts
@@ -1,0 +1,18 @@
+import { v1, reply } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { createCheckinLink } from "@/server/usecases/checkin-token";
+import { routes } from "@/lib/routes";
+import { baseUrl } from "@/lib/oauth";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Mint the fixture's check-in QR link (PROMPT-53): signed stateless token,
+ *  dies at the end of the fixture's local day. Session editors only. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "fixture", id, "write");
+    const { token, expires_at } = await createCheckinLink(auth, id);
+    return reply(201, { url: `${baseUrl(req)}${routes.checkin(token)}`, expires_at });
+  });
+}

--- a/apps/web/src/app/api/v1/me/fixtures/[id]/availability/route.ts
+++ b/apps/web/src/app/api/v1/me/fixtures/[id]/availability/route.ts
@@ -1,0 +1,20 @@
+import { v1, parseBody } from "@/server/api-v1/http";
+import { requireUser } from "@/lib/auth";
+import { assertUuid } from "@/server/api-v1/auth";
+import { PutAvailability } from "@/server/api-v1/schemas";
+import { setMyAvailability } from "@/server/usecases/me";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** RSVP (PROMPT-53): in/out/maybe + note, upsert per (fixture, my person).
+ *  Session only — the fixture must involve one of the caller's claimed
+ *  persons (403 NOT_YOUR_FIXTURE otherwise). */
+export async function PUT(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    assertUuid(id, "fixture");
+    const body = await parseBody(req, PutAvailability);
+    const user = await requireUser();
+    return setMyAvailability(user.id, id, body);
+  });
+}

--- a/apps/web/src/app/api/v1/me/fixtures/route.ts
+++ b/apps/web/src/app/api/v1/me/fixtures/route.ts
@@ -1,0 +1,13 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireUser } from "@/lib/auth";
+import { listMyFixtures } from "@/server/usecases/me";
+
+/** The player home read (PROMPT-53): upcoming fixtures, recent results and
+ *  teams for every claimed person of the caller, across all orgs. Session
+ *  only — mirrors /me/assigned-fixtures. */
+export async function GET() {
+  return v1(async () => {
+    const user = await requireUser();
+    return listMyFixtures(user.id);
+  });
+}

--- a/apps/web/src/app/api/v1/me/persons/[id]/consent/route.ts
+++ b/apps/web/src/app/api/v1/me/persons/[id]/consent/route.ts
@@ -1,0 +1,20 @@
+import { v1, parseBody } from "@/server/api-v1/http";
+import { requireUser } from "@/lib/auth";
+import { assertUuid } from "@/server/api-v1/auth";
+import { PatchMyConsent } from "@/server/api-v1/schemas";
+import { setMyConsent } from "@/server/usecases/me";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Player-owned consent flags (PROMPT-53, doc 06 §4.7 handover). Guardian
+ *  gate: under-16 by dob → 403 CONSENT_LOCKED, organiser values hold. The
+ *  write revalidates the person's public pages immediately. Session only. */
+export async function PATCH(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    assertUuid(id, "person");
+    const body = await parseBody(req, PatchMyConsent);
+    const user = await requireUser();
+    return setMyConsent(user.id, id, body);
+  });
+}

--- a/apps/web/src/app/api/v1/me/persons/route.ts
+++ b/apps/web/src/app/api/v1/me/persons/route.ts
@@ -1,0 +1,12 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireUser } from "@/lib/auth";
+import { listMyPersons } from "@/server/usecases/me";
+
+/** My claimed player profiles across orgs, with consent state (PROMPT-53).
+ *  dob never rides out — only the derived consent_locked flag. Session only. */
+export async function GET() {
+  return v1(async () => {
+    const user = await requireUser();
+    return listMyPersons(user.id);
+  });
+}

--- a/apps/web/src/app/api/v1/persons/[id]/claim-invites/route.ts
+++ b/apps/web/src/app/api/v1/persons/[id]/claim-invites/route.ts
@@ -1,0 +1,46 @@
+import { v1, parseBody, reply } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { CreateClaimInvite } from "@/server/api-v1/schemas";
+import {
+  createClaimInvite,
+  getOpenClaim,
+  revokeClaimInvite,
+} from "@/server/usecases/person-claims";
+import { sendClaimInviteEmail } from "@/lib/email";
+import { routes } from "@/lib/routes";
+import { baseUrl } from "@/lib/oauth";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Invite the person to claim their profile (PROMPT-53). Session editors
+ *  only (enforced in the usecase); the claim_url embeds the one-time secret.
+ *  Email delivery is best-effort — the console shows the copyable link + QR. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const { email } = await parseBody(req, CreateClaimInvite);
+    const auth = await requireResourceAuth(req, "person", id, "write");
+    const { secret, person_name, org_name, ...claim } = await createClaimInvite(auth, id, email);
+    const claim_url = `${baseUrl(req)}${routes.claim(secret)}`;
+    await sendClaimInviteEmail(email, { orgName: org_name, personName: person_name, claimUrl: claim_url });
+    return reply(201, { ...claim, claim_url });
+  });
+}
+
+/** The person's open invite, if any (no secret — it showed once). */
+export async function GET(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "person", id, "read");
+    return getOpenClaim(auth, id);
+  });
+}
+
+/** Withdraw the open invite (idempotent). */
+export async function DELETE(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "person", id, "write");
+    return revokeClaimInvite(auth, id);
+  });
+}

--- a/apps/web/src/app/api/v1/persons/[id]/claim-invites/route.ts
+++ b/apps/web/src/app/api/v1/persons/[id]/claim-invites/route.ts
@@ -22,8 +22,14 @@ export async function POST(req: Request, { params }: Ctx) {
     const auth = await requireResourceAuth(req, "person", id, "write");
     const { secret, person_name, org_name, ...claim } = await createClaimInvite(auth, id, email);
     const claim_url = `${baseUrl(req)}${routes.claim(secret)}`;
-    await sendClaimInviteEmail(email, { orgName: org_name, personName: person_name, claimUrl: claim_url });
-    return reply(201, { ...claim, claim_url });
+    // Email is the primary channel (owner decision 2026-07-13); the console
+    // shows the send outcome honestly and keeps the copyable link as fallback.
+    const email_sent = await sendClaimInviteEmail(email, {
+      orgName: org_name,
+      personName: person_name,
+      claimUrl: claim_url,
+    });
+    return reply(201, { ...claim, claim_url, email_sent });
   });
 }
 

--- a/apps/web/src/app/api/v1/persons/[id]/unlink/route.ts
+++ b/apps/web/src/app/api/v1/persons/[id]/unlink/route.ts
@@ -1,0 +1,16 @@
+import { v1 } from "@/server/api-v1/http";
+import { requireResourceAuth } from "@/server/api-v1/auth";
+import { unlinkPerson } from "@/server/usecases/person-claims";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** Staff unlink (PROMPT-53): detach the player login, revoke live claims.
+ *  Claim rows stay — claimed_at + revoked_at are the audit trail. */
+export async function POST(req: Request, { params }: Ctx) {
+  return v1(async () => {
+    const { id } = await params;
+    const auth = await requireResourceAuth(req, "person", id, "write");
+    await unlinkPerson(auth, id);
+    return { unlinked: true };
+  });
+}

--- a/apps/web/src/app/checkin/[token]/page.tsx
+++ b/apps/web/src/app/checkin/[token]/page.tsx
@@ -1,0 +1,62 @@
+// QR self-check-in landing (PROMPT-53): scanned at the venue. Logged out →
+// auth card with next back here; logged in → one tap to check in. The write
+// happens on the button POST, never on this GET (link scanners and prefetch
+// must not check anyone in). Unclaimed scanners get the claim-first
+// interstitial, not an error.
+import { getCurrentUser } from "@/lib/auth";
+import { HttpError } from "@/lib/errors";
+import { verifyCheckinToken } from "@/server/usecases/checkin-token";
+import { msg } from "@/lib/messages";
+import { AuthForm } from "@/components/auth-form";
+import { NightStage } from "@/components/night-stage";
+import { CheckinAction } from "@/components/checkin-action";
+
+export default async function CheckinPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const user = await getCurrentUser();
+
+  let dead: string | null = null;
+  try {
+    await verifyCheckinToken(token);
+  } catch (err) {
+    dead = err instanceof HttpError ? err.message : "This check-in code is not valid";
+  }
+
+  return (
+    <NightStage maxW="max-w-md">
+      {dead ? (
+        <div className="card p-6 text-center">
+          <h1 className="text-xl font-bold text-purple-900">{msg("checkin.title")}</h1>
+          <p className="mt-2 text-sm text-slate-500">{dead}</p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-6 text-center">
+            <h1 className="app-display text-3xl font-bold tracking-tight text-cream">
+              {msg("checkin.title")}
+            </h1>
+            <p className="mt-2 text-sm text-cream/70">
+              Tell the organiser you&apos;ve arrived — one tap.
+            </p>
+          </div>
+          {user ? (
+            <div className="card p-6">
+              <CheckinAction token={token} />
+            </div>
+          ) : (
+            <>
+              <p className="mb-4 text-center text-sm text-cream/70">
+                Sign in to check in — no password needed.
+              </p>
+              <AuthForm next={`/checkin/${token}`} />
+            </>
+          )}
+        </>
+      )}
+    </NightStage>
+  );
+}

--- a/apps/web/src/app/claim/[token]/page.tsx
+++ b/apps/web/src/app/claim/[token]/page.tsx
@@ -1,0 +1,94 @@
+// Claim a player profile (PROMPT-53): the emailed/QR link lands here. Logged
+// out → the auth card (magic-link) with next back to this page; logged in →
+// one-tap confirm. Each dead-end token state gets its own copy — never a
+// vague shared error.
+import { getCurrentUser } from "@/lib/auth";
+import { HttpError } from "@/lib/errors";
+import { resolveClaimToken, type ResolvedClaim } from "@/server/usecases/person-claims";
+import { AuthForm } from "@/components/auth-form";
+import { NightStage } from "@/components/night-stage";
+import { ClaimAccept } from "@/components/claim-accept";
+
+const DEAD_ENDS: Record<string, { title: string; body: string }> = {
+  CLAIM_INVALID: {
+    title: "Link not recognised",
+    body: "This claim link is not valid. Check you copied the whole link, or ask the organiser to send a fresh invite.",
+  },
+  CLAIM_EXPIRED: {
+    title: "Invite expired",
+    body: "Claim invites work for 14 days. Ask the organiser to send a new one — your profile is still there waiting.",
+  },
+  CLAIM_REVOKED: {
+    title: "Invite withdrawn",
+    body: "The organiser withdrew this invite. If that's unexpected, ask them to send a new one.",
+  },
+  CLAIM_CLAIMED: {
+    title: "Already claimed",
+    body: "This profile is already linked to an account. If that was you, just log in. If not, contact the organiser.",
+  },
+};
+
+export default async function ClaimPage({
+  params,
+}: {
+  params: Promise<{ token: string }>;
+}) {
+  const { token } = await params;
+  const user = await getCurrentUser();
+
+  let claim: ResolvedClaim | null = null;
+  let deadEnd: { title: string; body: string } | null = null;
+  try {
+    claim = await resolveClaimToken(token);
+  } catch (err) {
+    const code = err instanceof HttpError ? err.code : undefined;
+    deadEnd = DEAD_ENDS[code ?? "CLAIM_INVALID"] ?? DEAD_ENDS.CLAIM_INVALID;
+  }
+
+  return (
+    <NightStage maxW="max-w-md">
+      {deadEnd || !claim ? (
+        <div className="card p-6 text-center">
+          <h1 className="text-xl font-bold text-purple-900">{deadEnd?.title}</h1>
+          <p className="mt-2 text-sm text-slate-500">{deadEnd?.body}</p>
+        </div>
+      ) : (
+        <>
+          <div className="mb-6 text-center">
+            <h1 className="app-display text-3xl font-bold tracking-tight text-cream">
+              Claim your profile
+            </h1>
+            <p className="mt-2 text-sm text-cream/70">
+              <span className="font-medium text-lime-400">{claim.org_name}</span> set up a
+              player profile for <span className="font-medium text-lime-400">{claim.person_name}</span>.
+              Claiming it shows your matches in one place, lets you RSVP availability, and puts
+              your public visibility in your hands.
+            </p>
+          </div>
+          {user ? (
+            <div className="card p-6">
+              <p className="mb-1 text-sm text-slate-600">
+                Signed in as <span className="font-medium text-purple-700">{user.display_name}</span>{" "}
+                <span className="text-slate-400">({user.email})</span>
+              </p>
+              {user.email.toLowerCase() !== claim.email.toLowerCase() && (
+                <p className="mb-3 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
+                  This invite was sent to {claim.email}. That&apos;s fine if both are you —
+                  the profile links to the account you&apos;re signed in with now.
+                </p>
+              )}
+              <ClaimAccept token={token} personName={claim.person_name} />
+            </div>
+          ) : (
+            <>
+              <p className="mb-4 text-center text-sm text-cream/70">
+                Sign in or create an account to claim it — no password needed.
+              </p>
+              <AuthForm next={`/claim/${token}`} />
+            </>
+          )}
+        </>
+      )}
+    </NightStage>
+  );
+}

--- a/apps/web/src/app/claim/[token]/page.tsx
+++ b/apps/web/src/app/claim/[token]/page.tsx
@@ -66,19 +66,29 @@ export default async function ClaimPage({
             </p>
           </div>
           {user ? (
-            <div className="card p-6">
-              <p className="mb-1 text-sm text-slate-600">
-                Signed in as <span className="font-medium text-purple-700">{user.display_name}</span>{" "}
-                <span className="text-slate-400">({user.email})</span>
-              </p>
-              {user.email.toLowerCase() !== claim.email.toLowerCase() && (
-                <p className="mb-3 rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-700">
-                  This invite was sent to {claim.email}. That&apos;s fine if both are you —
-                  the profile links to the account you&apos;re signed in with now.
+            user.email.toLowerCase() === claim.email.toLowerCase() ? (
+              <div className="card p-6">
+                <p className="mb-3 text-sm text-slate-600">
+                  Signed in as <span className="font-medium text-purple-700">{user.display_name}</span>{" "}
+                  <span className="text-slate-400">({user.email})</span>
                 </p>
-              )}
-              <ClaimAccept token={token} personName={claim.person_name} />
-            </div>
+                <ClaimAccept token={token} personName={claim.person_name} />
+              </div>
+            ) : (
+              // Strict match (owner decision 2026-07-13): the invited address
+              // is the identity check — a forwarded link alone must not move
+              // the profile to a different account.
+              <div className="card p-6">
+                <h2 className="text-base font-bold text-purple-900">Wrong account for this invite</h2>
+                <p className="mt-2 text-sm text-slate-600">
+                  This invite was sent to{" "}
+                  <span className="font-medium text-purple-700">{claim.email}</span>, but
+                  you&apos;re signed in as <span className="font-medium">{user.email}</span>.
+                  Sign out, then sign in with the invited address to claim it. Wrong address
+                  on the invite? Ask the organiser to re-send it.
+                </p>
+              </div>
+            )
           ) : (
             <>
               <p className="mb-4 text-center text-sm text-cream/70">

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -2,10 +2,17 @@ export const dynamic = "force-dynamic";
 // Legacy home — the console lives at /o/[orgSlug] now (PROMPT-30). Temporary
 // redirect: the target depends on the viewer's active org.
 import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { isPlayerOnly } from "@/server/usecases/me";
 import { requirePageAuth } from "@/server/page-auth";
 import { routes } from "@/lib/routes";
 
 export default async function LegacyDashboard() {
+  // Claimed players without an org go home to /me (PROMPT-53) — BEFORE
+  // requirePageAuth, which would auto-provision them a "My organization".
+  const user = await getCurrentUser();
+  if (user && (await isPlayerOnly(user.id))) redirect(routes.me());
+
   const { org } = await requirePageAuth();
   redirect(routes.orgHome(org.slug));
 }

--- a/apps/web/src/app/directory/page.tsx
+++ b/apps/web/src/app/directory/page.tsx
@@ -79,6 +79,8 @@ async function PlayersTab() {
           consent: p.consent as { public_name?: boolean; public_photo?: boolean },
           external_ref: p.external_ref,
           photo_path: p.photo_path,
+          user_id: p.user_id,
+          claim_pending: p.claim_pending,
         }))}
         storageBase={storageBase}
         canEdit={canEdit}

--- a/apps/web/src/app/help/page.tsx
+++ b/apps/web/src/app/help/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import {
   ArrowRight, CalendarClock, ClipboardList, CreditCard, LayoutGrid,
-  Megaphone, Play, Rocket, Trophy, Users, Webhook,
+  Megaphone, Play, Rocket, Trophy, UserCheck, Users, Webhook,
 } from "lucide-react";
 import { helpNav } from "@/server/help-content";
 import { HelpSearch } from "@/components/help-search";
@@ -12,6 +12,7 @@ const SECTION_ICONS: Record<string, React.ComponentType<{ className?: string; st
   "getting-started": Rocket,
   formats: LayoutGrid,
   entrants: Users,
+  players: UserCheck,
   registration: ClipboardList,
   scheduling: CalendarClock,
   scoring: Play,

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -1,0 +1,204 @@
+export const dynamic = "force-dynamic";
+// Player home (PROMPT-53, doc 16 §1.3): the claimed player's locker room —
+// cross-org schedule with RSVP, recent results, teams, and the consent card.
+// Deliberately NOT org-scoped and NO org nav: a player may belong to three
+// clubs and none of their consoles. All plans, free included.
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getCurrentUser } from "@/lib/auth";
+import { routes } from "@/lib/routes";
+import { msg } from "@/lib/messages";
+import { listMyFixtures, listMyPersons, type MyFixture, type MyResult } from "@/server/usecases/me";
+import { RsvpControl } from "@/components/me/rsvp-control";
+import { ConsentCard } from "@/components/me/consent-card";
+import { LogoutButton } from "@/components/logout-button";
+
+export default async function MePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ claimed?: string }>;
+}) {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login?next=/me");
+  const [{ upcoming, results, teams }, persons] = await Promise.all([
+    listMyFixtures(user.id),
+    listMyPersons(user.id),
+  ]);
+  const { claimed } = await searchParams;
+  const [next, ...rest] = upcoming;
+
+  return (
+    <>
+      <header className="app-gantry">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3">
+          <span className="app-display text-base font-bold leading-none text-cream">
+            Seazn <span className="text-lime-400">Club</span>
+          </span>
+          <span className="text-sm text-cream/60">{msg("me.eyebrow")}</span>
+          <div className="flex-1" />
+          <span className="text-xs text-cream/60">{user.display_name}</span>
+          <LogoutButton />
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-8">
+        {claimed && (
+          <p className="mb-6 rounded-lg bg-lime-100 px-4 py-3 text-sm font-medium text-lime-900">
+            {msg("me.claimed")}
+          </p>
+        )}
+        <h1 className="page-title mb-6">{msg("me.title")}</h1>
+
+        {upcoming.length === 0 && results.length === 0 && (
+          <p className="card p-6 text-sm text-slate-500">{msg("me.empty")}</p>
+        )}
+
+        {next && (
+          <section className="app-empty-tile mb-8 rounded-2xl p-5 sm:p-6">
+            <p className="app-eyebrow mb-3 !text-lime-400">{msg("me.next.title")}</p>
+            <div className="flex flex-wrap items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="app-display text-2xl font-bold leading-tight text-cream sm:text-3xl">
+                  {next.entrant_name ?? "TBD"}{" "}
+                  <span className="text-cream/50">vs</span>{" "}
+                  {next.opponent_name ?? "TBD"}
+                </p>
+                <p className="mt-1.5 text-sm text-cream/70">
+                  <FixtureContext f={next} /> · {when(next.scheduled_at)}
+                  {next.venue ? ` · ${next.venue}` : ""}
+                  {next.court_label ? ` · ${next.court_label}` : ""}
+                </p>
+                {publicHref(next) && (
+                  <Link
+                    href={publicHref(next)!}
+                    className="mt-1 inline-block text-xs text-lime-400 underline decoration-lime-400/40 underline-offset-2 hover:decoration-lime-400"
+                  >
+                    Match page
+                  </Link>
+                )}
+              </div>
+              <div className="w-full sm:w-auto sm:min-w-[16rem]">
+                <RsvpControl
+                  fixtureId={next.id}
+                  initial={next.availability}
+                  checkedInAt={next.checked_in_at}
+                  onDark
+                />
+              </div>
+            </div>
+          </section>
+        )}
+
+        {rest.length > 0 && (
+          <section className="mb-8">
+            <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+              {msg("me.upcoming.title")}
+            </h2>
+            <ul className="space-y-2">
+              {rest.map((f) => (
+                <li key={`${f.id}:${f.person_id}`} className="card space-y-2 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-slate-800">
+                        {f.entrant_name ?? "TBD"} <span className="text-slate-400">vs</span>{" "}
+                        {f.opponent_name ?? "TBD"}
+                      </p>
+                      <p className="mt-0.5 text-xs text-slate-400">
+                        <FixtureContext f={f} /> · {when(f.scheduled_at)}
+                        {f.venue ? ` · ${f.venue}` : ""}
+                      </p>
+                    </div>
+                    {publicHref(f) && (
+                      <Link
+                        href={publicHref(f)!}
+                        className="text-xs text-purple-600 hover:underline"
+                      >
+                        Match page
+                      </Link>
+                    )}
+                  </div>
+                  <RsvpControl
+                    fixtureId={f.id}
+                    initial={f.availability}
+                    checkedInAt={f.checked_in_at}
+                  />
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {results.length > 0 && (
+          <section className="mb-8">
+            <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+              {msg("me.results.title")}
+            </h2>
+            <ul className="space-y-2">
+              {results.map((r) => (
+                <li key={r.id} className="card flex flex-wrap items-center gap-3 p-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-slate-800">
+                      {r.entrant_name ?? "TBD"} <span className="text-slate-400">vs</span>{" "}
+                      {r.opponent_name ?? "TBD"}
+                    </p>
+                    <p className="mt-0.5 text-xs text-slate-400">
+                      {r.competition_name} · {r.division_name} · {r.org_name}
+                    </p>
+                  </div>
+                  <span className="app-display text-lg font-bold text-slate-700">
+                    {headline(r) ?? "—"}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {teams.length > 0 && (
+          <section className="mb-8">
+            <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+              {msg("me.teams.title")}
+            </h2>
+            <ul className="flex flex-wrap gap-2">
+              {teams.map((t) => (
+                <li
+                  key={t.entrant_id}
+                  className="rounded-full border border-slate-200 bg-surface px-3 py-1.5 text-xs text-slate-600"
+                >
+                  <span className="font-medium text-slate-800">{t.entrant_name}</span>{" "}
+                  · {t.division_name} · {t.org_name}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {persons.length > 0 && <ConsentCard persons={persons} />}
+      </main>
+    </>
+  );
+}
+
+function FixtureContext({ f }: { f: MyFixture }) {
+  return (
+    <>
+      {f.competition_name} · {f.division_name} · {f.org_name}
+    </>
+  );
+}
+
+function when(iso: string | null): string {
+  if (!iso) return "unscheduled";
+  return new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+/** Spectator link — only competitions with a public page get one. */
+function publicHref(f: MyFixture): string | null {
+  if (f.competition_visibility !== "public" && f.competition_visibility !== "unlisted") return null;
+  return routes.sharedFixture(f.org_slug, f.competition_slug, f.division_slug, f.id);
+}
+
+function headline(r: MyResult): string | null {
+  const s = r.summary as { headline?: string } | null;
+  return s?.headline ?? null;
+}

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 // clubs and none of their consoles. All plans, free included.
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { getCurrentUser } from "@/lib/auth";
+import { getActiveOrgId, getCurrentUser, getUserOrgs } from "@/lib/auth";
 import { routes } from "@/lib/routes";
 import { msg } from "@/lib/messages";
 import { listMyFixtures, listMyPersons, type MyFixture, type MyResult } from "@/server/usecases/me";
@@ -20,10 +20,16 @@ export default async function MePage({
 }) {
   const user = await getCurrentUser();
   if (!user) redirect("/login?next=/me");
-  const [{ upcoming, results, teams }, persons] = await Promise.all([
+  const [{ upcoming, results, teams }, persons, orgs, activeOrgId] = await Promise.all([
     listMyFixtures(user.id),
     listMyPersons(user.id),
+    // Dual-role seam: organisers who are also players get a door back.
+    // Read-only resolve — resolveActiveOrg repairs the cookie, which a
+    // Server Component render is not allowed to do.
+    getUserOrgs(user.id),
+    getActiveOrgId(),
   ]);
+  const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? orgs[0] ?? null;
   const { claimed } = await searchParams;
   const [next, ...rest] = upcoming;
 
@@ -36,6 +42,14 @@ export default async function MePage({
           </span>
           <span className="text-sm text-cream/60">{msg("me.eyebrow")}</span>
           <div className="flex-1" />
+          {activeOrg && (
+            <Link
+              href={routes.orgHome(activeOrg.slug)}
+              className="rounded-md px-2.5 py-1.5 text-sm font-medium text-cream/70 transition-colors hover:bg-cream/10 hover:text-cream"
+            >
+              ← Console
+            </Link>
+          )}
           <span className="text-xs text-cream/60">{user.display_name}</span>
           <LogoutButton />
         </div>

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -174,6 +174,15 @@ export default async function MePage({
         )}
 
         {persons.length > 0 && <ConsentCard persons={persons} />}
+
+        {/* Growth seam (PROMPT-53): every claimed player is a future
+            organiser. Quiet, last, and only when they run nothing yet. */}
+        <p className="mt-10 text-center text-xs text-slate-400">
+          Run your own league or tournament?{" "}
+          <Link href="/orgs/new" className="text-purple-600 hover:underline">
+            Create an organisation
+          </Link>
+        </p>
       </main>
     </>
   );

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
@@ -21,6 +21,8 @@ import {
   type LineupSlotIn,
 } from "@/components/v2/fixture-console";
 import { DeviceLinkPanel } from "@/components/v2/device-link-panel";
+import { listFixtureAvailability } from "@/server/usecases/me";
+import { CheckinQr } from "@/components/v2/checkin-qr";
 
 export default async function FixturePage({
   params,
@@ -35,11 +37,12 @@ export default async function FixturePage({
   const id = page.fixtureId;
   const isScorer = auth.role === "scorer";
   const fixture = await getFixture(auth, id);
-  const [division, state, events, recorderNames] = await Promise.all([
+  const [division, state, events, recorderNames, availability] = await Promise.all([
     getDivision(auth, fixture.division_id),
     getFixtureState(auth, id),
     listEvents(auth, id, 0),
     eventRecorderNames(auth, id),
+    listFixtureAvailability(auth, id),
   ]);
   const competition = await getCompetition(auth, division.competition_id);
   const sportModule = resolveModule(division.sport_key, division.module_version);
@@ -115,6 +118,7 @@ export default async function FixturePage({
           }))}
           canEdit={canScore && !(competition.frozen ?? false)}
           recorderNames={recorderNames}
+          availability={availability}
           publicPath={
             // Share needs a page strangers can open (v3/10 #2) — private
             // competitions have none.
@@ -135,6 +139,10 @@ export default async function FixturePage({
                 fixtureId={fixture.id}
                 scorerLabel={sportModule.officialLabel.scorer}
               />
+              {/* Player self-check-in QR (PROMPT-53) — all plans. */}
+              <div className="mt-3">
+                <CheckinQr fixtureId={fixture.id} />
+              </div>
             </div>
           )}
       </main>

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
@@ -79,6 +79,18 @@ export default async function FixturePage({
           </p>
         )}
 
+        {/* Player self-check-in QR (PROMPT-53) — top of the match panel, and
+            only BEFORE the match starts (owner feedback 2026-07-13): check-in
+            is an arrival tool, once play begins it's just noise. */}
+        {!isScorer &&
+          canScore &&
+          !(competition.frozen ?? false) &&
+          fixture.status === "scheduled" && (
+            <div className="mb-3 flex justify-end">
+              <CheckinQr fixtureId={fixture.id} />
+            </div>
+          )}
+
         <FixtureConsole
           fixture={{
             id: fixture.id,
@@ -139,10 +151,6 @@ export default async function FixturePage({
                 fixtureId={fixture.id}
                 scorerLabel={sportModule.officialLabel.scorer}
               />
-              {/* Player self-check-in QR (PROMPT-53) — all plans. */}
-              <div className="mt-3">
-                <CheckinQr fixtureId={fixture.id} />
-              </div>
             </div>
           )}
       </main>

--- a/apps/web/src/components/checkin-action.tsx
+++ b/apps/web/src/components/checkin-action.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+// The check-in button + result states (PROMPT-53). needs_claim renders the
+// claim-first interstitial: direction, not an error.
+import { useState } from "react";
+import { api } from "@/lib/client";
+import { msg } from "@/lib/messages";
+
+type State = "idle" | "busy" | "done" | "needs_claim";
+
+export function CheckinAction({ token }: { token: string }) {
+  const [state, setState] = useState<State>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  async function checkIn() {
+    setState("busy");
+    setError(null);
+    try {
+      const out = await api<{ checked_in?: boolean; needs_claim?: boolean }>(
+        `/api/checkin/${token}`,
+        { method: "POST" },
+      );
+      setState(out.needs_claim ? "needs_claim" : "done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to check in");
+      setState("idle");
+    }
+  }
+
+  if (state === "done") {
+    return (
+      <div className="text-center" data-testid="checkin-done">
+        <p className="text-3xl" aria-hidden>
+          ✓
+        </p>
+        <h2 className="mt-1 text-lg font-bold text-emerald-700">{msg("checkin.done.title")}</h2>
+        <p className="mt-1 text-sm text-slate-500">{msg("checkin.done.line")}</p>
+      </div>
+    );
+  }
+
+  if (state === "needs_claim") {
+    return (
+      <div className="text-center" data-testid="checkin-needs-claim">
+        <h2 className="text-lg font-bold text-purple-900">{msg("checkin.needsClaim.title")}</h2>
+        <p className="mt-1 text-sm text-slate-500">{msg("checkin.needsClaim.line")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <button
+        onClick={checkIn}
+        disabled={state === "busy"}
+        className="btn btn-primary w-full py-2.5"
+      >
+        {state === "busy" ? "Checking in…" : "I'm here — check in"}
+      </button>
+      {error && <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/claim-accept.tsx
+++ b/apps/web/src/components/claim-accept.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/client";
+import { routes } from "@/lib/routes";
+
+/** Accept a claim the current (logged-in) user is viewing (PROMPT-53). */
+export function ClaimAccept({ token, personName }: { token: string; personName: string }) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function accept() {
+    setError(null);
+    setBusy(true);
+    try {
+      await api(`/api/claims/${token}/accept`, { method: "POST" });
+      router.push(`${routes.me()}?claimed=1`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to claim");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <button onClick={accept} disabled={busy} className="btn btn-primary w-full py-2.5">
+        {busy ? "Claiming…" : `This is me — claim ${personName}`}
+      </button>
+      {error && (
+        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/me/consent-card.tsx
+++ b/apps/web/src/components/me/consent-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+// Player-owned consent card (PROMPT-53, doc 06 §4.7): one block per claimed
+// profile (a player can exist at several clubs). Guardian-locked profiles
+// render read-only with plain-language copy — the lock is server-enforced.
+import { useState } from "react";
+import { apiV1 } from "@/lib/client-v1";
+import { msg } from "@/lib/messages";
+
+export interface ConsentPerson {
+  id: string;
+  full_name: string;
+  org_name: string;
+  consent: { public_name?: boolean; public_photo?: boolean };
+  consent_locked: boolean;
+}
+
+const FLAGS = [
+  { key: "public_name" as const, label: () => msg("me.consent.name") },
+  { key: "public_photo" as const, label: () => msg("me.consent.photo") },
+];
+
+export function ConsentCard({ persons }: { persons: ConsentPerson[] }) {
+  const [state, setState] = useState(() =>
+    Object.fromEntries(persons.map((p) => [p.id, p.consent])),
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle(person: ConsentPerson, key: "public_name" | "public_photo") {
+    const prev = state[person.id];
+    const next = { ...prev, [key]: !prev[key] };
+    setState((s) => ({ ...s, [person.id]: next }));
+    setError(null);
+    try {
+      await apiV1(`/api/v1/me/persons/${person.id}/consent`, {
+        method: "PATCH",
+        json: { [key]: next[key] },
+      });
+    } catch (err) {
+      setState((s) => ({ ...s, [person.id]: prev }));
+      setError(err instanceof Error ? err.message : "Failed");
+    }
+  }
+
+  return (
+    <section className="card p-4">
+      <h2 className="mb-1 text-sm font-semibold text-slate-800">{msg("me.consent.title")}</h2>
+      <p className="mb-3 text-xs text-slate-500">{msg("me.consent.line")}</p>
+      <div className="space-y-4">
+        {persons.map((p) => (
+          <div key={p.id}>
+            <p className="mb-1.5 text-xs font-medium uppercase tracking-wide text-slate-400">
+              {p.full_name} · {p.org_name}
+            </p>
+            <div className="space-y-1.5">
+              {FLAGS.map((f) => (
+                <label
+                  key={f.key}
+                  className={`flex items-center gap-2 text-sm ${
+                    p.consent_locked ? "text-slate-400" : "text-slate-600"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    disabled={p.consent_locked}
+                    checked={!!state[p.id]?.[f.key]}
+                    onChange={() => toggle(p, f.key)}
+                    className="h-4 w-4 rounded border-purple-200 accent-purple-600"
+                  />
+                  {f.label()}
+                </label>
+              ))}
+            </div>
+            {p.consent_locked && (
+              <p className="mt-1 text-xs text-slate-400">{msg("me.consent.locked")}</p>
+            )}
+          </div>
+        ))}
+      </div>
+      {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+    </section>
+  );
+}

--- a/apps/web/src/components/me/rsvp-control.tsx
+++ b/apps/web/src/components/me/rsvp-control.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+// RSVP segmented control (PROMPT-53): In / Maybe / Out as three floodlit
+// buttons, optimistic write, note folds out once a state is picked. `onDark`
+// styles it for the Next-match night hero; default is the light list rows.
+import { useState } from "react";
+import { apiV1 } from "@/lib/client-v1";
+import { msg } from "@/lib/messages";
+
+type Status = "in" | "out" | "maybe";
+
+const OPTIONS: { value: Status; mark: string; label: () => string }[] = [
+  { value: "in", mark: "✓", label: () => msg("me.rsvp.in") },
+  { value: "maybe", mark: "?", label: () => msg("me.rsvp.maybe") },
+  { value: "out", mark: "✗", label: () => msg("me.rsvp.out") },
+];
+
+const ACTIVE: Record<Status, string> = {
+  in: "bg-emerald-500 border-emerald-500 text-white",
+  maybe: "bg-amber-400 border-amber-400 text-slate-900",
+  out: "bg-zinc-500 border-zinc-500 text-white",
+};
+
+export function RsvpControl({
+  fixtureId,
+  initial,
+  checkedInAt,
+  onDark = false,
+}: {
+  fixtureId: string;
+  initial: { status: Status; note: string | null } | null;
+  checkedInAt: string | null;
+  onDark?: boolean;
+}) {
+  const [status, setStatus] = useState<Status | null>(initial?.status ?? null);
+  const [note, setNote] = useState(initial?.note ?? "");
+  const [savedNote, setSavedNote] = useState(initial?.note ?? "");
+  const [flash, setFlash] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function save(next: Status, nextNote: string) {
+    const prev = status;
+    setStatus(next);
+    setError(null);
+    try {
+      await apiV1(`/api/v1/me/fixtures/${fixtureId}/availability`, {
+        method: "PUT",
+        json: { status: next, note: nextNote.trim() || null },
+      });
+      setSavedNote(nextNote);
+      setFlash(true);
+      setTimeout(() => setFlash(false), 1600);
+    } catch (err) {
+      setStatus(prev);
+      setError(err instanceof Error ? err.message : "Failed");
+    }
+  }
+
+  const idle = onDark
+    ? "border-cream/25 text-cream/80 hover:border-cream/60"
+    : "border-slate-200 text-slate-500 hover:border-slate-400";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2" role="group" aria-label="Availability">
+        {OPTIONS.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            aria-pressed={status === o.value}
+            onClick={() => save(o.value, note)}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition ${
+              status === o.value ? ACTIVE[o.value] : idle
+            }`}
+          >
+            <span aria-hidden>{o.mark}</span>
+            {o.label()}
+          </button>
+        ))}
+        {checkedInAt && (
+          <span className="badge bg-lime-100 text-lime-800">{msg("me.checkedin")}</span>
+        )}
+        {flash && (
+          <span className={`text-xs ${onDark ? "text-lime-400" : "text-emerald-600"}`}>
+            {msg("me.rsvp.saved")}
+          </span>
+        )}
+      </div>
+      {status && (
+        <input
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          onBlur={() => {
+            if (note !== savedNote && status) void save(status, note);
+          }}
+          placeholder={msg("me.rsvp.notePlaceholder")}
+          aria-label={msg("me.rsvp.notePlaceholder")}
+          className={
+            onDark
+              ? "w-full rounded-md border border-cream/20 bg-white/5 px-3 py-1.5 text-sm text-cream placeholder:text-cream/40 focus:border-lime-400 focus:outline-none"
+              : "input py-1.5 text-sm"
+          }
+        />
+      )}
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -1,7 +1,8 @@
 import Link from "@/components/ui/console-link";
-import { LayoutDashboard, Settings, Users } from "lucide-react";
+import { CircleUserRound, LayoutDashboard, Settings, Users } from "lucide-react";
 import { HelpMenu } from "@/components/help-menu";
 import { getActiveOrgId, getCurrentUser, getUserOrgs } from "@/lib/auth";
+import { hasClaimedProfile } from "@/server/usecases/me";
 import { routes } from "@/lib/routes";
 import { needsTourAfterOnboarding } from "@/lib/activation";
 import { EDITOR_ROLES } from "@/lib/types";
@@ -34,6 +35,7 @@ export async function Nav() {
     }
   }
   const logoUrl = activeOrg ? orgLogoUrl(activeOrg) : null;
+  const isPlayer = !!user && (await hasClaimedProfile(user.id));
   // Tour targets editor flows (rename org, create competition) — viewers skip it.
   const canTour =
     !!user && !!activeOrg && (EDITOR_ROLES as readonly string[]).includes(activeOrg.role);
@@ -102,6 +104,18 @@ export async function Nav() {
                 <Settings className="h-4 w-4" strokeWidth={1.75} />
                 <span className="hidden sm:inline">Settings</span>
               </Link>
+              {/* Dual-role seam (PROMPT-53): an organiser who is ALSO a
+                  claimed player keeps a door to their own player home. */}
+              {isPlayer && (
+                <Link
+                  href={routes.me()}
+                  aria-label="Player home"
+                  className="flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-cream/85 transition-colors hover:bg-cream/10 hover:text-cream"
+                >
+                  <CircleUserRound className="h-4 w-4" strokeWidth={1.75} />
+                  <span className="hidden sm:inline">Player home</span>
+                </Link>
+              )}
             </nav>
             {/* The console "?" menu (v3/06 §3): closes on outside click/Esc. */}
             <HelpMenu />

--- a/apps/web/src/components/ui/tip.tsx
+++ b/apps/web/src/components/ui/tip.tsx
@@ -11,7 +11,16 @@ import { Info, X } from "lucide-react";
 import { TIPS, type TipId } from "@/config/tips";
 import { helpUrl } from "@/lib/help";
 
-export function Tip({ id, className = "" }: { id: TipId; className?: string }) {
+export function Tip({
+  id,
+  className = "",
+  small = false,
+}: {
+  id: TipId;
+  className?: string;
+  /** Table headers and other dense chrome — smaller ⓘ, same popover. */
+  small?: boolean;
+}) {
   const { title, body, helpSlug } = TIPS[id];
   const href = helpUrl(helpSlug);
   const [open, setOpen] = useState(false);
@@ -40,19 +49,33 @@ export function Tip({ id, className = "" }: { id: TipId; className?: string }) {
         aria-expanded={open}
         aria-label={`About: ${title}`}
         onClick={() => setOpen((v) => !v)}
-        className="grid h-5 w-5 place-items-center rounded-full text-slate-400 transition hover:text-purple-600"
+        className={`grid place-items-center rounded-full text-slate-400 transition hover:text-purple-600 ${
+          small ? "h-3.5 w-3.5" : "h-5 w-5"
+        }`}
       >
-        <Info className="h-3.5 w-3.5" strokeWidth={2} />
+        <Info className={small ? "h-3 w-3" : "h-3.5 w-3.5"} strokeWidth={2} />
       </button>
       {open && (
+        // normal-case/tracking-normal: hosts like table headers set uppercase
+        // + letter-spacing that the popover must never inherit — the copy
+        // renders at the standard tip size everywhere. `small` right-aligns:
+        // dense hosts sit in clipping scroll containers where a centered
+        // popover runs off the edge.
         <span
           role="note"
-          className="absolute left-1/2 top-7 z-30 w-64 -translate-x-1/2 rounded-xl border border-purple-100 bg-white p-3 text-left shadow-lg"
+          className={`absolute z-30 w-64 rounded-xl border border-purple-100 bg-white p-3 text-left normal-case tracking-normal shadow-lg ${
+            small ? "right-0 top-6" : "left-1/2 top-7 -translate-x-1/2"
+          }`}
         >
           <span className="block text-xs font-semibold text-slate-800">{title}</span>
-          <span className="mt-1 block text-xs leading-relaxed text-slate-600">{body}</span>
+          <span className="mt-1 block text-xs font-normal leading-relaxed text-slate-600">
+            {body}
+          </span>
           {href && (
-            <Link href={href} className="mt-2 block text-xs font-medium text-purple-600 hover:underline">
+            <Link
+              href={href}
+              className="mt-2 block text-xs font-medium text-purple-600 hover:underline"
+            >
               Learn more →
             </Link>
           )}

--- a/apps/web/src/components/v2/checkin-qr.tsx
+++ b/apps/web/src/components/v2/checkin-qr.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+// Fixture check-in QR (PROMPT-53): one tap mints the signed day-of link and
+// shows it as QR + copyable URL (invite-scorer modal pattern). Players scan
+// it at the venue to mark themselves present in the lineup picker.
+import { useState } from "react";
+import { apiV1 } from "@/lib/client-v1";
+
+export function CheckinQr({ fixtureId }: { fixtureId: string }) {
+  const [link, setLink] = useState<string | null>(null);
+  const [qr, setQr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  async function mint() {
+    setBusy(true);
+    setError(null);
+    try {
+      const out = await apiV1<{ url: string }>(`/api/v1/fixtures/${fixtureId}/checkin-link`, {
+        method: "POST",
+      });
+      setLink(out.url);
+      const QRCode = (await import("qrcode")).default;
+      setQr(await QRCode.toDataURL(out.url, { width: 240, margin: 1 }));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const close = () => {
+    setLink(null);
+    setQr(null);
+    setCopied(false);
+  };
+
+  if (link) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Player check-in QR"
+        onClick={close}
+      >
+        <div
+          className="w-full max-w-sm space-y-3 rounded-xl bg-white p-5 shadow-xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <h2 className="text-sm font-semibold text-slate-800">Player check-in</h2>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={close}
+              className="-m-1 p-1 text-slate-400 hover:text-slate-700"
+            >
+              ✕
+            </button>
+          </div>
+          {qr && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={qr}
+              alt="QR code players scan to check in to this match"
+              className="mx-auto rounded-lg border border-slate-200 p-1"
+              width={176}
+              height={176}
+              data-testid="checkin-qr"
+            />
+          )}
+          <div className="flex items-center gap-2">
+            <code
+              className="min-w-0 flex-1 truncate rounded bg-slate-100 px-2 py-1.5 text-xs text-slate-700"
+              data-testid="checkin-link"
+            >
+              {link}
+            </code>
+            <button
+              type="button"
+              className="btn btn-ghost px-2 py-1 text-xs"
+              onClick={() => {
+                void navigator.clipboard.writeText(link);
+                setCopied(true);
+              }}
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          </div>
+          <p className="text-[11px] text-slate-400">
+            Print it or pin it at the venue — claimed players scan to mark themselves here.
+            It stops working at midnight local time.
+          </p>
+          <button type="button" onClick={close} className="btn btn-primary w-full text-xs">
+            Done
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        disabled={busy}
+        onClick={mint}
+        className="btn btn-ghost px-3 py-1.5 text-xs"
+      >
+        {busy ? "Creating…" : "Check-in QR"}
+      </button>
+      {error && <span className="text-xs text-red-600">{error}</span>}
+    </span>
+  );
+}

--- a/apps/web/src/components/v2/fixture-console.tsx
+++ b/apps/web/src/components/v2/fixture-console.tsx
@@ -101,6 +101,14 @@ interface Props {
   /** Public fixture path — enables the share action once decided (v3/10 #2).
    *  Null when the competition isn't shared. */
   publicPath?: string | null;
+  /** Player RSVP/check-in per person (PROMPT-53) — chips in the lineup picker. */
+  availability?: Record<string, PersonAvailability>;
+}
+
+export interface PersonAvailability {
+  status: "in" | "out" | "maybe";
+  note: string | null;
+  checked_in_at: string | null;
 }
 
 export type SendEvent = (type: string, payload: unknown) => Promise<boolean>;
@@ -132,6 +140,7 @@ export function FixtureConsole({
   canEdit,
   recorderNames = {},
   publicPath = null,
+  availability = {},
 }: Props) {
   const router = useRouter();
   const [live, setLive] = useState<LiveState>(initialState);
@@ -343,6 +352,7 @@ export function FixtureConsole({
                 lineupSize={sport.lineupSize}
                 canEdit={canEdit && live.status === "scheduled"}
                 onSaved={() => router.refresh()}
+                availability={availability}
               />
             );
           })}

--- a/apps/web/src/components/v2/invite-claim.tsx
+++ b/apps/web/src/components/v2/invite-claim.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 // Player-account claim controls (PROMPT-53): per-person invite → pending →
-// claimed lifecycle in the Directory. The invite modal shows the one-time
-// claim link + QR (invite-scorer pattern) — the email goes out too, but the
-// print-at-the-club path never depends on inboxes.
+// claimed lifecycle in the Directory. Email is the channel (owner decision
+// 2026-07-13 — claims are strictly bound to the invited address, so a QR has
+// no claim path anymore); the modal reports the send outcome honestly and
+// keeps the one-time link as a manual fallback.
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1 } from "@/lib/client-v1";
@@ -22,7 +23,7 @@ export function InviteClaim({ personId, personName, claimed, claimPending }: Pro
   const [modal, setModal] = useState(false);
   const [email, setEmail] = useState("");
   const [link, setLink] = useState<string | null>(null);
-  const [qr, setQr] = useState<string | null>(null);
+  const [emailSent, setEmailSent] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
@@ -32,13 +33,12 @@ export function InviteClaim({ personId, personName, claimed, claimPending }: Pro
     setBusy(true);
     setError(null);
     try {
-      const out = await apiV1<{ claim_url: string }>(
+      const out = await apiV1<{ claim_url: string; email_sent: boolean }>(
         `/api/v1/persons/${personId}/claim-invites`,
         { method: "POST", json: { email } },
       );
       setLink(out.claim_url);
-      const QRCode = (await import("qrcode")).default;
-      setQr(await QRCode.toDataURL(out.claim_url, { width: 240, margin: 1 }));
+      setEmailSent(out.email_sent);
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed");
@@ -63,23 +63,24 @@ export function InviteClaim({ personId, personName, claimed, claimPending }: Pro
   const close = () => {
     setModal(false);
     setLink(null);
-    setQr(null);
     setEmail("");
     setCopied(false);
     setError(null);
   };
 
+  // State chips live in the table's Account column — this component renders
+  // only the verbs.
   if (claimed) {
     return (
       <span className="inline-flex items-center gap-2">
-        <span className="badge bg-emerald-100 text-emerald-700">{msg("claim.claimed")}</span>
         <button
           type="button"
           disabled={busy}
           onClick={() => setConfirmUnlink(true)}
-          className="text-slate-400 hover:text-red-600 hover:underline"
+          title={msg("claim.unlink.tip")}
+          className="btn btn-ghost px-2 py-1 text-xs text-red-600 hover:bg-red-50"
         >
-          {msg("claim.unlink").toLowerCase()}
+          {msg("claim.unlink")}
         </button>
         <ConfirmDialog
           open={confirmUnlink}
@@ -104,28 +105,27 @@ export function InviteClaim({ personId, personName, claimed, claimPending }: Pro
   return (
     <span className="inline-flex items-center gap-2">
       {claimPending && !modal ? (
-        <>
-          <span className="badge bg-amber-100 text-amber-700">{msg("claim.invited")}</span>
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() =>
-              run(() => apiV1(`/api/v1/persons/${personId}/claim-invites`, { method: "DELETE" }))
-            }
-            className="text-slate-400 hover:text-red-600 hover:underline"
-          >
-            {msg("claim.revoke").toLowerCase()}
-          </button>
-        </>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() =>
+            run(() => apiV1(`/api/v1/persons/${personId}/claim-invites`, { method: "DELETE" }))
+          }
+          title={msg("claim.revoke.tip")}
+          className="btn btn-ghost px-2 py-1 text-xs"
+        >
+          {msg("claim.revoke")}
+        </button>
       ) : (
         !modal && (
           <button
             type="button"
             disabled={busy}
             onClick={() => setModal(true)}
-            className="text-slate-400 hover:text-purple-600 hover:underline"
+            title={msg("claim.invite.tip")}
+            className="btn btn-ghost px-2 py-1 text-xs text-purple-700"
           >
-            {msg("claim.invite").toLowerCase()}…
+            {msg("claim.invite")}…
           </button>
         )
       )}
@@ -159,35 +159,41 @@ export function InviteClaim({ personId, personName, claimed, claimPending }: Pro
 
             {link ? (
               <>
-                {qr && (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={qr}
-                    alt={`QR code for ${personName}'s claim link`}
-                    className="mx-auto rounded-lg border border-slate-200 p-1"
-                    width={176}
-                    height={176}
-                    data-testid="claim-qr"
-                  />
+                {emailSent ? (
+                  <p
+                    className="rounded-md bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+                    data-testid="claim-emailed"
+                  >
+                    {msg("claim.invite.sent", { email })}
+                  </p>
+                ) : (
+                  // Send failure is the ONLY time the link shows — the
+                  // organiser needs a way out, and only the invited address
+                  // can accept it anyway (strict match).
+                  <>
+                    <p className="rounded-md bg-amber-50 px-3 py-2 text-sm text-amber-700">
+                      {msg("claim.invite.sendFailed")}
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <code
+                        className="min-w-0 flex-1 truncate rounded bg-slate-100 px-2 py-1.5 text-xs text-slate-700"
+                        data-testid="claim-link"
+                      >
+                        {link}
+                      </code>
+                      <button
+                        type="button"
+                        className="btn btn-ghost px-2 py-1 text-xs"
+                        onClick={() => {
+                          void navigator.clipboard.writeText(link);
+                          setCopied(true);
+                        }}
+                      >
+                        {copied ? "Copied" : "Copy"}
+                      </button>
+                    </div>
+                  </>
                 )}
-                <div className="flex items-center gap-2">
-                  <code
-                    className="min-w-0 flex-1 truncate rounded bg-slate-100 px-2 py-1.5 text-xs text-slate-700"
-                    data-testid="claim-link"
-                  >
-                    {link}
-                  </code>
-                  <button
-                    type="button"
-                    className="btn btn-ghost px-2 py-1 text-xs"
-                    onClick={() => {
-                      void navigator.clipboard.writeText(link);
-                      setCopied(true);
-                    }}
-                  >
-                    {copied ? "Copied" : "Copy"}
-                  </button>
-                </div>
                 <p className="text-[11px] text-slate-400">{msg("claim.invite.linkNote")}</p>
                 <button type="button" onClick={close} className="btn btn-primary w-full text-xs">
                   Done

--- a/apps/web/src/components/v2/invite-claim.tsx
+++ b/apps/web/src/components/v2/invite-claim.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+// Player-account claim controls (PROMPT-53): per-person invite → pending →
+// claimed lifecycle in the Directory. The invite modal shows the one-time
+// claim link + QR (invite-scorer pattern) — the email goes out too, but the
+// print-at-the-club path never depends on inboxes.
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiV1 } from "@/lib/client-v1";
+import { msg } from "@/lib/messages";
+import { ConfirmDialog } from "@/components/v2/confirm-dialog";
+
+interface Props {
+  personId: string;
+  personName: string;
+  claimed: boolean;
+  claimPending: boolean;
+}
+
+export function InviteClaim({ personId, personName, claimed, claimPending }: Props) {
+  const router = useRouter();
+  const [modal, setModal] = useState(false);
+  const [email, setEmail] = useState("");
+  const [link, setLink] = useState<string | null>(null);
+  const [qr, setQr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [confirmUnlink, setConfirmUnlink] = useState(false);
+
+  async function invite() {
+    setBusy(true);
+    setError(null);
+    try {
+      const out = await apiV1<{ claim_url: string }>(
+        `/api/v1/persons/${personId}/claim-invites`,
+        { method: "POST", json: { email } },
+      );
+      setLink(out.claim_url);
+      const QRCode = (await import("qrcode")).default;
+      setQr(await QRCode.toDataURL(out.claim_url, { width: 240, margin: 1 }));
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function run(fn: () => Promise<unknown>) {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const close = () => {
+    setModal(false);
+    setLink(null);
+    setQr(null);
+    setEmail("");
+    setCopied(false);
+    setError(null);
+  };
+
+  if (claimed) {
+    return (
+      <span className="inline-flex items-center gap-2">
+        <span className="badge bg-emerald-100 text-emerald-700">{msg("claim.claimed")}</span>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={() => setConfirmUnlink(true)}
+          className="text-slate-400 hover:text-red-600 hover:underline"
+        >
+          {msg("claim.unlink").toLowerCase()}
+        </button>
+        <ConfirmDialog
+          open={confirmUnlink}
+          title={msg("confirm.unlinkPlayer.title")}
+          confirmLabel={msg("confirm.unlinkPlayer.label")}
+          busy={busy}
+          onCancel={() => setConfirmUnlink(false)}
+          onConfirm={() =>
+            run(async () => {
+              await apiV1(`/api/v1/persons/${personId}/unlink`, { method: "POST" });
+              setConfirmUnlink(false);
+            })
+          }
+        >
+          {msg("confirm.unlinkPlayer.body", { name: personName })}
+        </ConfirmDialog>
+        {error && <span className="text-xs text-red-600">{error}</span>}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      {claimPending && !modal ? (
+        <>
+          <span className="badge bg-amber-100 text-amber-700">{msg("claim.invited")}</span>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() =>
+              run(() => apiV1(`/api/v1/persons/${personId}/claim-invites`, { method: "DELETE" }))
+            }
+            className="text-slate-400 hover:text-red-600 hover:underline"
+          >
+            {msg("claim.revoke").toLowerCase()}
+          </button>
+        </>
+      ) : (
+        !modal && (
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setModal(true)}
+            className="text-slate-400 hover:text-purple-600 hover:underline"
+          >
+            {msg("claim.invite").toLowerCase()}…
+          </button>
+        )
+      )}
+      {error && !modal && <span className="text-xs text-red-600">{error}</span>}
+
+      {modal && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={msg("claim.invite.title", { name: personName })}
+          onClick={close}
+        >
+          <div
+            className="w-full max-w-sm space-y-3 rounded-xl bg-white p-5 text-left shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <h2 className="text-sm font-semibold text-slate-800">
+                {msg("claim.invite.title", { name: personName })}
+              </h2>
+              <button
+                type="button"
+                aria-label="Close"
+                onClick={close}
+                className="-m-1 p-1 text-slate-400 hover:text-slate-700"
+              >
+                ✕
+              </button>
+            </div>
+
+            {link ? (
+              <>
+                {qr && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={qr}
+                    alt={`QR code for ${personName}'s claim link`}
+                    className="mx-auto rounded-lg border border-slate-200 p-1"
+                    width={176}
+                    height={176}
+                    data-testid="claim-qr"
+                  />
+                )}
+                <div className="flex items-center gap-2">
+                  <code
+                    className="min-w-0 flex-1 truncate rounded bg-slate-100 px-2 py-1.5 text-xs text-slate-700"
+                    data-testid="claim-link"
+                  >
+                    {link}
+                  </code>
+                  <button
+                    type="button"
+                    className="btn btn-ghost px-2 py-1 text-xs"
+                    onClick={() => {
+                      void navigator.clipboard.writeText(link);
+                      setCopied(true);
+                    }}
+                  >
+                    {copied ? "Copied" : "Copy"}
+                  </button>
+                </div>
+                <p className="text-[11px] text-slate-400">{msg("claim.invite.linkNote")}</p>
+                <button type="button" onClick={close} className="btn btn-primary w-full text-xs">
+                  Done
+                </button>
+              </>
+            ) : (
+              <form
+                className="space-y-3"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  void invite();
+                }}
+              >
+                <p className="text-xs text-slate-500">{msg("claim.invite.explain")}</p>
+                <label className="block">
+                  <span className="label">{msg("claim.invite.email")}</span>
+                  <input
+                    type="email"
+                    required
+                    autoFocus
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="input"
+                    placeholder="player@example.com"
+                  />
+                </label>
+                {error && <p className="text-xs text-red-600">{error}</p>}
+                <button
+                  type="submit"
+                  disabled={busy || !email.trim()}
+                  className="btn btn-primary w-full text-xs"
+                >
+                  {busy ? msg("claim.invite.sending") : msg("claim.invite.send")}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/components/v2/lineup-editor.tsx
+++ b/apps/web/src/components/v2/lineup-editor.tsx
@@ -5,7 +5,11 @@
 // (doc 08 §3); the engine validates size/roles at the scoring door.
 import { useState } from "react";
 import { apiV1 } from "@/lib/client-v1";
-import type { SideInfo, LineupSlotIn } from "@/components/v2/fixture-console";
+import type {
+  SideInfo,
+  LineupSlotIn,
+  PersonAvailability,
+} from "@/components/v2/fixture-console";
 
 interface Props {
   fixtureId: string;
@@ -15,6 +19,55 @@ interface Props {
   lineupSize: number;
   canEdit: boolean;
   onSaved: () => void;
+  /** Player RSVP/check-in per person (PROMPT-53). No entry → "—" chip. */
+  availability?: Record<string, PersonAvailability>;
+}
+
+// RSVP chip vocabulary: ✓ in / ✗ out / ? maybe / — no answer (or unclaimed).
+const AVAIL_CHIP: Record<PersonAvailability["status"], { mark: string; cls: string; label: string }> = {
+  in: { mark: "✓", cls: "bg-emerald-100 text-emerald-700", label: "available" },
+  out: { mark: "✗", cls: "bg-red-100 text-red-600", label: "unavailable" },
+  maybe: { mark: "?", cls: "bg-amber-100 text-amber-700", label: "maybe available" },
+};
+
+function AvailabilityChip({
+  personName,
+  info,
+}: {
+  personName: string;
+  info: PersonAvailability | undefined;
+}) {
+  if (!info) {
+    return (
+      <span
+        aria-label={`${personName}: no availability answer`}
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-slate-100 text-[11px] text-slate-400"
+        data-testid="availability-chip"
+      >
+        —
+      </span>
+    );
+  }
+  const chip = AVAIL_CHIP[info.status];
+  return (
+    <span className="inline-flex items-center gap-1" data-testid="availability-chip">
+      <span
+        aria-label={`${personName}: ${chip.label}${info.note ? ` — ${info.note}` : ""}`}
+        title={info.note ?? undefined}
+        className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${chip.cls}`}
+      >
+        {chip.mark}
+      </span>
+      {info.checked_in_at && (
+        <span
+          aria-label={`${personName}: checked in at the venue`}
+          title="Checked in at the venue"
+          className="inline-block h-2 w-2 rounded-full bg-lime-500"
+          data-testid="checkedin-dot"
+        />
+      )}
+    </span>
+  );
 }
 
 interface SlotDraft {
@@ -34,6 +87,7 @@ export function LineupEditor({
   lineupSize,
   canEdit,
   onSaved,
+  availability = {},
 }: Props) {
   const [slots, setSlots] = useState<SlotDraft[]>(() =>
     side.lineup.map((s: LineupSlotIn, i) => ({
@@ -114,6 +168,7 @@ export function LineupEditor({
           <li key={s.person_id} className="flex flex-wrap items-center gap-2 text-xs">
             <span className="w-7 font-mono text-slate-400">{i + 1}.</span>
             <span className="w-36 truncate font-medium text-slate-700">{s.full_name}</span>
+            <AvailabilityChip personName={s.full_name} info={availability[s.person_id]} />
             <select
               disabled={!canEdit}
               value={s.slot}
@@ -232,6 +287,7 @@ export function LineupEditor({
               .filter((m) => !inLineup.has(m.person_id))
               .map((m) => (
                 <span key={m.person_id} className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-2 py-0.5 text-xs text-slate-500">
+                  <AvailabilityChip personName={m.full_name} info={availability[m.person_id]} />
                   {m.full_name}
                   <button
                     type="button"

--- a/apps/web/src/components/v2/persons-panel.tsx
+++ b/apps/web/src/components/v2/persons-panel.tsx
@@ -4,7 +4,13 @@
 import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1 } from "@/lib/client-v1";
+import { msg } from "@/lib/messages";
 import { InviteClaim } from "@/components/v2/invite-claim";
+import { Tip } from "@/components/ui/tip";
+import {
+  ResponsiveTable,
+  type ResponsiveColumn,
+} from "@/components/ui/responsive-table";
 
 interface Person {
   id: string;
@@ -104,122 +110,178 @@ export function PersonsPanel({
         className="input max-w-xs"
       />
 
-      <section className="card scroll-x scroll-x-fade">
-        <table className="table">
-          <thead>
-            <tr>
-              <th className="px-4 py-2 text-left">Name</th>
-              <th className="px-4 py-2 text-left">DOB</th>
-              <th className="px-4 py-2 text-left">Gender</th>
-              <th className="px-4 py-2 text-left">Public name</th>
-              <th className="px-4 py-2 text-left">Public photo</th>
-              {canEdit && <th className="px-4 py-2 text-right">Actions</th>}
-            </tr>
-          </thead>
-          <tbody>
-            {filtered.length === 0 && (
-              <tr>
-                <td colSpan={canEdit ? 6 : 5} className="px-4 py-6 text-center text-sm text-slate-400">
-                  No players found.
-                </td>
-              </tr>
+      {(() => {
+        const identity = (p: Person) => (
+          <span className="flex min-w-0 items-center gap-2.5">
+            {p.photo_path ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={`${storageBase}/${p.photo_path}`}
+                alt={`${p.full_name} photo`}
+                className="h-8 w-8 shrink-0 rounded-full object-cover"
+              />
+            ) : (
+              <span
+                aria-hidden
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-100 text-xs text-slate-400"
+              >
+                {p.full_name.charAt(0).toUpperCase()}
+              </span>
             )}
-            {filtered.map((p) => (
-              <tr key={p.id}>
-                <td className="px-4 py-2 text-sm font-medium text-slate-800">
-                  <span className="flex items-center gap-2">
-                    {p.photo_path ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={`${storageBase}/${p.photo_path}`}
-                        alt={`${p.full_name} photo`}
-                        className="h-7 w-7 rounded-full object-cover"
-                      />
-                    ) : (
-                      <span
-                        aria-hidden
-                        className="flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 text-xs text-slate-400"
-                      >
-                        {p.full_name.charAt(0).toUpperCase()}
-                      </span>
-                    )}
-                    <span>
-                      {p.full_name}
-                      {p.external_ref && (
-                        <span className="ml-2 font-mono text-xs text-slate-400">
-                          {p.external_ref}
-                        </span>
-                      )}
-                    </span>
-                  </span>
-                </td>
-                <td className="px-4 py-2 text-sm text-slate-500">{p.dob ?? "—"}</td>
-                <td className="px-4 py-2 text-sm text-slate-500">{p.gender ?? "—"}</td>
-                {(["public_name", "public_photo"] as const).map((key) => (
-                  <td key={key} className="px-4 py-2">
-                    <button
-                      type="button"
-                      disabled={!canEdit || busy}
-                      onClick={() =>
-                        run(() =>
-                          apiV1(`/api/v1/persons/${p.id}`, {
-                            method: "PATCH",
-                            json: { consent: { ...p.consent, [key]: !p.consent[key] } },
-                          }),
-                        )
-                      }
-                      className={`badge ${
-                        p.consent[key]
-                          ? "bg-emerald-100 text-emerald-700"
-                          : "bg-slate-100 text-slate-500"
-                      } ${canEdit ? "cursor-pointer" : ""}`}
-                    >
-                      {p.consent[key] ? "yes" : "no"}
-                    </button>
-                  </td>
-                ))}
-                {canEdit && (
-                  <td className="px-4 py-2 text-right text-xs">
-                    <InviteClaim
-                      personId={p.id}
-                      personName={p.full_name}
-                      claimed={!!p.user_id}
-                      claimPending={!!p.claim_pending}
-                    />{" "}
-                    {mergeSource && mergeSource.id !== p.id ? (
-                      <button
-                        type="button"
-                        disabled={busy}
-                        onClick={() =>
-                          run(async () => {
-                            await apiV1(`/api/v1/persons/${p.id}/merge`, {
-                              method: "POST",
-                              json: { duplicate_id: mergeSource.id },
-                            });
-                            setMergeSource(null);
-                          })
-                        }
-                        className="btn btn-primary px-2 py-1 text-xs"
-                      >
-                        Keep this one
-                      </button>
-                    ) : (
-                      <button
-                        type="button"
-                        disabled={busy || mergeSource?.id === p.id}
-                        onClick={() => setMergeSource(p)}
-                        className="text-slate-400 hover:text-purple-600 hover:underline"
-                      >
-                        merge…
-                      </button>
-                    )}
-                  </td>
-                )}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
+            <span className="min-w-0">
+              <span className="block truncate text-sm font-medium text-slate-800">
+                {p.full_name}
+              </span>
+              <span className="block text-xs text-slate-400">
+                {[p.dob, p.gender, p.external_ref].filter(Boolean).join(" · ") || "—"}
+              </span>
+            </span>
+          </span>
+        );
+
+        const consentPills = (p: Person) => (
+          <span className="inline-flex flex-wrap gap-1.5">
+            {(
+              [
+                { key: "public_name" as const, label: "Name" },
+                { key: "public_photo" as const, label: "Photo" },
+              ]
+            ).map(({ key, label }) => {
+              const on = !!p.consent[key];
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  aria-pressed={on}
+                  disabled={!canEdit || busy}
+                  title={
+                    on
+                      ? `${label} is shown on public pages — click to hide`
+                      : `${label} is hidden from public pages — click to show`
+                  }
+                  onClick={() =>
+                    run(() =>
+                      apiV1(`/api/v1/persons/${p.id}`, {
+                        method: "PATCH",
+                        json: { consent: { ...p.consent, [key]: !on } },
+                      }),
+                    )
+                  }
+                  className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium transition ${
+                    on
+                      ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                      : "border-slate-200 bg-white text-slate-400"
+                  } ${canEdit ? "hover:border-slate-400" : ""}`}
+                >
+                  <span aria-hidden>{on ? "✓" : "–"}</span>
+                  {label}
+                </button>
+              );
+            })}
+          </span>
+        );
+
+        const accountChip = (p: Person) =>
+          p.user_id ? (
+            <span className="badge bg-emerald-100 text-emerald-700">{msg("claim.claimed")}</span>
+          ) : p.claim_pending ? (
+            <span className="badge bg-amber-100 text-amber-700">{msg("claim.invited")}</span>
+          ) : (
+            <span className="text-xs text-slate-400">—</span>
+          );
+
+        const actions = (p: Person) => (
+          <span className="inline-flex flex-wrap items-center justify-end gap-1.5">
+            <InviteClaim
+              personId={p.id}
+              personName={p.full_name}
+              claimed={!!p.user_id}
+              claimPending={!!p.claim_pending}
+            />
+            {mergeSource && mergeSource.id !== p.id ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() =>
+                  run(async () => {
+                    await apiV1(`/api/v1/persons/${p.id}/merge`, {
+                      method: "POST",
+                      json: { duplicate_id: mergeSource.id },
+                    });
+                    setMergeSource(null);
+                  })
+                }
+                className="btn btn-primary px-2 py-1 text-xs"
+              >
+                Keep this one
+              </button>
+            ) : (
+              <button
+                type="button"
+                disabled={busy || mergeSource?.id === p.id}
+                onClick={() => setMergeSource(p)}
+                title={msg("persons.merge.tip")}
+                className="btn btn-ghost px-2 py-1 text-xs"
+              >
+                Merge…
+              </button>
+            )}
+          </span>
+        );
+
+        const columns: ResponsiveColumn<Person>[] = [
+          { key: "player", header: "Player", render: identity },
+          { key: "public", header: "Public", render: consentPills },
+          { key: "account", header: "Account", render: accountChip },
+          ...(canEdit
+            ? [
+                {
+                  key: "actions",
+                  header: (
+                    <>
+                      Actions
+                      <Tip id="persons.actions" small className="ml-1 align-middle" />
+                    </>
+                  ),
+                  headerClassName: "text-right",
+                  className: "text-right",
+                  render: actions,
+                },
+              ]
+            : []),
+        ];
+
+        return (
+          <section className="card p-0 sm:p-0">
+            <ResponsiveTable
+              aria-label="Players"
+              columns={columns}
+              rows={filtered}
+              keyOf={(p) => p.id}
+              empty={
+                <p className="px-4 py-6 text-center text-sm text-slate-400">
+                  No players found.
+                </p>
+              }
+              renderCard={(p) => (
+                <div className="space-y-2.5">
+                  <div className="flex items-start justify-between gap-2">
+                    {identity(p)}
+                    {accountChip(p)}
+                  </div>
+                  {consentPills(p)}
+                  {canEdit && (
+                    <div className="flex flex-wrap justify-end gap-1.5 border-t border-slate-100 pt-2">
+                      {actions(p)}
+                    </div>
+                  )}
+                </div>
+              )}
+            />
+          </section>
+        );
+      })()}
+
     </div>
   );
 }

--- a/apps/web/src/components/v2/persons-panel.tsx
+++ b/apps/web/src/components/v2/persons-panel.tsx
@@ -4,6 +4,7 @@
 import { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1 } from "@/lib/client-v1";
+import { InviteClaim } from "@/components/v2/invite-claim";
 
 interface Person {
   id: string;
@@ -13,6 +14,8 @@ interface Person {
   consent: { public_name?: boolean; public_photo?: boolean };
   external_ref: string | null;
   photo_path: string | null;
+  user_id: string | null;
+  claim_pending?: boolean;
 }
 
 export function PersonsPanel({
@@ -177,6 +180,12 @@ export function PersonsPanel({
                 ))}
                 {canEdit && (
                   <td className="px-4 py-2 text-right text-xs">
+                    <InviteClaim
+                      personId={p.id}
+                      personName={p.full_name}
+                      claimed={!!p.user_id}
+                      claimPending={!!p.claim_pending}
+                    />{" "}
                     {mergeSource && mergeSource.id !== p.id ? (
                       <button
                         type="button"

--- a/apps/web/src/config/tips.ts
+++ b/apps/web/src/config/tips.ts
@@ -36,6 +36,11 @@ export const TIPS = {
     body: "Same person listed twice? Merge moves their team memberships, lineups and profiles onto the player you keep, then removes the duplicate. Results are untouched — but a merge can't be undone.",
     helpSlug: "entrants/duplicate-players",
   },
+  "persons.actions": {
+    title: "Player actions",
+    body: "Invite to claim emails the player a link to run their own profile — matches, RSVPs, consent. Unlink disconnects a claimed account; rosters and results stay. Merge… folds a duplicate into the player you keep.",
+    helpSlug: "players/invite-to-claim",
+  },
   "formats.picker": {
     title: "Choosing a format",
     body: "League plays everyone once and ranks by points. Knockout eliminates losers. Groups + knockout qualifies the top of each group. Swiss pairs equals with equals — good for big fields on short time.",

--- a/apps/web/src/lib/__tests__/guardian.test.ts
+++ b/apps/web/src/lib/__tests__/guardian.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { consentLocked } from "@/lib/guardian";
+
+// Guardian gate (PROMPT-53, owner decision 2026-07-13): a claimed player
+// under 16 by dob sees consent read-only — organiser-set values hold.
+describe("consentLocked", () => {
+  const now = new Date("2026-07-13T12:00:00Z");
+
+  it("unknown dob is not locked", () => {
+    expect(consentLocked(null, now)).toBe(false);
+  });
+
+  it("15-year-old is locked", () => {
+    expect(consentLocked("2011-07-14", now)).toBe(true);
+  });
+
+  it("day before the 16th birthday is still locked", () => {
+    expect(consentLocked("2010-07-14", now)).toBe(true);
+  });
+
+  it("16th birthday today unlocks", () => {
+    expect(consentLocked("2010-07-13", now)).toBe(false);
+  });
+
+  it("adult is not locked", () => {
+    expect(consentLocked("1986-01-01", now)).toBe(false);
+  });
+
+  it("unparseable dob is treated as unknown (not locked)", () => {
+    expect(consentLocked("not-a-date", now)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -310,6 +310,14 @@ export async function postAuthLanding(
       return { redirect: "/my-matches", orgId: orgs[0].id, hasOrg: true };
     }
   }
+  // Same rule for claimed players (PROMPT-53): their home is /me — a player
+  // must never be walked into organiser onboarding or handed a default org.
+  {
+    const { isPlayerOnly } = await import("@/server/usecases/me");
+    if (await isPlayerOnly(userId)) {
+      return { redirect: routes.me(), orgId: null, hasOrg: false };
+    }
+  }
   const orgId = await ensureActiveOrg(userId);
   // New users (onboarding_completed_at null) go to the first-run wizard.
   const { needsOnboarding } = await import("@/lib/activation");

--- a/apps/web/src/lib/email-templates/claim-invite.ts
+++ b/apps/web/src/lib/email-templates/claim-invite.ts
@@ -1,0 +1,36 @@
+import { button, linkFallback, paragraph, renderEmail } from "./compose";
+import { escapeHtml } from "./shared";
+
+export interface ClaimInviteArgs {
+  orgName: string;
+  personName: string;
+  claimUrl: string;
+}
+
+/** Player-account claim invite (PROMPT-53): the person takes ownership of
+ *  their profile — schedule, availability and consent flags. */
+export function claimInviteTemplate(args: ClaimInviteArgs): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const subject = `Claim your player profile at ${args.orgName}`;
+  return {
+    subject,
+    html: renderEmail({
+      subject,
+      preheader: `See your matches, tell organisers when you can play, and control what's public.`,
+      mastheadTag: args.orgName,
+      eyebrow: args.orgName,
+      title: "Claim your player profile",
+      contentHtml:
+        paragraph(
+          `An organiser at <strong>${escapeHtml(args.orgName)}</strong> set up a player profile for <strong>${escapeHtml(args.personName)}</strong>. Claim it to see all your matches in one place, RSVP your availability, and control what appears publicly.`,
+        ) +
+        button("Claim my profile", args.claimUrl) +
+        linkFallback(args.claimUrl),
+      footerNote: `You received this because an organiser at ${args.orgName} invited this address. Not you? Just ignore this email.`,
+    }),
+    text: `Claim your player profile at ${args.orgName}: ${args.claimUrl}`,
+  };
+}

--- a/apps/web/src/lib/email-templates/index.ts
+++ b/apps/web/src/lib/email-templates/index.ts
@@ -16,3 +16,4 @@ export {
 export { refundIssuedTemplate, type RefundIssuedArgs } from "./refund-issued";
 export { disputeAlertTemplate, type DisputeAlertArgs } from "./dispute-alert";
 export { funnelClaimTemplate, funnelReminderTemplate, type FunnelEmailArgs } from "./funnel";
+export { claimInviteTemplate, type ClaimInviteArgs } from "./claim-invite";

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -21,6 +21,8 @@ import {
   funnelClaimTemplate,
   funnelReminderTemplate,
   type FunnelEmailArgs,
+  claimInviteTemplate,
+  type ClaimInviteArgs,
 } from "@/lib/email-templates";
 
 const RESEND_ENDPOINT = "https://api.resend.com/emails";
@@ -132,6 +134,11 @@ export async function sendMagicLinkEmail(to: string, link: string): Promise<bool
 /** Funnel claim link (v3/07 §6) — transactional: it doubles as sign-in. */
 export async function sendFunnelClaimEmail(to: string, args: FunnelEmailArgs): Promise<boolean> {
   return send({ to, transactional: true, ...funnelClaimTemplate(args) });
+}
+
+/** Player-account claim invite (PROMPT-53). */
+export async function sendClaimInviteEmail(to: string, args: ClaimInviteArgs): Promise<boolean> {
+  return send({ to, transactional: true, ...claimInviteTemplate(args) });
 }
 
 /** One-shot +24h funnel reminder (v3/07 §6). */

--- a/apps/web/src/lib/guardian.ts
+++ b/apps/web/src/lib/guardian.ts
@@ -1,0 +1,26 @@
+// Guardian gate (PROMPT-53, owner decision 2026-07-13): claimed players under
+// 16 (by persons.dob) cannot edit their own consent flags — organiser-set
+// values hold. Full guardian-link accounts are out of scope. Pure and shared
+// by the server enforcement (usecases/me.ts) and the /me consent card UI.
+// dob itself never leaves the server — only this derived flag does.
+
+const CONSENT_SELF_SERVICE_AGE = 16;
+
+/** True when consent stays organiser-managed: dob known AND age < 16.
+ *  Unknown/unparseable dob fails open to self-service (the gate keys off
+ *  "dob says under 16", not "dob doesn't say adult"). Date-only UTC math —
+ *  the birthday itself unlocks. */
+export function consentLocked(dob: string | null, now: Date = new Date()): boolean {
+  if (!dob) return false;
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(dob);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  let age = now.getUTCFullYear() - year;
+  const beforeBirthday =
+    now.getUTCMonth() + 1 < month ||
+    (now.getUTCMonth() + 1 === month && now.getUTCDate() < day);
+  if (beforeBirthday) age -= 1;
+  return age < CONSENT_SELF_SERVICE_AGE;
+}

--- a/apps/web/src/lib/help.ts
+++ b/apps/web/src/lib/help.ts
@@ -16,6 +16,8 @@ export const HELP_ARTICLE_SLUGS = [
   "entrants/kinds",
   "entrants/withdrawals",
   "entrants/duplicate-players",
+  "players/claim-your-profile",
+  "players/invite-to-claim",
   "registration/open-registration",
   "registration/reference-numbers",
   "registration/waitlist",

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -189,6 +189,51 @@ export const messages = {
   "embed.copy": "Copy snippet",
   "sponsors.title": "Sponsors",
   "sponsors.line": "Sponsor logos appear on your public pages, the registration page and the TV slideshow.",
+
+  // ── Player accounts (PROMPT-53) ──
+  "claim.invite": "Invite to claim",
+  "claim.invite.title": "Invite {name} to claim their profile",
+  "claim.invite.explain":
+    "They get an email with a claim link — and you get the same link as a QR to show or print. Claiming lets them see their matches, RSVP availability and manage what's public.",
+  "claim.invite.email": "Their email",
+  "claim.invite.send": "Send invite",
+  "claim.invite.sending": "Sending…",
+  "claim.invite.linkNote":
+    "This link works for 14 days and is only shown here once — copy it or let them scan the QR now.",
+  "claim.invited": "Invite pending",
+  "claim.revoke": "Withdraw invite",
+  "claim.claimed": "Claimed",
+  "claim.unlink": "Unlink",
+  "confirm.unlinkPlayer.title": "Unlink this player account?",
+  "confirm.unlinkPlayer.body":
+    "{name} loses access to this profile on their player home. Matches and results stay. You can invite them to claim again later.",
+  "confirm.unlinkPlayer.label": "Unlink",
+  "me.title": "My matches & teams",
+  "me.eyebrow": "Player home",
+  "me.empty":
+    "Nothing here yet. When an organiser rosters you into a team or draw, your matches land on this page.",
+  "me.next.title": "Next match",
+  "me.upcoming.title": "Coming up",
+  "me.results.title": "Recent results",
+  "me.teams.title": "My teams",
+  "me.rsvp.in": "In",
+  "me.rsvp.maybe": "Maybe",
+  "me.rsvp.out": "Out",
+  "me.rsvp.notePlaceholder": "Add a note for the organiser (optional)",
+  "me.rsvp.saved": "Saved",
+  "me.checkedin": "Checked in",
+  "me.consent.title": "What's public about you",
+  "me.consent.line":
+    "These switches control whether your name and photo appear on public pages — per club.",
+  "me.consent.name": "Show my name publicly",
+  "me.consent.photo": "Show my photo publicly",
+  "me.consent.locked": "An organiser manages this until you're 16.",
+  "checkin.title": "Match check-in",
+  "checkin.done.title": "You're checked in",
+  "checkin.done.line": "The organiser can see you're here. Good luck!",
+  "checkin.needsClaim.title": "Claim your profile first",
+  "checkin.needsClaim.line":
+    "Check-in works once you've claimed your player profile. Ask the organiser to send you a claim invite, then scan again.",
 } as const;
 
 export type MessageKey = keyof typeof messages;

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -192,18 +192,27 @@ export const messages = {
 
   // ── Player accounts (PROMPT-53) ──
   "claim.invite": "Invite to claim",
+  "claim.invite.tip":
+    "Email this player a link to take over their profile — see their matches, RSVP availability, manage their own consent.",
   "claim.invite.title": "Invite {name} to claim their profile",
   "claim.invite.explain":
-    "They get an email with a claim link — and you get the same link as a QR to show or print. Claiming lets them see their matches, RSVP availability and manage what's public.",
+    "They get an email with a claim link — only an account signed in with that address can accept it. Claiming lets them see their matches, RSVP availability and manage what's public.",
   "claim.invite.email": "Their email",
   "claim.invite.send": "Send invite",
   "claim.invite.sending": "Sending…",
+  "claim.invite.sent": "Invite emailed to {email}.",
+  "claim.invite.sendFailed":
+    "The email couldn't be sent — copy the link below and share it with them yourself.",
   "claim.invite.linkNote":
-    "This link works for 14 days and is only shown here once — copy it or let them scan the QR now.",
+    "The link works for 14 days and is only shown here once. Whoever opens it must sign in as the invited address.",
   "claim.invited": "Invite pending",
   "claim.revoke": "Withdraw invite",
+  "claim.revoke.tip": "Cancel the pending invite — the emailed link stops working immediately.",
   "claim.claimed": "Claimed",
   "claim.unlink": "Unlink",
+  "claim.unlink.tip":
+    "Disconnect the player's account from this profile. Rosters and results stay; you can invite them again later.",
+  "persons.merge.tip": "Fold a duplicate entry into the player you keep. Can't be undone.",
   "confirm.unlinkPlayer.title": "Unlink this player account?",
   "confirm.unlinkPlayer.body":
     "{name} loses access to this profile on their player home. Matches and results stay. You can invite them to claim again later.",

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -210,6 +210,7 @@ export const messages = {
   "confirm.unlinkPlayer.label": "Unlink",
   "me.title": "My matches & teams",
   "me.eyebrow": "Player home",
+  "me.claimed": "Profile claimed — this is your player home now.",
   "me.empty":
     "Nothing here yet. When an organiser rosters you into a team or draw, your matches land on this page.",
   "me.next.title": "Next match",

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -36,4 +36,9 @@ export const routes = {
   /** Public dashboard — slug-based already, marker-less scheme, unchanged. */
   shared: (orgSlug: Slug, compSlug?: Slug, divSlug?: Slug) =>
     ["/shared", orgSlug, compSlug, divSlug].filter(Boolean).join("/"),
+  /** Player home (PROMPT-53) — cross-org, deliberately NOT under /o. */
+  me: () => "/me",
+  /** Token surfaces (PROMPT-53): the token IS the address, no org in the URL. */
+  claim: (token: string) => `/claim/${token}`,
+  checkin: (token: string) => `/checkin/${token}`,
 } as const;

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -36,6 +36,9 @@ export const routes = {
   /** Public dashboard — slug-based already, marker-less scheme, unchanged. */
   shared: (orgSlug: Slug, compSlug?: Slug, divSlug?: Slug) =>
     ["/shared", orgSlug, compSlug, divSlug].filter(Boolean).join("/"),
+  /** Public fixture page (spectator view — the link /me hands a player). */
+  sharedFixture: (orgSlug: Slug, compSlug: Slug, divSlug: Slug, fixtureId: string) =>
+    `/shared/${orgSlug}/${compSlug}/${divSlug}/fixtures/${fixtureId}`,
   /** Player home (PROMPT-53) — cross-org, deliberately NOT under /o. */
   me: () => "/me",
   /** Token surfaces (PROMPT-53): the token IS the address, no org in the URL. */

--- a/apps/web/src/server/api-v1/key-scopes.ts
+++ b/apps/web/src/server/api-v1/key-scopes.ts
@@ -198,6 +198,17 @@ export const NEVER_KEY_ROUTES: readonly string[] = [
   // Browser-upload handshake (v8): signed URLs are a console UX, not an API
   // surface — a leaked key must not mint writable storage URLs.
   "POST /divisions/:id/logo-upload-url",
+  // Player accounts (PROMPT-53): claim invites and check-in links mint login
+  // capabilities; the /me surface is session-personal. Never key-accessible.
+  "POST /persons/:id/claim-invites",
+  "GET /persons/:id/claim-invites",
+  "DELETE /persons/:id/claim-invites",
+  "POST /persons/:id/unlink",
+  "GET /me/fixtures",
+  "PUT /me/fixtures/:id/availability",
+  "GET /me/persons",
+  "PATCH /me/persons/:id/consent",
+  "POST /fixtures/:id/checkin-link",
 ];
 
 // /api/v1/public/** and openapi.json take no auth at all — out of key scope.

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -71,6 +71,16 @@ export const ROUTES: RouteSpec[] = [
   { path: "/persons/{id}/photo", method: "post", summary: "Upload a player photo (multipart `file`); public display gated by public_photo consent", tag: "persons", response: S.Person, errors: [400, 404, 415, 502] },
   { path: "/persons/{id}/profiles/{sport}", method: "get", summary: "Get a per-sport profile", tag: "persons" },
   { path: "/persons/{id}/profiles/{sport}", method: "put", summary: "Upsert a per-sport profile", tag: "persons", request: S.PutProfile, errors: [422] },
+  // Player accounts (PROMPT-53) — session-only, never key-accessible
+  { path: "/persons/{id}/claim-invites", method: "post", summary: "Invite the person to claim their profile (session editors only; claim_url embeds the one-time secret; revokes any prior open invite)", tag: "player-accounts", request: S.CreateClaimInvite, response: S.CreatedPersonClaim, status: 201, errors: [409] },
+  { path: "/persons/{id}/claim-invites", method: "get", summary: "The person's open claim invite, if any (never the secret)", tag: "player-accounts", response: S.PersonClaim.nullable() },
+  { path: "/persons/{id}/claim-invites", method: "delete", summary: "Withdraw the open claim invite (idempotent)", tag: "player-accounts", response: S.PersonClaim.nullable() },
+  { path: "/persons/{id}/unlink", method: "post", summary: "Staff unlink: detach the player login and revoke live claims (audited — claim rows are retained)", tag: "player-accounts" },
+  { path: "/me/fixtures", method: "get", summary: "Player home read: upcoming fixtures, recent results and teams for every claimed person of the caller, across orgs (session only)", tag: "player-accounts", response: S.MyFixtures },
+  { path: "/me/fixtures/{id}/availability", method: "put", summary: "RSVP in/out/maybe + note for the caller's person on this fixture (session only)", tag: "player-accounts", request: S.PutAvailability, response: S.Availability, errors: [403, 422] },
+  { path: "/me/persons", method: "get", summary: "The caller's claimed player profiles with consent state (session only)", tag: "player-accounts", response: z.array(S.MyPerson) },
+  { path: "/me/persons/{id}/consent", method: "patch", summary: "Player-owned consent flags; under-16 → 403 CONSENT_LOCKED (guardian gate)", tag: "player-accounts", request: S.PatchMyConsent, response: S.MyPerson, errors: [403] },
+  { path: "/fixtures/{id}/checkin-link", method: "post", summary: "Mint the fixture's self-check-in QR link (session editors only; signed token, dies at local midnight)", tag: "player-accounts", response: S.CheckinLink, status: 201, errors: [422] },
   // Stages
   { path: "/divisions/{id}/stages", method: "get", summary: "List stages", tag: "stages", response: z.array(S.Stage) },
   { path: "/divisions/{id}/stages", method: "post", summary: "Define the stage graph", tag: "stages", request: S.CreateStages, response: z.union([S.Stage, z.array(S.Stage)]), status: 201, errors: [409] },

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -280,6 +280,117 @@ export const Person = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Player accounts (PROMPT-53) — claims, availability, the /me surface
+// ---------------------------------------------------------------------------
+
+export const CreateClaimInvite = z.object({ email: z.email().max(200) });
+export type CreateClaimInvite = z.infer<typeof CreateClaimInvite>;
+
+export const PersonClaim = z.object({
+  id: Uuid,
+  person_id: Uuid,
+  email: z.string(),
+  invited_by: Uuid.nullable(),
+  expires_at: z.string(),
+  claimed_at: z.string().nullable(),
+  revoked_at: z.string().nullable(),
+  created_at: z.string(),
+});
+
+/** POST response only — claim_url embeds the secret, shown exactly once. */
+export const CreatedPersonClaim = PersonClaim.extend({ claim_url: z.string() });
+
+export const PutAvailability = z.object({
+  status: z.enum(["in", "out", "maybe"]),
+  note: z.string().max(280).nullish(),
+});
+export type PutAvailability = z.infer<typeof PutAvailability>;
+
+export const Availability = z.object({
+  fixture_id: Uuid,
+  person_id: Uuid,
+  status: z.enum(["in", "out", "maybe"]),
+  note: z.string().nullable(),
+  checked_in_at: z.string().nullable(),
+  updated_at: z.string(),
+});
+
+export const PatchMyConsent = z
+  .object({ public_name: z.boolean(), public_photo: z.boolean() })
+  .partial()
+  .refine((p) => Object.keys(p).length > 0, "empty patch");
+export type PatchMyConsent = z.infer<typeof PatchMyConsent>;
+
+/** dob never rides out — only the derived guardian lock does. */
+export const MyPerson = z.object({
+  id: Uuid,
+  full_name: z.string(),
+  org_name: z.string(),
+  consent: z.object({ public_name: z.boolean().optional(), public_photo: z.boolean().optional() }),
+  consent_locked: z.boolean(),
+});
+
+export const MyFixture = z.object({
+  id: Uuid,
+  fixture_no: z.number().int(),
+  person_id: Uuid,
+  person_name: z.string(),
+  org_name: z.string(),
+  org_slug: z.string(),
+  competition_name: z.string(),
+  competition_slug: z.string(),
+  competition_visibility: z.string(),
+  division_name: z.string(),
+  division_slug: z.string(),
+  sport_key: z.string(),
+  round_no: z.number().int(),
+  entrant_name: z.string().nullable(),
+  opponent_name: z.string().nullable(),
+  scheduled_at: z.string().nullable(),
+  venue: z.string().nullable(),
+  court_label: z.string().nullable(),
+  status: z.string(),
+  availability: z
+    .object({ status: z.enum(["in", "out", "maybe"]), note: z.string().nullable() })
+    .nullable(),
+  checked_in_at: z.string().nullable(),
+});
+
+export const MyResult = z.object({
+  id: Uuid,
+  fixture_no: z.number().int(),
+  competition_name: z.string(),
+  competition_slug: z.string(),
+  competition_visibility: z.string(),
+  division_name: z.string(),
+  division_slug: z.string(),
+  org_name: z.string(),
+  org_slug: z.string(),
+  entrant_name: z.string().nullable(),
+  opponent_name: z.string().nullable(),
+  scheduled_at: z.string().nullable(),
+  summary: z.unknown().nullable(),
+  outcome: z.unknown().nullable(),
+});
+
+export const MyTeam = z.object({
+  entrant_id: Uuid,
+  entrant_name: z.string(),
+  division_name: z.string(),
+  competition_name: z.string(),
+  org_name: z.string(),
+  sport_key: z.string(),
+});
+
+export const MyFixtures = z.object({
+  upcoming: z.array(MyFixture),
+  results: z.array(MyResult),
+  teams: z.array(MyTeam),
+});
+
+export const CheckinLink = z.object({ url: z.string(), expires_at: z.string() });
+
+// ---------------------------------------------------------------------------
 // Stages
 // ---------------------------------------------------------------------------
 

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -302,7 +302,11 @@ export const PersonClaim = z.object({
 });
 
 /** POST response only — claim_url embeds the secret, shown exactly once. */
-export const CreatedPersonClaim = PersonClaim.extend({ claim_url: z.string() });
+export const CreatedPersonClaim = PersonClaim.extend({
+  claim_url: z.string(),
+  /** Whether the invite email was accepted by the provider. */
+  email_sent: z.boolean(),
+});
 
 export const PutAvailability = z.object({
   status: z.enum(["in", "out", "maybe"]),

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -276,7 +276,11 @@ export const Person = z.object({
   gender: z.enum(["m", "f", "x"]).nullable(),
   consent: z.record(z.string(), z.unknown()),
   external_ref: z.string().nullable(),
+  /** Set once a player has claimed this row (PROMPT-53). */
+  user_id: Uuid.nullable(),
   created_at: z.string(),
+  /** List read only: an open, unexpired claim invite exists. */
+  claim_pending: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/usecases/__tests__/checkin-token.test.ts
+++ b/apps/web/src/server/usecases/__tests__/checkin-token.test.ts
@@ -1,0 +1,44 @@
+// PROMPT-53 check-in token lifecycle: round-trip, expiry, tamper resistance,
+// and the typ gate (a session JWT must never open the check-in door). Pure —
+// no DB needed.
+import { describe, expect, it } from "vitest";
+import { SignJWT } from "jose";
+import { mintCheckinToken, verifyCheckinToken } from "../checkin-token";
+
+const FIXTURE = "3b1a8dc4-9f10-4d5e-b0c7-0e6f6a2f9a11";
+
+describe("check-in tokens (PROMPT-53)", () => {
+  it("round-trips the fixture id", async () => {
+    const token = await mintCheckinToken(FIXTURE, new Date(Date.now() + 60_000));
+    await expect(verifyCheckinToken(token)).resolves.toBe(FIXTURE);
+  });
+
+  it("expired → 401 CHECKIN_EXPIRED", async () => {
+    const token = await mintCheckinToken(FIXTURE, new Date(Date.now() - 1_000));
+    await expect(verifyCheckinToken(token)).rejects.toMatchObject({
+      status: 401,
+      code: "CHECKIN_EXPIRED",
+    });
+  });
+
+  it("tampered or garbage → CHECKIN_INVALID", async () => {
+    const token = await mintCheckinToken(FIXTURE, new Date(Date.now() + 60_000));
+    await expect(verifyCheckinToken(token.slice(0, -4) + "AAAA")).rejects.toMatchObject({
+      code: "CHECKIN_INVALID",
+    });
+    await expect(verifyCheckinToken("not-a-jwt")).rejects.toMatchObject({
+      code: "CHECKIN_INVALID",
+    });
+  });
+
+  it("a session-shaped JWT (no typ) is rejected", async () => {
+    const key = new TextEncoder().encode("dev-insecure-secret-change-me");
+    const sessionish = await new SignJWT({ uid: "someone", fid: FIXTURE })
+      .setProtectedHeader({ alg: "HS256" })
+      .setExpirationTime("1h")
+      .sign(key);
+    await expect(verifyCheckinToken(sessionish)).rejects.toMatchObject({
+      code: "CHECKIN_INVALID",
+    });
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/me.test.ts
+++ b/apps/web/src/server/usecases/__tests__/me.test.ts
@@ -198,6 +198,18 @@ describe.skipIf(!HAS_DB)("player home /me (PROMPT-53)", () => {
     expect(await checkInToFixture(stranger, f1.id)).toBeNull();
   });
 
+  it("isPlayerOnly: claimed person + no org = true; members and strangers = false", async () => {
+    const { owner, ownerId } = await seedOrg("po");
+    const { persons } = await rig(owner);
+    const player = await makeUser("player");
+    await sql`update persons set user_id = ${player} where id = ${persons[0].id}`;
+
+    const { isPlayerOnly } = await import("../me");
+    expect(await isPlayerOnly(player)).toBe(true); // claimed, no memberships
+    expect(await isPlayerOnly(ownerId)).toBe(false); // org member
+    expect(await isPlayerOnly(await makeUser("stranger"))).toBe(false); // neither
+  });
+
   it("consent flip persists, revalidates the person's divisions; guardian gate 403s", async () => {
     const { owner } = await seedOrg("g");
     const adult = await rig(owner);

--- a/apps/web/src/server/usecases/__tests__/me.test.ts
+++ b/apps/web/src/server/usecases/__tests__/me.test.ts
@@ -1,0 +1,232 @@
+// PROMPT-53 /me reads and writes: cross-org isolation (user A never sees
+// user B's persons), RSVP upsert semantics, guardian-gated consent with tag
+// revalidation, QR check-in defaulting. Real Postgres required.
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages, generateStageFixtures } from "../stages";
+import { startDivision } from "../schedule";
+import { createPerson } from "../persons";
+import {
+  listMyFixtures,
+  setMyAvailability,
+  checkInToFixture,
+  listMyPersons,
+  setMyConsent,
+} from "../me";
+
+vi.mock("@/server/public-site/revalidate", () => ({
+  fireDivisionRevalidate: vi.fn(),
+}));
+import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const DIVISION_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+async function makeUser(name: string): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`${name}-${randomUUID().slice(0, 8)}@test.local`}, ${name}, true)
+    returning id`;
+  return id;
+}
+
+async function seedOrg(tag: string): Promise<{ orgId: string; ownerId: string; owner: AuthCtx }> {
+  const suffix = randomUUID().slice(0, 8);
+  const ownerId = await makeUser("owner");
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${`Me ${tag} ${suffix}`}, ${`me-${tag}-${suffix}`}, ${ownerId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  await sql`insert into subscriptions (org_id, plan_key, status) values (${orgId}, 'pro', 'active')
+            on conflict (org_id) do update set plan_key = 'pro', status = 'active'`;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(DIVISION_CONFIG)}, true)
+    on conflict do nothing`;
+  const owner: AuthCtx = { orgId, via: "session", userId: ownerId, role: "owner", keyId: null };
+  return { orgId, ownerId, owner };
+}
+
+/** Division of 4 individual entrants, each backed by a person; fixtures generated + started. */
+async function rig(owner: AuthCtx, opts: { dob?: string | null } = {}) {
+  const competition = await createCompetition(owner, {
+    name: "Me Cup " + randomUUID().slice(0, 6), visibility: "public", branding: {},
+  });
+  const division = await createDivision(owner, competition.id, {
+    name: "Open", sport_key: "generic", variant_key: "score",
+    config: { points: { w: 3, d: 1, l: 0 }, progressScore: false }, eligibility: [],
+  });
+  const persons = [];
+  for (const n of ["Ada", "Ben", "Cal", "Dee"]) {
+    persons.push(
+      await createPerson(owner, {
+        full_name: n, consent: {}, dob: opts.dob ?? null,
+      } as never),
+    );
+  }
+  const entrants = await createEntrants(
+    owner, division.id,
+    persons.map((p, i) => ({
+      kind: "individual" as const,
+      display_name: p.full_name,
+      seed: i + 1,
+      members: [{
+        person_id: p.id, squad_number: null, default_position_key: null,
+        is_captain: false, roles: [],
+      }],
+    })),
+  );
+  const [stage] = await createStages(owner, division.id, {
+    seq: 1, kind: "league", name: "L", config: {},
+  });
+  const { fixtures } = await generateStageFixtures(owner, stage.id);
+  await startDivision(owner, division.id);
+  return { competition, division, persons, entrants, fixtures };
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("player home /me (PROMPT-53)", () => {
+  it("cross-org isolation: my persons across orgs, nobody else's", async () => {
+    const a = await seedOrg("a");
+    const b = await seedOrg("b");
+    const rigA = await rig(a.owner);
+    const rigB = await rig(b.owner);
+    const player = await makeUser("player");
+    const stranger = await makeUser("stranger");
+    // Claim Ada in org A and Ben in org B for the same login.
+    await sql`update persons set user_id = ${player} where id = ${rigA.persons[0].id}`;
+    await sql`update persons set user_id = ${player} where id = ${rigB.persons[1].id}`;
+
+    const mine = await listMyFixtures(player);
+    const orgs = new Set(mine.upcoming.map((f) => f.org_name));
+    expect(orgs.size).toBe(2);
+    // League of 4: each entrant plays 3.
+    expect(mine.upcoming.filter((f) => f.person_id === rigA.persons[0].id)).toHaveLength(3);
+    expect(mine.teams).toHaveLength(2);
+
+    const theirs = await listMyFixtures(stranger);
+    expect(theirs.upcoming).toHaveLength(0);
+    expect(theirs.teams).toHaveLength(0);
+
+    const personsList = await listMyPersons(player);
+    expect(personsList.map((p) => p.full_name).sort()).toEqual(["Ada", "Ben"]);
+    // dob never rides out on the /me payload.
+    expect(Object.keys(personsList[0])).not.toContain("dob");
+  });
+
+  it("withdrawn entrants drop out of /me", async () => {
+    const { owner } = await seedOrg("w");
+    const { persons, entrants } = await rig(owner);
+    const player = await makeUser("player");
+    await sql`update persons set user_id = ${player} where id = ${persons[0].id}`;
+    expect((await listMyFixtures(player)).upcoming.length).toBeGreaterThan(0);
+    await sql`update entrants set status = 'withdrawn' where id = ${entrants[0].id}`;
+    expect((await listMyFixtures(player)).upcoming).toHaveLength(0);
+  });
+
+  it("RSVP upserts (in → out keeps one row), 403 on a fixture that isn't mine", async () => {
+    const { owner } = await seedOrg("r");
+    const { persons, fixtures } = await rig(owner);
+    const player = await makeUser("player");
+    await sql`update persons set user_id = ${player} where id = ${persons[0].id}`;
+    const myFixture = (await listMyFixtures(player)).upcoming[0];
+
+    const first = await setMyAvailability(player, myFixture.id, { status: "in" });
+    expect(first.status).toBe("in");
+    const second = await setMyAvailability(player, myFixture.id, {
+      status: "out", note: "away that weekend",
+    });
+    expect(second.status).toBe("out");
+    expect(second.note).toBe("away that weekend");
+    const rows = await sql`
+      select 1 from fixture_availability
+      where fixture_id = ${myFixture.id} and person_id = ${persons[0].id}`;
+    expect(rows).toHaveLength(1);
+
+    // A fixture between the OTHER entrants is not mine.
+    const mineIds = (await listMyFixtures(player)).upcoming.map((f) => f.id);
+    const other = fixtures.find((f) => !mineIds.includes(f.id))!;
+    expect(other).toBeDefined();
+    await expect(setMyAvailability(player, other.id, { status: "in" })).rejects.toMatchObject({
+      status: 403,
+      code: "NOT_YOUR_FIXTURE",
+    });
+  });
+
+  it("check-in stamps presence, defaults RSVP to 'in', never clobbers an 'out'", async () => {
+    const { owner } = await seedOrg("c");
+    const { persons } = await rig(owner);
+    const player = await makeUser("player");
+    await sql`update persons set user_id = ${player} where id = ${persons[0].id}`;
+    const [f1, f2] = (await listMyFixtures(player)).upcoming;
+
+    // Fresh row: turning up answers the RSVP.
+    const fresh = await checkInToFixture(player, f1.id);
+    expect(fresh?.status).toBe("in");
+    expect(fresh?.checked_in_at).not.toBeNull();
+
+    // Existing 'out' answer survives a check-in.
+    await setMyAvailability(player, f2.id, { status: "out" });
+    const kept = await checkInToFixture(player, f2.id);
+    expect(kept?.status).toBe("out");
+    expect(kept?.checked_in_at).not.toBeNull();
+
+    // No claimed person on the fixture → null (claim-first interstitial).
+    const stranger = await makeUser("stranger");
+    expect(await checkInToFixture(stranger, f1.id)).toBeNull();
+  });
+
+  it("consent flip persists, revalidates the person's divisions; guardian gate 403s", async () => {
+    const { owner } = await seedOrg("g");
+    const adult = await rig(owner);
+    const player = await makeUser("player");
+    await sql`update persons set user_id = ${player} where id = ${adult.persons[0].id}`;
+
+    vi.mocked(fireDivisionRevalidate).mockClear();
+    const updated = await setMyConsent(player, adult.persons[0].id, { public_name: true });
+    expect(updated.consent.public_name).toBe(true);
+    expect(updated.consent_locked).toBe(false);
+    expect(fireDivisionRevalidate).toHaveBeenCalledWith(
+      adult.division.id,
+      adult.competition.id,
+    );
+
+    // Under-16: read shows locked, write 403s, organiser values hold.
+    const minor = await rig(owner, { dob: "2013-01-01" });
+    const kid = await makeUser("kid");
+    await sql`update persons set user_id = ${kid} where id = ${minor.persons[0].id}`;
+    const [kidPerson] = await listMyPersons(kid);
+    expect(kidPerson.consent_locked).toBe(true);
+    await expect(setMyConsent(kid, minor.persons[0].id, { public_name: true })).rejects.toMatchObject({
+      status: 403,
+      code: "CONSENT_LOCKED",
+    });
+
+    // Not my person → 404 (no oracle about other users' persons).
+    await expect(setMyConsent(player, minor.persons[0].id, { public_name: true })).rejects.toMatchObject({
+      status: 404,
+    });
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/person-claims.test.ts
+++ b/apps/web/src/server/usecases/__tests__/person-claims.test.ts
@@ -1,0 +1,196 @@
+// PROMPT-53 claim lifecycle: invite → resolve → claim; expired/revoked/
+// claimed tokens fail with distinct codes; re-invite revokes the prior open
+// claim (the one-open-claim partial unique never trips); unlink detaches the
+// login and closes claim rows without deleting the audit trail.
+// Real Postgres required; skipped without DATABASE_URL.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import {
+  createClaimInvite,
+  revokeClaimInvite,
+  getOpenClaim,
+  resolveClaimToken,
+  claimPerson,
+  unlinkPerson,
+} from "../person-claims";
+import { createPerson } from "../persons";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function makeUser(name: string): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`${name}-${randomUUID().slice(0, 8)}@test.local`}, ${name}, true)
+    returning id`;
+  return id;
+}
+
+async function seedOrg(): Promise<{ orgId: string; ownerId: string }> {
+  const suffix = randomUUID().slice(0, 8);
+  const ownerId = await makeUser("owner");
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"Claim Org " + suffix}, ${"claim-org-" + suffix}, ${ownerId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  return { orgId, ownerId };
+}
+
+const asOwner = (orgId: string, userId: string): AuthCtx => ({
+  orgId,
+  via: "session",
+  userId,
+  role: "owner",
+  keyId: null,
+});
+
+async function rig() {
+  const { orgId, ownerId } = await seedOrg();
+  const owner = asOwner(orgId, ownerId);
+  const person = await createPerson(owner, {
+    full_name: "Sam Player",
+    consent: {},
+  } as never);
+  return { orgId, ownerId, owner, person };
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("person claims (PROMPT-53)", () => {
+  it("invite → resolve → claim links the user; token stored hashed", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    expect(invite.secret.startsWith("pc_")).toBe(true);
+    expect(invite.person_name).toBe("Sam Player");
+
+    // Raw secret never lands in the DB — only its sha256.
+    const stored = await sql<{ token_hash: string }[]>`
+      select token_hash from person_claims where id = ${invite.id}`;
+    expect(stored[0].token_hash).not.toContain(invite.secret);
+
+    const resolved = await resolveClaimToken(invite.secret);
+    expect(resolved.person_id).toBe(person.id);
+    expect(resolved.email).toBe("sam@test.local");
+
+    const playerId = await makeUser("sam");
+    await claimPerson(invite.secret, playerId);
+    const [linked] = await sql<{ user_id: string | null }[]>`
+      select user_id from persons where id = ${person.id}`;
+    expect(linked.user_id).toBe(playerId);
+
+    // The used token is dead with the CLAIMED code.
+    await expect(resolveClaimToken(invite.secret)).rejects.toMatchObject({
+      status: 409,
+      code: "CLAIM_CLAIMED",
+    });
+  });
+
+  it("inviting an already-claimed person → 409 ALREADY_CLAIMED", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    await claimPerson(invite.secret, await makeUser("sam"));
+    await expect(createClaimInvite(owner, person.id, "again@test.local")).rejects.toMatchObject({
+      status: 409,
+      code: "ALREADY_CLAIMED",
+    });
+  });
+
+  it("expired token → CLAIM_EXPIRED; claim refused", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    await sql`update person_claims set expires_at = now() - interval '1 minute'
+              where id = ${invite.id}`;
+    await expect(resolveClaimToken(invite.secret)).rejects.toMatchObject({
+      status: 401,
+      code: "CLAIM_EXPIRED",
+    });
+    await expect(claimPerson(invite.secret, await makeUser("sam"))).rejects.toMatchObject({
+      code: "CLAIM_EXPIRED",
+    });
+  });
+
+  it("revoked token → CLAIM_REVOKED; garbage token → CLAIM_INVALID", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    await revokeClaimInvite(owner, person.id);
+    await expect(resolveClaimToken(invite.secret)).rejects.toMatchObject({
+      status: 401,
+      code: "CLAIM_REVOKED",
+    });
+    await expect(resolveClaimToken("pc_not-a-real-token")).rejects.toMatchObject({
+      code: "CLAIM_INVALID",
+    });
+  });
+
+  it("re-invite revokes the prior open claim (one open claim per person)", async () => {
+    const { owner, person } = await rig();
+    const first = await createClaimInvite(owner, person.id, "one@test.local");
+    const second = await createClaimInvite(owner, person.id, "two@test.local");
+    await expect(resolveClaimToken(first.secret)).rejects.toMatchObject({
+      code: "CLAIM_REVOKED",
+    });
+    await expect(resolveClaimToken(second.secret)).resolves.toMatchObject({
+      person_id: person.id,
+    });
+    const open = await getOpenClaim(owner, person.id);
+    expect(open?.id).toBe(second.id);
+    expect(open && "secret" in open).toBe(false);
+  });
+
+  it("racing accepts: exactly one wins, the loser gets CLAIM_CLAIMED", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    const [a, b] = [await makeUser("a"), await makeUser("b")];
+    const results = await Promise.allSettled([
+      claimPerson(invite.secret, a),
+      claimPerson(invite.secret, b),
+    ]);
+    const wins = results.filter((r) => r.status === "fulfilled").length;
+    expect(wins).toBe(1);
+    const loser = results.find((r) => r.status === "rejected") as PromiseRejectedResult;
+    expect((loser.reason as HttpError).code).toBe("CLAIM_CLAIMED");
+  });
+
+  it("unlink detaches the login, closes claims, keeps the audit rows", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    await claimPerson(invite.secret, await makeUser("sam"));
+    await unlinkPerson(owner, person.id);
+
+    const [row] = await sql<{ user_id: string | null }[]>`
+      select user_id from persons where id = ${person.id}`;
+    expect(row.user_id).toBeNull();
+
+    // Audit trail intact: the claim row shows claimed AND later revoked.
+    const claims = await sql<{ claimed_at: string | null; revoked_at: string | null }[]>`
+      select claimed_at, revoked_at from person_claims where person_id = ${person.id}`;
+    expect(claims).toHaveLength(1);
+    expect(claims[0].claimed_at).not.toBeNull();
+    expect(claims[0].revoked_at).not.toBeNull();
+
+    // And the person can be invited again after unlink.
+    const again = await createClaimInvite(owner, person.id, "back@test.local");
+    await expect(resolveClaimToken(again.secret)).resolves.toMatchObject({
+      person_id: person.id,
+    });
+  });
+
+  it("api-key auth cannot mint or revoke claim invites", async () => {
+    const { orgId, person, owner } = await rig();
+    const keyAuth: AuthCtx = { orgId, via: "api_key", userId: null, role: null, keyId: "k1" };
+    await expect(createClaimInvite(keyAuth, person.id, "x@test.local")).rejects.toMatchObject({
+      status: 403,
+    });
+    await expect(revokeClaimInvite(keyAuth, person.id)).rejects.toMatchObject({ status: 403 });
+    // owner path still fine
+    await expect(createClaimInvite(owner, person.id, "x@test.local")).resolves.toBeTruthy();
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/person-claims.test.ts
+++ b/apps/web/src/server/usecases/__tests__/person-claims.test.ts
@@ -81,7 +81,7 @@ describe.skipIf(!HAS_DB)("person claims (PROMPT-53)", () => {
     expect(resolved.email).toBe("sam@test.local");
 
     const playerId = await makeUser("sam");
-    await claimPerson(invite.secret, playerId);
+    await claimPerson(invite.secret, playerId, "sam@test.local");
     const [linked] = await sql<{ user_id: string | null }[]>`
       select user_id from persons where id = ${person.id}`;
     expect(linked.user_id).toBe(playerId);
@@ -96,7 +96,7 @@ describe.skipIf(!HAS_DB)("person claims (PROMPT-53)", () => {
   it("inviting an already-claimed person → 409 ALREADY_CLAIMED", async () => {
     const { owner, person } = await rig();
     const invite = await createClaimInvite(owner, person.id, "sam@test.local");
-    await claimPerson(invite.secret, await makeUser("sam"));
+    await claimPerson(invite.secret, await makeUser("sam"), "sam@test.local");
     await expect(createClaimInvite(owner, person.id, "again@test.local")).rejects.toMatchObject({
       status: 409,
       code: "ALREADY_CLAIMED",
@@ -112,7 +112,9 @@ describe.skipIf(!HAS_DB)("person claims (PROMPT-53)", () => {
       status: 401,
       code: "CLAIM_EXPIRED",
     });
-    await expect(claimPerson(invite.secret, await makeUser("sam"))).rejects.toMatchObject({
+    await expect(
+      claimPerson(invite.secret, await makeUser("sam"), "sam@test.local"),
+    ).rejects.toMatchObject({
       code: "CLAIM_EXPIRED",
     });
   });
@@ -150,8 +152,8 @@ describe.skipIf(!HAS_DB)("person claims (PROMPT-53)", () => {
     const invite = await createClaimInvite(owner, person.id, "sam@test.local");
     const [a, b] = [await makeUser("a"), await makeUser("b")];
     const results = await Promise.allSettled([
-      claimPerson(invite.secret, a),
-      claimPerson(invite.secret, b),
+      claimPerson(invite.secret, a, "sam@test.local"),
+      claimPerson(invite.secret, b, "sam@test.local"),
     ]);
     const wins = results.filter((r) => r.status === "fulfilled").length;
     expect(wins).toBe(1);
@@ -159,10 +161,27 @@ describe.skipIf(!HAS_DB)("person claims (PROMPT-53)", () => {
     expect((loser.reason as HttpError).code).toBe("CLAIM_CLAIMED");
   });
 
+  it("strict match: a different signed-in address is refused; case doesn't matter", async () => {
+    const { owner, person } = await rig();
+    const invite = await createClaimInvite(owner, person.id, "sam@test.local");
+    await expect(
+      claimPerson(invite.secret, await makeUser("impostor"), "impostor@test.local"),
+    ).rejects.toMatchObject({
+      status: 403,
+      code: "CLAIM_EMAIL_MISMATCH",
+    });
+    // The person is untouched by the refused attempt…
+    const [row] = await sql<{ user_id: string | null }[]>`
+      select user_id from persons where id = ${person.id}`;
+    expect(row.user_id).toBeNull();
+    // …and the right address still claims, case-insensitively.
+    await claimPerson(invite.secret, await makeUser("sam"), "SAM@Test.Local");
+  });
+
   it("unlink detaches the login, closes claims, keeps the audit rows", async () => {
     const { owner, person } = await rig();
     const invite = await createClaimInvite(owner, person.id, "sam@test.local");
-    await claimPerson(invite.secret, await makeUser("sam"));
+    await claimPerson(invite.secret, await makeUser("sam"), "sam@test.local");
     await unlinkPerson(owner, person.id);
 
     const [row] = await sql<{ user_id: string | null }[]>`

--- a/apps/web/src/server/usecases/checkin-token.ts
+++ b/apps/web/src/server/usecases/checkin-token.ts
@@ -47,8 +47,10 @@ export async function createCheckinLink(
     const [fixture] = await tx<{ id: string; division_id: string; status: string }[]>`
       select id, division_id, status from fixtures where id = ${fixtureId}`;
     if (!fixture) throw new HttpError(404, "fixture not found");
-    if (fixture.status === "finalized" || fixture.status === "cancelled") {
-      throw new HttpError(422, `fixture is ${fixture.status} — check-in is closed`);
+    // Check-in is an arrival tool: mint only before play starts (the UI hides
+    // the button then too — this is the enforcement, not the hiding).
+    if (fixture.status !== "scheduled") {
+      throw new HttpError(422, `fixture is ${fixture.status} — check-in codes are minted before the match starts`);
     }
     const [settings] = await tx<{ tz: string }[]>`
       select tz from schedule_settings where division_id = ${fixture.division_id}`;

--- a/apps/web/src/server/usecases/checkin-token.ts
+++ b/apps/web/src/server/usecases/checkin-token.ts
@@ -1,0 +1,49 @@
+import "server-only";
+// Fixture check-in QR tokens (PROMPT-53): stateless HS256 JWTs signed with
+// AUTH_SECRET — the QR stays valid until local midnight (device-links day-of
+// policy) without a table row. A distinct `typ` keeps a stolen session JWT
+// from opening this door and vice versa.
+import { SignJWT, jwtVerify } from "jose";
+import { HttpError } from "@/lib/errors";
+
+const TYP = "seazn-checkin";
+
+function secretKey(): Uint8Array {
+  const secret = process.env.AUTH_SECRET;
+  if (!secret) {
+    if (process.env.NODE_ENV === "production")
+      throw new Error("AUTH_SECRET environment variable is required in production");
+    return new TextEncoder().encode("dev-insecure-secret-change-me");
+  }
+  return new TextEncoder().encode(secret);
+}
+
+/** Mint a check-in token for a fixture. Caller supplies the expiry (end of
+ *  the fixture's local day — reuse endOfLocalDay from device-links). */
+export async function mintCheckinToken(fixtureId: string, expiresAt: Date): Promise<string> {
+  return new SignJWT({ fid: fixtureId })
+    .setProtectedHeader({ alg: "HS256", typ: TYP })
+    .setIssuedAt()
+    .setExpirationTime(Math.floor(expiresAt.getTime() / 1000))
+    .sign(secretKey());
+}
+
+/** Verify a check-in token → fixture id. Distinct codes: CHECKIN_EXPIRED for
+ *  a stale QR (print from yesterday), CHECKIN_INVALID for everything else. */
+export async function verifyCheckinToken(token: string): Promise<string> {
+  try {
+    const { payload, protectedHeader } = await jwtVerify(token, secretKey(), {
+      typ: TYP,
+    });
+    if (protectedHeader.typ !== TYP || typeof payload.fid !== "string") {
+      throw new Error("wrong token type");
+    }
+    return payload.fid;
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (code === "ERR_JWT_EXPIRED") {
+      throw new HttpError(401, "This check-in code has expired — ask the organiser for today's", "CHECKIN_EXPIRED");
+    }
+    throw new HttpError(401, "This check-in code is not valid", "CHECKIN_INVALID");
+  }
+}

--- a/apps/web/src/server/usecases/checkin-token.ts
+++ b/apps/web/src/server/usecases/checkin-token.ts
@@ -4,7 +4,10 @@ import "server-only";
 // policy) without a table row. A distinct `typ` keeps a stolen session JWT
 // from opening this door and vice versa.
 import { SignJWT, jwtVerify } from "jose";
+import { withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { endOfLocalDay } from "./device-links";
 
 const TYP = "seazn-checkin";
 
@@ -26,6 +29,33 @@ export async function mintCheckinToken(fixtureId: string, expiresAt: Date): Prom
     .setIssuedAt()
     .setExpirationTime(Math.floor(expiresAt.getTime() / 1000))
     .sign(secretKey());
+}
+
+/**
+ * Organiser mint (editor session only, device-links rule): sign a check-in
+ * token for the fixture, valid until the end of the fixture's local day
+ * (schedule_settings.tz of its division, UTC fallback).
+ */
+export async function createCheckinLink(
+  auth: AuthCtx,
+  fixtureId: string,
+): Promise<{ token: string; expires_at: string }> {
+  if (auth.via !== "session" || !auth.userId) {
+    throw new HttpError(403, "Check-in codes can only be managed with a session login");
+  }
+  return withTenant(auth.orgId, async (tx) => {
+    const [fixture] = await tx<{ id: string; division_id: string; status: string }[]>`
+      select id, division_id, status from fixtures where id = ${fixtureId}`;
+    if (!fixture) throw new HttpError(404, "fixture not found");
+    if (fixture.status === "finalized" || fixture.status === "cancelled") {
+      throw new HttpError(422, `fixture is ${fixture.status} — check-in is closed`);
+    }
+    const [settings] = await tx<{ tz: string }[]>`
+      select tz from schedule_settings where division_id = ${fixture.division_id}`;
+    const expiresAt = endOfLocalDay(new Date(), settings?.tz ?? "UTC");
+    const token = await mintCheckinToken(fixtureId, expiresAt);
+    return { token, expires_at: expiresAt.toISOString() };
+  });
 }
 
 /** Verify a check-in token → fixture id. Distinct codes: CHECKIN_EXPIRED for

--- a/apps/web/src/server/usecases/me.ts
+++ b/apps/web/src/server/usecases/me.ts
@@ -239,6 +239,14 @@ export async function listFixtureAvailability(
   });
 }
 
+/** Does any claimed player profile point at this login? Drives the console
+ *  nav's "Player home" door for dual-role users (organiser + player). */
+export async function hasClaimedProfile(userId: string): Promise<boolean> {
+  const [row] = await sql<{ has: boolean }[]>`
+    select exists(select 1 from persons where user_id = ${userId}) as has`;
+  return row?.has === true;
+}
+
 /** True when the user's ONLY relationship to the platform is a claimed
  *  player profile (no org memberships). Their landing is /me — never the
  *  org dashboard, and never an auto-provisioned "My organization" (the

--- a/apps/web/src/server/usecases/me.ts
+++ b/apps/web/src/server/usecases/me.ts
@@ -4,9 +4,10 @@ import "server-only";
 // claimed player is usually NOT an org member, so the tenant door never
 // opens for them; every function pins rows through persons.user_id = me.
 // dob never leaves this module — only the derived consent_locked flag does.
-import { sql } from "@/lib/db";
+import { sql, withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { consentLocked } from "@/lib/guardian";
+import type { AuthCtx } from "@/server/api-v1/auth";
 import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
 
 export type AvailabilityStatus = "in" | "out" | "maybe";
@@ -215,6 +216,27 @@ export async function checkInToFixture(
       set checked_in_at = now(), updated_at = now()
     returning ${sql(FA_COLS)}`;
   return row;
+}
+
+export interface FixtureAvailability {
+  person_id: string;
+  status: AvailabilityStatus;
+  note: string | null;
+  checked_in_at: string | null;
+}
+
+/** Organiser-side read for the lineup picker (PROMPT-53): every RSVP/check-in
+ *  on the fixture, keyed by person. Tenant-bounded — unlike the /me reads. */
+export async function listFixtureAvailability(
+  auth: AuthCtx,
+  fixtureId: string,
+): Promise<Record<string, FixtureAvailability>> {
+  return withTenant(auth.orgId, async (tx) => {
+    const rows = await tx<FixtureAvailability[]>`
+      select person_id, status, note, checked_in_at
+      from fixture_availability where fixture_id = ${fixtureId}`;
+    return Object.fromEntries(rows.map((r) => [r.person_id, r]));
+  });
 }
 
 export interface MyPerson {

--- a/apps/web/src/server/usecases/me.ts
+++ b/apps/web/src/server/usecases/me.ts
@@ -239,6 +239,18 @@ export async function listFixtureAvailability(
   });
 }
 
+/** True when the user's ONLY relationship to the platform is a claimed
+ *  player profile (no org memberships). Their landing is /me — never the
+ *  org dashboard, and never an auto-provisioned "My organization" (the
+ *  scorer-only rule, doc 13 §4, extended to players). */
+export async function isPlayerOnly(userId: string): Promise<boolean> {
+  const [row] = await sql<{ player_only: boolean }[]>`
+    select exists(select 1 from persons where user_id = ${userId})
+       and not exists(select 1 from org_members where user_id = ${userId})
+       as player_only`;
+  return row?.player_only === true;
+}
+
 export interface MyPerson {
   id: string;
   full_name: string;

--- a/apps/web/src/server/usecases/me.ts
+++ b/apps/web/src/server/usecases/me.ts
@@ -1,0 +1,278 @@
+import "server-only";
+// Player home (PROMPT-53, doc 16 §1.3): cross-org "me" reads and writes for
+// claimed players. Superuser queries mirroring listAssignedFixtures — a
+// claimed player is usually NOT an org member, so the tenant door never
+// opens for them; every function pins rows through persons.user_id = me.
+// dob never leaves this module — only the derived consent_locked flag does.
+import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { consentLocked } from "@/lib/guardian";
+import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
+
+export type AvailabilityStatus = "in" | "out" | "maybe";
+
+export interface MyFixture {
+  id: string;
+  fixture_no: number;
+  person_id: string;
+  person_name: string;
+  org_name: string;
+  org_slug: string;
+  competition_name: string;
+  competition_slug: string;
+  competition_visibility: string;
+  division_name: string;
+  division_slug: string;
+  sport_key: string;
+  round_no: number;
+  entrant_name: string | null;
+  opponent_name: string | null;
+  scheduled_at: string | null;
+  venue: string | null;
+  court_label: string | null;
+  status: string;
+  availability: { status: AvailabilityStatus; note: string | null } | null;
+  checked_in_at: string | null;
+}
+
+export interface MyResult {
+  id: string;
+  fixture_no: number;
+  competition_name: string;
+  competition_slug: string;
+  competition_visibility: string;
+  division_name: string;
+  division_slug: string;
+  org_name: string;
+  org_slug: string;
+  entrant_name: string | null;
+  opponent_name: string | null;
+  scheduled_at: string | null;
+  summary: string | null;
+  outcome: unknown;
+}
+
+export interface MyTeam {
+  entrant_id: string;
+  entrant_name: string;
+  division_name: string;
+  competition_name: string;
+  org_name: string;
+  sport_key: string;
+}
+
+const ROSTERED = ["registered", "confirmed"];
+
+// The membership chain every /me read hangs off: my persons → their entrant
+// memberships → fixtures where that entrant plays. Fragment inlined per query
+// (postgres.js has no composable fragments with bindings across helpers).
+
+export async function listMyFixtures(userId: string): Promise<{
+  upcoming: MyFixture[];
+  results: MyResult[];
+  teams: MyTeam[];
+}> {
+  const upcoming = await sql<MyFixture[]>`
+    select distinct on (f.scheduled_at, f.id, p.id)
+           f.id, f.fixture_no, p.id as person_id, p.full_name as person_name,
+           o.name as org_name, o.slug as org_slug,
+           c.name as competition_name, c.slug as competition_slug,
+           c.visibility as competition_visibility,
+           d.name as division_name, d.slug as division_slug, d.sport_key,
+           f.round_no, e.display_name as entrant_name,
+           opp.display_name as opponent_name,
+           f.scheduled_at, f.venue, f.court_label, f.status,
+           case when fa.status is null then null
+                else jsonb_build_object('status', fa.status, 'note', fa.note) end
+             as availability,
+           fa.checked_in_at
+    from persons p
+    join entrant_members em on em.person_id = p.id
+    join entrants e on e.id = em.entrant_id and e.status in ${sql(ROSTERED)}
+    join fixtures f on (f.home_entrant_id = e.id or f.away_entrant_id = e.id)
+    join divisions d on d.id = f.division_id
+    join competitions c on c.id = d.competition_id
+    join organizations o on o.id = f.org_id
+    left join entrants opp on opp.id =
+      case when f.home_entrant_id = e.id then f.away_entrant_id else f.home_entrant_id end
+    left join fixture_availability fa on fa.fixture_id = f.id and fa.person_id = p.id
+    where p.user_id = ${userId}
+      and f.status in ('scheduled', 'in_play')
+      and (f.scheduled_at is null or f.scheduled_at >= date_trunc('day', now()))
+    order by f.scheduled_at nulls last, f.id, p.id
+    limit 100`;
+
+  const results = await sql<MyResult[]>`
+    select distinct on (f.scheduled_at, f.id)
+           f.id, f.fixture_no,
+           c.name as competition_name, c.slug as competition_slug,
+           c.visibility as competition_visibility,
+           d.name as division_name, d.slug as division_slug,
+           o.name as org_name, o.slug as org_slug,
+           e.display_name as entrant_name, opp.display_name as opponent_name,
+           f.scheduled_at, m.summary, f.outcome
+    from persons p
+    join entrant_members em on em.person_id = p.id
+    join entrants e on e.id = em.entrant_id and e.status in ${sql(ROSTERED)}
+    join fixtures f on (f.home_entrant_id = e.id or f.away_entrant_id = e.id)
+    left join match_states m on m.fixture_id = f.id
+    join divisions d on d.id = f.division_id
+    join competitions c on c.id = d.competition_id
+    join organizations o on o.id = f.org_id
+    left join entrants opp on opp.id =
+      case when f.home_entrant_id = e.id then f.away_entrant_id else f.home_entrant_id end
+    where p.user_id = ${userId} and f.status = 'finalized'
+    order by f.scheduled_at desc nulls last, f.id
+    limit 10`;
+
+  const teams = await sql<MyTeam[]>`
+    select distinct e.id as entrant_id, e.display_name as entrant_name,
+           d.name as division_name, c.name as competition_name,
+           o.name as org_name, d.sport_key
+    from persons p
+    join entrant_members em on em.person_id = p.id
+    join entrants e on e.id = em.entrant_id and e.status in ${sql(ROSTERED)}
+    join divisions d on d.id = e.division_id
+    join competitions c on c.id = d.competition_id
+    join organizations o on o.id = d.org_id
+    where p.user_id = ${userId}
+    order by o.name, c.name, d.name`;
+
+  return { upcoming, results, teams };
+}
+
+interface MyFixturePerson {
+  person_id: string;
+  org_id: string;
+  fixture_status: string;
+}
+
+/** MY person on this fixture (either side's roster), or null. */
+async function myPersonOnFixture(userId: string, fixtureId: string): Promise<MyFixturePerson | null> {
+  const [row] = await sql<MyFixturePerson[]>`
+    select p.id as person_id, f.org_id, f.status as fixture_status
+    from fixtures f
+    join entrants e on e.id in (f.home_entrant_id, f.away_entrant_id)
+      and e.status in ${sql(ROSTERED)}
+    join entrant_members em on em.entrant_id = e.id
+    join persons p on p.id = em.person_id and p.user_id = ${userId}
+    where f.id = ${fixtureId}
+    limit 1`;
+  return row ?? null;
+}
+
+export interface AvailabilityRow {
+  fixture_id: string;
+  person_id: string;
+  status: AvailabilityStatus;
+  note: string | null;
+  checked_in_at: string | null;
+  updated_at: string;
+}
+
+const FA_COLS = ["fixture_id", "person_id", "status", "note", "checked_in_at", "updated_at"] as const;
+
+/** RSVP (in/out/maybe + note). Player-only door: the fixture must involve a
+ *  roster containing one of MY claimed persons. */
+export async function setMyAvailability(
+  userId: string,
+  fixtureId: string,
+  input: { status: AvailabilityStatus; note?: string | null },
+): Promise<AvailabilityRow> {
+  const mine = await myPersonOnFixture(userId, fixtureId);
+  if (!mine) throw new HttpError(403, "This match doesn't involve any of your player profiles", "NOT_YOUR_FIXTURE");
+  if (mine.fixture_status === "finalized" || mine.fixture_status === "cancelled") {
+    throw new HttpError(422, `This match is ${mine.fixture_status} — availability is closed`);
+  }
+  const [row] = await sql<AvailabilityRow[]>`
+    insert into fixture_availability (fixture_id, person_id, org_id, status, note)
+    values (${fixtureId}, ${mine.person_id}, ${mine.org_id}, ${input.status}, ${input.note ?? null})
+    on conflict (fixture_id, person_id) do update
+      set status = excluded.status, note = excluded.note, updated_at = now()
+    returning ${sql(FA_COLS)}`;
+  return row;
+}
+
+/**
+ * QR self check-in: stamp presence. A fresh row defaults the RSVP to 'in'
+ * (turning up answers the question); an existing answer is never clobbered.
+ * Returns null when the caller has no claimed person on the fixture — the
+ * route turns that into the claim-first interstitial.
+ */
+export async function checkInToFixture(
+  userId: string,
+  fixtureId: string,
+): Promise<AvailabilityRow | null> {
+  const mine = await myPersonOnFixture(userId, fixtureId);
+  if (!mine) return null;
+  if (mine.fixture_status === "finalized" || mine.fixture_status === "cancelled") {
+    throw new HttpError(422, `This match is ${mine.fixture_status} — check-in is closed`);
+  }
+  const [row] = await sql<AvailabilityRow[]>`
+    insert into fixture_availability (fixture_id, person_id, org_id, status, checked_in_at)
+    values (${fixtureId}, ${mine.person_id}, ${mine.org_id}, 'in', now())
+    on conflict (fixture_id, person_id) do update
+      set checked_in_at = now(), updated_at = now()
+    returning ${sql(FA_COLS)}`;
+  return row;
+}
+
+export interface MyPerson {
+  id: string;
+  full_name: string;
+  org_name: string;
+  consent: { public_name?: boolean; public_photo?: boolean };
+  consent_locked: boolean;
+}
+
+/** My claimed persons across all orgs, with consent state. dob stays server-side. */
+export async function listMyPersons(userId: string): Promise<MyPerson[]> {
+  const rows = await sql<
+    (Omit<MyPerson, "consent_locked"> & { dob: string | null })[]
+  >`
+    select p.id, p.full_name, o.name as org_name, p.consent, p.dob
+    from persons p join organizations o on o.id = p.org_id
+    where p.user_id = ${userId}
+    order by o.name, p.full_name`;
+  return rows.map(({ dob, ...p }) => ({
+    ...p,
+    consent: (p.consent ?? {}) as MyPerson["consent"],
+    consent_locked: consentLocked(dob),
+  }));
+}
+
+/**
+ * Player-owned consent flags (doc 06 §4.7 handover): merge into
+ * persons.consent, then revalidate every division the person is rostered in
+ * so the public card and entrant lists flip immediately. Guardian gate:
+ * under-16 by dob → 403, organiser-set values hold.
+ */
+export async function setMyConsent(
+  userId: string,
+  personId: string,
+  patch: { public_name?: boolean; public_photo?: boolean },
+): Promise<MyPerson> {
+  const [person] = await sql<{ id: string; dob: string | null }[]>`
+    select id, dob from persons where id = ${personId} and user_id = ${userId}`;
+  if (!person) throw new HttpError(404, "player profile not found");
+  if (consentLocked(person.dob)) {
+    throw new HttpError(403, "An organiser manages consent for under-16 players", "CONSENT_LOCKED");
+  }
+  const clean: Record<string, boolean> = {};
+  if (typeof patch.public_name === "boolean") clean.public_name = patch.public_name;
+  if (typeof patch.public_photo === "boolean") clean.public_photo = patch.public_photo;
+  await sql`
+    update persons set consent = coalesce(consent, '{}'::jsonb) || ${sql.json(clean)}
+    where id = ${personId}`;
+
+  const memberships = await sql<{ division_id: string; competition_id: string }[]>`
+    select distinct e.division_id, d.competition_id
+    from entrant_members em
+    join entrants e on e.id = em.entrant_id
+    join divisions d on d.id = e.division_id
+    where em.person_id = ${personId}`;
+  for (const m of memberships) fireDivisionRevalidate(m.division_id, m.competition_id);
+
+  const [me] = await listMyPersons(userId).then((all) => all.filter((p) => p.id === personId));
+  return me;
+}

--- a/apps/web/src/server/usecases/person-claims.ts
+++ b/apps/web/src/server/usecases/person-claims.ts
@@ -1,0 +1,189 @@
+import "server-only";
+// Player-account claims (PROMPT-53, doc 16 §1.3): an organiser invites a
+// person to claim their row; the token holder links persons.user_id to their
+// login. Tokens are random secrets hashed at rest (device-links pattern);
+// resolution runs on the superuser connection because the claimant is not an
+// org member. Claim rows are never deleted — claimed_at/revoked_at/invited_by
+// are the audit trail for claim and staff unlink.
+import { createHash, randomBytes } from "node:crypto";
+import { sql, withTenant } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+export const CLAIM_PREFIX = "pc_";
+const CLAIM_DAYS = 14;
+
+export function hashClaimToken(secret: string): string {
+  return createHash("sha256").update(secret, "utf8").digest("hex");
+}
+
+/** Mint a new claim secret. Shown once; only the sha256 is stored. */
+export function mintClaimSecret(): string {
+  return CLAIM_PREFIX + randomBytes(32).toString("base64url");
+}
+
+export interface ClaimRow {
+  id: string;
+  person_id: string;
+  email: string;
+  invited_by: string | null;
+  expires_at: string;
+  claimed_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+const COLS = [
+  "id", "person_id", "email", "invited_by", "expires_at",
+  "claimed_at", "revoked_at", "created_at",
+] as const;
+
+function requireSessionEditor(auth: AuthCtx): void {
+  // Claim invites mint a login capability — session editors only, never an
+  // API key or device link (same rule as device-links minting).
+  if (auth.via !== "session" || !auth.userId) {
+    throw new HttpError(403, "Claim invites can only be managed with a session login");
+  }
+}
+
+/**
+ * Invite a person to claim their profile. One open claim per person: minting
+ * revokes any prior open invite. Secret returned exactly once.
+ */
+export async function createClaimInvite(
+  auth: AuthCtx,
+  personId: string,
+  email: string,
+): Promise<ClaimRow & { secret: string; person_name: string }> {
+  requireSessionEditor(auth);
+  const secret = mintClaimSecret();
+  const row = await withTenant(auth.orgId, async (tx) => {
+    const [person] = await tx<{ id: string; full_name: string; user_id: string | null }[]>`
+      select id, full_name, user_id from persons where id = ${personId}`;
+    if (!person) throw new HttpError(404, "person not found");
+    if (person.user_id) {
+      throw new HttpError(409, "This profile is already claimed", "ALREADY_CLAIMED");
+    }
+    await tx`
+      update person_claims set revoked_at = now()
+      where person_id = ${personId} and claimed_at is null and revoked_at is null`;
+    const [created] = await tx<ClaimRow[]>`
+      insert into person_claims (org_id, person_id, email, token_hash, invited_by, expires_at)
+      values (${auth.orgId}, ${personId}, ${email}, ${hashClaimToken(secret)},
+              ${auth.userId}, now() + ${`${CLAIM_DAYS} days`}::interval)
+      returning ${tx(COLS)}`;
+    return { ...created, person_name: person.full_name };
+  });
+  return { ...row, secret };
+}
+
+/** Revoke the person's open invite, if any (idempotent). */
+export async function revokeClaimInvite(auth: AuthCtx, personId: string): Promise<ClaimRow | null> {
+  requireSessionEditor(auth);
+  return withTenant(auth.orgId, async (tx) => {
+    const [row] = await tx<ClaimRow[]>`
+      update person_claims set revoked_at = now()
+      where person_id = ${personId} and claimed_at is null and revoked_at is null
+      returning ${tx(COLS)}`;
+    return row ?? null;
+  });
+}
+
+/** The person's open invite (organiser console; no secret — it showed once). */
+export async function getOpenClaim(auth: AuthCtx, personId: string): Promise<ClaimRow | null> {
+  return withTenant(auth.orgId, async (tx) => {
+    const [row] = await tx<ClaimRow[]>`
+      select ${tx(COLS)} from person_claims
+      where person_id = ${personId} and claimed_at is null and revoked_at is null
+      order by created_at desc limit 1`;
+    return row ?? null;
+  });
+}
+
+export interface ResolvedClaim {
+  id: string;
+  org_id: string;
+  org_name: string;
+  person_id: string;
+  person_name: string;
+  email: string;
+}
+
+/**
+ * Resolve a pc_ token for the /claim page. Distinct error codes so the page
+ * can render each dead-end with its own copy: CLAIM_INVALID / CLAIM_REVOKED /
+ * CLAIM_EXPIRED / CLAIM_CLAIMED.
+ */
+export async function resolveClaimToken(token: string): Promise<ResolvedClaim> {
+  const [claim] = await sql<
+    (ResolvedClaim & {
+      expires_at: string;
+      claimed_at: string | null;
+      revoked_at: string | null;
+      user_id: string | null;
+    })[]
+  >`
+    select pc.id, pc.org_id, o.name as org_name, pc.person_id,
+           p.full_name as person_name, pc.email,
+           pc.expires_at, pc.claimed_at, pc.revoked_at, p.user_id
+    from person_claims pc
+    join persons p on p.id = pc.person_id
+    join organizations o on o.id = pc.org_id
+    where pc.token_hash = ${hashClaimToken(token)} limit 1`;
+  if (!claim) throw new HttpError(401, "This claim link is not valid", "CLAIM_INVALID");
+  if (claim.claimed_at || claim.user_id) {
+    throw new HttpError(409, "This profile has already been claimed", "CLAIM_CLAIMED");
+  }
+  if (claim.revoked_at) {
+    throw new HttpError(401, "This invite was withdrawn — ask the organiser for a new one", "CLAIM_REVOKED");
+  }
+  if (new Date(claim.expires_at).getTime() <= Date.now()) {
+    throw new HttpError(401, "This invite has expired — ask the organiser for a new one", "CLAIM_EXPIRED");
+  }
+  return {
+    id: claim.id,
+    org_id: claim.org_id,
+    org_name: claim.org_name,
+    person_id: claim.person_id,
+    person_name: claim.person_name,
+    email: claim.email,
+  };
+}
+
+/**
+ * Link the person to the logged-in user. Transactional: the person row is
+ * locked so two racing accepts can't both win; the loser gets CLAIM_CLAIMED.
+ */
+export async function claimPerson(token: string, userId: string): Promise<ResolvedClaim> {
+  const claim = await resolveClaimToken(token);
+  await sql.begin(async (tx) => {
+    const [updated] = await tx<{ id: string }[]>`
+      update persons set user_id = ${userId}
+      where id = ${claim.person_id} and user_id is null
+      returning id`;
+    if (!updated) {
+      throw new HttpError(409, "This profile has already been claimed", "CLAIM_CLAIMED");
+    }
+    await tx`
+      update person_claims set claimed_at = now()
+      where id = ${claim.id} and claimed_at is null`;
+  });
+  return claim;
+}
+
+/**
+ * Staff unlink: detach the login and close every live claim row. The claimed
+ * row keeps claimed_at AND gains revoked_at — that pair is the unlink audit.
+ */
+export async function unlinkPerson(auth: AuthCtx, personId: string): Promise<void> {
+  requireSessionEditor(auth);
+  await withTenant(auth.orgId, async (tx) => {
+    const [person] = await tx<{ id: string }[]>`
+      select id from persons where id = ${personId}`;
+    if (!person) throw new HttpError(404, "person not found");
+    await tx`update persons set user_id = null where id = ${personId}`;
+    await tx`
+      update person_claims set revoked_at = now()
+      where person_id = ${personId} and revoked_at is null`;
+  });
+}

--- a/apps/web/src/server/usecases/person-claims.ts
+++ b/apps/web/src/server/usecases/person-claims.ts
@@ -153,11 +153,24 @@ export async function resolveClaimToken(token: string): Promise<ResolvedClaim> {
 }
 
 /**
- * Link the person to the logged-in user. Transactional: the person row is
+ * Link the person to the logged-in user. Strict email match (owner decision
+ * 2026-07-13): only an account signed in with the INVITED address may accept —
+ * the emailed link alone is not enough. Transactional: the person row is
  * locked so two racing accepts can't both win; the loser gets CLAIM_CLAIMED.
  */
-export async function claimPerson(token: string, userId: string): Promise<ResolvedClaim> {
+export async function claimPerson(
+  token: string,
+  userId: string,
+  userEmail: string,
+): Promise<ResolvedClaim> {
   const claim = await resolveClaimToken(token);
+  if (claim.email.toLowerCase() !== userEmail.toLowerCase()) {
+    throw new HttpError(
+      403,
+      `This invite was sent to ${claim.email} — sign in with that address to claim it`,
+      "CLAIM_EMAIL_MISMATCH",
+    );
+  }
   await sql.begin(async (tx) => {
     const [updated] = await tx<{ id: string }[]>`
       update persons set user_id = ${userId}

--- a/apps/web/src/server/usecases/person-claims.ts
+++ b/apps/web/src/server/usecases/person-claims.ts
@@ -54,7 +54,7 @@ export async function createClaimInvite(
   auth: AuthCtx,
   personId: string,
   email: string,
-): Promise<ClaimRow & { secret: string; person_name: string }> {
+): Promise<ClaimRow & { secret: string; person_name: string; org_name: string }> {
   requireSessionEditor(auth);
   const secret = mintClaimSecret();
   const row = await withTenant(auth.orgId, async (tx) => {
@@ -64,6 +64,8 @@ export async function createClaimInvite(
     if (person.user_id) {
       throw new HttpError(409, "This profile is already claimed", "ALREADY_CLAIMED");
     }
+    const [org] = await tx<{ name: string }[]>`
+      select name from organizations where id = ${auth.orgId}`;
     await tx`
       update person_claims set revoked_at = now()
       where person_id = ${personId} and claimed_at is null and revoked_at is null`;
@@ -72,7 +74,7 @@ export async function createClaimInvite(
       values (${auth.orgId}, ${personId}, ${email}, ${hashClaimToken(secret)},
               ${auth.userId}, now() + ${`${CLAIM_DAYS} days`}::interval)
       returning ${tx(COLS)}`;
-    return { ...created, person_name: person.full_name };
+    return { ...created, person_name: person.full_name, org_name: org?.name ?? "" };
   });
   return { ...row, secret };
 }

--- a/apps/web/src/server/usecases/persons.ts
+++ b/apps/web/src/server/usecases/persons.ts
@@ -18,10 +18,14 @@ export interface PersonRow {
   consent: unknown;
   external_ref: string | null;
   photo_path: string | null;
+  /** Set once a player has claimed this row (PROMPT-53). */
+  user_id: string | null;
   created_at: string;
+  /** listPersons only: an open, unexpired claim invite exists. */
+  claim_pending?: boolean;
 }
 
-const COLS = ["id", "full_name", "dob", "gender", "consent", "external_ref", "photo_path", "created_at"] as const;
+const COLS = ["id", "full_name", "dob", "gender", "consent", "external_ref", "photo_path", "user_id", "created_at"] as const;
 
 // Player photos ride the same public 'assets' bucket as club badges; the
 // public_photo consent flag gates display, not upload.
@@ -34,13 +38,23 @@ const PHOTO_MIME = new Map<string, string>([
 
 export async function listPersons(auth: AuthCtx, query: ListQuery): Promise<Page<PersonRow>> {
   return withTenant(auth.orgId, async (tx) => {
+    // claim_pending drives the console's invite → pending → claimed states
+    // (PROMPT-53) — computed on the list read only.
     const rows = query.cursor
       ? await tx<PersonRow[]>`
-          select ${tx(COLS)} from persons
+          select ${tx(COLS)},
+                 exists(select 1 from person_claims pc
+                        where pc.person_id = persons.id and pc.claimed_at is null
+                          and pc.revoked_at is null and pc.expires_at > now()) as claim_pending
+          from persons
           where (created_at, id) > (${query.cursor.createdAt}, ${query.cursor.id})
           order by created_at, id limit ${query.limit + 1}`
       : await tx<PersonRow[]>`
-          select ${tx(COLS)} from persons order by created_at, id limit ${query.limit + 1}`;
+          select ${tx(COLS)},
+                 exists(select 1 from person_claims pc
+                        where pc.person_id = persons.id and pc.claimed_at is null
+                          and pc.revoked_at is null and pc.expires_at > now()) as claim_pending
+          from persons order by created_at, id limit ${query.limit + 1}`;
     return page(rows, query.limit);
   });
 }

--- a/db/migration/deltas/V276__player_accounts.sql
+++ b/db/migration/deltas/V276__player_accounts.sql
@@ -1,0 +1,52 @@
+-- V276 — Player accounts (PROMPT-53): claim invites + per-fixture availability.
+-- persons.user_id + persons.consent exist since V204 — claiming only fills them.
+
+-- Claim invites: token hashed at rest (device-links pattern, doc 13 §7).
+-- Rows are never deleted — claimed_at/revoked_at/invited_by ARE the audit
+-- trail for claim/unlink (an org-wide person has no competition_events grain).
+create table person_claims (
+  id          uuid primary key default gen_random_uuid(),
+  org_id      uuid not null references organizations(id) on delete cascade,
+  person_id   uuid not null references persons(id) on delete cascade,
+  email       text not null,
+  token_hash  text not null unique,
+  invited_by  uuid references users(id) on delete set null,
+  expires_at  timestamptz not null,
+  claimed_at  timestamptz,
+  revoked_at  timestamptz,
+  created_at  timestamptz not null default now()
+);
+create index person_claims_person_idx on person_claims(person_id);
+create index person_claims_org_idx on person_claims(org_id);
+-- One OPEN claim per person: minting a new invite revokes the previous one.
+create unique index person_claims_open_uq on person_claims(person_id)
+  where claimed_at is null and revoked_at is null;
+
+alter table person_claims enable row level security;
+alter table person_claims force  row level security;
+create policy person_claims_tenant on person_claims for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+grant select, insert, update on person_claims to app_user;
+
+-- Player RSVP + QR self-check-in, one row per (fixture, person). Presence
+-- lives here (checked_in_at), not on lineups — a player can check in before
+-- the organiser has picked any lineup. Player-side writes go through the
+-- superuser connection (cross-org; the player is not an org member); the
+-- tenant policy serves organiser-console reads.
+create table fixture_availability (
+  fixture_id    uuid not null references fixtures(id) on delete cascade,
+  person_id     uuid not null references persons(id) on delete cascade,
+  org_id        uuid not null,
+  status        text not null check (status in ('in','out','maybe')),
+  note          text,
+  checked_in_at timestamptz,
+  updated_at    timestamptz not null default now(),
+  primary key (fixture_id, person_id)
+);
+create index fixture_availability_person_idx on fixture_availability(person_id);
+
+alter table fixture_availability enable row level security;
+alter table fixture_availability force  row level security;
+create policy fixture_availability_tenant on fixture_availability for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+grant select on fixture_availability to app_user;

--- a/docs/superpowers/plans/2026-07-13-player-accounts.md
+++ b/docs/superpowers/plans/2026-07-13-player-accounts.md
@@ -1,0 +1,248 @@
+# Player Accounts (PROMPT-53) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A person claims their `persons` row via an organiser-sent invite, gets a cross-org player home at `/me` (schedule + RSVP + consent), organisers see availability chips in the lineup picker, and players self-check-in via a fixture QR.
+
+**Architecture:** New migration V276 (`person_claims` + `fixture_availability`, house RLS). Claim tokens are random secrets hashed at rest (device-links pattern); check-in tokens are HS256 JWTs signed with `AUTH_SECRET` (stateless, fixture-scoped, die at local midnight). `/me` reads are superuser cross-org queries mirroring `listAssignedFixtures`; organiser-side reads stay inside `withTenant`. Consent writes by the player fire the existing division/competition tag revalidation so the public card flips immediately.
+
+**Tech Stack:** Next 16.2.9 (App Router), postgres.js tagged SQL, zod schemas in `server/api-v1/schemas.ts`, jose JWT, qrcode, Resend via `lib/email.ts` + `lib/email-templates/compose.ts`, vitest (DB-backed suites skip without `DATABASE_URL`), Playwright e2e.
+
+## Global Constraints
+
+- Migration number **V276** (`db/migration/deltas/V276__player_accounts.sql`). V275 = advisor indexes, taken.
+- Player accounts are **all plans, free included** — NO `requireFeature` gate on any new surface.
+- **Guardian gate (owner-confirmed 2026-07-13): under-16 (by `persons.dob`) sees the consent card read-only**; organiser-set values hold. Server-enforced, not UI-only.
+- Every new `/api/v1` route registered in **three** places: `key-scopes.ts` (`NEVER_KEY_ROUTES` — all new routes are session-bound), `openapi.ts` `ROUTES`, and committed `npm run openapi:gen` output (`openapi/v1*.json`).
+- Every new page href built in `lib/routes.ts` — raw console hrefs are lint-banned.
+- Every new UI string through `lib/messages.ts` (flat dot-namespaced keys).
+- `persons.dob` is NEVER in any public or player-facing payload (only the derived lock flag).
+- Each change ships with a test that fails without it. `npx tsc --noEmit` + unit suite green BEFORE push (run from `apps/web` cwd — root cwd breaks `@/` aliases).
+- Closing pass mandatory: `content/help/*.md`, `scripts/smoke.ts` (pro + free), i18n keys, routes.ts.
+- Worktree: `.claude/worktrees/player-accounts`, branch `feat/player-accounts`. Dev servers: `node <root>/node_modules/next/dist/bin/next dev` + `PORT=<n>` (rtk hook swallows `npx next dev`).
+- Local test DB recipe: ephemeral PG on :54329 (fall back :54331), `npm run db:apply`, then `DATABASE_URL=... DATABASE_SSL=disable npm test` from `apps/web`.
+
+---
+
+### Task 1: Migration V276 — person_claims + fixture_availability
+
+**Files:**
+- Create: `db/migration/deltas/V276__player_accounts.sql`
+
+**Interfaces:**
+- Produces tables `person_claims` (token_hash unique, one OPEN claim per person via partial unique index) and `fixture_availability` (PK fixture_id+person_id, status in/out/maybe, `checked_in_at` for QR presence).
+- Decision: QR check-in presence lives on `fixture_availability.checked_in_at` (same person+fixture grain) — no third table, lineups untouched.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- V276 — Player accounts (PROMPT-53): claim invites + per-fixture availability.
+-- persons.user_id + persons.consent exist since V204 — claim only fills them.
+
+-- Claim invites: token hashed at rest (device-links pattern, doc 13 §7).
+-- Rows are never deleted — claimed_at/revoked_at/invited_by ARE the audit trail.
+create table person_claims (
+  id          uuid primary key default gen_random_uuid(),
+  org_id      uuid not null references organizations(id) on delete cascade,
+  person_id   uuid not null references persons(id) on delete cascade,
+  email       text not null,
+  token_hash  text not null unique,
+  invited_by  uuid references users(id) on delete set null,
+  expires_at  timestamptz not null,
+  claimed_at  timestamptz,
+  revoked_at  timestamptz,
+  created_at  timestamptz not null default now()
+);
+create index person_claims_person_idx on person_claims(person_id);
+create index person_claims_org_idx on person_claims(org_id);
+-- One OPEN claim per person: minting revokes the previous invite first.
+create unique index person_claims_open_uq on person_claims(person_id)
+  where claimed_at is null and revoked_at is null;
+
+alter table person_claims enable row level security;
+alter table person_claims force  row level security;
+create policy person_claims_tenant on person_claims for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+grant select, insert, update on person_claims to app_user;
+
+-- Player RSVP + QR self-check-in, one row per (fixture, person).
+-- Player-side writes go through the superuser connection (cross-org, the
+-- player is not an org member); the tenant policy serves organiser reads.
+create table fixture_availability (
+  fixture_id    uuid not null references fixtures(id) on delete cascade,
+  person_id     uuid not null references persons(id) on delete cascade,
+  org_id        uuid not null,
+  status        text not null check (status in ('in','out','maybe')),
+  note          text,
+  checked_in_at timestamptz,
+  updated_at    timestamptz not null default now(),
+  primary key (fixture_id, person_id)
+);
+create index fixture_availability_person_idx on fixture_availability(person_id);
+
+alter table fixture_availability enable row level security;
+alter table fixture_availability force  row level security;
+create policy fixture_availability_tenant on fixture_availability for all to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+grant select on fixture_availability to app_user;
+```
+
+- [ ] **Step 2: Apply to the ephemeral test DB** (`npm run db:apply` against :54329 clone) — expect `Successfully applied 1 migration`.
+- [ ] **Step 3: Commit** `feat: V276 person_claims + fixture_availability`
+
+### Task 2: Guardian gate helper (pure)
+
+**Files:**
+- Create: `apps/web/src/lib/guardian.ts`
+- Test: `apps/web/src/lib/__tests__/guardian.test.ts`
+
+**Interfaces:**
+- Produces `consentLocked(dob: string | null, now?: Date): boolean` — true iff dob known AND age < 16. Consumed by Task 4 (`setMyConsent`) and Task 8 (`/me` consent card).
+
+- [ ] **Step 1: Failing tests** — cases: null dob → false; 15y364d → true; 16th birthday today → false; 40y → false; invalid date string → false (fail open to *locked*? No: unparseable = treat as unknown = false, organiser data quality issue, matches "dob says under 16").
+- [ ] **Step 2: Implement** (date-only math, UTC, birthday boundary exact).
+- [ ] **Step 3: `npx vitest run src/lib/__tests__/guardian.test.ts`** green. Commit.
+
+### Task 3: Claim lifecycle usecases
+
+**Files:**
+- Create: `apps/web/src/server/usecases/person-claims.ts`
+- Test: `apps/web/src/server/usecases/__tests__/person-claims.test.ts` (DB-backed, `describe.skipIf(!DATABASE_URL)`)
+
+**Interfaces:**
+- `CLAIM_PREFIX = "pc_"`, `mintClaimSecret()`, `hashClaimToken(secret)` (sha256 hex, device-links pattern).
+- `createClaimInvite(auth: AuthCtx, personId: string, email: string): Promise<ClaimRow & { secret: string }>` — 404 unknown person, 409 `ALREADY_CLAIMED` if `persons.user_id` set; auto-revokes prior open claim; 14-day expiry; secret returned once.
+- `revokeClaimInvite(auth, personId)` — revokes open claim (idempotent).
+- `getOpenClaim(auth, personId): Promise<ClaimRow | null>` — no secret.
+- `resolveClaimToken(token: string)` — superuser read; distinct errors `CLAIM_INVALID` / `CLAIM_REVOKED` / `CLAIM_EXPIRED` / `CLAIM_CLAIMED` (all 4xx); returns `{ id, org_id, person_id, person_name, org_name, email }` for the confirm screen.
+- `claimPerson(token: string, userId: string)` — transaction: re-resolve, guard person.user_id still null (else `CLAIM_CLAIMED`), set `persons.user_id`, stamp `claimed_at`.
+- `unlinkPerson(auth, personId)` — sets `user_id = null`, revokes any open claim; claim rows retained (audit).
+
+- [ ] **Step 1: Failing tests** — create→resolve→claim happy path; second claim on claimed person → `CLAIM_CLAIMED`; expired token → `CLAIM_EXPIRED`; revoked → `CLAIM_REVOKED`; re-invite auto-revokes prior (open-claim partial unique never violated); invite on already-claimed person → 409; unlink clears user_id and revokes; token is stored hashed (raw secret absent from DB).
+- [ ] **Step 2: Implement** (mirror `device-links.ts` structure; org writes in `withTenant`, token resolution via superuser `sql`).
+- [ ] **Step 3: Run suite** green. Commit.
+
+### Task 4: /me usecases (fixtures, availability, consent)
+
+**Files:**
+- Create: `apps/web/src/server/usecases/me.ts`
+- Test: `apps/web/src/server/usecases/__tests__/me.test.ts`
+
+**Interfaces:**
+- `listMyFixtures(userId): Promise<{ upcoming: MyFixture[]; results: MyResult[]; teams: MyTeam[] }>` — superuser read mirroring `listAssignedFixtures`: `persons.user_id = me` → `entrant_members` → entrants (`status in ('registered','confirmed')`) → fixtures home/away. Upcoming: `status in ('scheduled','in_play')`, unscheduled or `>= date_trunc('day', now())`, soonest first, limit 100, each row carries `person_id`, `availability: {status, note} | null`, `checked_in_at`, org/comp/div names + slugs + `competition_visibility`, entrant + opponent names, `fixture_no`. Results: `status = 'finalized'` newest 10 with `outcome`, `summary`. Teams: distinct entrants with div/comp/org labels.
+- `setMyAvailability(userId, fixtureId, { status, note }): Promise<AvailabilityRow>` — resolves MY person in that fixture (403 `NOT_YOUR_FIXTURE` when none); upsert on PK, `updated_at = now()`.
+- `listMyPersons(userId): Promise<MyPerson[]>` — per claimed person: id, full_name, org name, consent flags, `consent_locked` (Task 2 helper; dob itself NOT returned).
+- `setMyConsent(userId, personId, { public_name, public_photo })` — 404 if person not mine; 403 `CONSENT_LOCKED` when guardian-gated; merges into `persons.consent`; then `fireDivisionRevalidate(divisionId, competitionId)` for every distinct division the person is rostered in (public card + entrant lists flip immediately).
+- `checkInToFixture(userId, fixtureId)` — resolves MY person among the fixture's entrants (null → caller shows claim-first interstitial); upsert `fixture_availability` with `checked_in_at = now()`, status kept or defaulted `'in'`.
+
+- [ ] **Step 1: Failing tests** — cross-org isolation (user A with persons in org1+org2 sees both; user B sees none of A's); withdrawn entrant's fixtures excluded; RSVP upsert (in→out overwrite, note kept per write); RSVP against a fixture not mine → 403; consent flip persists + guardian-locked person 403s; unclaimed person untouched by everything; check-in stamps `checked_in_at` and defaults status `in` without clobbering an existing `out`.
+- [ ] **Step 2: Implement.** Revalidation via `fireDivisionRevalidate` is try/catch-safe outside request scope already.
+- [ ] **Step 3: Run suite** green. Commit.
+
+### Task 5: Check-in token (signed, stateless)
+
+**Files:**
+- Create: `apps/web/src/server/usecases/checkin-token.ts`
+- Test: `apps/web/src/server/usecases/__tests__/checkin-token.test.ts`
+
+**Interfaces:**
+- `mintCheckinToken(fixtureId: string, expiresAt: Date): Promise<string>` — jose `SignJWT({ fid: fixtureId }).setProtectedHeader({ alg: "HS256", typ: "seazn-checkin" })`, same `AUTH_SECRET` key derivation as `lib/auth.ts`.
+- `verifyCheckinToken(token: string): Promise<string>` — returns fixtureId; expired/garbage/typ-mismatch → `HttpError(401, …, "CHECKIN_EXPIRED" | "CHECKIN_INVALID")`.
+- Expiry: caller passes `endOfLocalDay(new Date(), tz)` re-exported from `device-links.ts` (fixture's division `schedule_settings.tz`, UTC fallback) — same day-of policy as device links.
+
+- [ ] **Step 1: Failing tests** — round-trip; expired → CHECKIN_EXPIRED; tampered/typ-mismatch (a session JWT!) → CHECKIN_INVALID.
+- [ ] **Step 2: Implement.** Step 3: green, commit.
+
+### Task 6: API routes + registries + schemas
+
+**Files:**
+- Create: `apps/web/src/app/api/v1/persons/[id]/claim-invites/route.ts` (POST create → `{...claim, claim_url}`; DELETE revoke; session editor via existing `requireResourceAuth`-style org resolution used by persons routes — copy the sibling `persons/[id]` route's auth)
+- Create: `apps/web/src/app/api/v1/persons/[id]/unlink/route.ts` (POST)
+- Create: `apps/web/src/app/api/v1/me/fixtures/route.ts` (GET — `requireUser()` only, mirror `me/assigned-fixtures`)
+- Create: `apps/web/src/app/api/v1/me/fixtures/[id]/availability/route.ts` (PUT)
+- Create: `apps/web/src/app/api/v1/me/persons/route.ts` (GET)
+- Create: `apps/web/src/app/api/v1/me/persons/[id]/consent/route.ts` (PATCH)
+- Create: `apps/web/src/app/api/v1/fixtures/[id]/checkin-link/route.ts` (POST — session editor, mints `{ url, expires_at }`)
+- Create: `apps/web/src/app/api/claims/[token]/route.ts` (GET status view — non-v1, token IS the auth, like `/api/invites`)
+- Create: `apps/web/src/app/api/claims/[token]/accept/route.ts` (POST — `requireUser()` + `claimPerson`)
+- Create: `apps/web/src/app/api/checkin/[token]/route.ts` (POST — `requireUser()` + verify + `checkInToFixture`; returns `{ checked_in: true }` or `{ needs_claim: true }`)
+- Modify: `apps/web/src/server/api-v1/schemas.ts` — `putAvailabilitySchema` (`status: z.enum(["in","out","maybe"])`, `note: z.string().max(280).nullish()`), `patchMyConsentSchema` (`public_name?: boolean, public_photo?: boolean`), `createClaimInviteSchema` (`email: z.email()`)
+- Modify: `apps/web/src/server/api-v1/key-scopes.ts` — add ALL seven v1 routes to `NEVER_KEY_ROUTES` (claim minting = credential minting; /me = session-bound)
+- Modify: `apps/web/src/server/api-v1/openapi.ts` ROUTES + run `npm run openapi:gen`, commit JSON
+- Test: `apps/web/src/server/api-v1/__tests__/` enumeration suites must stay green (they fail on any unregistered route — that IS the test)
+
+- [ ] Step 1: routes + schemas. Step 2: registries + `npm run openapi:gen`. Step 3: run enumeration + route unit suites, green. Commit.
+
+### Task 7: Claim invite email + organiser console (persons panel)
+
+**Files:**
+- Modify: `apps/web/src/lib/email.ts` — `sendClaimInviteEmail(to, { orgName, personName, claimUrl })` on the courtside shell: eyebrow `orgName`, title "Claim your player profile", paragraph + `button("Claim my profile", claimUrl)` + `linkFallback`.
+- Modify: `apps/web/src/components/v2/persons-panel.tsx` — per-person row action: unclaimed → "Invite to claim" (email prefill + send) opening a modal that shows the returned one-time link + QR (reuse `invite-scorer.tsx` link+QR modal pattern) + "open invite pending · revoke"; claimed → "Claimed" badge + "Unlink" (ConfirmDialog, `confirm.unlinkPlayer.*` messages).
+- Modify: `apps/web/src/lib/messages.ts` — `claim.*` keys.
+- Test: email template snapshot in the existing `email-html-templates.test.ts` pattern; panel logic covered by e2e (Task 10).
+
+- [ ] Step 1: email + test. Step 2: panel UI. Step 3: tsc + targeted vitest green. Commit.
+
+### Task 8: /claim/[token] page + /me player home + routes/messages
+
+**Files:**
+- Create: `apps/web/src/app/claim/[token]/page.tsx` — server component, `resolveClaimToken`: logged-out → magic-link login CTA (`/login?next=/claim/<token>`, email prefilled); logged-in → identity confirm card (person name, org, claim email vs session email mismatch warning) + accept button → POST accept → redirect `/me?claimed=1`. Distinct error states for invalid/expired/revoked/claimed (each its own copy, no shared vague error).
+- Create: `apps/web/src/app/me/page.tsx` + client components under `apps/web/src/components/me/` — console shell like `/my-matches` (app-gantry header, NO org nav, NOT org-scoped).
+- Modify: `apps/web/src/lib/routes.ts` — `me: () => "/me"`, `claim: (token) => `/claim/${token}``, `checkin: (token) => `/checkin/${token}``.
+- Modify: `apps/web/src/lib/messages.ts` — `me.*` keys.
+
+**Design (frontend-design pass, floodlit-console system):** `/me` is the player's locker room. Signature element: **"Next match" NightStage hero** — the dark stadium-night panel (existing `.app-*` vocabulary) holding the next fixture with the RSVP control rendered as three tactile floodlit buttons (✓ In / ? Maybe / ✗ Out — emerald/amber/zinc, pressed state visibly lit, note field folds out under). Everything below stays quiet and light: "Coming up" list (each row a compact RSVP segmented control + comp/div/org context + public-page link only when the competition is public/unlisted), "Recent results" (scoreline rows), "My teams" chips, and the consent card (two switches, per person/org; guardian-locked → disabled with plain-language line "An organiser manages this until you're 16."). Empty state = invitation: "No matches yet — when an organiser rosters you, they land here." Desktop AND 390px.
+
+- [ ] Step 1: routes + messages. Step 2: /claim page with 4 error states. Step 3: /me page + RSVP client component (optimistic write, rollback on error). Step 4: tsc green; visual check both viewports (screenshots). Commit.
+
+### Task 9: Organiser availability grid + QR check-in surfaces
+
+**Files:**
+- Modify: `apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx` — fetch fixture availability rows (withTenant) + claimed-person set; pass `availability` map into `FixtureConsole`.
+- Modify: `apps/web/src/components/v2/fixture-console.tsx` — thread `availability?: Record<personId, {status, note, checked_in_at}>` through to `LineupEditor`; add "Check-in QR" action (POST checkin-link → link+QR modal, invite-scorer pattern).
+- Modify: `apps/web/src/components/v2/lineup-editor.tsx` — per-person chip in lineup rows AND roster chips: ✓ (emerald) / ✗ (red) / ? (amber) with `title={note}`; no row → "—" (zinc, covers unclaimed + no-answer); `checked_in_at` → additional "at venue" dot. Chips only — no layout rework.
+- Create: `apps/web/src/app/checkin/[token]/page.tsx` — logged-out → login-with-next; logged-in POST → success state ("You're checked in — the organiser can see you're here") or claim-first interstitial ("This works once you've claimed your player profile — ask the organiser for your invite"). NOTE: page path is `/checkin/[token]` (root `f/` would shadow nothing but reads badly; routes.ts owns the shape; QR encodes absolute URL).
+- Test: component-level render test for the chip mapping (`lineup-editor` accepts availability map) or covered via e2e grid assertion; page logic via e2e.
+
+- [ ] Step 1: thread data server→console→editor. Step 2: chips + QR modal. Step 3: checkin page. Step 4: tsc green, visual check grid. Commit.
+
+### Task 10: E2E — full loop + regressions
+
+**Files:**
+- Create: `apps/web/e2e/player-accounts.spec.ts` (serial project — creates a user)
+
+Flow (magic-link `login_url` trick; budget: ONE extra magic-link send, stays under 5/5min):
+1. Pro storageState: create person (dob adult), entrant + roster them, generate fixtures.
+2. Invite to claim → grab `claim_url` from API response (e2e-friendly token precedent).
+3. Fresh context: open claim_url → login via magic-link login_url → confirm → land /me.
+4. /me shows the fixture → RSVP "out" + note.
+5. Organiser context: lineup picker shows ✗ chip + note tooltip; unclaimed teammate shows "—".
+6. Mint check-in QR link (API) → player context opens → checked-in state → organiser grid shows at-venue dot.
+7. Second claim attempt on same person (new invite impossible → 409; old link → CLAIM_CLAIMED copy).
+8. Consent flip: player toggles public_name on → public player card 200s with name; toggles off → 404 again (tag revalidation). Unclaimed person's card stays 404 throughout.
+
+- [ ] Step 1: spec written, runs green locally against dev server (env sourced: `set -a && source .env.local && set +a`). Step 2: full `test:e2e` parallel+serial green. Commit.
+
+### Task 11: Closing pass (mandatory)
+
+**Files:**
+- Create: `apps/web/content/help/getting-started/player-accounts.md` (player-facing: claim, /me, RSVP, check-in, consent + guardian line)
+- Modify: `apps/web/content/help/entrants/*.md` (or the persons/directory help page — organiser side: invite to claim, QR print path, unlink)
+- Modify: `scripts/smoke.ts` — gapSuite extension: invite → claim (API) → RSVP → availability visible in fixture payload, on pro AND free org (feature is all-plans; asserts no 402).
+- Verify `npm run openapi:gen` committed, messages sweep, routes sweep.
+
+- [ ] Step 1: help pages. Step 2: smoke extension + local smoke run. Step 3: commit.
+
+### Task 12: Verification before completion
+
+- [ ] `cd apps/web && npx tsc --noEmit` — clean.
+- [ ] Full unit suite vs ephemeral DB — green (baseline-compare any pre-existing failures on main first).
+- [ ] e2e player-accounts + touched suites — green.
+- [ ] Screenshots: `/me` desktop + 390px, lineup grid with chips (Playwright MCP).
+- [ ] `superpowers:requesting-code-review` then `superpowers:finishing-a-development-branch` → PR to main.
+
+## Self-Review Notes
+
+- Spec coverage: V276 ✓ (T1), claim flow email+QR+errors+unlink ✓ (T3/T6/T7/T8), /me + RSVP + consent + guardian ✓ (T4/T8), availability grid ✓ (T9), QR self-check-in + interstitial ✓ (T5/T6/T9), closing pass ✓ (T11), acceptance tests ✓ (T3/T4/T10/T12).
+- Deviations from spec text, with reasons: (a) presence stored as `fixture_availability.checked_in_at` not a lineups column — person may check in before any lineup exists; same grain, no third table. (b) check-in page path `/checkin/[token]` not `/f/[token]/checkin` — `/f` is not an existing root namespace; routes.ts is the single source anyway. (c) claim/checkin accept endpoints live under `/api/claims/*`, `/api/checkin/*` (non-v1, token-authed) mirroring `/api/invites/[token]/accept` — keeps key-scope enumeration clean.
+- Audit for unlink = retained `person_claims` rows (claimed_at/revoked_at/invited_by); `competition_events` is competition-scoped and wrong grain for an org-wide person.

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -7175,8 +7175,23 @@
                                   }
                                 ]
                               },
+                              "user_id": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
                               "created_at": {
                                 "type": "string"
+                              },
+                              "claim_pending": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -7186,6 +7201,7 @@
                               "gender",
                               "consent",
                               "external_ref",
+                              "user_id",
                               "created_at"
                             ],
                             "additionalProperties": false
@@ -7225,6 +7241,7 @@
                         "gender": "m",
                         "consent": {},
                         "external_ref": "example",
+                        "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "created_at": "example"
                       }
                     ],
@@ -7535,8 +7552,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7546,6 +7578,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -7565,6 +7598,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -7802,8 +7836,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7813,6 +7862,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -7832,6 +7882,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -8144,8 +8195,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -8155,6 +8221,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8174,6 +8241,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -8435,8 +8503,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -8446,6 +8529,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8465,6 +8549,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -8746,8 +8831,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -8757,6 +8857,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8776,6 +8877,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -9482,6 +9482,2822 @@
         ]
       }
     },
+    "/api/v1/persons/{id}/claim-invites": {
+      "post": {
+        "summary": "Invite the person to claim their profile (session editors only; claim_url embeds the one-time secret; revokes any prior open invite)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "maxLength": 200,
+                    "format": "email",
+                    "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
+                  }
+                },
+                "required": [
+                  "email"
+                ],
+                "additionalProperties": false
+              },
+              "example": {
+                "email": "example"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "person_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "invited_by": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "expires_at": {
+                          "type": "string"
+                        },
+                        "claimed_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "revoked_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "created_at": {
+                          "type": "string"
+                        },
+                        "claim_url": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "person_id",
+                        "email",
+                        "invited_by",
+                        "expires_at",
+                        "claimed_at",
+                        "revoked_at",
+                        "created_at",
+                        "claim_url"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "person_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "email": "example",
+                    "invited_by": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "expires_at": "example",
+                    "claimed_at": "example",
+                    "revoked_at": "example",
+                    "created_at": "example",
+                    "claim_url": "example"
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "get": {
+        "summary": "The person's open claim invite, if any (never the secret)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            "person_id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            "email": {
+                              "type": "string"
+                            },
+                            "invited_by": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "expires_at": {
+                              "type": "string"
+                            },
+                            "claimed_at": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "revoked_at": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "person_id",
+                            "email",
+                            "invited_by",
+                            "expires_at",
+                            "claimed_at",
+                            "revoked_at",
+                            "created_at"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "person_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "email": "example",
+                    "invited_by": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "expires_at": "example",
+                    "claimed_at": "example",
+                    "revoked_at": "example",
+                    "created_at": "example"
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Withdraw the open claim invite (idempotent)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            "person_id": {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            "email": {
+                              "type": "string"
+                            },
+                            "invited_by": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "uuid",
+                                  "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "expires_at": {
+                              "type": "string"
+                            },
+                            "claimed_at": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "revoked_at": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "created_at": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "person_id",
+                            "email",
+                            "invited_by",
+                            "expires_at",
+                            "claimed_at",
+                            "revoked_at",
+                            "created_at"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "person_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "email": "example",
+                    "invited_by": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "expires_at": "example",
+                    "claimed_at": "example",
+                    "revoked_at": "example",
+                    "created_at": "example"
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/persons/{id}/unlink": {
+      "post": {
+        "summary": "Staff unlink: detach the player login and revoke live claims (audited — claim rows are retained)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {},
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/me/fixtures": {
+      "get": {
+        "summary": "Player home read: upcoming fixtures, recent results and teams for every claimed person of the caller, across orgs (session only)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "upcoming": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "fixture_no": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "person_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "person_name": {
+                                "type": "string"
+                              },
+                              "org_name": {
+                                "type": "string"
+                              },
+                              "org_slug": {
+                                "type": "string"
+                              },
+                              "competition_name": {
+                                "type": "string"
+                              },
+                              "competition_slug": {
+                                "type": "string"
+                              },
+                              "competition_visibility": {
+                                "type": "string"
+                              },
+                              "division_name": {
+                                "type": "string"
+                              },
+                              "division_slug": {
+                                "type": "string"
+                              },
+                              "sport_key": {
+                                "type": "string"
+                              },
+                              "round_no": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "entrant_name": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "opponent_name": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "scheduled_at": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "venue": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "court_label": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "availability": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "status": {
+                                        "type": "string",
+                                        "enum": [
+                                          "in",
+                                          "out",
+                                          "maybe"
+                                        ]
+                                      },
+                                      "note": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "status",
+                                      "note"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "checked_in_at": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "fixture_no",
+                              "person_id",
+                              "person_name",
+                              "org_name",
+                              "org_slug",
+                              "competition_name",
+                              "competition_slug",
+                              "competition_visibility",
+                              "division_name",
+                              "division_slug",
+                              "sport_key",
+                              "round_no",
+                              "entrant_name",
+                              "opponent_name",
+                              "scheduled_at",
+                              "venue",
+                              "court_label",
+                              "status",
+                              "availability",
+                              "checked_in_at"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "results": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "fixture_no": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
+                              "competition_name": {
+                                "type": "string"
+                              },
+                              "competition_slug": {
+                                "type": "string"
+                              },
+                              "competition_visibility": {
+                                "type": "string"
+                              },
+                              "division_name": {
+                                "type": "string"
+                              },
+                              "division_slug": {
+                                "type": "string"
+                              },
+                              "org_name": {
+                                "type": "string"
+                              },
+                              "org_slug": {
+                                "type": "string"
+                              },
+                              "entrant_name": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "opponent_name": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "scheduled_at": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "summary": {
+                                "anyOf": [
+                                  {},
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "outcome": {
+                                "anyOf": [
+                                  {},
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "fixture_no",
+                              "competition_name",
+                              "competition_slug",
+                              "competition_visibility",
+                              "division_name",
+                              "division_slug",
+                              "org_name",
+                              "org_slug",
+                              "entrant_name",
+                              "opponent_name",
+                              "scheduled_at",
+                              "summary",
+                              "outcome"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "teams": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "entrant_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "entrant_name": {
+                                "type": "string"
+                              },
+                              "division_name": {
+                                "type": "string"
+                              },
+                              "competition_name": {
+                                "type": "string"
+                              },
+                              "org_name": {
+                                "type": "string"
+                              },
+                              "sport_key": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "entrant_id",
+                              "entrant_name",
+                              "division_name",
+                              "competition_name",
+                              "org_name",
+                              "sport_key"
+                            ],
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "required": [
+                        "upcoming",
+                        "results",
+                        "teams"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "upcoming": [
+                      {
+                        "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                        "fixture_no": -9007199254740991,
+                        "person_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                        "person_name": "example",
+                        "org_name": "example",
+                        "org_slug": "example",
+                        "competition_name": "example",
+                        "competition_slug": "example",
+                        "competition_visibility": "example",
+                        "division_name": "example",
+                        "division_slug": "example",
+                        "sport_key": "example",
+                        "round_no": -9007199254740991,
+                        "entrant_name": "example",
+                        "opponent_name": "example",
+                        "scheduled_at": "example",
+                        "venue": "example",
+                        "court_label": "example",
+                        "status": "example",
+                        "availability": {
+                          "status": "in",
+                          "note": "example"
+                        },
+                        "checked_in_at": "example"
+                      }
+                    ],
+                    "results": [
+                      {
+                        "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                        "fixture_no": -9007199254740991,
+                        "competition_name": "example",
+                        "competition_slug": "example",
+                        "competition_visibility": "example",
+                        "division_name": "example",
+                        "division_slug": "example",
+                        "org_name": "example",
+                        "org_slug": "example",
+                        "entrant_name": "example",
+                        "opponent_name": "example",
+                        "scheduled_at": "example",
+                        "summary": null,
+                        "outcome": null
+                      }
+                    ],
+                    "teams": [
+                      {
+                        "entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                        "entrant_name": "example",
+                        "division_name": "example",
+                        "competition_name": "example",
+                        "org_name": "example",
+                        "sport_key": "example"
+                      }
+                    ]
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/me/fixtures/{id}/availability": {
+      "put": {
+        "summary": "RSVP in/out/maybe + note for the caller's person on this fixture (session only)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "in",
+                      "out",
+                      "maybe"
+                    ]
+                  },
+                  "note": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "maxLength": 280
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "status"
+                ],
+                "additionalProperties": false
+              },
+              "example": {
+                "status": "in",
+                "note": "example"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "fixture_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "person_id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "status": {
+                          "type": "string",
+                          "enum": [
+                            "in",
+                            "out",
+                            "maybe"
+                          ]
+                        },
+                        "note": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "checked_in_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "updated_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "fixture_id",
+                        "person_id",
+                        "status",
+                        "note",
+                        "checked_in_at",
+                        "updated_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "fixture_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "person_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "status": "in",
+                    "note": "example",
+                    "checked_in_at": "example",
+                    "updated_at": "example"
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/me/persons": {
+      "get": {
+        "summary": "The caller's claimed player profiles with consent state (session only)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                          },
+                          "full_name": {
+                            "type": "string"
+                          },
+                          "org_name": {
+                            "type": "string"
+                          },
+                          "consent": {
+                            "type": "object",
+                            "properties": {
+                              "public_name": {
+                                "type": "boolean"
+                              },
+                              "public_photo": {
+                                "type": "boolean"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "consent_locked": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "full_name",
+                          "org_name",
+                          "consent",
+                          "consent_locked"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": [
+                    {
+                      "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                      "full_name": "example",
+                      "org_name": "example",
+                      "consent": {
+                        "public_name": true,
+                        "public_photo": true
+                      },
+                      "consent_locked": true
+                    }
+                  ],
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/me/persons/{id}/consent": {
+      "patch": {
+        "summary": "Player-owned consent flags; under-16 → 403 CONSENT_LOCKED (guardian gate)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "public_name": {
+                    "type": "boolean"
+                  },
+                  "public_photo": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "example": {
+                "public_name": true,
+                "public_photo": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "format": "uuid",
+                          "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                        },
+                        "full_name": {
+                          "type": "string"
+                        },
+                        "org_name": {
+                          "type": "string"
+                        },
+                        "consent": {
+                          "type": "object",
+                          "properties": {
+                            "public_name": {
+                              "type": "boolean"
+                            },
+                            "public_photo": {
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "consent_locked": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "full_name",
+                        "org_name",
+                        "consent",
+                        "consent_locked"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                    "full_name": "example",
+                    "org_name": "example",
+                    "consent": {
+                      "public_name": true,
+                      "public_photo": true
+                    },
+                    "consent_locked": true
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/fixtures/{id}/checkin-link": {
+      "post": {
+        "summary": "Mint the fixture's self-check-in QR link (session editors only; signed token, dies at local midnight)",
+        "tags": [
+          "player-accounts"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "url": {
+                          "type": "string"
+                        },
+                        "expires_at": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "url",
+                        "expires_at"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {
+                    "url": "example",
+                    "expires_at": "example"
+                  },
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Rejected by the engine",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
     "/api/v1/divisions/{id}/stages": {
       "get": {
         "summary": "List stages",

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -6974,8 +6974,23 @@
                                   }
                                 ]
                               },
+                              "user_id": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
                               "created_at": {
                                 "type": "string"
+                              },
+                              "claim_pending": {
+                                "type": "boolean"
                               }
                             },
                             "required": [
@@ -6985,6 +7000,7 @@
                               "gender",
                               "consent",
                               "external_ref",
+                              "user_id",
                               "created_at"
                             ],
                             "additionalProperties": false
@@ -7024,6 +7040,7 @@
                         "gender": "m",
                         "consent": {},
                         "external_ref": "example",
+                        "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "created_at": "example"
                       }
                     ],
@@ -7334,8 +7351,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7345,6 +7377,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -7364,6 +7397,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -7601,8 +7635,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7612,6 +7661,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -7631,6 +7681,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -7943,8 +7994,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -7954,6 +8020,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -7973,6 +8040,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -8234,8 +8302,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -8245,6 +8328,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8264,6 +8348,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -8545,8 +8630,23 @@
                             }
                           ]
                         },
+                        "user_id": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
                         "created_at": {
                           "type": "string"
+                        },
+                        "claim_pending": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -8556,6 +8656,7 @@
                         "gender",
                         "consent",
                         "external_ref",
+                        "user_id",
                         "created_at"
                       ],
                       "additionalProperties": false
@@ -8575,6 +8676,7 @@
                     "gender": "m",
                     "consent": {},
                     "external_ref": "example",
+                    "user_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "created_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -264,10 +264,125 @@ async function main() {
   // Before gapSuite — its destructive downgrade ends the org's pro quota.
   await regQueueSuite(admin);
 
+  // --- PROMPT-53: player accounts — claim → RSVP → grid → QR check-in.
+  // BEFORE gapSuite: its downgrade eats org2's competition headroom.
+  await playerAccountsSuite(admin, org2.id);
+
   await gapSuite(admin, org.id, org2.id);
 
   // --- design/v7 PROMPT-51: staff-console platform revenue report.
   await platformRevenueSuite(admin, `admin_${tag}@example.com`);
+}
+
+/** PROMPT-53 player accounts over real HTTP: invite → claim → RSVP →
+ *  organiser grid chip → QR check-in → clean 409 on a second invite; the
+ *  never-invited teammate stays untouched (no public card, "—" chip). The
+ *  free path runs on the player's own auto-provisioned COMMUNITY org —
+ *  claim invites must mint on every plan. */
+async function playerAccountsSuite(admin: Session, orgId: string): Promise<void> {
+  const player = newSession();
+  const playerVer = await signIn(player, `player_${tag}@example.com`);
+
+  admin.cookies["seazn_org"] = orgId; // active-org cookie targets the v1 calls
+  const orgs = (await call(admin, "/api/orgs")) as { id: string; slug: string }[];
+  const orgSlug = orgs.find((o) => o.id === orgId)!.slug;
+
+  const comp = await v1(admin, "/api/v1/competitions", "POST", {
+    name: `Claim Cup ${tag}`,
+    visibility: "public",
+  });
+  const compData = v1data<{ id: string; slug: string }>(comp);
+  const div = await v1(admin, `/api/v1/competitions/${compData.id}/divisions`, "POST", {
+    name: "Open",
+    sport_key: "generic",
+    variant_key: "score",
+    config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+  });
+  const divData = v1data<{ id: string; slug: string }>(div);
+  const pa = await v1(admin, "/api/v1/persons", "POST", {
+    full_name: `Pat Claimer ${tag}`, consent: {},
+  });
+  const pb = await v1(admin, "/api/v1/persons", "POST", {
+    full_name: `Uma Unclaimed ${tag}`, consent: {},
+  });
+  const personId = v1data<{ id: string }>(pa).id;
+  const unclaimedId = v1data<{ id: string }>(pb).id;
+  await v1(admin, `/api/v1/divisions/${divData.id}/entrants`, "POST", [
+    { kind: "individual", display_name: "Pat", seed: 1, members: [{ person_id: personId }] },
+    { kind: "individual", display_name: "Uma", seed: 2, members: [{ person_id: unclaimedId }] },
+  ]);
+  const stage = await v1(admin, `/api/v1/divisions/${divData.id}/stages`, "POST", {
+    seq: 1, kind: "league", name: "League",
+  });
+  const gen = await v1(admin, `/api/v1/stages/${v1data<{ id: string }>(stage).id}/generate`, "POST");
+  const fixture = v1data<{ fixtures: { id: string; fixture_no: number }[] }>(gen).fixtures[0]!;
+  await v1(admin, `/api/v1/divisions/${divData.id}/start`, "POST");
+  const fixturePath = `/o/${orgSlug}/c/${compData.slug}/d/${divData.slug}/f/${fixture.fixture_no}`;
+
+  // Invite → claim (the claim_url IS the credential; shown once).
+  const invite = await v1(admin, `/api/v1/persons/${personId}/claim-invites`, "POST", {
+    email: `player_${tag}@example.com`,
+  });
+  const claimUrl = v1data<{ claim_url: string }>(invite).claim_url ?? "";
+  check("pa claim invite minted", invite.status === 201 && claimUrl.includes("/claim/pc_"));
+  const accepted = (await call(player, `/api/claims/${claimUrl.split("/claim/")[1]}/accept`, "POST")) as {
+    person_id?: string;
+  };
+  check("pa player claimed the profile", accepted.person_id === personId);
+
+  // /me carries the fixture; RSVP out with a note.
+  const mine = await v1(player, "/api/v1/me/fixtures");
+  const upcoming = v1data<{ upcoming: { id: string }[] }>(mine).upcoming ?? [];
+  check("pa /me/fixtures lists the claimed fixture", upcoming.some((f) => f.id === fixture.id));
+  const rsvp = await v1(player, `/api/v1/me/fixtures/${fixture.id}/availability`, "PUT", {
+    status: "out",
+    note: "smoke note",
+  });
+  check("pa RSVP saved", rsvp.status === 200);
+
+  // Organiser grid: ✗ chip with the note; unclaimed teammate shows "—".
+  const gridRes = await fetch(`${BASE}${fixturePath}`, {
+    headers: { cookie: Object.entries(admin.cookies).map(([k, v]) => `${k}=${v}`).join("; ") },
+  });
+  const html = await gridRes.text();
+  check("pa grid shows the unavailable chip", gridRes.status === 200 && html.includes("unavailable — smoke note"));
+  check("pa unclaimed teammate shows no-answer chip", html.includes("no availability answer"));
+
+  // QR check-in: organiser mints, player taps; presence keeps the RSVP.
+  const link = await v1(admin, `/api/v1/fixtures/${fixture.id}/checkin-link`, "POST");
+  const url = v1data<{ url: string }>(link).url ?? "";
+  check("pa check-in link minted", link.status === 201 && url.includes("/checkin/"));
+  const checkedIn = (await call(player, `/api/checkin/${url.split("/checkin/")[1]}`, "POST")) as {
+    checked_in?: boolean;
+    status?: string;
+  };
+  check("pa QR check-in keeps the explicit RSVP", checkedIn.checked_in === true && checkedIn.status === "out");
+
+  // Unclaimed person untouched: no public card without consent.
+  const card = await fetch(`${BASE}/shared/${orgSlug}/${compData.slug}/players/${unclaimedId}`);
+  check("pa unclaimed person has no public card", card.status === 404);
+
+  // Second invite on a claimed person fails clean.
+  const again = await v1(admin, `/api/v1/persons/${personId}/claim-invites`, "POST", {
+    email: `else_${tag}@example.com`,
+  });
+  check("pa second invite on a claimed person is a clean 409", again.status === 409);
+
+  // Free path: the player's own org is a fresh COMMUNITY org — claim
+  // invites must mint there too (all plans, no requireFeature gate).
+  const freePerson = await v1(player, "/api/v1/persons", "POST", {
+    full_name: `Free Player ${tag}`, consent: {},
+  });
+  const freeInvite = await v1(
+    player,
+    `/api/v1/persons/${v1data<{ id: string }>(freePerson).id}/claim-invites`,
+    "POST",
+    { email: `else_${tag}@example.com` },
+  );
+  check(
+    "pa claim invite mints on a community org (no plan gate)",
+    playerVer.has_org === true && freeInvite.status === 201,
+  );
 }
 
 /** design/v6 PROMPT-48..50: the three new sports over real HTTP — a tennis


### PR DESCRIPTION
Ships the last PROMPT-20 tier-1 feature (design/v8/prompts/PROMPT-53-player-accounts.md): a person claims their \`persons\` row, gets a cross-org player home, RSVPs availability that organisers see in the lineup picker, self-checks-in via QR, and owns their consent flags. **All plans, free included** — no \`requireFeature\` gate anywhere.

## What's in

- **V276** — \`person_claims\` (token sha256 at rest, one open claim per person via partial unique index, rows retained as claim/unlink audit) + \`fixture_availability\` (RSVP in/out/maybe + note + \`checked_in_at\` presence; house RLS).
- **Claim flow** — Directory: *invite to claim* → email (courtside template) + one-time link/QR modal; \`/claim/[token]\` with four distinct dead-end states (invalid/expired/withdrawn/claimed); racing accepts resolved transactionally; staff **unlink** keeps history.
- **Player home \`/me\`** — night-stage "Next match" hero + RSVP segmented control (✓ In / ? Maybe / ✗ Out + note), upcoming list, recent results, teams, consent card. Cross-org superuser reads mirroring \`listAssignedFixtures\`; \`dob\` never leaves the server.
- **Guardian gate (owner decision 2026-07-13):** under-16 by dob → consent read-only on /me, server-enforced 403 \`CONSENT_LOCKED\`.
- **Consent handover** — player PATCH merges \`persons.consent\` and fires division/competition tag revalidation → public player card flips immediately.
- **Availability grid** — chips in the existing lineup picker rows/roster (✓/✗/? + note tooltip, "—" for no answer/unclaimed, lime dot = checked in). No layout rework.
- **QR self check-in** — stateless HS256 token (typ-gated, dies at local midnight, device-links day-of policy) → \`/checkin/[token]\`; write happens on the button POST, never on GET; unclaimed scanners get a claim-first interstitial.
- **Registries** — 7 new v1 routes all in \`NEVER_KEY_ROUTES\` + openapi ROUTES + regenerated \`openapi/v1*.json\`; token-authed \`/api/claims/*\` + \`/api/checkin/*\` mirror \`/api/invites\`.
- **Closing pass** — help section \`players/\` (player + organiser articles), \`routes.ts\`, \`messages.ts\` keys, smoke suite extension.

## Test plan

- Unit: 890 pass (claim lifecycle incl. racing accepts + one-open-claim; /me cross-org isolation; guardian gate by dob; check-in token expiry/tamper/typ; availability upsert semantics).
- E2E \`player-accounts.spec.ts\` (serial): invite → claim → RSVP → organiser grid chip + note tooltip → QR check-in → venue dot; second claim 409 + dead link copy; consent flip ON/OFF revalidates the public card; unclaimed person 404 throughout. 9/9 green locally.
- Smoke: +13 checks (full loop over HTTP + community-org mint proof) — 246 pass.
- \`npx tsc --noEmit\` clean; registry enumeration suites green; screenshots verified at 1440px and 390px (/me + lineup grid).

## Deploy

\`db:apply\` V276 (additive only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)