### PR TITLE
feat(disputes): recover lost-dispute amounts from the club (PROMPT-55)

### DIFF
--- a/apps/web/content/help/registration/card-payments.md
+++ b/apps/web/content/help/registration/card-payments.md
@@ -8,7 +8,7 @@ Card entry fees run on **Stripe Connect**: registrants pay at sign-up, the money
 
 ## 1. Connect and verify (one-time)
 
-Under **Settings → Payments**, press **Connect Stripe**. You're sent to Stripe's secure onboarding — Seazn Club never sees your details. Stripe verifies who receives the money (**KYC**): legal name, date of birth and bank account; clubs and companies may be asked for registration documents. Usually minutes; occasionally Stripe asks for more and it takes a day or two. You can leave and resume anytime.
+Under **Settings → Payments**, agree to the Terms of Service — connecting means your organisation bears the cost of chargebacks on its entry fees (see [§5 below](#5-disputes-chargebacks)) — then press **Connect Stripe**. You're sent to Stripe's secure onboarding — Seazn Club never sees your details. Stripe verifies who receives the money (**KYC**): legal name, date of birth and bank account; clubs and companies may be asked for registration documents. Usually minutes; occasionally Stripe asks for more and it takes a day or two. You can leave and resume anytime.
 
 When Stripe finishes, your Payments page shows **Live — charges enabled** and divisions can choose **Card at sign-up**. Until then, saving a card division is blocked — and if verification ever lapses later, card divisions close to new entries automatically rather than take money that can't be collected.
 
@@ -30,7 +30,11 @@ Refunds you make directly in the Stripe dashboard sync back — the entry shows 
 
 ## 5. Disputes (chargebacks)
 
-If a cardholder disputes a payment, the registration is **flagged on your console** the moment Stripe tells us, and you get an alert email. Press **Evidence pack** on the flagged entry — it downloads one document with everything that proves the entry was genuine: the registration record, a reconstruction of the confirmation email, the full activity log and the entrant's fixtures, mapped to Stripe's evidence fields. Respond to the dispute in your Stripe dashboard using it. If the dispute is lost, the payment returns to the cardholder. When it closes, the flag updates automatically.
+If a cardholder disputes a payment, the registration is **flagged on your console** the moment Stripe tells us, and you get an alert email. Press **Evidence pack** on the flagged entry — it downloads one document with everything that proves the entry was genuine: the registration record, a reconstruction of the confirmation email, the full activity log and the entrant's fixtures, mapped to Stripe's evidence fields. Seazn Club submits the response to Stripe. When the dispute closes, the flag updates automatically.
+
+**If the dispute is won**, the flag clears and nothing changes — the money stays yours.
+
+**If the dispute is lost**, Stripe repays the cardholder and the entry shows **dispute lost · refunded**. The disputed amount is then **recovered from your Stripe balance** — if the balance can't cover it, Stripe takes the difference from your upcoming payouts or your linked bank account on its own schedule. Seazn Club covers Stripe's dispute fee, and you get an email stating exactly what moved. Whether the entrant stays in the competition is your call — the entry is flagged, not withdrawn.
 
 ## Common questions
 

--- a/apps/web/src/app/api/v1/orgs/[id]/connect/route.ts
+++ b/apps/web/src/app/api/v1/orgs/[id]/connect/route.ts
@@ -28,6 +28,8 @@ export async function POST(req: Request, { params }: Ctx) {
     assertUuid(id, "organization");
     const auth = await requireOrgAuth(req, id, "write");
     const input = await parseBody(req, CreateConnectOnboarding);
-    return createConnectOnboardingLink(auth, id, baseUrl(req), input.return_path);
+    return createConnectOnboardingLink(
+      auth, id, baseUrl(req), input.return_path, input.tos_agreed,
+    );
   });
 }

