### PR TITLE
feat(invites): additive accept — invites never change an existing role

### DIFF
--- a/apps/web/content/help/getting-started/create-your-organisation.md
+++ b/apps/web/content/help/getting-started/create-your-organisation.md
@@ -11,7 +11,7 @@ Everything you run on seazn.club lives inside an **organisation** — your club,
 1. Sign in and open **Settings → Organisation**.
 2. **Rename** it to what players will recognise — the name appears on every public page.
 3. Add a **logo** and **brand colour** (Pro) so dashboards and share images carry your identity.
-4. Invite teammates under **Settings → Team** — owners and admins can edit everything, scorers only score their assigned matches, viewers can look but not touch.
+4. Invite teammates under **Settings → Team** — owners and admins can edit everything, scorers only score their assigned matches, viewers can look but not touch. Invites never change an existing member's role: a viewer who accepts an umpire invite keeps viewer access and just gains those matches to score ([how scorer invites work](/help/scoring/scorer-role)).
 
 ## Common questions
 

--- a/apps/web/content/help/scoring/scorer-role.md
+++ b/apps/web/content/help/scoring/scorer-role.md
@@ -16,8 +16,19 @@ Assign a scorer to a fixture, a division or a whole competition; the assignment 
 - ✅ See the schedule for their assignments.
 - ❌ Finalize matches, edit entrants, change schedules or settings, see billing.
 
+## Inviting someone who's already a member
+
+Scorer invites are **additive — they never change anyone's existing role**:
+
+- A **viewer** who accepts an umpire invite stays a viewer and gains the invited matches as scoring assignments. They keep their org-wide read access, can score exactly what they're assigned, and the scorer rules above apply to that scoring.
+- A **scorer** who accepts a second invite gains the new assignment on top of their existing ones — handy for umpires covering more than one division.
+- An **owner or admin** who opens their own invite link (say, to test the QR) changes nothing — they can already score everything, and the single-use link is not burnt.
+- Someone from a **different organization** simply joins yours as a scorer too; memberships are per organization and their other roles are untouched.
+
 ## Common questions
 
 **Community plan limits?** Community orgs get 3 members total across all roles; Pro is unlimited — mass day-of scoring is what [device links](/help/scoring/device-links) are for on any plan.
 
 **Can a scorer fix a wrong score?** They can correct a match they're assigned to until it's finalized; after that an admin steps in.
+
+**Does a viewer with assignments use a scorer seat?** No — they already hold a member seat. Scorer seats only count members whose role is scorer.

--- a/apps/web/src/app/api/invites/[token]/accept/route.ts
+++ b/apps/web/src/app/api/invites/[token]/accept/route.ts
@@ -1,11 +1,13 @@
 import { getOrgRole, requireUser, setActiveOrgId } from "@/lib/auth";
 import { handler } from "@/lib/http";
-import { grantInvite, inviteProblem, loadInvite } from "@/lib/invites";
+import { acceptInvite, inviteProblem, loadInvite } from "@/lib/invites";
 
 /**
  * Join the inviting org with the embedded role (must be logged in).
- * Seat quotas (doc 13 §5) bite inside grantInvite; a scorer invite with a
- * default_scope creates membership + assignment atomically (doc 13 §4).
+ * Invites are additive (acceptInvite): a non-member joins with the invite's
+ * role; a viewer/scorer accepting a scoped scorer invite keeps their role and
+ * gains the assignment; an editor's own test scan is a no-op. Seat quotas
+ * (doc 13 §5) bite inside grantInvite on the join path only.
  */
 export async function POST(
   _req: Request,
@@ -20,17 +22,21 @@ export async function POST(
     const problem = inviteProblem(invite);
     if (problem) throw new Error(problem);
 
-    const existing = await getOrgRole(invite.org_id, user.id);
-    if (!existing) await grantInvite(invite, user.id);
+    const outcome = await acceptInvite(invite, user.id);
 
     await setActiveOrgId(invite.org_id);
-    const role = existing ?? invite.role;
+    const role = (await getOrgRole(invite.org_id, user.id)) ?? invite.role;
+    // Scorer post-login landing (doc 13 §4): straight to My matches — and a
+    // member who just gained an umpire assignment lands there too, on the
+    // matches the invite was about.
+    const landing =
+      role === "scorer" || outcome === "scope_added" ? "/my-matches" : "/dashboard";
     return {
       org_id: invite.org_id,
       org_name: invite.org_name,
       role,
-      // Scorer post-login landing (doc 13 §4): straight to My matches.
-      landing: role === "scorer" ? "/my-matches" : "/dashboard",
+      outcome,
+      landing,
     };
   });
 }

