### PR TITLE
chore: regenerate openapi — email_sent missed the #84 squash

### DIFF
--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -9699,6 +9699,9 @@
                         },
                         "claim_url": {
                           "type": "string"
+                        },
+                        "email_sent": {
+                          "type": "boolean"
                         }
                       },
                       "required": [
@@ -9710,7 +9713,8 @@
                         "claimed_at",
                         "revoked_at",
                         "created_at",
-                        "claim_url"
+                        "claim_url",
+                        "email_sent"
                       ],
                       "additionalProperties": false
                     },
@@ -9731,7 +9735,8 @@
                     "claimed_at": "example",
                     "revoked_at": "example",
                     "created_at": "example",
-                    "claim_url": "example"
+                    "claim_url": "example",
+                    "email_sent": true
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
                 }


### PR DESCRIPTION
PR #84's final commit (openapi regen for `CreatedPersonClaim.email_sent`) landed on the branch seconds before the squash-merge snapshot was taken, so main's `openapi/v1.json` is stale and the CI drift gate is red. This is that regen, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)