--- a/apps/web/src/app/legal/terms/page.tsx
+++ b/apps/web/src/app/legal/terms/page.tsx
@@ -13,7 +13,7 @@ export default function TermsPage() {
       <MarketingNav />
       <main className="mx-auto max-w-3xl px-4 py-16">
         <h1 className="mb-2 text-3xl font-bold text-purple-900">Terms of Service</h1>
-        <p className="mb-8 text-sm text-slate-400">Last updated: 30 June 2026</p>
+        <p className="mb-8 text-sm text-slate-400">Last updated: 14 July 2026</p>
         <div className="space-y-6 text-sm text-slate-700">
 
           <section>
@@ -48,7 +48,16 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">5. Acceptable use</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">5. Entry-fee chargebacks</h2>
+            <ul className="list-disc space-y-1 pl-5">
+              <li>Card entry fees are collected through Stripe Connect and settle to your organisation&apos;s connected Stripe account. Seazn Club acts as merchant of record and manages responses to payment disputes (chargebacks) on your behalf.</li>
+              <li>Your organisation bears the cost of chargebacks on its entry fees. If a dispute is lost, the disputed amount is recovered from your connected Stripe balance; where the balance cannot cover it, Stripe recovers the difference from your future payouts or linked bank account under its Connect terms.</li>
+              <li>Seazn Club covers Stripe&apos;s dispute fees.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">6. Acceptable use</h2>
             <p>You may not:</p>
             <ul className="list-disc space-y-1 pl-5">
               <li>Use the service for unlawful purposes or to violate others' rights.</li>
@@ -59,37 +68,37 @@ export default function TermsPage() {
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">6. Your data</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">7. Your data</h2>
             <p>You retain ownership of data you upload. By using the service you grant us a limited licence to store and process that data to provide the service. See our <Link href="/legal/privacy" className="text-purple-600 underline">Privacy Policy</Link> for details.</p>
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">7. Availability and SLA</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">8. Availability and SLA</h2>
             <p>We aim for high availability but do not guarantee uninterrupted access. Planned maintenance will be communicated in advance. The service is provided "as is" without warranty of any kind.</p>
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">8. Limitation of liability</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">9. Limitation of liability</h2>
             <p>To the maximum extent permitted by law, Seazn Club' total liability for any claim arising from use of the service is limited to the amount you paid us in the 12 months preceding the claim. We are not liable for indirect, incidental, or consequential damages.</p>
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">9. Termination</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">10. Termination</h2>
             <p>You may close your account at any time from Settings → Account. We may suspend or terminate accounts that violate these Terms, with or without notice depending on severity. On termination, your data is scheduled for deletion as described in our Privacy Policy.</p>
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">10. Governing law</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">11. Governing law</h2>
             <p>These Terms are governed by the laws of England and Wales. Disputes shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">11. Changes</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">12. Changes</h2>
             <p>We will notify you of material changes by email at least 14 days before they take effect. Continued use after that date constitutes acceptance.</p>
           </section>
 
           <section>
-            <h2 className="mb-2 text-lg font-semibold text-slate-800">12. Contact</h2>
+            <h2 className="mb-2 text-lg font-semibold text-slate-800">13. Contact</h2>
             <p><a href="mailto:legal@seazn.club" className="text-purple-600 underline">legal@seazn.club</a></p>
           </section>
         </div>

--- a/apps/web/src/components/org-payment-instructions.tsx
+++ b/apps/web/src/components/org-payment-instructions.tsx
@@ -36,6 +36,7 @@ export function OrgPaymentInstructions({
   const [connect, setConnect] = useState<ConnectStatus | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
   const [connectBusy, setConnectBusy] = useState(false);
+  const [tosAgreed, setTosAgreed] = useState(false);
   const dirty = value.trim() !== (initialValue ?? "").trim();
 
   // Connect status is owner-only server-side; returning from Stripe
@@ -87,7 +88,7 @@ export function OrgPaymentInstructions({
     try {
       const { url } = await apiV1<{ url: string }>(`/api/v1/orgs/${orgId}/connect`, {
         method: "POST",
-        json: { return_path: "/settings/payments" },
+        json: { return_path: "/settings/payments", tos_agreed: tosAgreed },
       });
       window.location.assign(url);
     } catch (err) {
@@ -180,11 +181,37 @@ export function OrgPaymentInstructions({
               </li>
             ))}
           </ol>
+          {/* ToS gate (PROMPT-55): the first connect creates the Express
+              account, so the chargeback clause is accepted before it exists.
+              Resuming an existing onboarding never re-asks. */}
+          {!connect?.charges_enabled && !connect?.connected && (
+            <label className="mt-3 flex items-start gap-2 text-xs leading-5 text-slate-600">
+              <input
+                type="checkbox"
+                checked={tosAgreed}
+                onChange={(e) => setTosAgreed(e.target.checked)}
+                className="mt-0.5 accent-purple-600"
+              />
+              <span>
+                I agree to the{" "}
+                <a
+                  href="/legal/terms"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-purple-600 underline"
+                >
+                  Terms of Service
+                </a>
+                , including that my organisation bears the cost of chargebacks on its
+                entry fees — lost disputes are recovered from our Stripe balance.
+              </span>
+            </label>
+          )}
           {!connect?.charges_enabled && (
             <button
               type="button"
               onClick={startOnboarding}
-              disabled={connectBusy}
+              disabled={connectBusy || (!connect?.connected && !tosAgreed)}
               className="btn btn-primary mt-3 px-4 text-sm"
             >
               {connectBusy

--- a/apps/web/src/components/v2/registration-list.tsx
+++ b/apps/web/src/components/v2/registration-list.tsx
@@ -19,12 +19,17 @@ const STATUS_STYLE: Record<string, string> = {
 };
 
 /** Payment chip per row (spec §8): one glanceable money state. */
-function paymentChip(r: Registration): { label: string; cls: string } | null {
+function paymentChip(r: Registration): { label: string; cls: string; title?: string } | null {
   if (r.amount_cents <= 0 && !r.payment_intent_id) return null;
   // A closed-lost dispute leaves disputed_at set for history AND marks the
   // money returned — show that outcome, not a still-open-looking flag.
   if (r.disputed_at && r.refunded_cents >= r.amount_cents && r.amount_cents > 0)
-    return { label: "dispute lost · refunded", cls: "bg-rose-100 text-rose-700" };
+    return {
+      label: "dispute lost · refunded",
+      cls: "bg-rose-100 text-rose-700",
+      // Static copy (PROMPT-55): deep history lives in the activity log.
+      title: "The cardholder was repaid by Stripe and the amount was recovered from your Stripe balance.",
+    };
   if (r.disputed_at) return { label: "⚠ disputed", cls: "bg-rose-100 text-rose-700" };
   const partiallyRefunded = r.refunded_cents > 0 && r.refunded_cents < r.amount_cents;
   if (r.refunded_cents >= r.amount_cents && r.refunded_cents > 0)
@@ -231,7 +236,7 @@ export function RegistrationList({
                     <span className="badge bg-sky-100 font-mono text-sky-700">#{positions.get(r.id)}</span>
                   )}
                   {chip && (
-                    <span className={`badge ${chip.cls}`} data-testid="payment-chip">
+                    <span className={`badge ${chip.cls}`} data-testid="payment-chip" title={chip.title}>
                       {chip.label}
                     </span>
                   )}

--- a/apps/web/src/lib/__tests__/email-builders.test.ts
+++ b/apps/web/src/lib/__tests__/email-builders.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   accountDeletionTemplate,
   disputeAlertTemplate,
+  disputeLostTemplate,
   emailChangeConfirmTemplate,
   emailChangeNoticeTemplate,
   inviteTemplate,
@@ -74,6 +75,19 @@ const allBuilders: [string, { subject: string; html: string; text: string }][] =
       refCode: "SZ-ABCD-EFGH",
     }),
   ],
+  [
+    "dispute-lost",
+    disputeLostTemplate({
+      orgName: "Riverside Racquets",
+      competitionName: "Spring Open 2026",
+      displayName: "Alex",
+      amountCents: 2500,
+      currency: "gbp",
+      refCode: "SZ-ABCD-EFGH",
+      recoveredCents: 2375,
+      consoleUrl: LINK,
+    }),
+  ],
 ];
 
 describe("email builders compose from the html templates", () => {
@@ -116,6 +130,28 @@ describe("email builders compose from the html templates", () => {
     expect(card.html).toContain("https://checkout.stripe.test/cs_2");
     const offline = paymentReminderTemplate(registrationArgs);
     expect(offline.html).toContain("Bank transfer");
+  });
+
+  it("dispute-lost email states the loss, the balance debit and who pays the fee", () => {
+    const out = disputeLostTemplate({
+      orgName: "O", competitionName: "C", displayName: "D",
+      amountCents: 2000, currency: "gbp", refCode: "SZ-XXXX-YYYY",
+      recoveredCents: 1900, consoleUrl: LINK,
+    });
+    expect(out.subject.toLowerCase()).toContain("dispute lost");
+    expect(out.text).toContain("SZ-XXXX-YYYY");
+    expect(out.text).toContain("£20.00"); // disputed amount
+    expect(out.text).toContain("£19.00"); // recovered from the club's balance
+    expect(out.text.toLowerCase()).toContain("stripe balance");
+    expect(out.text.toLowerCase()).toContain("dispute fee");
+    expect(out.html).toContain(`href="${LINK}"`);
+    // Recovery failed → no false claim that money moved.
+    const failed = disputeLostTemplate({
+      orgName: "O", competitionName: "C", displayName: "D",
+      amountCents: 2000, currency: "gbp", refCode: null,
+      recoveredCents: 0, consoleUrl: LINK,
+    });
+    expect(failed.text.toLowerCase()).not.toContain("recovered from your stripe balance");
   });
 
   it("refund email states the amount; dispute alert warns the organiser", () => {

--- a/apps/web/src/lib/email-templates/dispute-alert.ts
+++ b/apps/web/src/lib/email-templates/dispute-alert.ts
@@ -34,7 +34,7 @@ export function disputeAlertTemplate(
         ) +
         panel(
           "What happens next",
-          "The registration is flagged on your console. If the dispute is lost, the payment is returned to the cardholder. " +
+          "The registration is flagged on your console. If the dispute is lost, the cardholder is repaid and the amount is recovered from your Stripe balance. " +
             "Check the entry, and gather anything that proves the registration was genuine (the confirmation email, check-in records).",
         ),
       footerNote: "You received this because you own the organisation on seazn.club.",
@@ -43,6 +43,6 @@ export function disputeAlertTemplate(
       `Payment dispute opened — ${opts.competitionName} (${opts.orgName}).\n` +
       `Disputed: ${amount} from ${opts.displayName}` +
       (opts.refCode ? ` (ref ${opts.refCode})` : "") +
-      `.\nThe registration is flagged on your console. If the dispute is lost, the payment is returned to the cardholder.`,
+      `.\nThe registration is flagged on your console. If the dispute is lost, the cardholder is repaid and the amount is recovered from your Stripe balance.`,
   };
 }

--- a/apps/web/src/lib/email-templates/dispute-lost.ts
+++ b/apps/web/src/lib/email-templates/dispute-lost.ts
@@ -1,0 +1,63 @@
+import { button, panel, paragraph, renderEmail } from "./compose";
+import { escapeHtml, money } from "./shared";
+
+export interface DisputeLostArgs {
+  orgName: string;
+  competitionName: string;
+  /** Registrant the disputed payment belonged to. */
+  displayName: string;
+  /** Disputed amount (the full write-off on the entry). */
+  amountCents: number;
+  currency: string;
+  refCode?: string | null;
+  /** What the transfer reversal actually pulled back from the club's Stripe
+   *  balance; 0 when the automatic recovery failed or was skipped. */
+  recoveredCents: number;
+  /** Registrations console for the affected division. */
+  consoleUrl: string;
+}
+
+/** Organiser-facing outcome mail: a chargeback was lost. States plainly that
+ *  the disputed amount was recovered from the club's Stripe balance while the
+ *  platform covered Stripe's dispute fee (PROMPT-55). */
+export function disputeLostTemplate(
+  opts: DisputeLostArgs,
+): { subject: string; html: string; text: string } {
+  const amount = money(opts.amountCents, opts.currency);
+  const recovered = money(opts.recoveredCents, opts.currency);
+  const ref = opts.refCode ? ` (ref ${opts.refCode})` : "";
+  const moneyLine =
+    opts.recoveredCents > 0
+      ? `${recovered} has been recovered from your Stripe balance — if your balance can't cover it, ` +
+        "Stripe deducts it from your upcoming payouts. Seazn Club covered Stripe's dispute fee."
+      : "We could not automatically recover the amount from your Stripe balance — our team will follow up. " +
+        "Seazn Club covered Stripe's dispute fee.";
+  return {
+    subject: `Dispute lost — ${opts.competitionName}`,
+    html: renderEmail({
+      subject: `Dispute lost — ${opts.competitionName}`,
+      preheader: `${amount} entry-fee dispute closed against you.`,
+      mastheadTag: opts.orgName,
+      eyebrow: `${opts.orgName} · ${opts.competitionName}`,
+      title: "Dispute lost",
+      contentHtml:
+        paragraph(
+          `The ${amount} entry-fee dispute from <strong>${escapeHtml(opts.displayName)}</strong>` +
+            (opts.refCode ? ` (ref ${escapeHtml(opts.refCode)})` : "") +
+            ` for ${escapeHtml(opts.competitionName)} was closed in the cardholder's favour. ` +
+            "The cardholder has been repaid by Stripe and the entry is marked refunded on your console.",
+        ) +
+        panel("What this means for you", escapeHtml(moneyLine)) +
+        button("Open registrations", opts.consoleUrl),
+      footerNote: "You received this because you own the organisation on seazn.club.",
+    }),
+    text:
+      `Dispute lost — ${opts.competitionName} (${opts.orgName}).\n` +
+      `Disputed: ${amount} from ${opts.displayName}${ref}.\n` +
+      `The cardholder has been repaid by Stripe and the entry is marked refunded.\n` +
+      (opts.recoveredCents > 0
+        ? `${recovered} has been recovered from your Stripe balance; Seazn Club covered Stripe's dispute fee.\n`
+        : `We could not automatically recover the amount from your Stripe balance — our team will follow up. Seazn Club covered Stripe's dispute fee.\n`) +
+      `Registrations: ${opts.consoleUrl}`,
+  };
+}

--- a/apps/web/src/lib/email-templates/index.ts
+++ b/apps/web/src/lib/email-templates/index.ts
@@ -15,5 +15,6 @@ export {
 } from "./registration-promoted";
 export { refundIssuedTemplate, type RefundIssuedArgs } from "./refund-issued";
 export { disputeAlertTemplate, type DisputeAlertArgs } from "./dispute-alert";
+export { disputeLostTemplate, type DisputeLostArgs } from "./dispute-lost";
 export { funnelClaimTemplate, funnelReminderTemplate, type FunnelEmailArgs } from "./funnel";
 export { claimInviteTemplate, type ClaimInviteArgs } from "./claim-invite";

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -18,6 +18,8 @@ import {
   type RefundIssuedArgs,
   disputeAlertTemplate,
   type DisputeAlertArgs,
+  disputeLostTemplate,
+  type DisputeLostArgs,
   funnelClaimTemplate,
   funnelReminderTemplate,
   type FunnelEmailArgs,
@@ -224,6 +226,17 @@ export interface DisputeAlertEmail extends DisputeAlertArgs {
 export async function sendDisputeAlertEmail(opts: DisputeAlertEmail): Promise<boolean> {
   const { to, ...args } = opts;
   return send({ to, ...disputeAlertTemplate(args) });
+}
+
+export interface DisputeLostEmail extends DisputeLostArgs {
+  to: string;
+}
+
+/** Organiser outcome mail: a chargeback closed lost — states the write-off
+ *  and the balance recovery (PROMPT-55). */
+export async function sendDisputeLostEmail(opts: DisputeLostEmail): Promise<boolean> {
+  const { to, ...args } = opts;
+  return send({ to, ...disputeLostTemplate(args) });
 }
 
 /** True when Resend is configured. */

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -985,6 +985,10 @@ export const ConnectStatus = z.object({
 export const CreateConnectOnboarding = z.object({
   /** App-relative path to return to after Stripe onboarding. */
   return_path: z.string().max(300).regex(/^\//, "app-relative path").default("/settings/billing"),
+  /** Acceptance of the entry-fee chargeback terms (ToS §5). Required for the
+   *  first connect — the Express account is only created once accepted;
+   *  resuming onboarding does not re-ask (PROMPT-55). */
+  tos_agreed: z.boolean().default(false),
 });
 export type CreateConnectOnboarding = z.infer<typeof CreateConnectOnboarding>;
 

--- a/apps/web/src/server/usecases/__tests__/registrations.test.ts
+++ b/apps/web/src/server/usecases/__tests__/registrations.test.ts
@@ -12,18 +12,34 @@ const stripeMock = vi.hoisted(() => {
   const checkoutCreate = vi.fn();
   const checkoutRetrieve = vi.fn();
   const refundCreate = vi.fn();
+  const chargeRetrieve = vi.fn();
+  const reversalCreate = vi.fn();
+  const reversalList = vi.fn();
   return {
     checkoutCreate,
     checkoutRetrieve,
     refundCreate,
+    chargeRetrieve,
+    reversalCreate,
+    reversalList,
     stripe: {
       checkout: { sessions: { create: checkoutCreate, retrieve: checkoutRetrieve } },
       refunds: { create: refundCreate },
+      charges: { retrieve: chargeRetrieve },
+      transfers: { createReversal: reversalCreate, listReversals: reversalList },
     },
   };
 });
 
 vi.mock("@/lib/stripe", () => ({ getStripe: () => stripeMock.stripe }));
+
+// Observe the dispute-lost organiser email without touching the rest of the
+// email module (send() is a no-op without RESEND_API_KEY either way).
+const emailMock = vi.hoisted(() => ({ disputeLost: vi.fn().mockResolvedValue(true) }));
+vi.mock("@/lib/email", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/email")>()),
+  sendDisputeLostEmail: emailMock.disputeLost,
+}));
 
 import { sql } from "@/lib/db";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
@@ -235,6 +251,10 @@ beforeEach(() => {
   }));
   stripeMock.refundCreate.mockReset().mockResolvedValue({ id: "re_test_1" });
   stripeMock.checkoutRetrieve.mockReset();
+  stripeMock.chargeRetrieve.mockReset();
+  stripeMock.reversalCreate.mockReset().mockResolvedValue({ id: "trr_test_1" });
+  stripeMock.reversalList.mockReset().mockResolvedValue({ data: [] });
+  emailMock.disputeLost.mockClear();
 });
 
 afterAll(async () => {
@@ -1154,5 +1174,205 @@ describe.skipIf(!HAS_DB)("card submit path (spec §3)", () => {
     expect(second.checkout_url).toBeNull();
     expect(second.registration.expires_at).toBeNull();
     expect(stripeMock.checkoutCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dispute loss recovery (PROMPT-55): lost card disputes reverse the club's
+// transfer so the platform only eats Stripe's dispute fee.
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!HAS_DB)("dispute loss recovery (PROMPT-55)", () => {
+  /** Paid card registration + the Stripe objects a lost dispute resolves. */
+  async function disputedRig(feeCents = 2000) {
+    const rigged = await stripeRig({ feeCents });
+    const res = await submitRegistration(rigged.orgSlug, rigged.competition.slug, {
+      ...SUBMIT_BASE, division_id: rigged.division.id,
+    }, "http://test.local");
+    await handleRegistrationCheckoutCompleted(fakeSession(res.registration.id, feeCents));
+    const intent = "pi_test_" + res.registration.id.slice(0, 8);
+    const chargeId = "ch_" + res.registration.id.slice(0, 8);
+    const transferId = "tr_" + res.registration.id.slice(0, 8);
+    // Verified against the live API in test mode (2026-07-14): destination
+    // charges transfer the FULL amount; the application fee is collected from
+    // the connected account separately — so the club's net is
+    // transfer.amount − application_fee_amount.
+    stripeMock.chargeRetrieve.mockResolvedValue({
+      id: chargeId, amount: feeCents, application_fee_amount: 100,
+      transfer: { id: transferId, amount: feeCents, amount_reversed: 0 },
+    });
+    return { ...rigged, regId: res.registration.id, intent, chargeId, transferId };
+  }
+
+  const disputeObj = (over: Record<string, unknown>) =>
+    ({ status: "lost", ...over }) as unknown as Stripe.Dispute;
+
+  async function auditRows(type: string, regId: string) {
+    return sql<{ payload: Record<string, unknown> }[]>`
+      select payload from competition_events
+      where type = ${type} and payload->>'registration_id' = ${regId}`;
+  }
+
+  it("lost dispute reverses the club's net share with a dispute-scoped idempotency key", async () => {
+    const { regId, orgId, intent, chargeId, transferId } = await disputedRig();
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r1", payment_intent: intent, charge: chargeId, amount: 2000,
+      status: "needs_response",
+    }), "created");
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r1", payment_intent: intent, charge: chargeId, amount: 2000,
+    }), "closed");
+
+    const [row] = await sql<RegistrationRow[]>`
+      select * from registrations where id = ${regId}`;
+    expect(row.refunded_cents).toBe(2000);
+
+    expect(stripeMock.chargeRetrieve).toHaveBeenCalledWith(chargeId, { expand: ["transfer"] });
+    expect(stripeMock.reversalCreate).toHaveBeenCalledTimes(1);
+    expect(stripeMock.reversalCreate).toHaveBeenCalledWith(
+      transferId,
+      {
+        amount: 1900, // 2000 transfer − 100 app fee: the net the club received
+        metadata: { dispute_id: "dp_r1", registration_id: regId },
+      },
+      { idempotencyKey: "dispute-reversal-dp_r1" },
+    );
+
+    const recovered = await auditRows("registration.dispute_recovered", regId);
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0].payload).toMatchObject({
+      dispute_id: "dp_r1", transfer_id: transferId, reversed_cents: 1900,
+    });
+
+    // Organiser hears about the loss + recovery — addressed to the current
+    // owner (org_members), not organizations.created_by.
+    const [owner] = await sql<{ email: string }[]>`
+      select u.email from org_members m join users u on u.id = m.user_id
+      where m.org_id = ${orgId} and m.role = 'owner'`;
+    expect(emailMock.disputeLost).toHaveBeenCalledTimes(1);
+    expect(emailMock.disputeLost).toHaveBeenCalledWith(
+      expect.objectContaining({ to: owner.email, amountCents: 2000, recoveredCents: 1900 }),
+    );
+  });
+
+  it("write-off lands even when the reversal throws (recovery_failed audited)", async () => {
+    const { regId, intent, chargeId } = await disputedRig();
+    stripeMock.reversalCreate.mockRejectedValue(new Error("stripe down"));
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r2", payment_intent: intent, charge: chargeId, amount: 2000,
+    }), "closed");
+
+    const [row] = await sql<RegistrationRow[]>`
+      select * from registrations where id = ${regId}`;
+    expect(row.refunded_cents).toBe(2000); // the write-off never depends on Stripe
+
+    expect(await auditRows("registration.dispute_recovered", regId)).toHaveLength(0);
+    const failed = await auditRows("registration.dispute_recovery_failed", regId);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].payload.error).toContain("stripe down");
+    expect(emailMock.disputeLost).toHaveBeenCalledWith(
+      expect.objectContaining({ recoveredCents: 0 }),
+    );
+  });
+
+  it("replayed lost event short-circuits on the metadata guard — one reversal, one email", async () => {
+    const { regId, intent, chargeId, transferId } = await disputedRig();
+    stripeMock.reversalList
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValue({
+        data: [{ id: "trr_prior", amount: 1900, metadata: { dispute_id: "dp_r3" } }],
+      });
+    const lost = disputeObj({
+      id: "dp_r3", payment_intent: intent, charge: chargeId, amount: 2000,
+    });
+    await handleRegistrationDispute(lost, "closed");
+    await handleRegistrationDispute(lost, "closed"); // /admin/billing-events replay
+
+    expect(stripeMock.reversalCreate).toHaveBeenCalledTimes(1);
+    expect(stripeMock.reversalList).toHaveBeenCalledWith(transferId, { limit: 100 });
+    expect(await auditRows("registration.dispute_recovered", regId)).toHaveLength(1);
+    expect(emailMock.disputeLost).toHaveBeenCalledTimes(1);
+  });
+
+  it("partial dispute reverses the proportional net share, capped by the unreversed remainder", async () => {
+    const a = await disputedRig();
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r4", payment_intent: a.intent, charge: a.chargeId, amount: 500,
+    }), "closed");
+    // 500 of 2000 disputed → club's net share = 500 × 1900/2000 = 475.
+    expect(stripeMock.reversalCreate).toHaveBeenCalledWith(
+      a.transferId, expect.objectContaining({ amount: 475 }), expect.anything(),
+    );
+
+    // Mostly-reversed transfer: never exceed what's left.
+    const b = await disputedRig();
+    stripeMock.chargeRetrieve.mockResolvedValue({
+      id: b.chargeId, amount: 2000, application_fee_amount: 100,
+      transfer: { id: b.transferId, amount: 2000, amount_reversed: 1800 },
+    });
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r5", payment_intent: b.intent, charge: b.chargeId, amount: 500,
+    }), "closed");
+    expect(stripeMock.reversalCreate).toHaveBeenLastCalledWith(
+      b.transferId, expect.objectContaining({ amount: 200 }), expect.anything(),
+    );
+  });
+
+  it("no transfer on the charge → skip with an audit note, no reversal call", async () => {
+    const { regId, intent, chargeId } = await disputedRig();
+    stripeMock.chargeRetrieve.mockResolvedValue({
+      id: chargeId, amount: 2000, application_fee_amount: null, transfer: null,
+    });
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r6", payment_intent: intent, charge: chargeId, amount: 2000,
+    }), "closed");
+
+    expect(stripeMock.reversalCreate).not.toHaveBeenCalled();
+    const skipped = await auditRows("registration.dispute_recovery_skipped", regId);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].payload.reason).toBe("no_transfer");
+    const [row] = await sql<RegistrationRow[]>`
+      select * from registrations where id = ${regId}`;
+    expect(row.refunded_cents).toBe(2000);
+  });
+
+  it("won dispute never touches transfers", async () => {
+    const { regId, intent, chargeId } = await disputedRig();
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r7", payment_intent: intent, charge: chargeId, amount: 2000,
+      status: "needs_response",
+    }), "created");
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r7", payment_intent: intent, charge: chargeId, amount: 2000, status: "won",
+    }), "closed");
+
+    expect(stripeMock.chargeRetrieve).not.toHaveBeenCalled();
+    expect(stripeMock.reversalCreate).not.toHaveBeenCalled();
+    expect(emailMock.disputeLost).not.toHaveBeenCalled();
+    const [row] = await sql<RegistrationRow[]>`
+      select * from registrations where id = ${regId}`;
+    expect(row.refunded_cents).toBe(0);
+    expect(row.disputed_at).toBeNull();
+  });
+
+  it("dispute-lost email goes to the CURRENT owner after a transfer-owner flip", async () => {
+    const { regId, orgId, intent, chargeId } = await disputedRig();
+    const newOwnerId = await makeUser("newowner");
+    await sql`update org_members set role = 'admin'
+              where org_id = ${orgId} and role = 'owner'`;
+    await sql`insert into org_members (org_id, user_id, role)
+              values (${orgId}, ${newOwnerId}, 'owner')`;
+    const [{ email: newOwnerEmail }] = await sql<{ email: string }[]>`
+      select email from users where id = ${newOwnerId}`;
+
+    await handleRegistrationDispute(disputeObj({
+      id: "dp_r8", payment_intent: intent, charge: chargeId, amount: 2000,
+    }), "closed");
+
+    expect(emailMock.disputeLost).toHaveBeenCalledTimes(1);
+    expect(emailMock.disputeLost).toHaveBeenCalledWith(
+      expect.objectContaining({ to: newOwnerEmail }),
+    );
+    expect(await auditRows("registration.dispute_recovered", regId)).toHaveLength(1);
   });
 });

