### PR TITLE
feat: GDPR consent capture — clickwrap on auth, explicit consent on registration (V279)

### DIFF
--- a/apps/web/content/help/players/claim-your-profile.md
+++ b/apps/web/content/help/players/claim-your-profile.md
@@ -8,7 +8,7 @@ Organisers add players to their club directory; claiming links that entry to you
 
 ## How claiming works
 
-An organiser sends you a **claim invite** by email. Open the link, sign in with **that same email address** (a magic link, no password), and tap **This is me**. The link works for 14 days and for one profile.
+An organiser sends you a **claim invite** by email. Open the link, sign in with **that same email address** (a magic link, no password), and tap **This is me**. The link works for 14 days and for one profile. Signing in accepts our [Terms of Service](/legal/terms) and [Privacy Policy](/legal/privacy) — the notice sits under the sign-in button.
 
 Signed in with a different address? The page will tell you — sign out and sign in with the invited one. If the organiser used the wrong address, ask them to re-send the invite. If the link says *expired*, *withdrawn* or *already claimed*, a fresh invite fixes it — your profile and history are unaffected.
 

--- a/apps/web/content/help/registration/open-registration.md
+++ b/apps/web/content/help/registration/open-registration.md
@@ -18,6 +18,10 @@ The division's **registration settings** are grouped by what matters when — **
   - **Card at sign-up** (Pro / Event Pass) — Stripe checkout during registration, settling straight to your connected Stripe account. Connect Stripe first under *Settings → Payments* (a short one-time onboarding). Paid entries are **confirmed automatically**; unpaid ones hold their spot for **48 hours** (reminder at 24h) and then expire, promoting the waitlist. The full journey — KYC, payouts, refunds and disputes — is in [how card entry fees flow](/help/registration/card-payments).
 - **Custom questions** (in **Sign-up form**) — shirt size, dietary needs, emergency contact; answers export with the entrant list.
 
+## Privacy consent
+
+Every registrant ticks a consent box before submitting: they agree that your organisation and Seazn Club store and process the details on the form (name, email address, date of birth) to run the competition. The form won't submit without it, and the acceptance — with its time and policy version — is stored on the entry, so you can demonstrate consent later if a registrant asks. The [Privacy Policy](/legal/privacy) is linked right on the checkbox.
+
 ## After someone registers
 
 They get a **reference number** like `SZ-7F3K-Q2ND` and a tear-off ticket — their key to checking status, paying and withdrawing without an account ([how references work](/help/registration/reference-numbers)).

--- a/apps/web/content/help/registration/youth.md
+++ b/apps/web/content/help/registration/youth.md
@@ -8,7 +8,7 @@ Set an under-age eligibility rule (U16, U12…) on a division and it is automati
 
 ## Guardian consent
 
-The registration form adds a consent step: a parent or guardian ticks the box and gives their name. Entries without it can't be submitted.
+The registration form adds a consent step: a parent or guardian ticks the box and gives their name. Entries without it can't be submitted. This sits alongside the standard privacy-consent checkbox every registrant ticks — on a youth division the guardian gives both.
 
 ## Name privacy on public pages
 

--- a/apps/web/e2e/reg-console.spec.ts
+++ b/apps/web/e2e/reg-console.spec.ts
@@ -48,7 +48,7 @@ test("pulse, queue order, #N in line, and public waitlist count all match one se
       request,
       `/api/v1/public/orgs/${org.slug}/competitions/${rig.compSlug}/register`,
       "POST",
-      { division_id: rig.divisionId, display_name: name, contact_email: email },
+      { division_id: rig.divisionId, display_name: name, contact_email: email, privacy_consent: true },
     );
 
   await submit("Holder One", `holder-${TAG}@e.com`); // takes the only spot (pending)

