### PR TITLE
feat: staff console — pending Stripe events list + replay (/admin/billing-events)

### DIFF
--- a/apps/web/src/app/admin/billing-events/page.tsx
+++ b/apps/web/src/app/admin/billing-events/page.tsx
@@ -1,0 +1,174 @@
+import type Stripe from "stripe";
+import { requireStaff, logStaffAction } from "@/lib/admin";
+import { getStripe } from "@/lib/stripe";
+import {
+  HANDLED_EVENT_TYPES,
+  eventStatus,
+  ledgerByIds,
+  stuckLedgerEvents,
+  type EventStatus,
+  type LedgerRow,
+} from "@/server/usecases/billing-events";
+import { ProcessEventButton } from "@/components/admin-process-event";
+import { sql } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_CHIP: Record<EventStatus, { label: string; cls: string }> = {
+  processed: { label: "✓ processed", cls: "bg-emerald-500/10 text-emerald-400" },
+  received: { label: "⏳ received, not processed", cls: "bg-amber-500/10 text-amber-400" },
+  missing: { label: "✖ never received", cls: "bg-red-500/10 text-red-400" },
+};
+
+interface Row {
+  id: string;
+  type: string;
+  created: string;
+  orgName: string | null;
+  status: EventStatus;
+}
+
+/** Live events straight from Stripe (the diff source). Null = no key or the
+ *  call failed — the page degrades to the ledger-only view. */
+async function liveEvents(): Promise<Stripe.Event[] | null> {
+  if (!process.env.STRIPE_SECRET_KEY) return null;
+  try {
+    const page = await getStripe().events.list({
+      limit: 50,
+      types: [...HANDLED_EVENT_TYPES],
+    });
+    return page.data;
+  } catch {
+    return null;
+  }
+}
+
+/** Org names for events the ledger has never seen (metadata is all we have). */
+async function orgNamesByIds(ids: string[]): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const rows = await sql<{ id: string; name: string }[]>`
+    select id, name from organizations where id in ${sql(ids)}`;
+  return new Map(rows.map((r) => [r.id, r.name]));
+}
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+
+export default async function AdminBillingEventsPage() {
+  const staff = await requireStaff();
+  await logStaffAction(staff.id, "billing_events_viewed", "platform", "billing_events");
+
+  const live = await liveEvents();
+  const ledger = await ledgerByIds((live ?? []).map((e) => e.id));
+  const stuck = await stuckLedgerEvents((live ?? []).map((e) => e.id));
+
+  const metaOrgIds = (live ?? [])
+    .map((e) => (e.data.object as { metadata?: { org_id?: string } }).metadata?.org_id)
+    .filter((id): id is string => !!id && UUID_RE.test(id));
+  const orgNames = await orgNamesByIds([...new Set(metaOrgIds)]);
+
+  const liveRows: Row[] = (live ?? []).map((e) => {
+    const row = ledger.get(e.id);
+    const metaOrg = (e.data.object as { metadata?: { org_id?: string } }).metadata?.org_id;
+    return {
+      id: e.id,
+      type: e.type,
+      created: new Date(e.created * 1000).toISOString(),
+      orgName: row?.org_name ?? (metaOrg ? (orgNames.get(metaOrg) ?? null) : null),
+      status: eventStatus(row),
+    };
+  });
+  const stuckRows: Row[] = stuck.map((r: LedgerRow) => ({
+    id: r.id,
+    type: r.type,
+    created: new Date(r.received_at).toISOString(),
+    orgName: r.org_name ?? null,
+    status: "received" as const,
+  }));
+  const pendingCount =
+    liveRows.filter((r) => r.status !== "processed").length + stuckRows.length;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-bold text-white">Stripe events</h1>
+        <p className="mt-1 text-xs text-slate-500">
+          The last 50 handled-type events straight from Stripe, checked against the
+          billing_events ledger. <span className="text-red-400">✖ never received</span> means
+          the webhook missed it entirely; <span className="text-amber-400">⏳ received</span>{" "}
+          means the handler didn&apos;t finish. Process now re-fetches the event from Stripe
+          and runs the normal handler — every handler is idempotent.
+        </p>
+      </div>
+
+      {live === null && (
+        <p className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-xs text-amber-300">
+          Stripe isn&apos;t reachable (no STRIPE_SECRET_KEY or the API call failed) — showing
+          the local ledger only. Events Stripe sent but this app never received can&apos;t be
+          listed without the key.
+        </p>
+      )}
+
+      <p className="text-xs text-slate-400">
+        {pendingCount === 0
+          ? "Nothing pending — every event listed has been processed."
+          : `${pendingCount} pending event${pendingCount === 1 ? "" : "s"} need${pendingCount === 1 ? "s" : ""} attention.`}
+      </p>
+
+      <EventTable title={live === null ? "Stuck ledger events" : "Live from Stripe"} rows={liveRows.length ? liveRows : stuckRows} />
+      {live !== null && stuckRows.length > 0 && (
+        <EventTable title="Older stuck ledger events" rows={stuckRows} />
+      )}
+    </div>
+  );
+}
+
+function EventTable({ title, rows }: { title: string; rows: Row[] }) {
+  return (
+    <section>
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+        {title}
+      </h2>
+      <div className="overflow-x-auto rounded-lg border border-slate-800">
+        <table className="w-full text-left text-xs">
+          <thead className="bg-slate-900 text-slate-400">
+            <tr>
+              <th className="px-3 py-2">Created</th>
+              <th className="px-3 py-2">Type</th>
+              <th className="px-3 py-2">Event</th>
+              <th className="px-3 py-2">Organisation</th>
+              <th className="px-3 py-2">Status</th>
+              <th className="px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800/60">
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-6 text-center text-slate-500">
+                  No events.
+                </td>
+              </tr>
+            )}
+            {rows.map((r) => (
+              <tr key={r.id} className="text-slate-300">
+                <td className="whitespace-nowrap px-3 py-2 text-slate-400">
+                  {r.created.slice(0, 16).replace("T", " ")}
+                </td>
+                <td className="px-3 py-2 font-mono">{r.type}</td>
+                <td className="px-3 py-2 font-mono text-slate-500">{r.id}</td>
+                <td className="px-3 py-2">{r.orgName ?? "—"}</td>
+                <td className="px-3 py-2">
+                  <span className={`rounded px-1.5 py-0.5 ${STATUS_CHIP[r.status].cls}`}>
+                    {STATUS_CHIP[r.status].label}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {r.status !== "processed" && <ProcessEventButton eventId={r.id} />}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -20,6 +20,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <Link href="/admin/users" className="hover:text-white">Users</Link>
           <Link href="/admin/coupons" className="hover:text-white">Coupons</Link>
           <Link href="/admin/revenue" className="hover:text-white">Revenue</Link>
+          <Link href="/admin/billing-events" className="hover:text-white">Stripe</Link>
           <Link href="/admin/settings" className="hover:text-white">Settings</Link>
           <Link href="/admin/audit" className="hover:text-white">Audit</Link>
         </nav>

--- a/apps/web/src/app/api/admin/billing-events/[id]/process/route.ts
+++ b/apps/web/src/app/api/admin/billing-events/[id]/process/route.ts
@@ -1,0 +1,36 @@
+import { requireStaff, logStaffAction } from "@/lib/admin";
+import { handler, HttpError } from "@/lib/http";
+import { getStripe } from "@/lib/stripe";
+import { replayEvent } from "@/server/usecases/billing-events";
+
+type Ctx = { params: Promise<{ id: string }> };
+
+/** POST /api/admin/billing-events/{id}/process — staff replay of a missed or
+ *  stuck Stripe event. The event is re-fetched from Stripe by id (the API is
+ *  the trust anchor, standing in for the webhook signature); the stored
+ *  payload is never replayed. Handlers are idempotent, and replayEvent skips
+ *  anything the ledger already saw through. Audited. */
+export async function POST(_req: Request, { params }: Ctx) {
+  return handler(async () => {
+    const staff = await requireStaff();
+    const { id } = await params;
+    if (!/^evt_[A-Za-z0-9]+$/.test(id)) throw new HttpError(400, "Not a Stripe event id");
+    if (!process.env.STRIPE_SECRET_KEY) {
+      throw new HttpError(503, "Stripe is not configured");
+    }
+
+    let event;
+    try {
+      event = await getStripe().events.retrieve(id);
+    } catch {
+      throw new HttpError(404, "Stripe doesn't know this event id");
+    }
+
+    const outcome = await replayEvent(event);
+    await logStaffAction(staff.id, "billing_event_processed", "platform", id, {
+      type: event.type,
+      outcome,
+    });
+    return { id, type: event.type, outcome };
+  });
+}

--- a/apps/web/src/app/api/webhooks/stripe/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.ts
@@ -2,120 +2,12 @@ import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
-import { recordPassPurchase, syncSubscription } from "@/lib/billing";
-import { invalidateOrgEntitlements } from "@/lib/entitlements";
-import {
-  handleRegistrationCheckoutCompleted,
-  handleRegistrationDispute,
-  syncRegistrationRefund,
-} from "@/server/usecases/registrations";
-import { syncConnectAccount } from "@/server/usecases/stripe-connect";
-import { captureServer } from "@/lib/posthog-server";
-import { EVENTS } from "@/lib/analytics-events";
+import { runEvent } from "@/server/usecases/billing-events";
 
-/** Best-effort person id for org-scoped revenue events: the org owner, falling
- *  back to a synthetic org id so the event still lands on the org group. */
-async function ownerDistinctId(orgId: string): Promise<string> {
-  const [row] = await sql<{ created_by: string | null }[]>`
-    select created_by from organizations where id = ${orgId}`;
-  return row?.created_by ?? `org:${orgId}`;
-}
-
-// ---------------------------------------------------------------------------
-// Event handlers
-// ---------------------------------------------------------------------------
-
-async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
-  // Entry-fee checkouts (PROMPT-20a) share the endpoint; kind disambiguates.
-  if (session.metadata?.kind === "registration") {
-    await handleRegistrationCheckoutCompleted(session);
-    return;
-  }
-  const orgId = session.metadata?.org_id;
-  if (!orgId) return;
-
-  // Event Pass one-time purchase (v3/07 §3) — reconcile-on-return usually
-  // lands first; recordPassPurchase is idempotent either way.
-  if (session.metadata?.pass_key === "event_pass") {
-    const competitionId = session.metadata.competition_id;
-    if (competitionId && session.payment_status === "paid") {
-      await recordPassPurchase({
-        orgId,
-        competitionId,
-        paymentIntent:
-          typeof session.payment_intent === "string" ? session.payment_intent : null,
-      });
-    }
-    return;
-  }
-
-  // Link the Stripe customer to this org
-  if (session.customer) {
-    await sql`
-      update subscriptions set stripe_customer_id = ${session.customer as string}
-      where org_id = ${orgId}`;
-  }
-
-  // Subscription details arrive via subscription.created; nothing more to do here.
-}
-
-async function handleSubscriptionChanged(stripeSub: Stripe.Subscription) {
-  const orgId = stripeSub.metadata?.org_id;
-  if (!orgId) return;
-  await syncSubscription(orgId, stripeSub);
-  await invalidateOrgEntitlements(orgId);
-}
-
-async function handleSubscriptionDeleted(stripeSub: Stripe.Subscription) {
-  const orgId = stripeSub.metadata?.org_id;
-  if (!orgId) return;
-  await sql`
-    update subscriptions
-    set plan_key = 'community', status = 'canceled', updated_at = now()
-    where org_id = ${orgId}`;
-  await invalidateOrgEntitlements(orgId);
-  await captureServer({
-    event: EVENTS.SUBSCRIPTION_CANCELED,
-    distinctId: await ownerDistinctId(orgId),
-    orgId,
-  });
-}
-
-/** In Stripe v22 the subscription ref moved to invoice.parent.subscription_details.subscription */
-function invoiceSubId(invoice: Stripe.Invoice): string | null {
-  const sub = invoice.parent?.subscription_details?.subscription;
-  if (!sub) return null;
-  return typeof sub === "string" ? sub : sub.id;
-}
-
-async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
-  const subId = invoiceSubId(invoice);
-  if (!subId) return;
-  const [row] = await sql<{ org_id: string }[]>`
-    update subscriptions set status = 'past_due', updated_at = now()
-    where stripe_subscription_id = ${subId}
-    returning org_id`;
-  if (row) {
-    await captureServer({
-      event: EVENTS.PAYMENT_FAILED,
-      distinctId: await ownerDistinctId(row.org_id),
-      orgId: row.org_id,
-    });
-  }
-}
-
-async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
-  const subId = invoiceSubId(invoice);
-  if (!subId) return;
-  await sql`
-    update subscriptions set status = 'active', updated_at = now()
-    where stripe_subscription_id = ${subId} and status != 'trialing'`;
-}
-
-// ---------------------------------------------------------------------------
-// Route handler
-// ---------------------------------------------------------------------------
-
+// Signed Stripe webhook. The dispatch table lives in
+// server/usecases/billing-events.ts, shared with the staff console's
+// "process now" replay — this route only owns signature verification and
+// the already-processed fast path.
 export async function POST(req: Request) {
   const rawBody = await req.text();
   const sig = req.headers.get("stripe-signature");
@@ -132,69 +24,15 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  // Idempotency: skip if already processed
+  // Idempotency: skip if already recorded (processed or mid-flight).
   const [existing] = await sql<{ id: string }[]>`
     select id from billing_events where id = ${event.id}`;
   if (existing) return NextResponse.json({ received: true });
 
-  // Record event before processing (idempotency guard)
-  const orgId = (event.data.object as { metadata?: { org_id?: string } })
-    .metadata?.org_id ?? null;
-  await sql`
-    insert into billing_events (id, type, org_id, payload)
-    values (${event.id}, ${event.type}, ${orgId}, ${JSON.stringify(event.data.object)})
-    on conflict (id) do nothing`;
-
   try {
-    switch (event.type) {
-      case "checkout.session.completed":
-        await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
-        break;
-      case "customer.subscription.created":
-      case "customer.subscription.updated": {
-        const stripeSub = event.data.object as Stripe.Subscription;
-        await handleSubscriptionChanged(stripeSub);
-        // Fire the activation-of-revenue event once, on creation only.
-        if (event.type === "customer.subscription.created" && stripeSub.metadata?.org_id) {
-          await captureServer({
-            event: EVENTS.SUBSCRIPTION_STARTED,
-            distinctId: await ownerDistinctId(stripeSub.metadata.org_id),
-            orgId: stripeSub.metadata.org_id,
-            properties: { plan_key: stripeSub.metadata?.plan_key, status: stripeSub.status },
-          });
-        }
-        break;
-      }
-      case "customer.subscription.deleted":
-        await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
-        break;
-      case "invoice.payment_failed":
-        await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice);
-        break;
-      case "invoice.payment_succeeded":
-        await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice);
-        break;
-      case "account.updated":
-        // Connect Express onboarding progress (PROMPT-20a): mirror the
-        // charges_enabled flag that gates entry-fee checkout.
-        await syncConnectAccount(event.data.object as Stripe.Account);
-        break;
-      case "charge.dispute.created":
-        // Entry-fee chargeback (spec issue #5): flag + alert the organiser.
-        await handleRegistrationDispute(event.data.object as Stripe.Dispute, "created");
-        break;
-      case "charge.dispute.closed":
-        await handleRegistrationDispute(event.data.object as Stripe.Dispute, "closed");
-        break;
-      case "charge.refunded":
-        // Refunds made in the Stripe dashboard still show on the console.
-        await syncRegistrationRefund(event.data.object as Stripe.Charge);
-        break;
-      // Unhandled events are silently ACKed
-    }
-
-    await sql`
-      update billing_events set processed_at = now() where id = ${event.id}`;
+    // Records the row first, stamps processed_at only after the handler ran —
+    // a throw leaves it visible as "received" on /admin/billing-events.
+    await runEvent(event);
   } catch (err) {
     // Return 5xx so Stripe retries
     console.error("Webhook processing error:", err);

--- a/apps/web/src/components/admin-process-event.tsx
+++ b/apps/web/src/components/admin-process-event.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+// "Process now" for a missed/stuck Stripe event on /admin/billing-events.
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { api } from "@/lib/client";
+
+export function ProcessEventButton({ eventId }: { eventId: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function run() {
+    setBusy(true);
+    setError(null);
+    try {
+      await api(`/api/admin/billing-events/${eventId}/process`, { method: "POST" });
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        disabled={busy}
+        onClick={run}
+        className="rounded-md border border-purple-500/60 px-2.5 py-1 text-xs font-medium text-purple-300 transition hover:bg-purple-500/10 disabled:opacity-50"
+      >
+        {busy ? "Processing…" : "Process now"}
+      </button>
+      {error && <span className="text-xs text-red-400">{error}</span>}
+    </span>
+  );
+}

--- a/apps/web/src/server/usecases/__tests__/billing-events.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-events.test.ts
@@ -1,0 +1,88 @@
+// Staff-console Stripe event replay (spec 2026-07-13): eventStatus drives the
+// processed/received/missing chips; runEvent stamps processed_at only after
+// the handler ran; replayEvent refuses to double-run what the ledger already
+// saw through. DB parts skipped without DATABASE_URL.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
+import { sql } from "@/lib/db";
+import {
+  eventStatus,
+  ledgerByIds,
+  replayEvent,
+  runEvent,
+  stuckLedgerEvents,
+} from "../billing-events";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+/** Unhandled type on purpose: the dispatch is a no-op, so these tests pin the
+ *  ledger mechanics without touching subscriptions/registrations state. */
+function fakeEvent(over: Partial<{ id: string; type: string }> = {}): Stripe.Event {
+  return {
+    id: over.id ?? `evt_test_${randomUUID().replace(/-/g, "")}`,
+    type: over.type ?? "product.created",
+    created: Math.floor(Date.now() / 1000),
+    data: { object: { metadata: {} } },
+  } as unknown as Stripe.Event;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe("eventStatus (pure)", () => {
+  it("no ledger row → missing (webhook never received it)", () => {
+    expect(eventStatus(undefined)).toBe("missing");
+  });
+  it("row without processed_at → received (handler didn't finish)", () => {
+    expect(eventStatus({ processed_at: null })).toBe("received");
+  });
+  it("processed_at set → processed", () => {
+    expect(eventStatus({ processed_at: "2026-07-13T00:00:00Z" })).toBe("processed");
+    expect(eventStatus({ processed_at: new Date() })).toBe("processed");
+  });
+});
+
+describe.skipIf(!HAS_DB)("event ledger mechanics", () => {
+  it("runEvent records the row and stamps processed_at", async () => {
+    const event = fakeEvent();
+    await runEvent(event);
+    const rows = await ledgerByIds([event.id]);
+    expect(eventStatus(rows.get(event.id))).toBe("processed");
+  });
+
+  it("replayEvent skips an already-processed event, heals a stuck one", async () => {
+    const done = fakeEvent();
+    await runEvent(done);
+    expect(await replayEvent(done)).toBe("already_processed");
+
+    // A stuck row: received (inserted) but the handler never finished.
+    const stuck = fakeEvent();
+    await sql`
+      insert into billing_events (id, type, org_id, payload)
+      values (${stuck.id}, ${stuck.type}, null, '{}')`;
+    const before = await ledgerByIds([stuck.id]);
+    expect(eventStatus(before.get(stuck.id))).toBe("received");
+    expect((await stuckLedgerEvents([])).some((r) => r.id === stuck.id)).toBe(true);
+
+    expect(await replayEvent(stuck)).toBe("processed");
+    const after = await ledgerByIds([stuck.id]);
+    expect(eventStatus(after.get(stuck.id))).toBe("processed");
+    expect((await stuckLedgerEvents([])).some((r) => r.id === stuck.id)).toBe(false);
+  });
+
+  it("stuckLedgerEvents honours the exclusion list (live-window dedupe)", async () => {
+    const stuck = fakeEvent();
+    await sql`
+      insert into billing_events (id, type, org_id, payload)
+      values (${stuck.id}, ${stuck.type}, null, '{}')`;
+    expect((await stuckLedgerEvents([stuck.id])).some((r) => r.id === stuck.id)).toBe(false);
+    // cleanup so other assertions on the shared DB stay stable
+    await sql`delete from billing_events where id = ${stuck.id}`;
+  });
+});

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -1,0 +1,260 @@
+import "server-only";
+// Stripe event processing (extracted from the webhook route so the staff
+// console can replay events): one dispatch table, shared by the signed
+// webhook POST and the admin "process now" path. billing_events is the
+// idempotency ledger — received_at set on arrival, processed_at only after
+// the handler ran, so a NULL processed_at is a stuck event and a missing row
+// is an event we never received (the deleted-endpoint incident class).
+import type Stripe from "stripe";
+import { sql } from "@/lib/db";
+import { recordPassPurchase, syncSubscription } from "@/lib/billing";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import {
+  handleRegistrationCheckoutCompleted,
+  handleRegistrationDispute,
+  syncRegistrationRefund,
+} from "@/server/usecases/registrations";
+import { syncConnectAccount } from "@/server/usecases/stripe-connect";
+import { captureServer } from "@/lib/posthog-server";
+import { EVENTS } from "@/lib/analytics-events";
+
+/** Every event type the dispatch below acts on — also the filter the staff
+ *  console asks Stripe for. Anything else is silently ACKed. */
+export const HANDLED_EVENT_TYPES = [
+  "checkout.session.completed",
+  "customer.subscription.created",
+  "customer.subscription.updated",
+  "customer.subscription.deleted",
+  "invoice.payment_failed",
+  "invoice.payment_succeeded",
+  "account.updated",
+  "charge.dispute.created",
+  "charge.dispute.closed",
+  "charge.refunded",
+] as const;
+
+/** Best-effort person id for org-scoped revenue events: the org owner, falling
+ *  back to a synthetic org id so the event still lands on the org group. */
+async function ownerDistinctId(orgId: string): Promise<string> {
+  const [row] = await sql<{ created_by: string | null }[]>`
+    select created_by from organizations where id = ${orgId}`;
+  return row?.created_by ?? `org:${orgId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
+  // Entry-fee checkouts (PROMPT-20a) share the endpoint; kind disambiguates.
+  if (session.metadata?.kind === "registration") {
+    await handleRegistrationCheckoutCompleted(session);
+    return;
+  }
+  const orgId = session.metadata?.org_id;
+  if (!orgId) return;
+
+  // Event Pass one-time purchase (v3/07 §3) — reconcile-on-return usually
+  // lands first; recordPassPurchase is idempotent either way.
+  if (session.metadata?.pass_key === "event_pass") {
+    const competitionId = session.metadata.competition_id;
+    if (competitionId && session.payment_status === "paid") {
+      await recordPassPurchase({
+        orgId,
+        competitionId,
+        paymentIntent:
+          typeof session.payment_intent === "string" ? session.payment_intent : null,
+      });
+    }
+    return;
+  }
+
+  // Link the Stripe customer to this org
+  if (session.customer) {
+    await sql`
+      update subscriptions set stripe_customer_id = ${session.customer as string}
+      where org_id = ${orgId}`;
+  }
+
+  // Subscription details arrive via subscription.created; nothing more to do here.
+}
+
+async function handleSubscriptionChanged(stripeSub: Stripe.Subscription) {
+  const orgId = stripeSub.metadata?.org_id;
+  if (!orgId) return;
+  await syncSubscription(orgId, stripeSub);
+  await invalidateOrgEntitlements(orgId);
+}
+
+async function handleSubscriptionDeleted(stripeSub: Stripe.Subscription) {
+  const orgId = stripeSub.metadata?.org_id;
+  if (!orgId) return;
+  await sql`
+    update subscriptions
+    set plan_key = 'community', status = 'canceled', updated_at = now()
+    where org_id = ${orgId}`;
+  await invalidateOrgEntitlements(orgId);
+  await captureServer({
+    event: EVENTS.SUBSCRIPTION_CANCELED,
+    distinctId: await ownerDistinctId(orgId),
+    orgId,
+  });
+}
+
+/** In Stripe v22 the subscription ref moved to invoice.parent.subscription_details.subscription */
+function invoiceSubId(invoice: Stripe.Invoice): string | null {
+  const sub = invoice.parent?.subscription_details?.subscription;
+  if (!sub) return null;
+  return typeof sub === "string" ? sub : sub.id;
+}
+
+async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
+  const subId = invoiceSubId(invoice);
+  if (!subId) return;
+  const [row] = await sql<{ org_id: string }[]>`
+    update subscriptions set status = 'past_due', updated_at = now()
+    where stripe_subscription_id = ${subId}
+    returning org_id`;
+  if (row) {
+    await captureServer({
+      event: EVENTS.PAYMENT_FAILED,
+      distinctId: await ownerDistinctId(row.org_id),
+      orgId: row.org_id,
+    });
+  }
+}
+
+async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
+  const subId = invoiceSubId(invoice);
+  if (!subId) return;
+  await sql`
+    update subscriptions set status = 'active', updated_at = now()
+    where stripe_subscription_id = ${subId} and status != 'trialing'`;
+}
+
+/** The dispatch table (formerly inline in the webhook route). Unhandled
+ *  types are a silent no-op — the caller still stamps processed_at. */
+export async function processStripeEvent(event: Stripe.Event): Promise<void> {
+  switch (event.type) {
+    case "checkout.session.completed":
+      await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+      break;
+    case "customer.subscription.created":
+    case "customer.subscription.updated": {
+      const stripeSub = event.data.object as Stripe.Subscription;
+      await handleSubscriptionChanged(stripeSub);
+      // Fire the activation-of-revenue event once, on creation only.
+      if (event.type === "customer.subscription.created" && stripeSub.metadata?.org_id) {
+        await captureServer({
+          event: EVENTS.SUBSCRIPTION_STARTED,
+          distinctId: await ownerDistinctId(stripeSub.metadata.org_id),
+          orgId: stripeSub.metadata.org_id,
+          properties: { plan_key: stripeSub.metadata?.plan_key, status: stripeSub.status },
+        });
+      }
+      break;
+    }
+    case "customer.subscription.deleted":
+      await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
+      break;
+    case "invoice.payment_failed":
+      await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice);
+      break;
+    case "invoice.payment_succeeded":
+      await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice);
+      break;
+    case "account.updated":
+      // Connect Express onboarding progress (PROMPT-20a): mirror the
+      // charges_enabled flag that gates entry-fee checkout.
+      await syncConnectAccount(event.data.object as Stripe.Account);
+      break;
+    case "charge.dispute.created":
+      // Entry-fee chargeback (spec issue #5): flag + alert the organiser.
+      await handleRegistrationDispute(event.data.object as Stripe.Dispute, "created");
+      break;
+    case "charge.dispute.closed":
+      await handleRegistrationDispute(event.data.object as Stripe.Dispute, "closed");
+      break;
+    case "charge.refunded":
+      // Refunds made in the Stripe dashboard still show on the console.
+      await syncRegistrationRefund(event.data.object as Stripe.Charge);
+      break;
+    // Unhandled events are silently ACKed
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ledger
+// ---------------------------------------------------------------------------
+
+export interface LedgerRow {
+  id: string;
+  type: string;
+  org_id: string | null;
+  org_name?: string | null;
+  received_at: string;
+  processed_at: string | null;
+}
+
+export type EventStatus = "processed" | "received" | "missing";
+
+/** Status of a Stripe event against the ledger: no row = never received
+ *  (webhook missed), row without processed_at = handler didn't finish. */
+export function eventStatus(row: { processed_at: string | Date | null } | undefined): EventStatus {
+  if (!row) return "missing";
+  return row.processed_at ? "processed" : "received";
+}
+
+/**
+ * Record + process one event, stamping processed_at only after the handler
+ * ran (a throw leaves the row in the "received" state for the console).
+ * Shared by the signed webhook and the staff replay.
+ */
+export async function runEvent(event: Stripe.Event): Promise<void> {
+  const orgId =
+    (event.data.object as { metadata?: { org_id?: string } }).metadata?.org_id ?? null;
+  await sql`
+    insert into billing_events (id, type, org_id, payload)
+    values (${event.id}, ${event.type}, ${orgId}, ${JSON.stringify(event.data.object)})
+    on conflict (id) do nothing`;
+  await processStripeEvent(event);
+  await sql`
+    update billing_events set processed_at = now() where id = ${event.id}`;
+}
+
+/** Staff replay: skip events the ledger already saw through. */
+export async function replayEvent(
+  event: Stripe.Event,
+): Promise<"processed" | "already_processed"> {
+  const [existing] = await sql<{ processed_at: string | null }[]>`
+    select processed_at from billing_events where id = ${event.id}`;
+  if (existing?.processed_at) return "already_processed";
+  await runEvent(event);
+  return "processed";
+}
+
+/** Ledger rows for a set of live Stripe event ids (the diff read). */
+export async function ledgerByIds(ids: string[]): Promise<Map<string, LedgerRow>> {
+  if (ids.length === 0) return new Map();
+  const rows = await sql<LedgerRow[]>`
+    select b.id, b.type, b.org_id, o.name as org_name, b.received_at, b.processed_at
+    from billing_events b
+    left join organizations o on o.id = b.org_id
+    where b.id in ${sql(ids)}`;
+  return new Map(rows.map((r) => [r.id, r]));
+}
+
+/** Stuck rows outside the live window: received, never processed. */
+export async function stuckLedgerEvents(
+  excludeIds: string[],
+  limit = 50,
+): Promise<LedgerRow[]> {
+  return sql<LedgerRow[]>`
+    select b.id, b.type, b.org_id, o.name as org_name, b.received_at, b.processed_at
+    from billing_events b
+    left join organizations o on o.id = b.org_id
+    where b.processed_at is null
+      ${excludeIds.length ? sql`and b.id not in ${sql(excludeIds)}` : sql``}
+    order by b.received_at desc
+    limit ${limit}`;
+}

--- a/docs/superpowers/specs/2026-07-13-admin-stripe-events-design.md
+++ b/docs/superpowers/specs/2026-07-13-admin-stripe-events-design.md
@@ -1,0 +1,26 @@
+# Admin Stripe Events — Design (2026-07-13)
+
+**Request:** staff console list of pending Stripe events, with the ability to process them (user-picked scope: live diff + ledger + retry button).
+
+## Problem
+
+`billing_events` is a write-only idempotency ledger. Two failure classes are invisible today: events Stripe sent that the webhook never received (the deleted-endpoint incident class — `reconcileCheckout` exists because of one), and events received whose handler threw (row inserted, `processed_at` never stamped; Stripe's retry is refused by the idempotency fast-path, so they stay stuck forever).
+
+## Design
+
+**`/admin/billing-events`** ("Stripe" in the staff nav, staff-gated by the admin layout + `requireStaff()` on the page, view audited via `logStaffAction`).
+
+- **Live diff:** `stripe.events.list({ limit: 50, types: HANDLED_EVENT_TYPES })` matched against the ledger. Status per event: `processed` (row + `processed_at`) / `received` (row, no stamp — handler died) / `missing` (no row — webhook never got it).
+- **Stuck ledger section:** unprocessed rows older than the live window.
+- **Keyless degrade:** no `STRIPE_SECRET_KEY` (or API failure) → ledger-only view + banner.
+- **Process now** on non-processed rows → `POST /api/admin/billing-events/{id}/process`: re-fetches the event from Stripe by id (API is the trust anchor, replacing the webhook signature — the stored payload is never replayed), runs the shared dispatch, stamps `processed_at`, audited. `replayEvent` refuses already-processed events; all handlers are idempotent.
+
+**Extraction:** the webhook route's dispatch switch and handlers move verbatim to `server/usecases/billing-events.ts` (`processStripeEvent`, `runEvent`, `HANDLED_EVENT_TYPES`); the route keeps signature verification and the already-recorded fast path. No behavior change, proven by the existing webhook suite.
+
+## Non-goals
+
+Automatic background sweeping (cron) of missed events; org-facing surfaces; replaying from stored payloads; pagination beyond the last 50 + stuck rows.
+
+## Tests
+
+Pure `eventStatus`; DB-backed ledger mechanics (runEvent stamps, replayEvent skips processed / heals stuck, exclusion-list dedupe); existing webhook FK suite stays green.


### PR DESCRIPTION
Staff request: see pending Stripe events in the admin portal and act on them.

## What's in

- **/admin/billing-events** ("Stripe" nav tab, staff-gated, view audited): the last 50 handled-type events pulled live from Stripe, checked against the \`billing_events\` ledger. Three states: **✓ processed**, **⏳ received but not processed** (row inserted, handler threw — Stripe's retry is refused by the idempotency fast-path, so these stayed stuck forever), **✖ never received** (webhook missed it — the deleted-endpoint incident class \`reconcileCheckout\` was born from). Stuck ledger rows older than the live window get their own section. No \`STRIPE_SECRET_KEY\` → ledger-only view + banner.
- **Process now** → \`POST /api/admin/billing-events/{id}/process\`: re-fetches the event from Stripe by id (the API is the trust anchor, standing in for the webhook signature — the stored payload is never replayed), runs the shared dispatch, stamps \`processed_at\`, writes \`staff_audit_log\`. \`replayEvent\` returns \`already_processed\` without re-running anything the ledger saw through.
- **Extraction**: the webhook route's dispatch switch + handlers moved verbatim to \`server/usecases/billing-events.ts\` (\`processStripeEvent\`, \`runEvent\`, \`HANDLED_EVENT_TYPES\`); the route keeps signature verification + the recorded fast-path. No behavior change.

## Verified

- Unit: 864 pass — pure \`eventStatus\`, DB-backed ledger mechanics (runEvent stamps; replayEvent skips processed / heals stuck; live-window dedupe), existing webhook FK suite green through the extraction. tsc + eslint clean.
- Live against the Stripe test account: page listed 50 real events with org names resolved; "Process now" healed them (each POST audited); double-processing the same event returned \`already_processed\` twice with zero side effects.

No migration. Spec: docs/superpowers/specs/2026-07-13-admin-stripe-events-design.md.

Note: on the shared test key, events minted by other environments show as "never received" locally — expected noise in dev; prod keys are environment-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)