--- a/apps/web/src/server/usecases/__tests__/stripe-connect.test.ts
+++ b/apps/web/src/server/usecases/__tests__/stripe-connect.test.ts
@@ -1,0 +1,100 @@
+// ToS gate on Stripe Connect onboarding (PROMPT-55): the Express account is
+// only created after the owner accepts the entry-fee chargeback terms; the
+// acceptance timestamp is recorded on the Stripe account metadata. Real
+// Postgres required; skipped without DATABASE_URL.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+const stripeMock = vi.hoisted(() => {
+  const accountCreate = vi.fn();
+  const accountLinkCreate = vi.fn();
+  return {
+    accountCreate,
+    accountLinkCreate,
+    stripe: {
+      accounts: { create: accountCreate },
+      accountLinks: { create: accountLinkCreate },
+    },
+  };
+});
+
+vi.mock("@/lib/stripe", () => ({ getStripe: () => stripeMock.stripe }));
+
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createConnectOnboardingLink } from "../stripe-connect";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function seedProOrg(): Promise<{ owner: AuthCtx; orgId: string }> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: ownerId }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name)
+    values (${`owner-${suffix}@test.local`}, 'owner') returning id`;
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"Connect Org " + suffix}, ${"cn-org-" + suffix}, ${ownerId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  await sql`insert into subscriptions (org_id, plan_key, status)
+            values (${orgId}, 'pro', 'active')
+            on conflict (org_id) do update set plan_key = 'pro', status = 'active'`;
+  return { owner: { orgId, via: "session", userId: ownerId, role: "owner", keyId: null }, orgId };
+}
+
+beforeEach(() => {
+  stripeMock.accountCreate
+    .mockReset()
+    .mockImplementation(async () => ({ id: "acct_test_" + randomUUID().slice(0, 8) }));
+  stripeMock.accountLinkCreate
+    .mockReset()
+    .mockResolvedValue({ url: "https://connect.stripe.test/onboard" });
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("Connect onboarding ToS gate (PROMPT-55)", () => {
+  it("first connect without agreement → 422, no Stripe account created", async () => {
+    const { owner, orgId } = await seedProOrg();
+    await expect(
+      createConnectOnboardingLink(owner, orgId, "http://test.local", "/settings/payments"),
+    ).rejects.toMatchObject({ status: 422 });
+    expect(stripeMock.accountCreate).not.toHaveBeenCalled();
+    const [org] = await sql<{ stripe_account_id: string | null }[]>`
+      select stripe_account_id from organizations where id = ${orgId}`;
+    expect(org.stripe_account_id).toBeNull();
+  });
+
+  it("agreement creates the account with the acceptance stamped in metadata", async () => {
+    const { owner, orgId } = await seedProOrg();
+    const { url } = await createConnectOnboardingLink(
+      owner, orgId, "http://test.local", "/settings/payments", true,
+    );
+    expect(url).toBe("https://connect.stripe.test/onboard");
+    expect(stripeMock.accountCreate).toHaveBeenCalledTimes(1);
+    const args = stripeMock.accountCreate.mock.calls[0][0] as {
+      metadata: { org_id: string; tos_agreed_at: string };
+    };
+    expect(args.metadata.org_id).toBe(orgId);
+    expect(new Date(args.metadata.tos_agreed_at).getTime()).not.toBeNaN();
+    const [org] = await sql<{ stripe_account_id: string | null }[]>`
+      select stripe_account_id from organizations where id = ${orgId}`;
+    expect(org.stripe_account_id).not.toBeNull();
+  });
+
+  it("resuming onboarding on an existing account does not re-ask", async () => {
+    const { owner, orgId } = await seedProOrg();
+    await sql`update organizations set stripe_account_id = ${"acct_prior_" + orgId.slice(0, 8)}
+              where id = ${orgId}`;
+    const { url } = await createConnectOnboardingLink(
+      owner, orgId, "http://test.local", "/settings/payments",
+    );
+    expect(url).toBe("https://connect.stripe.test/onboard");
+    expect(stripeMock.accountCreate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/server/usecases/registrations.ts
+++ b/apps/web/src/server/usecases/registrations.ts
@@ -28,7 +28,9 @@ import {
   sendRegistrationPromotedEmail,
   sendRefundIssuedEmail,
   sendDisputeAlertEmail,
+  sendDisputeLostEmail,
 } from "@/lib/email";
+import { routes } from "@/lib/routes";
 import { generateRefCode, isValidRefCode, normalizeRefCode } from "@/lib/ref-code";
 import { maskDisplayName, resolveNameDisplay } from "@/lib/name-display";
 import type { AuthCtx } from "@/server/api-v1/auth";
@@ -292,6 +294,7 @@ interface DivisionCtx {
   comp_visibility: string;
   starts_on: string | null;
   ends_on: string | null;
+  div_slug: string;
   org_slug: string;
   org_name: string;
   payment_instructions: string | null;
@@ -300,7 +303,7 @@ interface DivisionCtx {
 
 async function divisionCtx(db: AnySql, divisionId: string): Promise<DivisionCtx> {
   const [row] = await db<DivisionCtx[]>`