--- a/apps/web/src/app/api/v1/public/fixtures/[id]/realtime-token/route.ts
+++ b/apps/web/src/app/api/v1/public/fixtures/[id]/realtime-token/route.ts
@@ -3,7 +3,7 @@ import { HttpError } from "@/lib/errors";
 import { getCurrentUser, getOrgRole } from "@/lib/auth";
 import { publicRateLimit } from "@/server/usecases/public";
 import { fixtureRealtimeEligible } from "@/server/public-site/data";
-import { fixtureScope, scorerCovers } from "@/server/usecases/scorers";
+import { fixtureScope, scorerCovers, scoresViaAssignment } from "@/server/usecases/scorers";
 import { mintPublicFixtureToken } from "@/lib/realtime";
 
 type Ctx = { params: Promise<{ id: string }> };
@@ -50,5 +50,5 @@ async function isFixtureOfficial(fixtureId: string): Promise<boolean> {
   if (!scope) return false;
   const role = await getOrgRole(scope.org_id, user.id);
   if (role === "owner" || role === "admin") return true;
-  return role === "scorer" && (await scorerCovers(scope.org_id, user.id, scope));
+  return scoresViaAssignment(role) && (await scorerCovers(scope.org_id, user.id, scope));
 }

--- a/apps/web/src/app/join/[token]/page.tsx
+++ b/apps/web/src/app/join/[token]/page.tsx
@@ -1,5 +1,6 @@
-import { getCurrentUser } from "@/lib/auth";
-import { inviteProblem, loadInvite } from "@/lib/invites";
+import { getCurrentUser, getOrgRole } from "@/lib/auth";
+import { inviteProblem, loadInvite, type InviteRow } from "@/lib/invites";
+import type { OrgRole } from "@/lib/types";
 import { AuthForm } from "@/components/auth-form";
 import { JoinInvite } from "@/components/join-invite";
 import { NightStage } from "@/components/night-stage";
@@ -8,7 +9,23 @@ const ROLE_BLURB: Record<string, string> = {
   admin: "Admins can create and manage tournaments, results and members.",
   viewer: "Viewers get read-only access to the board.",
   owner: "Owners have full control of the organization.",
+  scorer: "Scorers record results for the matches assigned to them.",
 };
