### PR TITLE
fix: one trial per organisation — close the downgrade→upgrade trial loop

### DIFF
--- a/apps/web/content/help/billing/plans.md
+++ b/apps/web/content/help/billing/plans.md
@@ -10,7 +10,7 @@ Run real competitions, free: 2 active competitions, 3 team members, 16 entrants 
 
 ## Pro
 
-Everything unlimited, plus the organiser toolkit: your branding on public pages and share images, entry fees via Stripe, spreadsheet imports and exports, clubs, player stats, advanced formats, API keys and embeds. Starts with a 14-day trial, no card required.
+Everything unlimited, plus the organiser toolkit: your branding on public pages and share images, entry fees via Stripe, spreadsheet imports and exports, clubs, player stats, advanced formats, API keys and embeds. Starts with a 14-day trial, no card required — one trial per organisation; if you come back to Pro later, billing starts from day one.
 
 ## Event Pass
 

--- a/apps/web/src/app/api/billing/checkout/route.ts
+++ b/apps/web/src/app/api/billing/checkout/route.ts
@@ -5,7 +5,11 @@ import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
 import { baseUrl } from "@/lib/oauth";
 import { checkoutSchema } from "@/lib/types";
-import { buildEmbeddedCheckoutParams } from "@/lib/billing";
+import {
+  assertCheckoutAllowed,
+  buildEmbeddedCheckoutParams,
+  checkoutTrialDays,
+} from "@/lib/billing";
 import { preferredCurrency } from "@/lib/currency-server";
 import { routes } from "@/lib/routes";
 