-    select d.id, d.competition_id, d.org_id, d.eligibility,
+    select d.id, d.competition_id, d.org_id, d.eligibility, d.slug as div_slug,
            c.name as comp_name, c.slug as comp_slug, c.visibility as comp_visibility,
            c.starts_on, c.ends_on,
            o.slug as org_slug, o.name as org_name, o.payment_instructions,
@@ -1094,14 +1097,10 @@ export async function handleRegistrationDispute(
       dispute_id: dispute.id,
       amount_cents: dispute.amount,
     }, null);
-    // Current owner via org_members, NOT organizations.created_by — ownership
-    // transfers flip the role but leave created_by on the original creator.
-    const [owner] = await sql<{ email: string }[]>`
-      select u.email from org_members m join users u on u.id = m.user_id
-      where m.org_id = ${reg.org_id} and m.role = 'owner' limit 1`;
+    const owner = await currentOwnerEmail(reg.org_id);
     if (owner) {
       void sendDisputeAlertEmail({
-        to: owner.email,
+        to: owner,
         orgName: ctx.org_name,
         competitionName: ctx.comp_name,
         displayName: reg.display_name,
@@ -1120,6 +1119,8 @@ export async function handleRegistrationDispute(
       dispute_id: dispute.id,
     }, null);
   } else if (dispute.status === "lost") {
+    // The write-off must land whatever Stripe does next — same contract as
+    // refund failure never undoing a withdrawal.
     await sql`update registrations
               set refunded_cents = amount_cents,
                   refunded_at = coalesce(refunded_at, now()), updated_at = now()
@@ -1128,6 +1129,121 @@ export async function handleRegistrationDispute(
       registration_id: reg.id,
       dispute_id: dispute.id,
     }, null);
+    const recovery = await recoverDisputedTransfer(dispute, reg, ctx);
+    // `already` = a replayed close (metadata guard hit) — everything below
+    // already happened on the first run.
+    if (!recovery.already) {
+      const owner = await currentOwnerEmail(reg.org_id);
+      if (owner) {
+        void sendDisputeLostEmail({
+          to: owner,
+          orgName: ctx.org_name,
+          competitionName: ctx.comp_name,
+          displayName: reg.display_name,
+          amountCents: dispute.amount,
+          currency: reg.currency ?? "gbp",
+          refCode: reg.ref_code,
+          recoveredCents: recovery.recoveredCents,
+          consoleUrl:
+            fallbackOrigin() +
+            routes.divisionRegistrations(ctx.org_slug, ctx.comp_slug, ctx.div_slug),
+        }).catch(() => {});
+      }
+    }
+  }
+}
+
+/** Current owner via org_members, NOT organizations.created_by — ownership
+ *  transfers flip the role but leave created_by on the original creator. */
+async function currentOwnerEmail(orgId: string): Promise<string | null> {
+  const [owner] = await sql<{ email: string }[]>`
+    select u.email from org_members m join users u on u.id = m.user_id
+    where m.org_id = ${orgId} and m.role = 'owner' limit 1`;
+  return owner?.email ?? null;
+}
+
+/**
+ * PROMPT-55: on a LOST entry-fee dispute, pull the club's net back off its
+ * connected balance so the platform's loss is Stripe's dispute fee only.
+ *
+ * Mechanics verified against the live API in test mode (2026-07-14, GBP):
+ * destination charges transfer the FULL charge amount to the connected
+ * account and collect the application fee from it separately, and a lost
+ * dispute auto-reverses NEITHER — the platform is debited
+ * dispute.amount + Stripe's dispute fee, the transfer stays unreversed and
+ * the application fee stays earned. Worked example (fee 2000, app fee 100,
+ * GBP dispute fee 2000): transfer = 2000, club net = 1900; on loss the
+ * platform is debited 4000. Reversing 1900 leaves the club exactly flat on
+ * the entry (2000 in − 100 app fee − 1900 reversed = 0) and the platform's
+ * net cost is the dispute fee alone (−4000 + 1900 recovered + 100 app fee
+ * kept = −2000). Absorbing that fee is the cost of owning the dispute flow.
+ *
+ * The reversal may push the club's Express balance negative; Stripe then
+ * recovers from future payouts or bank debits per the Connect settings —
+ * that is the intended liability chain: the platform owns the dispute
+ * response (Express accounts have no dispute surface), clubs own the
+ * economic risk of their own registrants.
+ *
+ * Never throws: recovery failure is audited and must not block the webhook
+ * ACK or the write-off above. Stripe calls stay OUTSIDE any sql tx.
+ */
+async function recoverDisputedTransfer(
+  dispute: Stripe.Dispute,
+  reg: RegistrationRow,
+  ctx: DivisionCtx,
+): Promise<{ recoveredCents: number; already: boolean }> {
+  const note = (type: string, extra: Record<string, unknown>) =>
+    audit(sql, ctx.competition_id, reg.org_id, type, {
+      registration_id: reg.id,
+      dispute_id: dispute.id,
+      ...extra,
+    }, null);
+  try {
+    const chargeId = typeof dispute.charge === "string" ? dispute.charge : dispute.charge?.id;
+    if (!chargeId) {
+      await note("registration.dispute_recovery_skipped", { reason: "no_charge" });
+      return { recoveredCents: 0, already: false };
+    }
+    const stripe = getStripe();
+    const charge = await stripe.charges.retrieve(chargeId, { expand: ["transfer"] });
+    let transfer = charge.transfer;
+    if (typeof transfer === "string") transfer = await stripe.transfers.retrieve(transfer);
+    if (!transfer) {
+      // e.g. the charge predates the Connect wiring.
+      await note("registration.dispute_recovery_skipped", { reason: "no_transfer" });
+      return { recoveredCents: 0, already: false };
+    }
+    // Stripe idempotency keys expire (~24h) but /admin/billing-events can
+    // replay a closed event much later — this metadata check is the durable
+    // guard against double reversals; the key below covers webhook retries.
+    const existing = await stripe.transfers.listReversals(transfer.id, { limit: 100 });
+    if (existing.data.some((r) => r.metadata?.dispute_id === dispute.id)) {
+      return { recoveredCents: 0, already: true };
+    }
+    // Club's net share of the disputed amount (partial disputes exist),
+    // capped by whatever is still unreversed on the transfer.
+    const net = transfer.amount - (charge.application_fee_amount ?? 0);
+    const share = Math.round((dispute.amount * net) / charge.amount);
+    const amount = Math.min(share, transfer.amount - transfer.amount_reversed);
+    if (amount <= 0) {
+      await note("registration.dispute_recovery_skipped", { reason: "nothing_to_reverse" });
+      return { recoveredCents: 0, already: false };
+    }
+    await stripe.transfers.createReversal(
+      transfer.id,
+      { amount, metadata: { dispute_id: dispute.id, registration_id: reg.id } },
+      { idempotencyKey: `dispute-reversal-${dispute.id}` },
+    );
+    await note("registration.dispute_recovered", {
+      transfer_id: transfer.id,
+      reversed_cents: amount,
+    });
+    return { recoveredCents: amount, already: false };
+  } catch (err) {
+    await note("registration.dispute_recovery_failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { recoveredCents: 0, already: false };
   }
 }
 

--- a/apps/web/src/server/usecases/stripe-connect.ts
+++ b/apps/web/src/server/usecases/stripe-connect.ts
@@ -76,6 +76,7 @@ export async function createConnectOnboardingLink(
   orgId: string,
   origin: string,
   returnPath: string,
+  tosAgreed = false,
 ): Promise<{ url: string }> {
   requireOwnerSession(auth, orgId);
   // Connect is org-wide plumbing: any Event Pass in the org unlocks it too,
@@ -83,13 +84,24 @@ export async function createConnectOnboardingLink(
   const [anyPass] = await sql<{ ok: number }[]>`
     select 1 as ok from competition_passes where org_id = ${orgId} limit 1`;
   if (!anyPass) await requireFeature(orgId, "registration.paid");
-  const stripe = getStripe();
 
   let { stripe_account_id: accountId } = await orgConnect(orgId);
+  // ToS gate (PROMPT-55): the org accepts the entry-fee chargeback clause
+  // (lost disputes are recovered from its connected balance) BEFORE the
+  // Express account exists. Resuming onboarding never re-asks; the
+  // acceptance timestamp lives on the account metadata — no DB column.
+  // Checked before getStripe() so the 422 answers even keyless.
+  if (!accountId && !tosAgreed) {
+    throw new HttpError(
+      422,
+      "Agree to the Terms of Service (entry-fee chargebacks) before connecting Stripe",
+    );
+  }
+  const stripe = getStripe();
   if (!accountId) {
     const account = await stripe.accounts.create({
       type: "express",
-      metadata: { org_id: orgId },
+      metadata: { org_id: orgId, tos_agreed_at: new Date().toISOString() },
       capabilities: {
         card_payments: { requested: true },
         transfers: { requested: true },

--- a/design/v9/README.md
+++ b/design/v9/README.md
@@ -1,7 +1,9 @@
 # v9 — Dispute Loss Recovery
 
-> **Status (2026-07-14):** not started. PROMPT-55 ⏳.
-> Branch (planned): `feat/v9-dispute-loss-recovery` (worktree).
+> **Status (2026-07-14):** PROMPT-55 ✅ implemented on
+> `feat/v9-dispute-loss-recovery` (worktree) — reversal + email + ToS gate
+> before Connect (owner ask, 2026-07-14). Live `createReversal` smoke-run
+> pending: the local restricted key needs "Transfers Write" enabled.
 > Migrations: none expected (all state already exists: `disputed_at`,
 > `dispute_id`, `refunded_cents`; Stripe holds the reversal state).
 > **Prereq:** PR #89 merged — it ships the dispute UX this builds on

--- a/docs/simulating-disputes.md
+++ b/docs/simulating-disputes.md
@@ -1,0 +1,61 @@
+# Simulating entry-fee disputes (test mode)
+
+Dev/ops runbook for the chargeback flow (PROMPT-55). Everything here is
+Stripe **test mode** — nothing moves real money.
+
+## Test cards
+
+| Card | Behaviour |
+| --- | --- |
+| `4000 0000 0000 0259` | Payment succeeds, then is disputed automatically (`charge.dispute.created` fires right after the charge). |
+| `4000 0000 0000 2685` | Disputed like above, but the dispute is **unwinnable** — closing evidence always loses. |
+
+Any future expiry + CVC. In API-driven tests, `pm_card_createDispute` is the
+payment-method token equivalent of `0259`.
+
+## Local webhook loop
+
+```sh
+stripe listen --forward-to localhost:3000/api/webhooks/stripe
+```
+
+Copy the printed signing secret into `STRIPE_WEBHOOK_SECRET`. Register with a
+card division, pay with `0259`, and the dispute lands: entry flagged
+`⚠ disputed`, organiser alert email sent.
+
+## Closing the dispute
+
+Submit evidence whose text controls the outcome (test mode only):
+
+```sh
+stripe disputes update dp_... -d "evidence[uncategorized_text]=losing_evidence" -d submit=true
+stripe disputes update dp_... -d "evidence[uncategorized_text]=winning_evidence" -d submit=true
+```
+
+The dispute passes through `under_review` and closes a few seconds later
+(`charge.dispute.closed`). On **lost**: chip flips to
+`dispute lost · refunded`, the club's transfer is reversed
+(`registration.dispute_recovered` in the activity log, reversal visible on
+the transfer in the platform Dashboard) and the dispute-lost email goes to
+the current org owner. On **won**: flag clears, nothing moves.
+
+## Verified mechanics (live test-mode run, 2026-07-14)
+
+- Destination charges transfer the **full** charge amount; the application
+  fee is collected from the connected account separately. The club's net is
+  `transfer.amount − application_fee_amount`.
+- A lost dispute debits the platform `dispute.amount` **plus** Stripe's
+  dispute fee (£20.00 in test-mode GBP) and auto-reverses **nothing** — no
+  transfer reversal, no application-fee refund. The reversal in
+  `recoverDisputedTransfer` is what makes the club bear the loss.
+- Replaying `charge.dispute.closed` from /admin/billing-events is safe: the
+  reversal carries `metadata.dispute_id` and the handler skips when one
+  already exists (Stripe idempotency keys alone expire after ~24h).
+
+## Key permissions
+
+`transfers.createReversal` needs **Transfers Write** on restricted keys. If
+the environment's `STRIPE_SECRET_KEY` is an `rk_` key, enable it in the
+Stripe dashboard (Developers → API keys → edit key), or the recovery path
+audits `registration.dispute_recovery_failed` with a permission error while
+the write-off still lands.

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -29423,15 +29423,21 @@
                     "type": "string",
                     "maxLength": 300,
                     "pattern": "^\\/"
+                  },
+                  "tos_agreed": {
+                    "default": false,
+                    "type": "boolean"
                   }
                 },
                 "required": [
-                  "return_path"
+                  "return_path",
+                  "tos_agreed"
                 ],
                 "additionalProperties": false
               },
               "example": {
-                "return_path": "example"
+                "return_path": "example",
+                "tos_agreed": true
               }
             }
           }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -307,10 +307,45 @@ async function main() {
   // BEFORE gapSuite: its downgrade eats org2's competition headroom.
   await playerAccountsSuite(admin, org2.id);
 
+  // --- design/v9 PROMPT-55: dispute-loss recovery surfaces.
+  await disputeSurfacesSuite();
+
   await gapSuite(admin, org.id, org2.id);
 
   // --- design/v7 PROMPT-51: staff-console platform revenue report.
   await platformRevenueSuite(admin, `admin_${tag}@example.com`);
+}
+
+/** design/v9 PROMPT-55: the chargeback-liability copy is live on the public
+ *  surfaces (same pages on free and pro — both plans' organisers are bound
+ *  by the same clause), and connecting Stripe refuses without accepting it.
+ *  The reversal itself is webhook-driven and covered by the DB-backed vitest
+ *  suite; smoke pins what organisers actually read and click. Runs on its
+ *  own org — the shared pro org already carries a smoke-flipped Connect
+ *  account, which skips the first-connect gate by design. */
+async function disputeSurfacesSuite() {
+  const terms = await html(newSession(), "/legal/terms");
+  check(
+    "p55: ToS carries the entry-fee chargeback clause",
+    terms.status === 200 &&
+      terms.body.includes("Entry-fee chargebacks") &&
+      terms.body.includes("recovered from your connected Stripe balance"),
+  );
+  const helpCards = await html(newSession(), "/help/registration/card-payments");
+  check(
+    "p55: card-payments help states the lost-dispute outcome",
+    helpCards.status === 200 && helpCards.body.includes("recovered from your Stripe balance"),
+  );
+  // First connect without accepting the terms is refused before any Stripe
+  // call — asserts the server-side gate, not just the disabled checkbox
+  // (keyless-safe: the 422 answers before getStripe()).
+  const owner = newSession();
+  const who = await signIn(owner, `tos_${tag}@example.com`);
+  await setPlan(who.org_id, "pro");
+  const refused = await v1(owner, `/api/v1/orgs/${who.org_id}/connect`, "POST", {
+    return_path: "/settings/payments",
+  });
+  check("p55: connect refuses without ToS agreement (422)", refused.status === 422);
 }
 
 /** PROMPT-53 player accounts over real HTTP: invite → claim → RSVP →
@@ -2354,6 +2389,7 @@ async function cleanup(tag: string): Promise<void> {
     `ui_free_${tag}@example.com`,
     `pass_${tag}@example.com`,
     `funnel_${tag}@example.com`,
+    `tos_${tag}@example.com`,
   ];
   const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
   const sql = postgres(url, {


### PR DESCRIPTION
## What

When a card entry-fee dispute is **lost**, the platform no longer eats the disputed amount: the lost branch of `handleRegistrationDispute` now reverses the club's transfer, so the platform's cost shrinks to Stripe's dispute fee (the price of owning the dispute flow). Implements `design/v9/prompts/PROMPT-55-dispute-loss-recovery.md` plus one owner ask from review: **agree to the ToS before connecting Stripe**.

## Mechanics — verified against the live API in test mode (2026-07-14)

Probe run (destination charge, GBP 20.00 fee, 1.00 app fee, `pm_card_createDispute`, closed with `losing_evidence`):

```
transfer:      { amount: 2000, amount_reversed: 0, reversed: false }   ← FULL charge amount, app fee collected separately
dispute (lost) balance tx: { amount: -2000, fee: 2000, net: -4000 }    ← platform debited amount + £20 dispute fee
app fee after loss: { amount: 100, refunded: false }                   ← NOT auto-refunded
transfer after loss: { amount_reversed: 0 }                            ← NOT auto-reversed
```

So the club's net is `transfer.amount − application_fee_amount` (the prompt assumed the transfer was already net — it isn't). Worked example in the code comment: fee 2000 / app fee 100 → reverse **1900**; club ends flat on the entry, platform's net cost = the dispute fee alone.

⚠️ **One live check outstanding:** `transfers.createReversal` itself returned `Permission denied` — the local `rk_test_…` restricted key lacks **Transfers Write**. Please enable it (Dashboard → Developers → API keys) and check the prod/stg key too; until then the recovery path audits `dispute_recovery_failed` (write-off still lands). Full simulation runbook: `docs/simulating-disputes.md`.

## Idempotency (replay-safe)

- Stripe idempotency key `dispute-reversal-{dispute.id}` covers webhook retries.
- Keys expire ~24h and `/admin/billing-events` replays at will → belt-and-braces: reversals carry `metadata.dispute_id`; the handler lists existing reversals and short-circuits (no second reversal, no duplicate audit, no second email).

## ToS gate on Connect (owner ask)

First connect now requires accepting the chargeback terms — checkbox in Settings → Payments **and** a server-side 422 before the Express account is created (keyless-safe: checked before `getStripe()`). Acceptance timestamp stamped in the account's `metadata.tos_agreed_at` — no migration. Resuming onboarding never re-asks.

## ⚠️ Legal surface — owner review requested

`/legal/terms` gains **§5 Entry-fee chargebacks** (sections renumbered 5→13): organisations bear chargeback costs on their entry fees; lost-dispute amounts are recovered from their connected Stripe balance (negative balances recovered by Stripe per its Connect terms); Seazn Club covers Stripe's dispute fees. **The clause is a draft, not counsel — please review the wording before merge.**

## Also

- `dispute-lost` organiser email on the night chrome (recovered vs could-not-recover variants); sent to the **current owner via org_members** (created_by trap regression-tested)
- dispute-alert email + help §5 copy updated to state the real lost outcome; static tooltip on the `dispute lost · refunded` chip
- `docs/simulating-disputes.md` (test cards 0259/2685, `stripe listen`, winning/losing evidence)
- smoke: `p55` suite — terms clause live, help copy live, connect 422 without agreement (own org; the shared pro org carries a smoke-flipped Connect account by design)

## Verification

- `tsc --noEmit` clean; eslint clean on touched files
- DB-backed vitest: registrations (incl. 7 new recovery tests: reversal args/idempotency-key, failure-still-writes-off, replay short-circuit, partial-dispute proportional+cap, no-transfer skip, won-untouched, owner-flip email), stripe-connect gate ×3, email-builders (chrome pins incl. new template), dispute-evidence, billing-events, help-content — all green
- Full local smoke: **258/258** (three p55 checks included)
- UI verified in-browser at desktop + 390px: checkbox gates the Connect button, enables on tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)