--- a/apps/web/e2e/registration-payments.spec.ts
+++ b/apps/web/e2e/registration-payments.spec.ts
@@ -72,6 +72,7 @@ test("offline journey: instructions on the receipt, Mark paid confirms the entry
   await page.getByRole("radio").first().check();
   await page.getByLabel(/Full name/).fill(`Cash Payer ${TAG}`);
   await page.getByLabel(/Contact email/).fill(`cash-${TAG}@example.com`);
+  await page.getByRole("checkbox", { name: /I agree that/ }).check();
   await page.getByRole("button", { name: /Enter — £15\.00/ }).click();
 
   // Receipt: held spot + the division's own instructions (org override).
@@ -138,6 +139,7 @@ test("full paid division: waitlist promises no payment until promotion", async (
       division_id: rig.divisionId,
       display_name: "First In",
       contact_email: `first-pay-${TAG}@e.com`,
+      privacy_consent: true,
     },
   );
 
@@ -146,6 +148,7 @@ test("full paid division: waitlist promises no payment until promotion", async (
   await expect(page.getByText("Full — join the waitlist, pay only if promoted.")).toBeVisible();
   await page.getByLabel(/Full name/).fill("Wait Payer");
   await page.getByLabel(/Contact email/).fill(`waitpay-${TAG}@example.com`);
+  await page.getByRole("checkbox", { name: /I agree that/ }).check();
   await page.getByRole("button", { name: "Join the waitlist" }).click();
   await page.waitForURL(/register\/status\?rid=/, { timeout: 20_000 });
   await expect(page.getByText("no payment is taken while you wait")).toBeVisible();

--- a/apps/web/e2e/registration-v2.spec.ts
+++ b/apps/web/e2e/registration-v2.spec.ts
@@ -62,6 +62,7 @@ test("individual registers through the ticket page; /r/[ref] resolves; withdraw 
   await page.getByRole("radio").first().check();
   await page.getByLabel(/Full name/).fill(`Walk In ${TAG}`);
   await page.getByLabel(/Contact email/).fill(`walkin-${TAG}@example.com`);
+  await page.getByRole("checkbox", { name: /I agree that/ }).check();
   await page.getByRole("button", { name: "Enter the competition" }).click();
 
   // Success screen = the tear-off ticket with the huge mono ref.
@@ -135,6 +136,7 @@ test("pair and team kinds submit with their own identity blocks", async ({ page,
   await page.getByLabel(/Your name/).fill("Alex Pairman");
   await page.getByLabel(/Partner's name/).fill("Sam Partner");
   await page.getByLabel(/Contact email/).fill(`pair-${TAG}@example.com`);
+  await page.getByRole("checkbox", { name: /I agree that/ }).check();
   await page.getByRole("button", { name: "Enter the competition" }).click();
   await page.waitForURL(/register\/status\?rid=/, { timeout: 20_000 });
   await expect(page.getByText("Alex Pairman & Sam Partner")).toBeVisible();
@@ -147,6 +149,7 @@ test("pair and team kinds submit with their own identity blocks", async ({ page,
   await page.getByLabel(/Contact email/).fill(`team-${TAG}@example.com`);
   await page.getByRole("button", { name: "+ Add player" }).click();
   await page.getByLabel("Player 1 name").fill("Jordan Blake");
+  await page.getByRole("checkbox", { name: /I agree that/ }).check();
   await page.getByRole("button", { name: "Enter the competition" }).click();
   await page.waitForURL(/register\/status\?rid=/, { timeout: 20_000 });
   expect((await page.getByTestId("ref-code").textContent())?.trim()).toMatch(REF_RE);
@@ -165,7 +168,12 @@ test("full division flips to the waitlist state (an invitation, not a dead end)"
     request,
     `/api/v1/public/orgs/${org.slug}/competitions/${rig.compSlug}/register`,
     "POST",
-    { division_id: rig.divisions[0]!.id, display_name: "First In", contact_email: `first-${TAG}@e.com` },
+    {
+      division_id: rig.divisions[0]!.id,
+      display_name: "First In",
+      contact_email: `first-${TAG}@e.com`,
+      privacy_consent: true,
+    },
   );
 
   await page.goto(`/shared/${org.slug}/${rig.compSlug}/register`);
@@ -174,6 +182,7 @@ test("full division flips to the waitlist state (an invitation, not a dead end)"
   await expect(page.getByText("This division is full")).toBeVisible();
   await page.getByLabel(/Full name/).fill("Wait Lister");
   await page.getByLabel(/Contact email/).fill(`wait-${TAG}@example.com`);
+  await page.getByRole("checkbox", { name: /I agree that/ }).check();
   await page.getByRole("button", { name: "Join the waitlist" }).click();
   await page.waitForURL(/register\/status\?rid=/, { timeout: 20_000 });
   await expect(page.getByText("You're on the waitlist")).toBeVisible();
@@ -193,6 +202,7 @@ test("organiser panel: ref column renders and search-by-ref finds the row", asyn
       division_id: rig.divisions[0]!.id,
       display_name: "Findable Person",
       contact_email: `find-${TAG}@example.com`,
+      privacy_consent: true,
     },
   );
   const ref = reg.data!.ref_code;
@@ -253,11 +263,14 @@ test("youth division: public surfaces render first-initial names; open divisions
     "Henry Adams",
   ]);
 
-  // The consent section never renders on an open division without a minor
-  // DOB. (Select by label — the register panel orders divisions by name.)
+  // GDPR (spec 2026-07-14): the consent section always renders (privacy
+  // checkbox for everyone); the guardian block still only appears on youth
+  // divisions. (Select by label — the register panel orders divisions by name.)
   await page.goto(`/shared/${org.slug}/${rig.compSlug}/register`);
   await page.getByRole("radio", { name: /Open Public/ }).check();
-  await expect(page.locator("[data-section='consent']")).toHaveCount(0);
+  await expect(page.locator("[data-section='consent']")).toBeVisible();
+  await expect(page.getByText(/guardian consent/i)).toHaveCount(0);
   await page.getByRole("radio", { name: /U16 Public/ }).check();
   await expect(page.locator("[data-section='consent']")).toBeVisible();
+  await expect(page.getByText(/guardian consent/i).first()).toBeVisible();
 });

--- a/apps/web/e2e/registration.spec.ts
+++ b/apps/web/e2e/registration.spec.ts
@@ -47,6 +47,8 @@ test("public registration: open → register → confirm to entrant", async ({
     await anon.getByText("Singles").first().click(); // division radio card
     await anon.getByLabel(/full name/i).fill(`Reg Runner ${TAG}`);
     await anon.getByLabel(/contact email/i).fill(`e2e-reg-${TAG}@example.com`);
+    // GDPR (spec 2026-07-14): the form requires explicit privacy consent.
+    await anon.getByRole("checkbox", { name: /I agree that/ }).check();
     // Registration v2 (PROMPT-34) renamed the submit CTA.
     await anon.getByRole("button", { name: "Enter the competition" }).click();
 

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { sql } from "@/lib/db";
 import { createSession, postAuthLanding, invalidateUser } from "@/lib/auth";
+import { stampTermsAcceptance } from "@/lib/legal";
 import {
   GOOGLE_TOKEN_URL,
   GOOGLE_USERINFO_URL,
@@ -62,6 +63,9 @@ export async function GET(req: Request) {
   const userId = await upsertGoogleUser(profile as GoogleProfile);
   // upsert may refresh display_name/avatar for an existing user.
   await invalidateUser(userId);
+  // "Continue with Google" sits under the clickwrap notice (GDPR spec
+  // 2026-07-14) — record acceptance; no-op if already stamped.
+  await stampTermsAcceptance(userId);
 
   // 4. Sign in.
   await createSession(userId);

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,5 +1,6 @@
 import { sql } from "@/lib/db";
 import { createSession, postAuthLanding, verifyPassword } from "@/lib/auth";
+import { stampTermsAcceptance } from "@/lib/legal";
 import { handler } from "@/lib/http";
 import { baseUrl } from "@/lib/oauth";
 import { sendVerificationEmail } from "@/lib/email";
@@ -45,6 +46,9 @@ export async function POST(req: Request) {
     }
 
     await createSession(user.id);
+    // Login happened under the clickwrap notice (GDPR spec 2026-07-14) —
+    // backfills pre-policy accounts; no-op once stamped.
+    await stampTermsAcceptance(user.id);
 
     const landing = await postAuthLanding(user.id, next);
     return {

--- a/apps/web/src/app/api/auth/magic-link/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/route.ts
@@ -1,6 +1,7 @@
 import { sql } from "@/lib/db";
 import { handler } from "@/lib/http";
 import { safeNextPath } from "@/lib/auth";
+import { stampTermsAcceptance } from "@/lib/legal";
 import { sendMagicLinkEmail } from "@/lib/email";
 import { createLoginLink } from "@/lib/login-link";
 import { baseUrl } from "@/lib/oauth";
@@ -68,6 +69,9 @@ export async function POST(req: Request) {
 
     let devLink: string | undefined;
     if (userId) {
+      // The submit sat under the "By continuing, you agree…" notice (GDPR
+      // spec 2026-07-14) — record acceptance; no-op if already stamped.
+      await stampTermsAcceptance(userId);
       const token = await createLoginLink(userId);
       const nextQuery = next ? `&next=${encodeURIComponent(next)}` : "";
       const link = `${baseUrl(req)}/magic-link?token=${token}${nextQuery}`;

--- a/apps/web/src/app/api/auth/signup/route.ts
+++ b/apps/web/src/app/api/auth/signup/route.ts
@@ -1,5 +1,6 @@
 import { sql } from "@/lib/db";
 import { hashPassword, safeNextPath } from "@/lib/auth";
+import { stampTermsAcceptance } from "@/lib/legal";
 import { handler } from "@/lib/http";
 import { baseUrl } from "@/lib/oauth";
 import { sendVerificationEmail } from "@/lib/email";
@@ -37,6 +38,8 @@ export async function POST(req: Request) {
       insert into users (email, password_hash, display_name, email_verified)
       values (${email}, ${password_hash}, ${display_name}, false)
       returning id`;
+    // Sign-up happened under the clickwrap notice (GDPR spec 2026-07-14).
+    await stampTermsAcceptance(user.id);
 
     // Email a single-use verification link. The account stays inactive (no
     // session) until the link is opened. A safe `next` (e.g. an invite) is

--- a/apps/web/src/app/legal/privacy/page.tsx
+++ b/apps/web/src/app/legal/privacy/page.tsx
@@ -14,7 +14,7 @@ export default function PrivacyPage() {
       <MarketingNav />
       <main className="mx-auto max-w-3xl px-4 py-16">
         <h1 className="mb-2 text-3xl font-bold text-purple-900">Privacy Policy</h1>
-        <p className="mb-8 text-sm text-slate-400">Last updated: 30 June 2026</p>
+        <p className="mb-8 text-sm text-slate-400">Last updated: 14 July 2026</p>
         <div className="prose prose-slate max-w-none space-y-6 text-sm text-slate-700">
 
           <section>
@@ -31,6 +31,7 @@ export default function PrivacyPage() {
               <li><strong>Billing data:</strong> subscription status, plan. Card details are held by Stripe and never stored on our servers.</li>
               <li><strong>Usage data:</strong> product analytics events (e.g. "first tournament created", page views) collected via PostHog, only with your consent. Withdraw anytime by clearing cookies or rejecting the cookie banner.</li>
               <li><strong>Communication preferences:</strong> email suppression list (bounces / complaints).</li>
+              <li><strong>Consent records:</strong> when you create an account or submit a competition registration we record the time and policy version of your acceptance, so we can demonstrate it later.</li>
             </ul>
           </section>
 

--- a/apps/web/src/components/auth-form.tsx
+++ b/apps/web/src/components/auth-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { api } from "@/lib/client";
+import { LegalNotice } from "@/components/legal-notice";
 
 /**
  * Passwordless sign-in: Google, or a one-time link emailed to the address.
@@ -114,6 +115,7 @@ export function AuthForm({ next }: { next?: string }) {
       <p className="mt-4 text-center text-xs text-slate-400">
         No password needed. New here? Entering your email creates your account.
       </p>
+      <LegalNotice className="mt-2 text-center" />
     </div>
   );
 }

--- a/apps/web/src/components/legal-notice.tsx
+++ b/apps/web/src/components/legal-notice.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+/** Clickwrap notice under any action that signs in / creates an account
+ *  (GDPR spec 2026-07-14). Server-side stamping lives in lib/legal.ts. */
+export function LegalNotice({ className }: { className?: string }) {
+  return (
+    <p className={`text-xs text-slate-400 ${className ?? "text-center"}`}>
+      By continuing, you agree to our{" "}
+      <Link href="/legal/terms" className="underline hover:text-slate-600">
+        Terms of Service
+      </Link>{" "}
+      and{" "}
+      <Link href="/legal/privacy" className="underline hover:text-slate-600">
+        Privacy Policy
+      </Link>
+      .
+    </p>
+  );
+}

--- a/apps/web/src/components/public-site/register-form.tsx
+++ b/apps/web/src/components/public-site/register-form.tsx
@@ -128,6 +128,7 @@ export function RegisterForm({
   const [gender, setGender] = useState("");
   const [guardianName, setGuardianName] = useState("");
   const [guardianConsent, setGuardianConsent] = useState(false);
+  const [privacyConsent, setPrivacyConsent] = useState(false);
   const [answers, setAnswers] = useState<Record<string, unknown>>({});
   const [players, setPlayers] = useState<Player[]>([]);
   const [importText, setImportText] = useState("");
@@ -177,6 +178,7 @@ export function RegisterForm({
           gender: gender || null,
           guardian_name: guardianName || null,
           guardian_consent: guardianConsent,
+          privacy_consent: privacyConsent,
           answers,
           website: website || undefined,
           players:
@@ -356,36 +358,62 @@ export function RegisterForm({
         {
           key: "consent",
           title: msg("register.section.consent"),
-          show: needsGuardian,
+          show: true,
           body: (
-            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
-              <p className="flex items-center gap-1.5 text-sm font-medium text-amber-800">
-                {msg("register.guardian.title")}
-                <Tip id="register.youth" />
-              </p>
-              <label className="mt-2 block text-sm">
-                <span className="text-zinc-700">Parent / guardian name *</span>
-                <input
-                  required
-                  value={guardianName}
-                  onChange={(e) => setGuardianName(e.target.value)}
-                  maxLength={120}
-                  className={INPUT_CLASS}
-                />
-              </label>
-              <label className="mt-2 flex items-start gap-2 text-sm text-zinc-700">
+            <div className="space-y-3">
+              {/* GDPR (spec 2026-07-14): explicit processing consent, every registrant. */}
+              <label className="flex items-start gap-2 text-sm text-zinc-700">
                 <input
                   type="checkbox"
                   required
-                  checked={guardianConsent}
-                  onChange={(e) => setGuardianConsent(e.target.checked)}
+                  checked={privacyConsent}
+                  onChange={(e) => setPrivacyConsent(e.target.checked)}
                   className="mt-0.5"
                 />
                 <span>
-                  I am the parent/guardian and consent to this registration and to the
-                  competition&apos;s handling of the player&apos;s details.
+                  {msg("register.consent.data", { org: org.name })}{" "}
+                  <a
+                    href="/legal/privacy"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline"
+                  >
+                    {msg("register.consent.privacy")}
+                  </a>{" "}
+                  *
                 </span>
               </label>
+              {needsGuardian && (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+                  <p className="flex items-center gap-1.5 text-sm font-medium text-amber-800">
+                    {msg("register.guardian.title")}
+                    <Tip id="register.youth" />
+                  </p>
+                  <label className="mt-2 block text-sm">
+                    <span className="text-zinc-700">Parent / guardian name *</span>
+                    <input
+                      required
+                      value={guardianName}
+                      onChange={(e) => setGuardianName(e.target.value)}
+                      maxLength={120}
+                      className={INPUT_CLASS}
+                    />
+                  </label>
+                  <label className="mt-2 flex items-start gap-2 text-sm text-zinc-700">
+                    <input
+                      type="checkbox"
+                      required
+                      checked={guardianConsent}
+                      onChange={(e) => setGuardianConsent(e.target.checked)}
+                      className="mt-0.5"
+                    />
+                    <span>
+                      I am the parent/guardian and consent to this registration and to the
+                      competition&apos;s handling of the player&apos;s details.
+                    </span>
+                  </label>
+                </div>
+              )}
             </div>
           ),
         },

--- a/apps/web/src/components/start-wizard.tsx
+++ b/apps/web/src/components/start-wizard.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { api } from "@/lib/client";
 import { recommendFormats, type Recommendation } from "@/lib/format-recommend";
 import { FUNNEL_SPORTS } from "@/components/start-funnel-form";
+import { LegalNotice } from "@/components/legal-notice";
 
 interface Initial {
   sport?: string;
@@ -233,6 +234,7 @@ export function StartWizard({ initial }: { initial: Initial }) {
             We’ll email you one link that signs you in and creates the
             competition. No password, no spam.
           </p>
+          <LegalNotice className="text-left" />
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex gap-2">
             <button type="button" onClick={() => setStep(1)} className="btn btn-ghost flex-none">

--- a/apps/web/src/lib/__tests__/legal.test.ts
+++ b/apps/web/src/lib/__tests__/legal.test.ts
@@ -1,0 +1,32 @@
+// GDPR clickwrap stamping (spec 2026-07-14). Real Postgres required; skipped
+// without DATABASE_URL, like the other DB-backed suites.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { LEGAL_VERSION, stampTermsAcceptance } from "@/lib/legal";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+describe.skipIf(!HAS_DB)("stampTermsAcceptance", () => {
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  it("stamps first acceptance and never moves it", async () => {
+    const email = `legal-${randomUUID()}@example.com`;
+    const [u] = await sql<{ id: string }[]>`
+      insert into users (email, display_name) values (${email}, 'Legal Test') returning id`;
+
+    await stampTermsAcceptance(u.id);
+    const [first] = await sql<{ terms_accepted_at: Date; terms_version: string }[]>`
+      select terms_accepted_at, terms_version from users where id = ${u.id}`;
+    expect(first.terms_accepted_at).toBeInstanceOf(Date);
+    expect(first.terms_version).toBe(LEGAL_VERSION);
+
+    await stampTermsAcceptance(u.id);
+    const [second] = await sql<{ terms_accepted_at: Date }[]>`
+      select terms_accepted_at from users where id = ${u.id}`;
+    // Compare via getTime() — Date identity assertions are a vitest trap.
+    expect(second.terms_accepted_at.getTime()).toBe(first.terms_accepted_at.getTime());
+  });
+});

--- a/apps/web/src/lib/legal.ts
+++ b/apps/web/src/lib/legal.ts
@@ -1,0 +1,18 @@
+import { sql } from "@/lib/db";
+
+/** "Last updated" date of /legal/terms + /legal/privacy — bump when the text
+ *  changes. (Cookie-banner consent versioning lives separately in consent.ts.) */
+export const LEGAL_VERSION = "2026-07-14";
+
+/**
+ * Record clickwrap acceptance of Terms + Privacy (GDPR spec 2026-07-14): the
+ * user acted under a "By continuing, you agree…" notice. First acceptance
+ * wins — later logins must not move the timestamp.
+ */
+export async function stampTermsAcceptance(userId: string): Promise<void> {
+  await sql`
+    update users set
+      terms_accepted_at = coalesce(terms_accepted_at, now()),
+      terms_version     = coalesce(terms_version, ${LEGAL_VERSION})
+    where id = ${userId}`;
+}

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -156,7 +156,7 @@ export const messages = {
   "register.ticket.save": "Save ticket",
   "register.guardian.title": "Under-18 entry — guardian consent",
   "register.consent.data":
-    "I agree that {org} and Seazn Club will store and process the details on this form (name, contact email, date of birth) to run this competition.",
+    "I agree that {org} and Seazn Club will store and process the details on this form (name, email address, date of birth) to run this competition.",
   "register.consent.privacy": "Privacy Policy",
 
   // ── Showcase opt-in (doc 15 §1) — exact consent copy, shared by the

--- a/apps/web/src/lib/messages.ts
+++ b/apps/web/src/lib/messages.ts
@@ -155,6 +155,9 @@ export const messages = {
   "register.ticket.calendar": "Add to calendar",
   "register.ticket.save": "Save ticket",
   "register.guardian.title": "Under-18 entry — guardian consent",
+  "register.consent.data":
+    "I agree that {org} and Seazn Club will store and process the details on this form (name, contact email, date of birth) to run this competition.",
+  "register.consent.privacy": "Privacy Policy",
 
   // ── Showcase opt-in (doc 15 §1) — exact consent copy, shared by the
   // create wizard and competition settings ──

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -918,6 +918,8 @@ export const PublicRegisterRequest = z.object({
   gender: z.enum(["m", "f", "x"]).nullish(),
   guardian_name: z.string().max(120).nullish(),
   guardian_consent: z.boolean().default(false),
+  /** GDPR (spec 2026-07-14): explicit agreement to store/process the form's PII. */
+  privacy_consent: z.boolean().default(false),
   answers: z.record(z.string(), z.unknown()).default({}),
   // Team registrations may include a squad roster (typed or imported). Ignored
   // for individual/pair entrants.

--- a/apps/web/src/server/usecases/__tests__/reg-console-public.test.ts
+++ b/apps/web/src/server/usecases/__tests__/reg-console-public.test.ts
@@ -87,6 +87,7 @@ const SUBMIT_BASE = {
   gender: null,
   guardian_name: null,
   guardian_consent: false,
+  privacy_consent: true,
   answers: {},
   players: [],
 };

--- a/apps/web/src/server/usecases/__tests__/registrations.test.ts
+++ b/apps/web/src/server/usecases/__tests__/registrations.test.ts
@@ -60,6 +60,7 @@ import {
   type RegistrationRow,
 } from "../registrations";
 import { isValidRefCode } from "@/lib/ref-code";
+import { LEGAL_VERSION } from "@/lib/legal";
 import { resolveNameDisplay } from "@/lib/name-display";
 
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -214,6 +215,7 @@ const SUBMIT_BASE = {
   gender: null,
   guardian_name: null,
   guardian_consent: false,
+  privacy_consent: true,
   answers: {},
   players: [],
 };
@@ -261,6 +263,12 @@ describe.skipIf(!HAS_DB)("registration flows (doc 16 §1.1, PROMPT-20a)", () => 
     expect(res.registration.status).toBe("pending");
     expect(res.checkout_url).toBeNull();
     expect(res.access_token.startsWith("rg_")).toBe(true);
+
+    // GDPR (spec 2026-07-14): consent is demonstrable — timestamp + version stored.
+    const [stored] = await sql<{ privacy_consent_at: Date | null; privacy_consent_version: string | null }[]>`
+      select privacy_consent_at, privacy_consent_version from registrations where id = ${res.registration.id}`;
+    expect(stored.privacy_consent_at).toBeInstanceOf(Date);
+    expect(stored.privacy_consent_version).toBe(LEGAL_VERSION);
 
     const confirmed = await confirmRegistration(owner, res.registration.id);
     expect(confirmed.status).toBe("confirmed");
@@ -475,6 +483,22 @@ describe.skipIf(!HAS_DB)("registration flows (doc 16 §1.1, PROMPT-20a)", () => 
       ...base, dob: "2012-05-01", guardian_name: "Pat Parent", guardian_consent: true,
     }, "http://t.local");
     expect(ok.registration.status).toBe("pending");
+  });
+
+  it("rejects submissions without privacy consent (GDPR, spec 2026-07-14)", async () => {
+    const { orgId, orgSlug, ownerId } = await seedOrg("pro");
+    const owner = asOwner(orgId, ownerId);
+    const { competition, division } = await rig(owner);
+    await putRegistrationSettings(owner, division.id, {
+      enabled: true, entrant_kind: "individual", fee_cents: 0, currency: "usd",
+      form_fields: [], opens_at: null, closes_at: null, capacity: null, refund_lock_at: null,
+    });
+
+    await expect(
+      submitRegistration(orgSlug, competition.slug, {
+        ...SUBMIT_BASE, division_id: division.id, privacy_consent: false,
+      }, "http://t.local"),
+    ).rejects.toThrow(/privacy/i);
   });
 
   it("custom form answers validate against the bounded builder", async () => {

--- a/apps/web/src/server/usecases/registrations.ts
+++ b/apps/web/src/server/usecases/registrations.ts
@@ -17,6 +17,7 @@ import type postgres from "postgres";
 import type Stripe from "stripe";
 import { sql, withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
+import { LEGAL_VERSION } from "@/lib/legal";
 import { getLimit, requireFeature } from "@/lib/entitlements";
 import { platformFeeDefault } from "@/lib/platform-settings";
 import { getStripe } from "@/lib/stripe";
@@ -763,6 +764,12 @@ export async function submitRegistration(
     }
   }
 
+  // GDPR consent (spec 2026-07-14): explicit agreement before we store the
+  // registrant's details; timestamp + policy version make it demonstrable.
+  if (!input.privacy_consent) {
+    throw new HttpError(422, "Please agree to the privacy policy to register");
+  }
+
   const answers = validateAnswers(settings.form_fields ?? [], input.answers);
   const secret = mintRegistrationToken();
 
@@ -807,13 +814,15 @@ export async function submitRegistration(
             const [r] = await sp<RegistrationRow[]>`
               insert into registrations
                 (division_id, status, ref_code, display_name, contact_email, dob, gender,
-                 guardian_name, guardian_consent, answers, roster, amount_cents, currency,
+                 guardian_name, guardian_consent, privacy_consent_at, privacy_consent_version,
+                 answers, roster, amount_cents, currency,
                  payment_method, expires_at, access_token_hash)
               values
                 (${input.division_id}, ${waitlisted ? "waitlisted" : "pending"}, ${ref},
                  ${input.display_name}, ${input.contact_email}, ${input.dob ?? null},
                  ${input.gender ?? null}, ${input.guardian_name ?? null},
-                 ${input.guardian_consent}, ${sp.json(answers as never)},
+                 ${input.guardian_consent}, now(), ${LEGAL_VERSION},
+                 ${sp.json(answers as never)},
                  ${sp.json(roster as never)},
                  ${waitlisted ? 0 : settings.fee_cents}, ${settings.currency},
                  ${settings.payment_method},

--- a/db/migration/deltas/V279__consent.sql
+++ b/db/migration/deltas/V279__consent.sql
@@ -1,0 +1,9 @@
+-- GDPR consent capture (spec 2026-07-14): clickwrap acceptance on accounts,
+-- explicit processing consent on public registrations. Null = pre-policy row.
+alter table users
+  add column if not exists terms_accepted_at timestamptz,
+  add column if not exists terms_version     text;
+
+alter table registrations
+  add column if not exists privacy_consent_at      timestamptz,
+  add column if not exists privacy_consent_version text;

--- a/docs/superpowers/plans/2026-07-14-gdpr-consent.md
+++ b/docs/superpowers/plans/2026-07-14-gdpr-consent.md
@@ -1,0 +1,443 @@
+# GDPR Consent Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record terms/privacy acceptance in the DB for every account-creating email entry (clickwrap notice) and require an explicit, stored consent checkbox on public registration.
+
+**Architecture:** One new migration (V279) adds consent columns to `users` and `registrations`. A tiny server module `lib/legal.ts` owns the policy version constant and the idempotent stamp function. UI is one shared `<LegalNotice/>` under account-creating forms plus a required checkbox in the register form's existing consent section (now always shown). Spec: `docs/superpowers/specs/2026-07-14-gdpr-consent-design.md`.
+
+**Tech Stack:** Next.js (custom fork — see AGENTS.md), postgres.js tagged templates, zod v4 (`z.email()`, `z.iso.date()`), vitest (DB-backed suites skip without `DATABASE_URL`), Playwright e2e, Flyway migrations.
+
+## Global Constraints
+
+- AGENTS.md: this Next.js has breaking changes — check `node_modules/next/dist/docs/` before using any Next API you're unsure of.
+- Worktree only: `git worktree add .claude/worktrees/gdpr-consent -b feat/gdpr-consent` from repo root. NEVER `git checkout`/`switch` in the main repo dir.
+- DB-backed tests: ephemeral PG on 127.0.0.1:54329 (fall back 54331 if squatted), `DATABASE_SSL=disable`, run vitest from `apps/web` cwd (repo-root cwd breaks `@/` aliases).
+- `LEGAL_VERSION = "2026-07-14"` everywhere (privacy page "Last updated" bumps to 14 July 2026 in Task 7).
+- Every code change ships with a test that fails without it (standing feedback).
+- Copy style: sentence case, plain verbs; consent label = "I agree that {org} and Seazn Club will store and process the details on this form (name, contact email, date of birth) to run this competition."
+- rtk hook swallows `npx next dev` — launch dev servers as `node <root>/node_modules/next/dist/bin/next dev` with `PORT=<n>`.
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 0: Worktree + test DB
+
+**Files:** none (environment).
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+cd /Users/ashokhein/github/seazn.club
+git fetch origin && git worktree add .claude/worktrees/gdpr-consent -b feat/gdpr-consent origin/main
+cp -cR node_modules .claude/worktrees/gdpr-consent/node_modules
+cp -cR apps/web/node_modules .claude/worktrees/gdpr-consent/apps/web/node_modules
+```
+
+(APFS clonefile copies — Turbopack refuses symlinks outside project root.)
+
+- [ ] **Step 2: Start ephemeral Postgres (skip if already running from this session)**
+
+```bash
+initdb -D /private/tmp/claude-501/-Users-ashokhein-github-seazn-club/85e3447f-cffb-4871-93fa-d5747746da42/scratchpad/pg -U postgres --no-locale -E UTF8
+pg_ctl -D <same>/pg -o "-p 54329 -c listen_addresses=127.0.0.1 -c unix_socket_directories=/tmp/seazn-pg-sock" -l <same>/pg.log start
+createdb -h 127.0.0.1 -p 54329 -U postgres seazn_gdpr
+cd .claude/worktrees/gdpr-consent
+DATABASE_URL="postgresql://postgres@127.0.0.1:54329/seazn_gdpr" DATABASE_SSL=disable npm run db:apply
+npm run sync:sports  # with same env, if smoke will be run later
+```
+
+Expected: Flyway migrates through V278. If port 54329 is squatted use 54331 + socket dir `/tmp/seazn-pg2`.
+
+### Task 1: Migration V279
+
+**Files:**
+- Create: `db/migration/deltas/V279__consent.sql`
+
+**Interfaces:**
+- Produces: columns `users.terms_accepted_at timestamptz`, `users.terms_version text`, `registrations.privacy_consent_at timestamptz`, `registrations.privacy_consent_version text`. All later tasks rely on these names.
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- GDPR consent capture (spec 2026-07-14): clickwrap acceptance on accounts,
+-- explicit processing consent on public registrations. Null = pre-policy row.
+alter table users
+  add column if not exists terms_accepted_at timestamptz,
+  add column if not exists terms_version     text;
+
+alter table registrations
+  add column if not exists privacy_consent_at      timestamptz,
+  add column if not exists privacy_consent_version text;
+```
+
+- [ ] **Step 2: Apply and verify**
+
+```bash
+DATABASE_URL="postgresql://postgres@127.0.0.1:54329/seazn_gdpr" DATABASE_SSL=disable npm run db:apply
+psql "postgresql://postgres@127.0.0.1:54329/seazn_gdpr" -c "set search_path=seazn_club; \d users" | grep terms
+```
+
+Expected: V279 applied; both `terms_*` columns listed (schema is `seazn_club`, not `public`).
+
+- [ ] **Step 3: Commit** — `git add db/migration/deltas/V279__consent.sql && git commit -m "feat(db): V279 consent columns on users + registrations"`
+
+### Task 2: `lib/legal.ts` — version constant + stamp function (TDD)
+
+**Files:**
+- Create: `apps/web/src/lib/legal.ts`
+- Test: `apps/web/src/lib/__tests__/legal.test.ts`
+
+**Interfaces:**
+- Produces: `LEGAL_VERSION: string` (= `"2026-07-14"`), `stampTermsAcceptance(userId: string): Promise<void>` — idempotent, first acceptance wins.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// DB-backed (skipped without DATABASE_URL, like registrations.test.ts).
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { LEGAL_VERSION, stampTermsAcceptance } from "@/lib/legal";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+describe.skipIf(!HAS_DB)("stampTermsAcceptance", () => {
+  afterAll(async () => {
+    await sql.end();
+  });
+
+  it("stamps first acceptance and never moves it", async () => {
+    const email = `legal-${randomUUID()}@example.com`;
+    const [u] = await sql<{ id: string }[]>`
+      insert into users (email, display_name) values (${email}, 'Legal Test') returning id`;
+
+    await stampTermsAcceptance(u.id);
+    const [first] = await sql<{ terms_accepted_at: Date; terms_version: string }[]>`
+      select terms_accepted_at, terms_version from users where id = ${u.id}`;
+    expect(first.terms_accepted_at).toBeInstanceOf(Date);
+    expect(first.terms_version).toBe(LEGAL_VERSION);
+
+    await stampTermsAcceptance(u.id);
+    const [second] = await sql<{ terms_accepted_at: Date }[]>`
+      select terms_accepted_at from users where id = ${u.id}`;
+    // Date equality via getTime() — toBe on Dates is a known vitest trap here.
+    expect(second.terms_accepted_at.getTime()).toBe(first.terms_accepted_at.getTime());
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd apps/web && DATABASE_URL="postgresql://postgres@127.0.0.1:54329/seazn_gdpr" DATABASE_SSL=disable npx vitest run src/lib/__tests__/legal.test.ts
+```
+
+Expected: FAIL — cannot resolve `@/lib/legal`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import { sql } from "@/lib/db";
+
+/** "Last updated" date of /legal/terms + /legal/privacy — bump when the text changes.
+ *  (Cookie-banner consent versioning lives separately in lib/consent.ts.) */
+export const LEGAL_VERSION = "2026-07-14";
+
+/**
+ * Record clickwrap acceptance of Terms + Privacy (GDPR spec 2026-07-14): the
+ * user acted under a "By continuing, you agree…" notice. First acceptance
+ * wins — later logins must not move the timestamp.
+ */
+export async function stampTermsAcceptance(userId: string): Promise<void> {
+  await sql`
+    update users set
+      terms_accepted_at = coalesce(terms_accepted_at, now()),
+      terms_version     = coalesce(terms_version, ${LEGAL_VERSION})
+    where id = ${userId}`;
+}
+```
+
+- [ ] **Step 4: Run test — PASS.** Same command as Step 2.
+- [ ] **Step 5: Commit** — `git add -A apps/web/src/lib && git commit -m "feat: lib/legal — LEGAL_VERSION + idempotent terms-acceptance stamp"`
+
+### Task 3: Registration consent enforcement (TDD)
+
+**Files:**
+- Modify: `apps/web/src/server/api-v1/schemas.ts` (~line 920, `PublicRegisterRequest`)
+- Modify: `apps/web/src/server/usecases/registrations.ts` (guardian check ~line 760; insert ~line 807)
+- Test: `apps/web/src/server/usecases/__tests__/registrations.test.ts`
+
+**Interfaces:**
+- Consumes: `LEGAL_VERSION` from Task 2.
+- Produces: `PublicRegisterRequest.privacy_consent: boolean` (default false); `submitRegistration` throws `HttpError(422)` when false; stored rows carry `privacy_consent_at` + `privacy_consent_version`.
+
+- [ ] **Step 1: Write the failing test.** In `registrations.test.ts`, find the guardian-consent 422 test (near line 463, uses a shared `base` payload) and add alongside, matching the file's existing rejection-assertion style:
+
+```ts
+it("rejects submissions without privacy consent (GDPR)", async () => {
+  await expect(
+    submitRegistration(orgSlug, competition.slug, { ...base, privacy_consent: false }, "http://t.local"),
+  ).rejects.toMatchObject({ status: 422 });
+});
+```
+
+(Adapt `orgSlug`/`competition`/`base` names and the exact rejects-matcher to what the surrounding tests actually use — read them first.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd apps/web && DATABASE_URL="postgresql://postgres@127.0.0.1:54329/seazn_gdpr" DATABASE_SSL=disable npx vitest run src/server/usecases/__tests__/registrations.test.ts -t "privacy consent"
+```
+
+Expected: FAIL — submission succeeds (no check exists yet) or TS error on unknown field.
+
+- [ ] **Step 3: Implement.**
+
+3a. `schemas.ts` — inside `PublicRegisterRequest`, after `guardian_consent`:
+
+```ts
+/** GDPR (spec 2026-07-14): explicit agreement to store/process the form's PII. */
+privacy_consent: z.boolean().default(false),
+```
+
+3b. `registrations.ts` — import `LEGAL_VERSION` from `@/lib/legal`; after the guardian-consent 422 block (~line 764):
+
+```ts
+// GDPR consent (spec 2026-07-14): explicit agreement before we store the
+// registrant's details; timestamp + policy version make it demonstrable.
+if (!input.privacy_consent) {
+  throw new HttpError(422, "Please agree to the privacy policy to register");
+}
+```
+
+3c. Insert statement (~line 807): add `privacy_consent_at, privacy_consent_version` to the column list and `now(), ${LEGAL_VERSION}` to values (keep positions aligned).
+
+- [ ] **Step 4: Extend a happy-path test to pin storage.** In the basic successful-submission test, after the assertion on the result:
+
+```ts
+const [stored] = await sql<{ privacy_consent_at: Date | null; privacy_consent_version: string | null }[]>`
+  select privacy_consent_at, privacy_consent_version from registrations where id = ${res.registration_id}`;
+expect(stored.privacy_consent_at).toBeInstanceOf(Date);
+expect(stored.privacy_consent_version).toBe(LEGAL_VERSION);
+```
+
+(Import `LEGAL_VERSION`; use whatever the test names its result/`sql` handle.)
+
+- [ ] **Step 5: Fix existing payloads.** Every `submitRegistration(...)` happy-path payload in this test file now needs `privacy_consent: true` (add it to the shared `base` object and any inline payloads). Grep: `grep -n "submitRegistration(" src/server/usecases/__tests__/registrations.test.ts`.
+
+- [ ] **Step 6: Run full registrations suite — PASS**
+
+```bash
+cd apps/web && DATABASE_URL="postgresql://postgres@127.0.0.1:54329/seazn_gdpr" DATABASE_SSL=disable npx vitest run src/server/usecases/__tests__/registrations.test.ts
+```
+
+- [ ] **Step 7: Commit** — `git commit -am "feat(registration): require + record explicit privacy consent (422 without)"`
+
+### Task 4: Auth route stamping
+
+**Files:**
+- Modify: `apps/web/src/app/api/auth/magic-link/route.ts` (~line 67)
+- Modify: `apps/web/src/app/api/auth/google/callback/route.ts` (caller of `resolveUser` — grep `resolveUser(`)
+- Modify: `apps/web/src/app/api/auth/signup/route.ts` (~line 39)
+- Modify: `apps/web/src/app/api/auth/login/route.ts` (~line 47)
+
+**Interfaces:**
+- Consumes: `stampTermsAcceptance(userId)` from Task 2.
+
+The stamp function itself is unit-tested (Task 2); these are one-line wire-ups verified by smoke (Task 6). Rationale per surface: the form/button sits directly above the `<LegalNotice/>` added in Task 5, so the submit is the agree act — for existing users each login re-affirms only if never stamped (coalesce).
+
+- [ ] **Step 1: magic-link** — in `POST`, inside the `if (userId) { … }` block, first line:
+
+```ts
+await stampTermsAcceptance(userId);
+```
+
+- [ ] **Step 2: google callback** — in the handler, immediately after the user id is resolved (the `resolveUser(p)` call site): `await stampTermsAcceptance(userId);` (match the local variable name).
+
+- [ ] **Step 3: signup** — after the `insert into users … returning id`: `await stampTermsAcceptance(user.id);`
+
+- [ ] **Step 4: password login** — after `await createSession(user.id);`: `await stampTermsAcceptance(user.id);`
+
+- [ ] **Step 5: Typecheck** — `cd apps/web && npx tsc --noEmit` (expected: clean) — then commit: `git commit -am "feat(auth): stamp terms acceptance on signup + logins"`
+
+### Task 5: UI — LegalNotice + register-form checkbox
+
+**Files:**
+- Create: `apps/web/src/components/legal-notice.tsx`
+- Modify: `apps/web/src/components/auth-form.tsx` (~line 114)
+- Modify: `apps/web/src/components/start-wizard.tsx` (~line 232)
+- Modify: `apps/web/src/components/public-site/register-form.tsx` (consent section ~line 356; state ~line 130; submit json ~line 172)
+- Modify: `apps/web/src/lib/messages.ts` (register.* block)
+
+**Interfaces:**
+- Consumes: `privacy_consent` request field from Task 3.
+- Produces: `<LegalNotice className?: string>`; register form sends `privacy_consent: privacyConsent`.
+
+- [ ] **Step 1: LegalNotice component**
+
+```tsx
+import Link from "next/link";
+
+/** Clickwrap notice under any action that signs in / creates an account
+ *  (GDPR spec 2026-07-14). Server stamping: lib/legal.ts. */
+export function LegalNotice({ className = "" }: { className?: string }) {
+  return (
+    <p className={`text-center text-xs text-slate-400 ${className}`}>
+      By continuing, you agree to our{" "}
+      <Link href="/legal/terms" className="underline hover:text-slate-600">
+        Terms of Service
+      </Link>{" "}
+      and{" "}
+      <Link href="/legal/privacy" className="underline hover:text-slate-600">
+        Privacy Policy
+      </Link>
+      .
+    </p>
+  );
+}
+```
+
+- [ ] **Step 2: auth-form.tsx** — import it; directly under the existing `<p className="mt-4 …">No password needed…</p>` add `<LegalNotice className="mt-2" />`. (Covers /login, /claim/[token], /join — they all render `<AuthForm/>`.)
+
+- [ ] **Step 3: start-wizard.tsx** — after the "We'll email you one link…" paragraph (~line 235) add `<LegalNotice className="text-left" />` (form is left-aligned; keep the notice consistent with the paragraph above it — drop `text-center` via className).
+
+Note: `text-center` + `text-left` conflict — give LegalNotice `text-center` only as default and let className win by ordering: `className={`text-xs text-slate-400 ${className || "text-center"}`}` — adjust Step 1 accordingly if needed.
+
+- [ ] **Step 4: messages.ts** — in the register.* block add:
+
+```ts
+"register.consent.data":
+  "I agree that {org} and Seazn Club will store and process the details on this form (name, contact email, date of birth) to run this competition.",
+"register.consent.privacy": "Privacy Policy",
+```
+
+- [ ] **Step 5: register-form.tsx** —
+
+5a. State (near `guardianConsent`, ~line 130): `const [privacyConsent, setPrivacyConsent] = useState(false);`
+
+5b. Submit json (~line 179, after `guardian_consent`): `privacy_consent: privacyConsent,`
+
+5c. Consent section: change `show: needsGuardian` → `show: true` and make the body render the new checkbox always + the existing amber guardian block only when `needsGuardian`:
+
+```tsx
+{
+  key: "consent",
+  title: msg("register.section.consent"),
+  show: true,
+  body: (
+    <div className="space-y-3">
+      <label className="flex items-start gap-2 text-sm text-zinc-700">
+        <input
+          type="checkbox"
+          required
+          checked={privacyConsent}
+          onChange={(e) => setPrivacyConsent(e.target.checked)}
+          className="mt-0.5"
+        />
+        <span>
+          {msg("register.consent.data", { org: org.name })}{" "}
+          <a href="/legal/privacy" target="_blank" rel="noreferrer" className="underline">
+            {msg("register.consent.privacy")}
+          </a>{" "}
+          *
+        </span>
+      </label>
+      {needsGuardian && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+          {/* existing guardian title/name/checkbox content moves here unchanged */}
+        </div>
+      )}
+    </div>
+  ),
+},
+```
+
+(Keep the existing guardian JSX verbatim inside the conditional. Verify `org.name` exists on the `org` prop — logo/name already used in the masthead.)
+
+- [ ] **Step 6: Visual verify (frontend-design mirror rule).** Start dev server in the worktree (`PORT=3014`, `node <root>/node_modules/next/dist/bin/next dev`, env from Task 0 DB). Playwright-MCP screenshot `/login` and a seeded register page at desktop 1280px and mobile 390px. Notice must read as quiet caption text, not compete with the primary action; checkbox row must not wrap awkwardly at 390px. Screenshots land in the MCP server cwd (main repo root), not session cwd.
+
+- [ ] **Step 7: Commit** — `git commit -am "feat(ui): clickwrap LegalNotice + explicit registration consent checkbox"`
+
+### Task 6: E2E + smoke updates
+
+**Files:**
+- Modify: `apps/web/e2e/registration.spec.ts`, `apps/web/e2e/registration-v2.spec.ts`, `apps/web/e2e/registration-payments.spec.ts`
+- Modify: `scripts/smoke.ts`
+
+**Interfaces:**
+- Consumes: checkbox labelled via `register.consent.data` ("I agree that …"); 422 behaviour from Task 3; stamp behaviour from Task 4.
+
+- [ ] **Step 1: e2e form flows.** In every UI flow that fills `Contact email` and submits, add before the submit click:
+
+```ts
+await page.getByRole("checkbox", { name: /I agree that/ }).check();
+```
+
+(`name: /I agree that/` disambiguates from the guardian checkbox "I am the parent/guardian…". Grep: `grep -n "Contact email" e2e/registration*.spec.ts`.)
+
+- [ ] **Step 2: rewrite the inverted assertion.** `registration-v2.spec.ts` ~line 256 asserts the consent section does NOT render without a minor — now it always renders. Change the assertion to: consent section visible, guardian block absent, e.g.
+
+```ts
+await expect(page.locator("[data-section='consent']")).toBeVisible();
+await expect(page.getByText(/parent\/guardian/i)).toBeHidden();
+```
+
+(Read the actual test first; keep its structure, flip only what the feature changed. The `#20` DOM-order test at line 91 should still pass untouched.)
+
+- [ ] **Step 3: smoke payloads.** Add `privacy_consent: true` to every public register POST body in `scripts/smoke.ts` (grep `` /register` `` — 7 sites incl. lines ~621, 1153, 1176, 1200, 1231, 1266, 2030).
+
+- [ ] **Step 4: smoke negative + stamp checks.** Near the honeypot check (~line 1176) add, following the file's `check()` idiom:
+
+```ts
+const noConsent = await v1(newSession(), `/api/v1/public/orgs/${proOrgSlug}/competitions/${comp.slug}/register`, "POST", {
+  division_id: div.id, display_name: `No Consent ${tag}`,
+  contact_email: `noconsent_${tag}@example.com`,
+});
+check("registration without privacy consent is 422", noConsent.status === 422);
+```
+
+And after any magic-link request smoke already performs (or add one fresh email via `/api/auth/magic-link`), assert the stamp with the file's SQL helper:
+
+```ts
+check("magic-link signup stamps terms acceptance", !!(await sqlRow(`select terms_accepted_at from users where email = '...'`))?.terms_accepted_at);
+```
+
+(Adapt to smoke.ts's actual SQL/HTTP helper names — read the top of the file.)
+
+- [ ] **Step 5: Run targeted e2e + full smoke locally.** E2e per repo conventions (dev server from Task 5 Step 6): `npx playwright test e2e/registration.spec.ts e2e/registration-v2.spec.ts e2e/registration-payments.spec.ts` from `apps/web`. Then full smoke: `SMOKE_BASE=http://localhost:3014 DATABASE_URL=… node --experimental-strip-types scripts/smoke.ts` from repo root (worktree). Expected: all green (memory: don't pipe smoke through `tail` — it eats failures).
+
+- [ ] **Step 6: Commit** — `git commit -am "test: consent coverage in e2e + smoke (422 path, stamp check)"`
+
+### Task 7: Docs, openapi, final verify
+
+**Files:**
+- Modify: `apps/web/src/app/legal/privacy/page.tsx`
+- Modify: `apps/web/content/help/registration/open-registration.md`, `apps/web/content/help/registration/youth.md`, `apps/web/content/help/players/claim-your-profile.md`
+- Modify: `openapi/v1.json` (generated)
+
+- [ ] **Step 1: Privacy page.** Bump `Last updated: 14 July 2026`. Add one sentence under the data-collection section: acceptance of these terms is recorded (timestamp + policy version) when an account is created or a registration is submitted.
+
+- [ ] **Step 2: Help pages (MANDATORY closing pass).** `open-registration.md`: registrants must tick a consent checkbox; what is stored and why. `youth.md`: guardian consent now sits alongside the standard privacy consent. `claim-your-profile.md`: signing in accepts Terms/Privacy (one line). Match each file's existing tone/frontmatter.
+
+- [ ] **Step 3: Regenerate openapi** — from worktree root: `npm run openapi:gen`, commit the diff (drift gate is CI-enforced).
+
+- [ ] **Step 4: Full verify before push** (standing feedback: tsc + units):
+
+```bash
+cd apps/web && npx tsc --noEmit && DATABASE_URL="postgresql://postgres@127.0.0.1:54329/seazn_gdpr" DATABASE_SSL=disable npx vitest run
+```
+
+Expected: tsc clean; suites green (known env flake: full-suite parallel runs against one local DB — re-run failing files individually before blaming the change).
+
+- [ ] **Step 5: Commit + push + PR**
+
+```bash
+git add -A && git commit -m "docs: privacy update + help pages + openapi for consent capture"
+git push -u origin feat/gdpr-consent
+gh pr create --title "feat: GDPR consent capture — clickwrap on auth, explicit consent on registration (V279)" --body "…spec + summary…
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+PR body: link spec file, list V279 columns, note deploy step (Flyway V279 on stg/prod alongside pending V278).

--- a/docs/superpowers/plans/2026-07-14-gdpr-consent.md
+++ b/docs/superpowers/plans/2026-07-14-gdpr-consent.md
@@ -15,7 +15,7 @@
 - DB-backed tests: ephemeral PG on 127.0.0.1:54329 (fall back 54331 if squatted), `DATABASE_SSL=disable`, run vitest from `apps/web` cwd (repo-root cwd breaks `@/` aliases).
 - `LEGAL_VERSION = "2026-07-14"` everywhere (privacy page "Last updated" bumps to 14 July 2026 in Task 7).
 - Every code change ships with a test that fails without it (standing feedback).
-- Copy style: sentence case, plain verbs; consent label = "I agree that {org} and Seazn Club will store and process the details on this form (name, contact email, date of birth) to run this competition."
+- Copy style: sentence case, plain verbs; consent label = "I agree that {org} and Seazn Club will store and process the details on this form (name, email address, date of birth) to run this competition."
 - rtk hook swallows `npx next dev` — launch dev servers as `node <root>/node_modules/next/dist/bin/next dev` with `PORT=<n>`.
 - Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
 
@@ -308,7 +308,7 @@ Note: `text-center` + `text-left` conflict — give LegalNotice `text-center` on
 
 ```ts
 "register.consent.data":
-  "I agree that {org} and Seazn Club will store and process the details on this form (name, contact email, date of birth) to run this competition.",
+  "I agree that {org} and Seazn Club will store and process the details on this form (name, email address, date of birth) to run this competition.",
 "register.consent.privacy": "Privacy Policy",
 ```
 

--- a/docs/superpowers/specs/2026-07-14-gdpr-consent-design.md
+++ b/docs/superpowers/specs/2026-07-14-gdpr-consent-design.md
@@ -1,0 +1,63 @@
+# GDPR / EU consent capture — design
+
+Date: 2026-07-14. Status: approved (auto-approve standing preference; forks resolved via Q&A: record in DB, all account-creating surfaces).
+
+## Problem
+
+Emails (and registrant PII) are collected with no terms/privacy acceptance anywhere:
+
+- `/login` (`auth-form.tsx`) — magic link + Google; an unknown email silently creates an account.
+- `/start` wizard and `/claim` invite-claim — also create accounts via email entry.
+- Public division registration (`public-site/register-form.tsx`) — collects name, email, DOB, gender; only guardian consent exists (youth/minors).
+
+GDPR Art. 7 requires being able to *demonstrate* consent/acceptance, so UI notices alone are not enough.
+
+## Decision
+
+Consent columns on existing tables + one shared notice component. No consent-history table (YAGNI — revisit if policy re-consent flows are ever needed).
+
+### Legal basis
+
+- Registration data processing = contract necessity (Art. 6(1)(b)); the explicit checkbox is transparency + belt-and-braces.
+- Account creation = clickwrap acceptance of Terms + Privacy ("By continuing…" under the submit action).
+
+### DB — V279 (`db/migration/deltas/V279__consent.sql`)
+
+- `users.terms_accepted_at timestamptz`, `users.terms_version text`
+- `registrations.privacy_consent_at timestamptz`, `registrations.privacy_consent_version text`
+- No backfill. Null = pre-policy account; stamped on next login through a form that carries the notice.
+
+### Version constant
+
+`lib/legal.ts` exports `LEGAL_VERSION` — the "Last updated" date of `/legal/privacy`. This change itself amends the policy (consent-record disclosure), so both become `2026-07-14`. Bump manually when the policy text changes. (Distinct from `lib/consent.ts`, which already versions the cookie/analytics banner.)
+
+### Server stamping
+
+- `POST /api/auth/magic-link`: stamp on user create; also update-if-null for existing users (the form submit under the notice is the agree act).
+- Google OAuth callback: stamp on insert; update-if-null on returning login.
+- `POST /api/auth/signup` and password login route: same pattern.
+- Public register endpoint (`server/usecases/registrations.ts` + route schema): `privacy_consent: z.literal(true)` — request without it fails 422 with a clear message; persist `privacy_consent_at = now()` + `privacy_consent_version = LEGAL_VERSION`.
+
+### UI
+
+- `<LegalNotice/>` (in or beside `lib/legal.ts`): "By continuing, you agree to our [Terms of Service](/legal/terms) and [Privacy Policy](/legal/privacy)." Small muted text under the primary action.
+- Surfaces: `auth-form.tsx` (covers `/login`, `/claim/[token]`, `/join` — all render `<AuthForm/>`) and `start-wizard.tsx` (email step). `v2/invite-claim.tsx` is excluded: there the organiser types the player's email; the player themself agrees on `/claim` via AuthForm.
+- `register-form.tsx`: consent section now shows for ALL registrants (previously only guardian cases). Required checkbox: "I agree that {org} and Seazn Club process the details on this form (name, email, date of birth) to run this competition — see Privacy Policy." i18n keys in `lib/messages.ts` (all locale files). Guardian consent unchanged, stacked in same section for youth.
+
+### Out of scope
+
+- Cookie banner (no third-party marketing cookies today; `/legal/cookie-policy` already exists).
+- Marketing-email opt-in (no marketing sends exist).
+- Data export / erasure tooling (users table already has `deleted_at`/`purge_after`).
+- Re-consent UX on version bump.
+
+## Testing
+
+- Unit: register schema rejects missing/false `privacy_consent` (422); accepts `true` and row carries timestamp + version. Magic-link create stamps `terms_accepted_at`; existing-null user gets stamped on re-request.
+- E2E: public registration flow checks the consent checkbox (spec update).
+- Smoke: `scripts/smoke.ts` registration paths send `privacy_consent: true`.
+- openapi regenerated (drift gate).
+
+## Delivery
+
+Worktree `.claude/worktrees/gdpr-consent`, branch `feat/gdpr-consent`, PR to main. Closing pass: `content/help/*.md` updated (registration help + account/privacy mentions), tsc + unit tests before push.

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -30210,6 +30210,10 @@
                     "default": false,
                     "type": "boolean"
                   },
+                  "privacy_consent": {
+                    "default": false,
+                    "type": "boolean"
+                  },
                   "answers": {
                     "default": {},
                     "type": "object",
@@ -30271,6 +30275,7 @@
                   "display_name",
                   "contact_email",
                   "guardian_consent",
+                  "privacy_consent",
                   "answers",
                   "players"
                 ],
@@ -30282,6 +30287,7 @@
                 "contact_email": "example",
                 "dob": "2026-08-01",
                 "guardian_consent": true,
+                "privacy_consent": true,
                 "answers": {},
                 "players": [
                   {

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -23747,6 +23747,10 @@
                     "default": false,
                     "type": "boolean"
                   },
+                  "privacy_consent": {
+                    "default": false,
+                    "type": "boolean"
+                  },
                   "answers": {
                     "default": {},
                     "type": "object",
@@ -23808,6 +23812,7 @@
                   "display_name",
                   "contact_email",
                   "guardian_consent",
+                  "privacy_consent",
                   "answers",
                   "players"
                 ],
@@ -23819,6 +23824,7 @@
                 "contact_email": "example",
                 "dob": "2026-08-01",
                 "guardian_consent": true,
+                "privacy_consent": true,
                 "answers": {},
                 "players": [
                   {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -93,6 +93,9 @@ async function main() {
   check("active org cookie set", admin.cookies["seazn_org"] === ver.org_id);
   // A brand-new account (no onboarding completed) lands on the first-run wizard.
   check("new user routed to onboarding", ver.redirect === "/onboarding");
+  // GDPR (spec 2026-07-14): requesting the magic link under the clickwrap
+  // notice stamps terms acceptance on the account.
+  await checkTermsStamp(`admin_${tag}@example.com`);
   const org = { id: ver.org_id };
 
   // --- Competition lifecycle guards (v2 service layer) ---
@@ -622,6 +625,7 @@ async function regQueueSuite(admin: Session): Promise<void> {
       division_id: div.id,
       display_name: name,
       contact_email: `${name.replace(/ /g, "").toLowerCase()}_${tag}@example.com`,
+      privacy_consent: true,
     });
     if (res.status !== 201) {
       console.log(`queue submit "${name}" failed:`, res.status, JSON.stringify(res.json));
@@ -650,6 +654,27 @@ async function regQueueSuite(admin: Session): Promise<void> {
     "public card shows waitlist count",
     registerPage.status === 200 && registerPage.body.includes("full — waitlist: 2"),
   );
+}
+
+/** GDPR (spec 2026-07-14): assert the magic-link request stamped terms
+ *  acceptance — same SQL convention as setStaff/setConnect. */
+async function checkTermsStamp(email: string): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) return; // keyless run: nothing to assert against
+  const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
+  const sql = postgres(url, {
+    connection: { search_path: process.env.DB_SCHEMA ?? "seazn_club" },
+    ssl: process.env.DATABASE_SSL === "disable" ? false : isLocal ? false : "require",
+    prepare: !url.includes(":6543"),
+    max: 1,
+  });
+  try {
+    const [row] = await sql<{ terms_accepted_at: Date | null; terms_version: string | null }[]>`
+      select terms_accepted_at, terms_version from users where email = ${email}`;
+    check("auth terms acceptance stamped", !!row?.terms_accepted_at && !!row?.terms_version);
+  } finally {
+    await sql.end();
+  }
 }
 
 /** Flip the staff-console flag on a user — same SQL-flip convention as
@@ -1154,6 +1179,7 @@ async function schedRegV3Suite(
     division_id: div.id,
     display_name: `Ref Probe ${tag}`,
     contact_email: `refprobe_${tag}@example.com`,
+    privacy_consent: true,
   });
   const regData = v1data<{ ref_code: string }>(reg);
   check(
@@ -1181,6 +1207,14 @@ async function schedRegV3Suite(
   });
   check("reg honeypot rejects bots (400)", honey.status === 400);
 
+  // GDPR (spec 2026-07-14): a submission without privacy consent is refused.
+  const noConsent = await v1(newSession(), `/api/v1/public/orgs/${proOrgSlug}/competitions/${comp.slug}/register`, "POST", {
+    division_id: div.id,
+    display_name: `No Consent ${tag}`,
+    contact_email: `noconsent_${tag}@example.com`,
+  });
+  check("reg without privacy consent refused (422)", noConsent.status === 422);
+
   // --- Dual payments (spec 2026-07-12): offline mark-paid + card gates (pro) ---
   const orgsList = (await call(admin, "/api/orgs")) as { id: string; slug: string }[];
   const proOrgId = orgsList.find((o) => o.slug === proOrgSlug)!.id;
@@ -1201,6 +1235,7 @@ async function schedRegV3Suite(
     division_id: payDiv.id,
     display_name: `Cash Payer ${tag}`,
     contact_email: `cash_${tag}@example.com`,
+    privacy_consent: true,
   });
   const offRegData = v1data<{ registration_id: string; checkout_url: string | null }>(offReg);
   check(
@@ -1232,6 +1267,7 @@ async function schedRegV3Suite(
     division_id: payDiv.id,
     display_name: `Card Payer ${tag}`,
     contact_email: `card_${tag}@example.com`,
+    privacy_consent: true,
   });
   const cardRegData = v1data<{ registration_id: string; status: string }>(cardReg);
   // No Stripe key in smoke: the session mint fails gracefully — the row still
@@ -1267,6 +1303,7 @@ async function schedRegV3Suite(
     division_id: fDiv.id,
     display_name: `Free Ref ${tag}`,
     contact_email: `freeref_${tag}@example.com`,
+    privacy_consent: true,
   });
   const fRegData = v1data<{ ref_code: string }>(fReg);
   check(
@@ -2031,6 +2068,7 @@ async function gapSuite(admin: Session, org1Id: string, proOrgId: string): Promi
     division_id: divId,
     display_name: `Walk In ${tag}`,
     contact_email: `walkin_${tag}@example.com`,
+    privacy_consent: true,
   });
   const regData = v1data<{ registration_id: string; status: string; access_token: string }>(reg);
   check(


### PR DESCRIPTION
GDPR/EU compliance for email + registrant PII collection. Spec: docs/superpowers/specs/2026-07-14-gdpr-consent-design.md.

## What

- **V279**: users.terms_accepted_at/terms_version, registrations.privacy_consent_at/privacy_consent_version. Null = pre-policy row; backfilled on next login.
- **Clickwrap (auto-agree)**: LegalNotice ("By continuing, you agree to Terms + Privacy") under /login (covers /claim + /join via AuthForm) and the /start wizard email step. Server stamps acceptance idempotently (lib/legal.ts) on magic-link request, Google callback, signup, and password login — first acceptance wins, later logins never move the timestamp.
- **Explicit registration consent**: consent section now renders for every registrant with a required checkbox ("I agree that {org} and Seazn Club will store and process… "); API rejects without it (422) and stores timestamp + LEGAL_VERSION. Guardian consent unchanged, nested for youth.
- **Privacy page**: Last updated 14 July 2026 + consent-records disclosure. LEGAL_VERSION = "2026-07-14".
- Help pages (open-registration, youth, claim-your-profile) + openapi regenerated.

## Tests

- Unit: stamp idempotence (legal.test.ts), 422-without-consent + stored at/version (registrations.test.ts). Full vitest: 925/929, 1 fail = known env-badminton sync:sports issue (funnel.test.ts), 3 skipped.
- E2E: registration/registration-v2/registration-payments/reg-console updated (checkbox in flows, API payloads, always-visible consent section assertion) — 13/13 green locally.
- Smoke: 257/257 incl. new "reg without privacy consent refused (422)" and "auth terms acceptance stamped" checks.
- Consent copy says "email address" (not "contact email") — the checkbox's accessible name collided with getByLabel(/contact email/i).

## Deploy

Flyway V279 on stg/prod (alongside pending V278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)