@@ -34,16 +38,26 @@ export async function POST(req: Request) {
 
     // Reuse existing Stripe customer if we already have one
     const [[sub], [org]] = await Promise.all([
-      sql<{ stripe_customer_id: string | null }[]>`
-        select stripe_customer_id from subscriptions where org_id = ${orgId}`,
+      sql<{
+        stripe_customer_id: string | null;
+        stripe_subscription_id: string | null;
+        status: string | null;
+        trial_used_at: string | null;
+      }[]>`
+        select stripe_customer_id, stripe_subscription_id, status, trial_used_at
+        from subscriptions where org_id = ${orgId}`,
       sql<{ slug: string }[]>`select slug from organizations where id = ${orgId}`,
     ]);
+    // A live Stripe sub changes plan in-app, never via a second checkout.
+    assertCheckoutAllowed(sub);
 
     const session = await getStripe().checkout.sessions.create(
       buildEmbeddedCheckoutParams({
         priceId: plan.price_id,
         orgId,
         returnUrl: `${baseUrl(req)}${routes.billing(org.slug)}?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+        // One trial per org — a re-subscribing org pays from day one.
+        trialDays: checkoutTrialDays(sub),
         currency: await preferredCurrency(orgId, req),
         customerId: sub?.stripe_customer_id ?? undefined,
         customerEmail: user.email,

--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -76,6 +76,9 @@ export default async function BillingPage({
   const planKey = sub?.plan_key ?? "community";
   const status = sub?.status ?? "active";
   const isPro = planKey === "pro";
+  // One trial per org (V277): the upgrade CTA must not promise a trial the
+  // checkout won't grant.
+  const trialAvailable = !sub?.trial_used_at;
   // A comped/dev-granted Pro org has no Stripe subscription — it gets the
   // in-app downgrade instead of the cancel-at-period-end flow.
   const hasStripeSubscription = !!sub?.stripe_subscription_id;
@@ -368,13 +371,15 @@ export default async function BillingPage({
               </div>
             </div>
             <p className="mb-4 text-xs text-slate-500">
-              14-day free trial · no card required · cancel anytime
+              {trialAvailable
+                ? "14-day free trial · no card required · cancel anytime"
+                : "Billed from day one — your free trial has already been used · cancel anytime"}
             </p>
             {/* Annual leads (v3/07 §4): 12 for the price of 10, said plainly. */}
             <div className="flex flex-wrap items-center gap-3">
               <UpgradeButton
                 interval="annual"
-                label={`Start free trial — ${formatMinor(
+                label={`${trialAvailable ? "Start free trial" : "Go Pro"} — ${formatMinor(
                   Math.round(proPrice("annual", currency) / 12),
                   currency,
                 )}/mo billed yearly`}

--- a/apps/web/src/lib/__tests__/billing-checkout.test.ts
+++ b/apps/web/src/lib/__tests__/billing-checkout.test.ts
@@ -3,7 +3,12 @@
 // ui_mode, the return_url contract, the 14-day no-card trial and the
 // pass/currency extensions (v3/07 §3–4) that the checkout routes depend on.
 import { describe, expect, it } from "vitest";
-import { buildEmbeddedCheckoutParams, buildPassCheckoutParams } from "@/lib/billing";
+import {
+  assertCheckoutAllowed,
+  buildEmbeddedCheckoutParams,
+  buildPassCheckoutParams,
+  checkoutTrialDays,
+} from "@/lib/billing";
 import {
   currencyFromAcceptLanguage,
   formatMinor,
@@ -15,6 +20,7 @@ const base = {
   priceId: "price_123",
   orgId: "org-abc",
   returnUrl: "https://app.test/settings/billing?checkout=success&session_id={CHECKOUT_SESSION_ID}",
+  trialDays: 14,
 };
 
 describe("buildEmbeddedCheckoutParams", () => {
@@ -36,6 +42,15 @@ describe("buildEmbeddedCheckoutParams", () => {
     expect(p.subscription_data?.trial_settings?.end_behavior?.missing_payment_method).toBe("cancel");
   });
 
+  it("trialDays 0: no trial keys, card collection required, metadata kept", () => {
+    const p = buildEmbeddedCheckoutParams({ ...base, trialDays: 0, customerEmail: "a@b.com" });
+    expect(p.subscription_data && "trial_period_days" in p.subscription_data).toBe(false);
+    expect(p.subscription_data && "trial_settings" in p.subscription_data).toBe(false);
+    // No trial → payment due at checkout, so the card is always collected.
+    expect("payment_method_collection" in p).toBe(false);
+    expect(p.subscription_data?.metadata).toEqual({ org_id: "org-abc" });
+  });
+
   it("reuses an existing customer id, else falls back to customer_email", () => {
     const withCust = buildEmbeddedCheckoutParams({ ...base, customerId: "cus_9" });
     expect(withCust.customer).toBe("cus_9");
@@ -52,6 +67,35 @@ describe("buildEmbeddedCheckoutParams", () => {
     const usd = buildEmbeddedCheckoutParams({ ...base, currency: "usd" });
     expect("currency" in usd).toBe(false);
     expect("currency" in buildEmbeddedCheckoutParams(base)).toBe(false);
+  });
+});
+
+describe("one trial per org (product gap 2026-07-13)", () => {
+  it("first-ever checkout gets the 14-day trial", () => {
+    expect(checkoutTrialDays(undefined)).toBe(14);
+    expect(checkoutTrialDays({ trial_used_at: null })).toBe(14);
+  });
+
+  it("an org that ever trialed gets no second trial — downgrade/upgrade loop closed", () => {
+    expect(checkoutTrialDays({ trial_used_at: "2026-01-01T00:00:00Z" })).toBe(0);
+  });
+
+  it("checkout is refused while a live Stripe subscription exists", () => {
+    for (const status of ["active", "trialing"]) {
+      expect(() =>
+        assertCheckoutAllowed({ stripe_subscription_id: "sub_1", status }),
+      ).toThrowError(/manage/i);
+    }
+  });
+
+  it("checkout is allowed with no sub row, a canceled sub, or comped Pro", () => {
+    expect(() => assertCheckoutAllowed(undefined)).not.toThrow();
+    expect(() =>
+      assertCheckoutAllowed({ stripe_subscription_id: "sub_1", status: "canceled" }),
+    ).not.toThrow();
+    expect(() =>
+      assertCheckoutAllowed({ stripe_subscription_id: null, status: "active" }),
+    ).not.toThrow();
   });
 });
 

--- a/apps/web/src/lib/__tests__/billing-sync-trial.test.ts
+++ b/apps/web/src/lib/__tests__/billing-sync-trial.test.ts
@@ -1,0 +1,99 @@
+// trial_used_at lifecycle (product gap 2026-07-13): syncSubscription stamps
+// it the first time a Stripe sub carries a trial, and the stamp SURVIVES the
+// downgrade→upgrade loop — a second checkout must resolve trialDays 0.
+// Real Postgres required; skipped without DATABASE_URL.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
+import { sql } from "@/lib/db";
+import { checkoutTrialDays, syncSubscription } from "@/lib/billing";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function seedOrg(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: ownerId }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`trial-${suffix}@test.local`}, 'Trial Owner', true) returning id`;
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"Trial Org " + suffix}, ${"trial-org-" + suffix}, ${ownerId}) returning id`;
+  await sql`insert into subscriptions (org_id, plan_key, status)
+            values (${orgId}, 'community', 'active')`;
+  return orgId;
+}
+
+/** Minimal Stripe.Subscription shape syncSubscription reads. */
+function stripeSub(over: {
+  id: string;
+  status: Stripe.Subscription.Status;
+  trial_end?: number | null;
+}): Stripe.Subscription {
+  return {
+    id: over.id,
+    status: over.status,
+    trial_end: over.trial_end ?? null,
+    cancel_at_period_end: false,
+    currency: "usd",
+    items: {
+      data: [
+        {
+          price: { id: "price_unknown" },
+          current_period_end: Math.floor(Date.now() / 1000) + 86_400,
+        },
+      ],
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("trial_used_at stamping (one trial per org)", () => {
+  it("stamps on the first trialing sync; never re-arms through the loop", async () => {
+    const orgId = await seedOrg();
+    const readSub = async () =>
+      (
+        await sql<{ trial_used_at: string | null }[]>`
+          select trial_used_at from subscriptions where org_id = ${orgId}`
+      )[0];
+
+    // Fresh org: no stamp → a checkout would carry the 14-day trial.
+    expect((await readSub()).trial_used_at).toBeNull();
+    expect(checkoutTrialDays(await readSub())).toBe(14);
+
+    // Trial starts (reconcile/webhook path).
+    await syncSubscription(
+      orgId,
+      stripeSub({ id: "sub_trial1", status: "trialing", trial_end: Math.floor(Date.now() / 1000) + 14 * 86_400 }),
+    );
+    const stamped = (await readSub()).trial_used_at;
+    expect(stamped).not.toBeNull();
+    expect(checkoutTrialDays(await readSub())).toBe(0);
+
+    // Trial lapses → Stripe cancels → org back on community. Stamp survives.
+    await syncSubscription(
+      orgId,
+      stripeSub({ id: "sub_trial1", status: "canceled", trial_end: null }),
+    );
+    expect((await readSub()).trial_used_at).toEqual(stamped);
+    expect(checkoutTrialDays(await readSub())).toBe(0);
+
+    // Second (no-trial) subscription syncs — stamp still the original.
+    await syncSubscription(orgId, stripeSub({ id: "sub_paid2", status: "active" }));
+    expect((await readSub()).trial_used_at).toEqual(stamped);
+  });
+
+  it("a paid-from-day-one sub does not stamp a trial", async () => {
+    const orgId = await seedOrg();
+    await syncSubscription(orgId, stripeSub({ id: "sub_paid", status: "active" }));
+    const [row] = await sql<{ trial_used_at: string | null }[]>`
+      select trial_used_at from subscriptions where org_id = ${orgId}`;
+    expect(row.trial_used_at).toBeNull();
+  });
+});

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -8,15 +8,19 @@ import { invalidateOrgEntitlements } from "@/lib/entitlements";
 /**
  * Params for an EMBEDDED subscription checkout (rendered in-page via Stripe's
  * Embedded Checkout, not a redirect). Pure — no Stripe/DB — so it's unit-tested.
- * Honours the 14-day no-card trial: `payment_method_collection: "if_required"`
- * + cancel when no card is added by trial end. `ui_mode: "embedded"` requires a
- * `return_url` (not success/cancel urls); Stripe redirects there on completion,
- * where the billing page reconciles from the session id.
+ * `trialDays` 14 = the no-card trial (`payment_method_collection:
+ * "if_required"` + cancel when no card is added by trial end); 0 = no trial
+ * block at all, so Stripe charges at checkout and always collects a card —
+ * one trial per org, decided by the caller via checkoutTrialDays().
+ * `ui_mode: "embedded"` requires a `return_url` (not success/cancel urls);
+ * Stripe redirects there on completion, where the billing page reconciles
+ * from the session id.
  */
 export function buildEmbeddedCheckoutParams(args: {
   priceId: string;
   orgId: string;
   returnUrl: string;
+  trialDays: number;
   customerId?: string;
   customerEmail?: string;
   /** ISO currency picking one of the price's currency_options (v3/07 §4);
@@ -30,10 +34,14 @@ export function buildEmbeddedCheckoutParams(args: {
     ...(args.customerId ? { customer: args.customerId } : { customer_email: args.customerEmail }),
     ...(args.currency && args.currency !== "usd" ? { currency: args.currency } : {}),
     metadata: { org_id: args.orgId },
-    payment_method_collection: "if_required",
+    ...(args.trialDays > 0 ? { payment_method_collection: "if_required" as const } : {}),
     subscription_data: {
-      trial_period_days: 14,
-      trial_settings: { end_behavior: { missing_payment_method: "cancel" } },
+      ...(args.trialDays > 0
+        ? {
+            trial_period_days: args.trialDays,
+            trial_settings: { end_behavior: { missing_payment_method: "cancel" as const } },
+          }
+        : {}),
       metadata: { org_id: args.orgId },
     },
     line_items: [{ price: args.priceId, quantity: 1 }],
@@ -42,6 +50,32 @@ export function buildEmbeddedCheckoutParams(args: {
     tax_id_collection: { enabled: true },
     automatic_tax: { enabled: true },
   };
+}
+
+/**
+ * One trial per organisation (product gap 2026-07-13): the downgrade→upgrade
+ * loop must not re-arm the 14-day trial. `trial_used_at` is stamped by
+ * syncSubscription the first time a trialing sub syncs and never cleared.
+ */
+export function checkoutTrialDays(
+  sub: { trial_used_at: string | null } | undefined,
+): number {
+  return sub?.trial_used_at ? 0 : 14;
+}
+
+/**
+ * A live Stripe subscription means plan changes go through the in-app manage
+ * flow — a second checkout would mint a second subscription for the same org.
+ */
+export function assertCheckoutAllowed(
+  sub: { stripe_subscription_id: string | null; status: string | null } | undefined,
+): void {
+  if (sub?.stripe_subscription_id && (sub.status === "active" || sub.status === "trialing")) {
+    throw new HttpError(
+      409,
+      "This organization already has a subscription — manage your plan from the billing page instead.",
+    );
+  }
 }
 
 /**
@@ -141,12 +175,13 @@ export async function syncSubscription(
   await sql`
     insert into subscriptions
       (org_id, plan_key, status, stripe_subscription_id,
-       current_period_end, trial_end, cancel_at_period_end, currency, updated_at)
+       current_period_end, trial_end, trial_used_at, cancel_at_period_end, currency, updated_at)
     values
       (${orgId}, ${planKey ?? "community"}, ${status},
        ${stripeSub.id},
        ${periodEnd ? new Date(periodEnd * 1000).toISOString() : null},
        ${stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null},
+       ${stripeSub.trial_end ? new Date().toISOString() : null},
        ${stripeSub.cancel_at_period_end},
        ${stripeSub.currency ?? null},
        now())
@@ -156,6 +191,8 @@ export async function syncSubscription(
       stripe_subscription_id = excluded.stripe_subscription_id,
       current_period_end     = excluded.current_period_end,
       trial_end              = excluded.trial_end,
+      -- One trial per org: stamped the first time a trial appears, never cleared.
+      trial_used_at          = coalesce(subscriptions.trial_used_at, excluded.trial_used_at),
       cancel_at_period_end   = excluded.cancel_at_period_end,
       currency               = coalesce(excluded.currency, subscriptions.currency),
       updated_at             = now()`;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -174,6 +174,8 @@ export interface Subscription {
   stripe_subscription_id: string | null;
   current_period_end: string | null;
   trial_end: string | null;
+  /** One trial per org (V277): stamped when the first trial starts, never cleared. */
+  trial_used_at: string | null;
   cancel_at_period_end: boolean;
   updated_at: string;
 }

--- a/db/migration/deltas/V277__one_trial_per_org.sql
+++ b/db/migration/deltas/V277__one_trial_per_org.sql
@@ -1,0 +1,14 @@
+-- V277 — one trial per organisation (product gap 2026-07-13): the
+-- downgrade→upgrade loop re-granted the 14-day no-card trial on every new
+-- checkout session. trial_used_at is stamped when the first trialing
+-- subscription syncs (webhook/reconcile) and is never cleared; the checkout
+-- route omits trial_period_days once it's set.
+alter table subscriptions add column if not exists trial_used_at timestamptz;
+
+-- Backfill: any org that ever held a Stripe subscription (or a recorded
+-- trial window) has had its chance — an existing customer re-subscribing
+-- should not restart a trial.
+update subscriptions
+   set trial_used_at = coalesce(trial_end, updated_at, now())
+ where trial_used_at is null
+   and (trial_end is not null or stripe_subscription_id is not null);


### PR DESCRIPTION
**Product gap (reported 2026-07-13):** every \`POST /api/billing/checkout\` hard-coded \`trial_period_days: 14\` with \`payment_method_collection: "if_required"\`, and nothing remembered a past trial — so downgrade (or let the no-card trial lapse) → upgrade again minted a **fresh 14-day trial every cycle**. Perpetual free Pro, one click a fortnight.

## Fix

- **V277** — \`subscriptions.trial_used_at timestamptz\`: stamped the first time a trialing subscription syncs (webhook AND reconcile path share \`syncSubscription\`), **never cleared** (\`coalesce\` in the upsert). Backfilled for any org that ever held a Stripe subscription or trial window — existing customers re-subscribing don't restart a trial.
- \`buildEmbeddedCheckoutParams\` now takes \`trialDays\`; at 0 the trial block is omitted entirely and the card is always collected (payment due at checkout). Decision lives in pure \`checkoutTrialDays()\`.
- \`assertCheckoutAllowed()\`: checkout 409s while a live (active/trialing) Stripe subscription exists — plan changes go through in-app manage, a second parallel subscription can no longer be minted (secondary gap, same route).
- Billing page CTA is honest: "Start free trial" / "14-day free trial · no card required" only while the trial is actually available; otherwise "Go Pro — billed from day one". Help copy (\`billing/plans.md\`) states one trial per organisation.

## Tests

- Pure: \`checkoutTrialDays\` (fresh org 14 / used 0), \`assertCheckoutAllowed\` (409 on active+trialing, allowed on none/canceled/comped), params builder with \`trialDays: 0\` (no trial keys, card required) and 14 (unchanged contract).
- DB-backed: full loop — trial sync stamps \`trial_used_at\` → cancel → re-sync → **stamp survives, second checkout resolves 0 days**; paid-from-day-one sub never stamps.
- Full unit suite green (865), \`npx tsc --noEmit\` clean, V001→V277 applies clean on a fresh DB.

## Merge order

**Merge after #84** — that PR owns V276; this one takes V277 (Flyway rejects out-of-order versions).

## Deploy

\`db:apply\` V277 (additive + one-time backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)