+
+/** What accepting will do for someone who is ALREADY a member (invites are
+ *  additive — they never change an existing role). */
+function memberBlurb(invite: InviteRow, existing: OrgRole): string {
+  const additive =
+    invite.role === "scorer" &&
+    invite.default_scope !== null &&
+    (existing === "viewer" || existing === "scorer");
+  if (additive) {
+    return `You are already a ${existing} of this organization — accepting adds ` +
+      "the invited matches to your scoring assignments. Your current access is unchanged.";
+  }
+  return `You are already ${existing === "admin" || existing === "owner" ? "an" : "a"} ` +
+    `${existing} of this organization — accepting changes nothing.`;
+}
 
 export default async function JoinPage({
   params,
@@ -18,6 +35,8 @@ export default async function JoinPage({
   const { token } = await params;
   const [user, invite] = await Promise.all([getCurrentUser(), loadInvite(token)]);
   const problem = invite ? inviteProblem(invite) : "Invite not found";
+  const existingRole =
+    user && invite ? await getOrgRole(invite.org_id, user.id) : null;
 
   return (
     <NightStage maxW="max-w-md">
@@ -49,6 +68,11 @@ export default async function JoinPage({
                 </span>
                 .
               </p>
+              {existingRole && (
+                <p className="mb-4 rounded-md bg-purple-50 px-3 py-2 text-sm text-purple-800">
+                  {memberBlurb(invite, existingRole)}
+                </p>
+              )}
               <JoinInvite token={token} />
             </div>
           ) : (

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
@@ -31,9 +31,11 @@ export default async function FixturePage({
   const fixtureNo = Number(no);
   if (!Number.isInteger(fixtureNo) || fixtureNo < 1) notFound();
   const page = await requireFixturePage(orgSlug, compSlug, divSlug, fixtureNo);
-  const { auth, canScore } = page;
+  const { auth, canScore, canEdit } = page;
   const id = page.fixtureId;
-  const isScorer = auth.role === "scorer";
+  // Scorer-role members and viewers scoring via assignment share the umpire
+  // chrome (My-matches breadcrumb); editors keep the organiser surface.
+  const isScorer = canScore && !canEdit;
   const fixture = await getFixture(auth, id);
   const [division, state, events, recorderNames] = await Promise.all([
     getDivision(auth, fixture.division_id),
@@ -125,8 +127,7 @@ export default async function FixturePage({
         />
 
         {/* Day-of device link (doc 13 §7): editors only — scorers never mint. */}
-        {!isScorer &&
-          canScore &&
+        {canEdit &&
           !(competition.frozen ?? false) &&
           fixture.status !== "finalized" &&
           fixture.status !== "cancelled" && (

--- a/apps/web/src/lib/invites.ts
+++ b/apps/web/src/lib/invites.ts
@@ -77,3 +77,39 @@ export async function grantInvite(invite: InviteRow, userId: string): Promise<vo
   const { invalidateUserOrgs } = await import("@/lib/auth");
   await invalidateUserOrgs(userId);
 }
+
+export type AcceptOutcome = "joined" | "scope_added" | "already_member";
+
+/**
+ * Accept an invite for a (possibly already-member) user. Invites are
+ * additive and never change an existing role:
+ *  - not a member → grantInvite (join with the invite's role + assignment);
+ *  - viewer/scorer × a scoped scorer invite → the assignment is added on top
+ *    of their current role (the umpire-QR-at-courtside case) and a use is
+ *    consumed — no seat charged, their existing seat already counts;
+ *  - anything else (owner/admin scanning their own QR, role invites to
+ *    members) → no-op, and the use is NOT burnt.
+ */
+export async function acceptInvite(invite: InviteRow, userId: string): Promise<AcceptOutcome> {
+  const { getOrgRole } = await import("@/lib/auth");
+  const existing = await getOrgRole(invite.org_id, userId);
+  if (!existing) {
+    await grantInvite(invite, userId);
+    return "joined";
+  }
+  const scope = invite.default_scope;
+  const additive =
+    invite.role === "scorer" && scope !== null &&
+    (existing === "viewer" || existing === "scorer");
+  if (!additive) return "already_member";
+  await sql.begin(async (tx) => {
+    await tx`
+      insert into scorer_assignments (org_id, user_id, scope_type, scope_id, created_by)
+      values (${invite.org_id}, ${userId}, ${scope.type}, ${scope.id}, null)
+      on conflict (org_id, user_id, scope_type, scope_id) do nothing`;
+    await tx`
+      update org_invites set used_count = used_count + 1
+      where id = ${invite.id}`;
+  });
+  return "scope_added";
+}

--- a/apps/web/src/server/api-v1/auth.ts
+++ b/apps/web/src/server/api-v1/auth.ts
@@ -260,9 +260,11 @@ export async function requireFixtureActor(
   const ctx: AuthCtx = { orgId, via: "session", userId: user.id, role, keyId: null };
   if (role === "owner" || role === "admin") return ctx;
   if (role === "viewer" && intent === "read") return ctx;
-  if (role === "scorer") {
-    const { requireScorable } = await import("@/server/usecases/scorers");
-    await requireScorable(ctx, fixtureId); // 403 without a covering assignment
+  const { requireScorable, scoresViaAssignment } = await import("@/server/usecases/scorers");
+  if (scoresViaAssignment(role)) {
+    // Scorers always, viewers when writing (additive umpire invites) — both
+    // need a covering assignment; 403 without one.
+    await requireScorable(ctx, fixtureId);
     return ctx;
   }
   throw new HttpError(403, "Insufficient permissions");

--- a/apps/web/src/server/page-auth.ts
+++ b/apps/web/src/server/page-auth.ts
@@ -160,6 +160,12 @@ export async function requireFixturePage(
     const scope = await fixtureScope(fixture.id);
     if (!scope || !(await scorerCovers(org.id, user.id, scope))) notFound();
     canScore = true;
+  } else if (membership.role === "viewer") {
+    // A viewer scores the fixtures their umpire-invite assignments cover
+    // (additive invites) — the page stays readable either way.
+    const { fixtureScope, scorerCovers } = await import("@/server/usecases/scorers");
+    const scope = await fixtureScope(fixture.id);
+    canScore = !!scope && (await scorerCovers(org.id, user.id, scope));
   }
   return {
     auth: { orgId: org.id, via: "session", userId: user.id, role: membership.role, keyId: null },
@@ -207,6 +213,11 @@ export async function requireResourcePageAuth(
     const scope = await fixtureScope(id);
     if (!scope || !(await scorerCovers(orgId, user.id, scope))) notFound();
     canScore = true;
+  } else if (org.role === "viewer" && kind === "fixture") {
+    // Additive invites: a viewer's covering assignment turns the score pad on.
+    const { fixtureScope, scorerCovers } = await import("@/server/usecases/scorers");
+    const scope = await fixtureScope(id);
+    canScore = !!scope && (await scorerCovers(orgId, user.id, scope));
   }
   return {
     auth: { orgId, via: "session", userId: user.id, role: org.role, keyId: null },

--- a/apps/web/src/server/usecases/__tests__/scorers.test.ts
+++ b/apps/web/src/server/usecases/__tests__/scorers.test.ts
@@ -7,7 +7,7 @@ import { randomUUID } from "node:crypto";
 import { sql } from "@/lib/db";
 import { PaymentRequiredError, HttpError } from "@/lib/errors";
 import { createOrgForUser } from "@/lib/auth";
-import { grantInvite, loadInvite } from "@/lib/invites";
+import { acceptInvite, grantInvite, loadInvite } from "@/lib/invites";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { OrgRole } from "@/lib/types";
 import { createCompetition } from "../competitions";
@@ -345,6 +345,139 @@ describe.skipIf(!HAS_DB)("scorer role (doc 13, PROMPT-18)", () => {
     });
     await expect(assertMemberNotFrozen(orgId, admins[2])).resolves.toBeUndefined();
     await expect(assertMemberNotFrozen(orgId, ownerId)).resolves.toBeUndefined();
+  });
+
+  it("viewer with a covering assignment scores; scorer config gates apply to them", async () => {
+    const { orgId, ownerId } = await seedOrg();
+    const owner = asRole(orgId, ownerId, "owner");
+    const { division, fixtures } = await rig(owner);
+    const viewerId = await addMember(orgId, "viewer");
+    await createAssignment(orgId, viewerId, { type: "division", id: division.id }, ownerId);
+
+    const viewer = asRole(orgId, viewerId, "viewer");
+    const fx = fixtures[0].id;
+    await expect(requireScorable(viewer, fx)).resolves.toBeTruthy();
+
+    // Assignments show up in their "My matches" like any umpire's.
+    const mine = await listAssignedFixtures(viewerId);
+    expect(new Set(mine.map((f) => f.division_id))).toEqual(new Set([division.id]));
+
+    // They score like a scorer — and the per-division scorer config gates
+    // bind them too (they are not editors).
+    await scoreEvent(viewer, fx, { expected_seq: 0, type: "core.start", payload: {} });
+    const decided = await scoreEvent(viewer, fx, {
+      expected_seq: 1, type: "generic.result", payload: { p1Score: 2, p2Score: 0 },
+    });
+    await sql`update divisions set scorer_can_finalize = false where id = ${division.id}`;
+    await expect(finalizeFixture(viewer, fx, decided.seq)).rejects.toMatchObject({ status: 403 });
+    await sql`update divisions set scorer_can_finalize = true where id = ${division.id}`;
+    const finalized = await finalizeFixture(viewer, fx, decided.seq);
+
+    // Post-finalize void stays an editor's power.
+    const [starter] = await sql<{ id: string }[]>`
+      select id from score_events where fixture_id = ${fx} and seq = 1`;
+    await expect(
+      scoreEvent(viewer, fx, {
+        expected_seq: finalized.seq, type: "core.void", payload: { event_id: starter.id },
+      }),
+    ).rejects.toMatchObject({ status: 403 });
+
+    // Lineup config gate binds viewers-with-assignment as it does scorers.
+    const fx2 = fixtures[1];
+    const entrantId = (fx2.home_entrant_id ?? fx2.away_entrant_id) as string;
+    await sql`update divisions set scorer_can_enter_lineups = false where id = ${division.id}`;
+    await expect(putLineup(viewer, fx2.id, entrantId, { slots: [] })).rejects.toMatchObject({
+      status: 403,
+    });
+
+    // Their unassigned fixtures stay 403 — assignment, not role, is the key.
+    const other = await rig(owner);
+    await expect(requireScorable(viewer, other.fixtures[0].id)).rejects.toMatchObject({
+      status: 403,
+    });
+  });
+
+  it("accept, existing viewer × scorer invite: scope added, role kept, no scorer seat", async () => {
+    const { orgId, ownerId } = await seedOrg(); // community: scorers.max 1
+    const owner = asRole(orgId, ownerId, "owner");
+    const { division, fixtures } = await rig(owner);
+
+    // Fill the single scorer seat so the additive path would 402 if it
+    // (wrongly) charged the scorer pool.
+    const seatFiller = await makeInvite(orgId, "scorer");
+    await grantInvite((await loadInvite(seatFiller))!, await makeUser("seat"));
+
+    const viewerId = await addMember(orgId, "viewer");
+    const token = await makeInvite(orgId, "scorer", { type: "division", id: division.id });
+    const outcome = await acceptInvite((await loadInvite(token))!, viewerId);
+    expect(outcome).toBe("scope_added");
+
+    const [membership] = await sql<{ role: string }[]>`
+      select role from org_members where org_id = ${orgId} and user_id = ${viewerId}`;
+    expect(membership.role).toBe("viewer"); // never a silent role change
+    const scope = (await fixtureScope(fixtures[0].id))!;
+    expect(await scorerCovers(orgId, viewerId, scope)).toBe(true);
+    const [{ used_count }] = await sql<{ used_count: number }[]>`
+      select used_count from org_invites where token = ${token}`;
+    expect(used_count).toBe(1);
+  });
+
+  it("accept, existing scorer × second invite: assignment added for the new scope", async () => {
+    const { orgId, ownerId } = await seedOrg();
+    const owner = asRole(orgId, ownerId, "owner");
+    const first = await rig(owner);
+    const second = await rig(owner);
+
+    const scorerId = await addMember(orgId, "scorer");
+    await createAssignment(orgId, scorerId, { type: "division", id: first.division.id }, ownerId);
+
+    const token = await makeInvite(orgId, "scorer", {
+      type: "division", id: second.division.id,
+    });
+    const outcome = await acceptInvite((await loadInvite(token))!, scorerId);
+    expect(outcome).toBe("scope_added");
+
+    const scope = (await fixtureScope(second.fixtures[0].id))!;
+    expect(await scorerCovers(orgId, scorerId, scope)).toBe(true);
+    // First assignment untouched.
+    const firstScope = (await fixtureScope(first.fixtures[0].id))!;
+    expect(await scorerCovers(orgId, scorerId, firstScope)).toBe(true);
+  });
+
+  it("accept, editor × scorer invite: no-op — role kept, no assignment, use not burnt", async () => {
+    const { orgId, ownerId } = await seedOrg();
+    const owner = asRole(orgId, ownerId, "owner");
+    const { division, fixtures } = await rig(owner);
+
+    const token = await makeInvite(orgId, "scorer", { type: "division", id: division.id });
+    const outcome = await acceptInvite((await loadInvite(token))!, ownerId);
+    expect(outcome).toBe("already_member");
+
+    const [membership] = await sql<{ role: string }[]>`
+      select role from org_members where org_id = ${orgId} and user_id = ${ownerId}`;
+    expect(membership.role).toBe("owner"); // never downgraded by scanning own QR
+    const scope = (await fixtureScope(fixtures[0].id))!;
+    expect(await scorerCovers(orgId, ownerId, scope)).toBe(false);
+    const [{ used_count }] = await sql<{ used_count: number }[]>`
+      select used_count from org_invites where token = ${token}`;
+    expect(used_count).toBe(0); // the single-use link survives an owner's test scan
+  });
+
+  it("accept, fresh user: joins as scorer with the assignment (unchanged path)", async () => {
+    const { orgId, ownerId } = await seedOrg();
+    const owner = asRole(orgId, ownerId, "owner");
+    const { division, fixtures } = await rig(owner);
+
+    const userId = await makeUser("fresh");
+    const token = await makeInvite(orgId, "scorer", { type: "division", id: division.id });
+    const outcome = await acceptInvite((await loadInvite(token))!, userId);
+    expect(outcome).toBe("joined");
+
+    const [membership] = await sql<{ role: string }[]>`
+      select role from org_members where org_id = ${orgId} and user_id = ${userId}`;
+    expect(membership.role).toBe("scorer");
+    const scope = (await fixtureScope(fixtures[0].id))!;
+    expect(await scorerCovers(orgId, userId, scope)).toBe(true);
   });
 
   it("viewer role never scores; HttpError carries 403 not 401", async () => {

--- a/apps/web/src/server/usecases/fixtures.ts
+++ b/apps/web/src/server/usecases/fixtures.ts
@@ -8,6 +8,7 @@ import type { AuthCtx } from "@/server/api-v1/auth";
 import type { PatchFixture, PutLineup } from "@/server/api-v1/schemas";
 import { FIXTURE_COLS, type FixtureRow } from "./stages";
 import { moveFixture } from "./schedule";
+import { scoresViaAssignment } from "./scorers";
 
 /** Doc 13 §7: a device link reads fixture state/events ONLY — every other
  *  fixture surface (detail, lineups, schedule) is 403 for dl_ tokens. */
@@ -86,9 +87,10 @@ export async function putLineup(
       from fixtures f join divisions d on d.id = f.division_id
       where f.id = ${fixtureId}`;
     if (!fixture) throw new HttpError(404, "fixture not found");
-    // Doc 13 §2: lineup entry is config-gated for scorers (courtside reality
-    // default: allowed). Coverage was proven at the door.
-    if (auth.role === "scorer" && !fixture.scorer_can_enter_lineups) {
+    // Doc 13 §2: lineup entry is config-gated for anyone scoring via
+    // assignment (courtside reality default: allowed). Coverage was proven
+    // at the door.
+    if (scoresViaAssignment(auth.role) && !fixture.scorer_can_enter_lineups) {
       throw new HttpError(403, "Lineup entry is restricted to organisers in this division");
     }
     if (fixture.home_entrant_id !== entrantId && fixture.away_entrant_id !== entrantId) {

--- a/apps/web/src/server/usecases/scorers.ts
+++ b/apps/web/src/server/usecases/scorers.ts
@@ -46,20 +46,29 @@ export async function scorerCovers(
   return rows.length > 0;
 }
 
+/** Roles whose scoring rights come from assignments, not the role itself:
+ *  scorers always; viewers additively (an accepted umpire invite keeps their
+ *  role and adds the assignment). The scorer capability config gates bind
+ *  both — only editors bypass them. */
+export function scoresViaAssignment(role: string | null): boolean {
+  return role === "scorer" || role === "viewer";
+}
+
 /**
- * THE scorer gate (doc 13 §2/§3): editor roles and write-scoped API keys pass;
- * a scorer passes iff a covering assignment exists. Everyone else — viewers
- * included, for scoring — is 403. Returns the fixture scope so callers can
- * apply the capability config without a second lookup.
+ * THE scorer gate (doc 13 §2/§3): editor roles and write-scoped API keys
+ * pass; scorers — and viewers, whose umpire invites grant assignments on top
+ * of their read role — pass iff a covering assignment exists. Everyone else
+ * is 403. Returns the fixture scope so callers can apply the capability
+ * config without a second lookup.
  */
 export async function requireScorable(auth: AuthCtx, fixtureId: string): Promise<FixtureScope> {
   const scope = await fixtureScope(fixtureId);
   if (!scope || scope.org_id !== auth.orgId) throw new HttpError(404, "fixture not found");
   if (auth.via === "api_key") return scope; // scope checked at key auth (write)
   if (auth.role === "owner" || auth.role === "admin") return scope;
-  if (auth.role === "scorer") {
+  if (scoresViaAssignment(auth.role)) {
     if (auth.userId && (await scorerCovers(auth.orgId, auth.userId, scope))) return scope;
-    throw new HttpError(403, "You are not assigned to this fixture");
+    if (auth.role === "scorer") throw new HttpError(403, "You are not assigned to this fixture");
   }
   throw new HttpError(403, "Your role cannot record scores");
 }

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -23,6 +23,7 @@ import type { AuthCtx } from "@/server/api-v1/auth";
 import type { AppendEventRequest } from "@/server/api-v1/schemas";
 import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { requiredFeatureForEvent } from "./fidelity";
+import { scoresViaAssignment } from "./scorers";
 import { fillSlot } from "./stages";
 
 export interface ScoreOutcome {
@@ -200,9 +201,10 @@ async function assertEntitledToScore(
 
   // Scorer capabilities (doc 13 §2): coverage was proven at the door
   // (requireFixtureActor → requireScorable); here the per-division config
-  // gates apply. Finalize is config-gated; undo is own-fixture PRE-finalize
-  // only — a finalized ledger is an editor's to reopen.
-  if (auth.role === "scorer") {
+  // gates apply — to scorers and to viewers scoring via assignment alike.
+  // Finalize is config-gated; undo is own-fixture PRE-finalize only — a
+  // finalized ledger is an editor's to reopen.
+  if (scoresViaAssignment(auth.role)) {
     if (input.type === "core.finalize" && !ctx.scorer_can_finalize) {
       throw new HttpError(403, "Finalizing is restricted to organisers in this division");
     }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1780,6 +1780,54 @@ async function gapSuite(admin: Session, org1Id: string, proOrgId: string): Promi
   const seatFull = await raw(scorer2, `/api/invites/${scorerInvite2.token}/accept`, "POST", {});
   check("gap second scorer seat blocked (scorers.max)", seatFull.status === 402);
 
+  // --- Additive invites: accepting never changes an existing role. An
+  // editor's own test scan is a no-op that doesn't burn the link; a viewer
+  // accepting the same link keeps viewer and gains the assignment — even
+  // with the scorer seat pool full (no seat is charged) ---
+  const gapViewerInvite = (await call(admin, `/api/orgs/${proOrgId}/invites`, "POST", {
+    role: "viewer",
+    max_uses: 1,
+  })) as { token: string };
+  const gapViewer = newSession();
+  await signIn(gapViewer, `gap_viewer_${tag}@example.com`);
+  await call(gapViewer, `/api/invites/${gapViewerInvite.token}/accept`, "POST", {});
+  const umpInvite = (await call(admin, `/api/orgs/${proOrgId}/invites`, "POST", {
+    role: "scorer",
+    max_uses: 1,
+    default_scope: { type: "division", id: divId },
+  })) as { token: string };
+  const ownScan = (await call(admin, `/api/invites/${umpInvite.token}/accept`, "POST", {})) as {
+    outcome: string;
+    role: string;
+  };
+  check(
+    "gap editor test-scan is a no-op (role kept)",
+    ownScan.outcome === "already_member" && ownScan.role !== "scorer",
+  );
+  const vAccept = (await call(gapViewer, `/api/invites/${umpInvite.token}/accept`, "POST", {})) as {
+    outcome: string;
+    role: string;
+    landing: string;
+  };
+  check(
+    "gap viewer umpire invite: scope added, role kept",
+    vAccept.outcome === "scope_added" && vAccept.role === "viewer" &&
+      vAccept.landing === "/my-matches",
+  );
+  const vAssigned = await v1(gapViewer, "/api/v1/me/assigned-fixtures");
+  check(
+    "gap viewer sees assigned fixtures",
+    vAssigned.status === 200 && v1data<unknown[]>(vAssigned).length > 0,
+  );
+  const vFixture = v1data<{ fixtures: { id: string }[] }>(gen).fixtures[1]!.id;
+  const vState = await v1(gapViewer, `/api/v1/fixtures/${vFixture}/state`);
+  const vEvent = await v1(gapViewer, `/api/v1/fixtures/${vFixture}/events`, "POST", {
+    expected_seq: v1data<{ last_seq: number }>(vState).last_seq,
+    type: "generic.result",
+    payload: { p1Score: 1, p2Score: 0 },
+  });
+  check("gap viewer scores via assignment", vEvent.status === 201);
+
   // --- Discovery: public + discoverable (started division passes the quality
   // floor); discoverable without public visibility is rejected ---
   const pub = await v1(admin, `/api/v1/competitions/${compId}`, "PATCH", { visibility: "public" });


### PR DESCRIPTION
## Problem

Accepting an invite while already a member of the org was a silent no-op (`if (!existing) grantInvite(...)`). Real-world fallout:

- A **viewer** handed an umpire QR at courtside clicked join, saw the dashboard, and got 403 at the score pad — no upgrade path via invite at all.
- A **scorer** invited to a second division gained nothing; the admin believed it worked.
- The single-use link burnt a use for nothing when an editor test-scanned their own QR (pre-existing behavior kept: it did NOT burn — now guaranteed and tested).

## Design: invites are additive, roles are never silently changed

Role = read tier, assignment = scoring capability.

| Accepting user | Scorer invite w/ scope | Result |
|---|---|---|
| Non-member | joins | role `scorer` + assignment (unchanged path, quota applies) |
| Viewer | scope added | keeps org-wide read, gains the assignment, **no scorer seat charged** |
| Scorer | scope added | new assignment on top of existing ones |
| Owner/Admin | no-op | role kept, use **not** burnt (safe to test-scan own QR) |

Viewers with a covering assignment now score like scorers: `requireScorable` passes them, the per-division scorer config gates (`scorer_can_finalize`, `scorer_can_enter_lineups`), the post-finalize-void editor lock, the fixture-actor door, realtime officials bypass and page-level `canScore` all bind them via a single `scoresViaAssignment` predicate. Editor-only surfaces (device-link minting) stay editor-gated.

UX: the join page now tells an existing member exactly what accepting will do; a member who gains an assignment lands on **/my-matches**.

## Tests

- 5 new DB-backed vitest cases (red-green): viewer-scores-via-assignment incl. config gates, all four accept outcomes, seat-pool non-charge, use-not-burnt.
- smoke.ts: editor test-scan no-op, viewer scope-add with scorer pool full, viewer scores via API. Full local run: **238 passed, 0 failed**.
- Full apps/web suite: **863 passed, 0 failed**. tsc + eslint clean.

## Help docs

- `scoring/scorer-role.md`: new “Inviting someone who's already a member” section + seat FAQ.
- `getting-started/create-your-organisation.md`: additive-invite note with link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)