### PR TITLE
feat(games): Seazn Games platform + Chess Quest (full quest, 8 games, profiles)

### DIFF
--- a/apps/web/e2e/games.spec.ts
+++ b/apps/web/e2e/games.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+// Seazn Games surface (Phase A): listing, player page, 404s, subdomain
+// rewrite. No fixtures needed — the registry is static data.
+
+test("games listing renders registry cards", async ({ page }) => {
+  await page.goto("/games");
+  await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
+  await expect(page.getByText("Chess Quest")).toBeVisible();
+  await expect(page.getByText("Coming soon")).toBeVisible();
+});
+
+test("coming-soon game shows teaser, not a dead page", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await expect(page.getByText("Chess Quest is coming soon")).toBeVisible();
+  await expect(page.getByRole("link", { name: "← Games" })).toBeVisible();
+});
+
+test("unknown game slug 404s", async ({ page }) => {
+  const res = await page.goto("/games/not-a-game");
+  expect(res?.status()).toBe(404);
+});
+
+test("games.* host serves the games tree", async ({ browser }) => {
+  // The proxy prefers x-forwarded-host, which is what Fly sets in production.
+  const ctx = await browser.newContext({
+    extraHTTPHeaders: { "x-forwarded-host": "games.seazn.club" },
+  });
+  const page = await ctx.newPage();
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
+  await page.goto("/chess-quest");
+  await expect(page.getByText("Chess Quest is coming soon")).toBeVisible();
+  await ctx.close();
+});

--- a/apps/web/e2e/games.spec.ts
+++ b/apps/web/e2e/games.spec.ts
@@ -1,19 +1,31 @@
 import { test, expect } from "@playwright/test";
 
-// Seazn Games surface (Phase A): listing, player page, 404s, subdomain
-// rewrite. No fixtures needed — the registry is static data.
+// Seazn Games surface: listing, player hub, deterministic play-through, 404s,
+// subdomain rewrite. No fixtures needed — the registry is static data.
 
-test("games listing renders registry cards", async ({ page }) => {
+test("games listing renders the Chess Quest card as playable", async ({ page }) => {
   await page.goto("/games");
   await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
-  await expect(page.getByText("Chess Quest")).toBeVisible();
-  await expect(page.getByText("Coming soon")).toBeVisible();
+  await expect(page.getByRole("link", { name: /Chess Quest/ })).toBeVisible();
+  await expect(page.getByText("Play →")).toBeVisible();
 });
 
-test("coming-soon game shows teaser, not a dead page", async ({ page }) => {
+test("chess quest hub lists the mini-games", async ({ page }) => {
   await page.goto("/games/chess-quest");
-  await expect(page.getByText("Chess Quest is coming soon")).toBeVisible();
   await expect(page.getByRole("link", { name: "← Games" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Chess Quest" })).toBeVisible();
+  // A few of the eight game cards.
+  await expect(page.getByRole("heading", { name: "Mate in 1" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Pawn Wars" })).toBeVisible();
+});
+
+test("Mate in 1 can be solved end to end", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await page.getByRole("button", { name: /Mate in 1/ }).click();
+  // Puzzle 1 "Sneak down the hallway": Re1–e8 is mate.
+  await page.locator('[data-square="e1"]').click();
+  await page.locator('[data-square="e8"]').click();
+  await expect(page.getByText(/Checkmate/)).toBeVisible();
 });
 
 test("unknown game slug 404s", async ({ page }) => {
@@ -30,6 +42,6 @@ test("games.* host serves the games tree", async ({ browser }) => {
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
   await page.goto("/chess-quest");
-  await expect(page.getByText("Chess Quest is coming soon")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Chess Quest" })).toBeVisible();
   await ctx.close();
 });

--- a/apps/web/e2e/games.spec.ts
+++ b/apps/web/e2e/games.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-// Seazn Games surface: listing, player hub, deterministic play-through, 404s,
-// subdomain rewrite. No fixtures needed — the registry is static data.
+// Seazn Games surface: listing, quest hub, lesson→game launch + persistence,
+// free-play arcade, 404s, subdomain rewrite. No fixtures — static registry +
+// localStorage.
 
 test("games listing renders the Chess Quest card as playable", async ({ page }) => {
   await page.goto("/games");
@@ -10,19 +11,37 @@ test("games listing renders the Chess Quest card as playable", async ({ page }) 
   await expect(page.getByText("Play →")).toBeVisible();
 });
 
-test("chess quest hub lists the mini-games", async ({ page }) => {
+test("quest hub shows the map and the Day 1 lesson", async ({ page }) => {
   await page.goto("/games/chess-quest");
-  await expect(page.getByRole("link", { name: "← Games" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Chess Quest" })).toBeVisible();
-  // A few of the eight game cards.
-  await expect(page.getByRole("heading", { name: "Mate in 1" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Pawn Wars" })).toBeVisible();
+  await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
+  await page.reload();
+  await expect(page.getByText("First Steps")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Board Land" })).toBeVisible();
 });
 
-test("Mate in 1 can be solved end to end", async ({ page }) => {
+test("marking a day done persists across a reload", async ({ page }) => {
   await page.goto("/games/chess-quest");
+  await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
+  await page.reload();
+  await page.getByRole("button", { name: /Mark day done/ }).click();
+  await expect(page.getByRole("button", { name: /Done — undo/ })).toBeVisible();
+  await page.reload();
+  // Day 1 stays done — its map stop shows a check.
+  await expect(page.getByRole("button", { name: "Day 1: Board Land" })).toHaveText("✓");
+});
+
+test("a lesson launches its mini-game", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await page.getByRole("button", { name: /Play Square Race/ }).click();
+  await expect(page.getByRole("button", { name: /Back to quest/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Square Race" })).toBeVisible();
+});
+
+test("free-play arcade lists the eight games and one solves", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await page.getByRole("button", { name: "Free play" }).click();
+  await expect(page.getByRole("heading", { name: "Mate in 1" })).toBeVisible();
   await page.getByRole("button", { name: /Mate in 1/ }).click();
-  // Puzzle 1 "Sneak down the hallway": Re1–e8 is mate.
   await page.locator('[data-square="e1"]').click();
   await page.locator('[data-square="e8"]').click();
   await expect(page.getByText(/Checkmate/)).toBeVisible();
@@ -34,7 +53,6 @@ test("unknown game slug 404s", async ({ page }) => {
 });
 
 test("games.* host serves the games tree", async ({ browser }) => {
-  // The proxy prefers x-forwarded-host, which is what Fly sets in production.
   const ctx = await browser.newContext({
     extraHTTPHeaders: { "x-forwarded-host": "games.seazn.club" },
   });
@@ -42,6 +60,6 @@ test("games.* host serves the games tree", async ({ browser }) => {
   await page.goto("/");
   await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
   await page.goto("/chess-quest");
-  await expect(page.getByRole("heading", { name: "Chess Quest" })).toBeVisible();
+  await expect(page.getByRole("banner").getByRole("heading", { name: "Chess Quest" })).toBeVisible();
   await ctx.close();
 });

--- a/apps/web/public/games/chess-quest/pieces/LICENSE.md
+++ b/apps/web/public/games/chess-quest/pieces/LICENSE.md
@@ -1,0 +1,9 @@
+# Chess piece images
+
+Standard SVG chess pieces by Colin M.L. Burnett ("Cburnett"), from Wikimedia
+Commons (https://commons.wikimedia.org/wiki/Category:SVG_chess_pieces),
+files `Chess_{k,q,r,b,n,p}{l,d}t45.svg`.
+
+License: CC BY-SA 3.0 (https://creativecommons.org/licenses/by-sa/3.0/) /
+GFDL. These SVG files remain under that license; renaming here (`kl.svg` =
+king light, `pd.svg` = pawn dark, …) is the only modification.

--- a/apps/web/public/games/chess-quest/pieces/bd.svg
+++ b/apps/web/public/games/chess-quest/pieces/bd.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:none; fill-rule:evenodd; fill-opacity:1; stroke:#000000; stroke-width:1.5; stroke-linecap:round; stroke-linejoin:round; stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.6)">
+    <g style="fill:#000000; stroke:#000000; stroke-linecap:butt;">
+      <path d="M 9,36 C 12.39,35.03 19.11,36.43 22.5,34 C 25.89,36.43 32.61,35.03 36,36 C 36,36 37.65,36.54 39,38 C 38.32,38.97 37.35,38.99 36,38.5 C 32.61,37.53 25.89,38.96 22.5,37.5 C 19.11,38.96 12.39,37.53 9,38.5 C 7.65,38.99 6.68,38.97 6,38 C 7.35,36.54 9,36 9,36 z"/>
+      <path d="M 15,32 C 17.5,34.5 27.5,34.5 30,32 C 30.5,30.5 30,30 30,30 C 30,27.5 27.5,26 27.5,26 C 33,24.5 33.5,14.5 22.5,10.5 C 11.5,14.5 12,24.5 17.5,26 C 17.5,26 15,27.5 15,30 C 15,30 14.5,30.5 15,32 z"/>
+      <path d="M 25 8 A 2.5 2.5 0 1 1  20,8 A 2.5 2.5 0 1 1  25 8 z"/>
+    </g>
+    <path d="M 17.5,26 L 27.5,26 M 15,30 L 30,30 M 22.5,15.5 L 22.5,20.5 M 20,18 L 25,18" style="fill:none; stroke:#ffffff; stroke-linejoin:miter;"/>
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/bl.svg
+++ b/apps/web/public/games/chess-quest/pieces/bl.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:none; fill-rule:evenodd; fill-opacity:1; stroke:#000000; stroke-width:1.5; stroke-linecap:round; stroke-linejoin:round; stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.6)">
+    <g style="fill:#ffffff; stroke:#000000; stroke-linecap:butt;">
+      <path d="M 9,36 C 12.39,35.03 19.11,36.43 22.5,34 C 25.89,36.43 32.61,35.03 36,36 C 36,36 37.65,36.54 39,38 C 38.32,38.97 37.35,38.99 36,38.5 C 32.61,37.53 25.89,38.96 22.5,37.5 C 19.11,38.96 12.39,37.53 9,38.5 C 7.65,38.99 6.68,38.97 6,38 C 7.35,36.54 9,36 9,36 z"/>
+      <path d="M 15,32 C 17.5,34.5 27.5,34.5 30,32 C 30.5,30.5 30,30 30,30 C 30,27.5 27.5,26 27.5,26 C 33,24.5 33.5,14.5 22.5,10.5 C 11.5,14.5 12,24.5 17.5,26 C 17.5,26 15,27.5 15,30 C 15,30 14.5,30.5 15,32 z"/>
+      <path d="M 25 8 A 2.5 2.5 0 1 1  20,8 A 2.5 2.5 0 1 1  25 8 z"/>
+    </g>
+    <path d="M 17.5,26 L 27.5,26 M 15,30 L 30,30 M 22.5,15.5 L 22.5,20.5 M 20,18 L 25,18" style="fill:none; stroke:#000000; stroke-linejoin:miter;"/>
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/kd.svg
+++ b/apps/web/public/games/chess-quest/pieces/kd.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="fill:none; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;">
+    <path d="M 22.5,11.63 L 22.5,6" style="fill:none; stroke:#000000; stroke-linejoin:miter;" id="path6570"/>
+    <path d="M 22.5,25 C 22.5,25 27,17.5 25.5,14.5 C 25.5,14.5 24.5,12 22.5,12 C 20.5,12 19.5,14.5 19.5,14.5 C 18,17.5 22.5,25 22.5,25" style="fill:#000000;fill-opacity:1; stroke-linecap:butt; stroke-linejoin:miter;"/>
+    <path d="M 12.5,37 C 18,40.5 27,40.5 32.5,37 L 32.5,30 C 32.5,30 41.5,25.5 38.5,19.5 C 34.5,13 25,16 22.5,23.5 L 22.5,27 L 22.5,23.5 C 20,16 10.5,13 6.5,19.5 C 3.5,25.5 12.5,30 12.5,30 L 12.5,37" style="fill:#000000; stroke:#000000;"/>
+    <path d="M 20,8 L 25,8" style="fill:none; stroke:#000000; stroke-linejoin:miter;"/>
+    <path d="M 32,29.5 C 32,29.5 40.5,25.5 38.03,19.85 C 34.15,14 25,18 22.5,24.5 L 22.5,26.6 L 22.5,24.5 C 20,18 10.85,14 6.97,19.85 C 4.5,25.5 13,29.5 13,29.5" style="fill:none; stroke:#ffffff;"/>
+    <path d="M 12.5,30 C 18,27 27,27 32.5,30 M 12.5,33.5 C 18,30.5 27,30.5 32.5,33.5 M 12.5,37 C 18,34 27,34 32.5,37" style="fill:none; stroke:#ffffff;"/>
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/kl.svg
+++ b/apps/web/public/games/chess-quest/pieces/kl.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="45" height="45">
+  <g fill="none" fill-rule="evenodd" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+    <path stroke-linejoin="miter" d="M22.5 11.63V6M20 8h5"/>
+    <path fill="#fff" stroke-linecap="butt" stroke-linejoin="miter" d="M22.5 25s4.5-7.5 3-10.5c0 0-1-2.5-3-2.5s-3 2.5-3 2.5c-1.5 3 3 10.5 3 10.5"/>
+    <path fill="#fff" d="M12.5 37c5.5 3.5 14.5 3.5 20 0v-7s9-4.5 6-10.5c-4-6.5-13.5-3.5-16 4V27v-3.5c-2.5-7.5-12-10.5-16-4-3 6 6 10.5 6 10.5v7"/>
+    <path d="M12.5 30c5.5-3 14.5-3 20 0m-20 3.5c5.5-3 14.5-3 20 0m-20 3.5c5.5-3 14.5-3 20 0"/>
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/nd.svg
+++ b/apps/web/public/games/chess-quest/pieces/nd.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:none; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.3)">
+    <path
+      d="M 22,10 C 32.5,11 38.5,18 38,39 L 15,39 C 15,30 25,32.5 23,18"
+      style="fill:#000000; stroke:#000000;" />
+    <path
+      d="M 24,18 C 24.38,20.91 18.45,25.37 16,27 C 13,29 13.18,31.34 11,31 C 9.958,30.06 12.41,27.96 11,28 C 10,28 11.19,29.23 10,30 C 9,30 5.997,31 6,26 C 6,24 12,14 12,14 C 12,14 13.89,12.1 14,10.5 C 13.27,9.506 13.5,8.5 13.5,7.5 C 14.5,6.5 16.5,10 16.5,10 L 18.5,10 C 18.5,10 19.28,8.008 21,7 C 22,7 22,10 22,10"
+      style="fill:#000000; stroke:#000000;" />
+    <path
+      d="M 9.5 25.5 A 0.5 0.5 0 1 1 8.5,25.5 A 0.5 0.5 0 1 1 9.5 25.5 z"
+      style="fill:#ffffff; stroke:#ffffff;" />
+    <path
+      d="M 15 15.5 A 0.5 1.5 0 1 1  14,15.5 A 0.5 1.5 0 1 1  15 15.5 z"
+      transform="matrix(0.866,0.5,-0.5,0.866,9.693,-5.173)"
+      style="fill:#ffffff; stroke:#ffffff;" />
+    <path
+      d="M 24.55,10.4 L 24.1,11.85 L 24.6,12 C 27.75,13 30.25,14.49 32.5,18.75 C 34.75,23.01 35.75,29.06 35.25,39 L 35.2,39.5 L 37.45,39.5 L 37.5,39 C 38,28.94 36.62,22.15 34.25,17.66 C 31.88,13.17 28.46,11.02 25.06,10.5 L 24.55,10.4 z "
+      style="fill:#ffffff; stroke:none;" />
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/nl.svg
+++ b/apps/web/public/games/chess-quest/pieces/nl.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:none; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.3)">
+    <path
+      d="M 22,10 C 32.5,11 38.5,18 38,39 L 15,39 C 15,30 25,32.5 23,18"
+      style="fill:#ffffff; stroke:#000000;" />
+    <path
+      d="M 24,18 C 24.38,20.91 18.45,25.37 16,27 C 13,29 13.18,31.34 11,31 C 9.958,30.06 12.41,27.96 11,28 C 10,28 11.19,29.23 10,30 C 9,30 5.997,31 6,26 C 6,24 12,14 12,14 C 12,14 13.89,12.1 14,10.5 C 13.27,9.506 13.5,8.5 13.5,7.5 C 14.5,6.5 16.5,10 16.5,10 L 18.5,10 C 18.5,10 19.28,8.008 21,7 C 22,7 22,10 22,10"
+      style="fill:#ffffff; stroke:#000000;" />
+    <path
+      d="M 9.5 25.5 A 0.5 0.5 0 1 1 8.5,25.5 A 0.5 0.5 0 1 1 9.5 25.5 z"
+      style="fill:#000000; stroke:#000000;" />
+    <path
+      d="M 15 15.5 A 0.5 1.5 0 1 1  14,15.5 A 0.5 1.5 0 1 1  15 15.5 z"
+      transform="matrix(0.866,0.5,-0.5,0.866,9.693,-5.173)"
+      style="fill:#000000; stroke:#000000;" />
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/pd.svg
+++ b/apps/web/public/games/chess-quest/pieces/pd.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <path d="m 22.5,9 c -2.21,0 -4,1.79 -4,4 0,0.89 0.29,1.71 0.78,2.38 C 17.33,16.5 16,18.59 16,21 c 0,2.03 0.94,3.84 2.41,5.03 C 15.41,27.09 11,31.58 11,39.5 H 34 C 34,31.58 29.59,27.09 26.59,26.03 28.06,24.84 29,23.03 29,21 29,18.59 27.67,16.5 25.72,15.38 26.21,14.71 26.5,13.89 26.5,13 c 0,-2.21 -1.79,-4 -4,-4 z" style="opacity:1; fill:#000000; fill-opacity:1; fill-rule:nonzero; stroke:#000000; stroke-width:1.5; stroke-linecap:round; stroke-linejoin:miter; stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;"/>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/pl.svg
+++ b/apps/web/public/games/chess-quest/pieces/pl.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <path d="m 22.5,9 c -2.21,0 -4,1.79 -4,4 0,0.89 0.29,1.71 0.78,2.38 C 17.33,16.5 16,18.59 16,21 c 0,2.03 0.94,3.84 2.41,5.03 C 15.41,27.09 11,31.58 11,39.5 H 34 C 34,31.58 29.59,27.09 26.59,26.03 28.06,24.84 29,23.03 29,21 29,18.59 27.67,16.5 25.72,15.38 26.21,14.71 26.5,13.89 26.5,13 c 0,-2.21 -1.79,-4 -4,-4 z" style="opacity:1; fill:#ffffff; fill-opacity:1; fill-rule:nonzero; stroke:#000000; stroke-width:1.5; stroke-linecap:round; stroke-linejoin:miter; stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;"/>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/qd.svg
+++ b/apps/web/public/games/chess-quest/pieces/qd.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45"
+height="45">
+  <g style="fill:#000000;stroke:#000000;stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round">
+
+    <path d="M 9,26 C 17.5,24.5 30,24.5 36,26 L 38.5,13.5 L 31,25 L 30.7,10.9 L 25.5,24.5 L 22.5,10 L 19.5,24.5 L 14.3,10.9 L 14,25 L 6.5,13.5 L 9,26 z"
+    style="stroke-linecap:butt;fill:#000000" />
+    <path d="m 9,26 c 0,2 1.5,2 2.5,4 1,1.5 1,1 0.5,3.5 -1.5,1 -1,2.5 -1,2.5 -1.5,1.5 0,2.5 0,2.5 6.5,1 16.5,1 23,0 0,0 1.5,-1 0,-2.5 0,0 0.5,-1.5 -1,-2.5 -0.5,-2.5 -0.5,-2 0.5,-3.5 1,-2 2.5,-2 2.5,-4 -8.5,-1.5 -18.5,-1.5 -27,0 z" />
+    <path d="M 11.5,30 C 15,29 30,29 33.5,30" />
+    <path d="m 12,33.5 c 6,-1 15,-1 21,0" />
+    <circle cx="6" cy="12" r="2" />
+    <circle cx="14" cy="9" r="2" />
+    <circle cx="22.5" cy="8" r="2" />
+    <circle cx="31" cy="9" r="2" />
+    <circle cx="39" cy="12" r="2" />
+    <path d="M 11,38.5 A 35,35 1 0 0 34,38.5"
+    style="fill:none; stroke:#000000;stroke-linecap:butt;" />
+    <g style="fill:none; stroke:#ffffff;">
+      <path d="M 11,29 A 35,35 1 0 1 34,29" />
+      <path d="M 12.5,31.5 L 32.5,31.5" />
+      <path d="M 11.5,34.5 A 35,35 1 0 0 33.5,34.5" />
+      <path d="M 10.5,37.5 A 35,35 1 0 0 34.5,37.5" />
+    </g>
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/ql.svg
+++ b/apps/web/public/games/chess-quest/pieces/ql.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="fill:#ffffff;stroke:#000000;stroke-width:1.5;stroke-linejoin:round">
+    <path d="M 9,26 C 17.5,24.5 30,24.5 36,26 L 38.5,13.5 L 31,25 L 30.7,10.9 L 25.5,24.5 L 22.5,10 L 19.5,24.5 L 14.3,10.9 L 14,25 L 6.5,13.5 L 9,26 z"/>
+    <path d="M 9,26 C 9,28 10.5,28 11.5,30 C 12.5,31.5 12.5,31 12,33.5 C 10.5,34.5 11,36 11,36 C 9.5,37.5 11,38.5 11,38.5 C 17.5,39.5 27.5,39.5 34,38.5 C 34,38.5 35.5,37.5 34,36 C 34,36 34.5,34.5 33,33.5 C 32.5,31 32.5,31.5 33.5,30 C 34.5,28 36,28 36,26 C 27.5,24.5 17.5,24.5 9,26 z"/>
+    <path d="M 11.5,30 C 15,29 30,29 33.5,30" style="fill:none"/>
+    <path d="M 12,33.5 C 18,32.5 27,32.5 33,33.5" style="fill:none"/>
+    <circle cx="6" cy="12" r="2" />
+    <circle cx="14" cy="9" r="2" />
+    <circle cx="22.5" cy="8" r="2" />
+    <circle cx="31" cy="9" r="2" />
+    <circle cx="39" cy="12" r="2" />
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/rd.svg
+++ b/apps/web/public/games/chess-quest/pieces/rd.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:#000000; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.3)">
+    <path
+      d="M 9,39 L 36,39 L 36,36 L 9,36 L 9,39 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 12.5,32 L 14,29.5 L 31,29.5 L 32.5,32 L 12.5,32 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 12,36 L 12,32 L 33,32 L 33,36 L 12,36 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 14,29.5 L 14,16.5 L 31,16.5 L 31,29.5 L 14,29.5 z "
+      style="stroke-linecap:butt;stroke-linejoin:miter;" />
+    <path
+      d="M 14,16.5 L 11,14 L 34,14 L 31,16.5 L 14,16.5 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 11,14 L 11,9 L 15,9 L 15,11 L 20,11 L 20,9 L 25,9 L 25,11 L 30,11 L 30,9 L 34,9 L 34,14 L 11,14 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 12,35.5 L 33,35.5 L 33,35.5"
+      style="fill:none; stroke:#ffffff; stroke-width:1; stroke-linejoin:miter;" />
+    <path
+      d="M 13,31.5 L 32,31.5"
+      style="fill:none; stroke:#ffffff; stroke-width:1; stroke-linejoin:miter;" />
+    <path
+      d="M 14,29.5 L 31,29.5"
+      style="fill:none; stroke:#ffffff; stroke-width:1; stroke-linejoin:miter;" />
+    <path
+      d="M 14,16.5 L 31,16.5"
+      style="fill:none; stroke:#ffffff; stroke-width:1; stroke-linejoin:miter;" />
+    <path
+      d="M 11,14 L 34,14"
+      style="fill:none; stroke:#ffffff; stroke-width:1; stroke-linejoin:miter;" />
+  </g>
+</svg>

--- a/apps/web/public/games/chess-quest/pieces/rl.svg
+++ b/apps/web/public/games/chess-quest/pieces/rl.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="45" height="45">
+  <g style="opacity:1; fill:#ffffff; fill-opacity:1; fill-rule:evenodd; stroke:#000000; stroke-width:1.5; stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4; stroke-dasharray:none; stroke-opacity:1;" transform="translate(0,0.3)">
+    <path
+      d="M 9,39 L 36,39 L 36,36 L 9,36 L 9,39 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 12,36 L 12,32 L 33,32 L 33,36 L 12,36 z "
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 11,14 L 11,9 L 15,9 L 15,11 L 20,11 L 20,9 L 25,9 L 25,11 L 30,11 L 30,9 L 34,9 L 34,14"
+      style="stroke-linecap:butt;" />
+    <path
+      d="M 34,14 L 31,17 L 14,17 L 11,14" />
+    <path
+      d="M 31,17 L 31,29.5 L 14,29.5 L 14,17"
+      style="stroke-linecap:butt; stroke-linejoin:miter;" />
+    <path
+      d="M 31,29.5 L 32.5,32 L 12.5,32 L 14,29.5" />
+    <path
+      d="M 11,14 L 34,14"
+      style="fill:none; stroke:#000000; stroke-linejoin:miter;" />
+  </g>
+</svg>

--- a/apps/web/src/__tests__/games-player-map.test.ts
+++ b/apps/web/src/__tests__/games-player-map.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { liveGames } from "@/games/registry";
+import { PLAYER_MAP } from "@/games/player-map";
+
+describe("games player map", () => {
+  it("every live game has a playable component", () => {
+    for (const g of liveGames()) {
+      expect(PLAYER_MAP[g.slug], `missing PLAYER_MAP entry for ${g.slug}`).toBeDefined();
+    }
+  });
+
+  it("chess-quest is wired (ready for the Phase C status flip)", () => {
+    expect(PLAYER_MAP["chess-quest"]).toBeDefined();
+  });
+});

--- a/apps/web/src/__tests__/games-registry.test.ts
+++ b/apps/web/src/__tests__/games-registry.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { GAMES, getGame, liveGames } from "@/games/registry";
+
+describe("games registry", () => {
+  it("has at least chess-quest", () => {
+    expect(getGame("chess-quest")).toMatchObject({ title: "Chess Quest" });
+  });
+
+  it("slugs are unique, url-safe, descriptive", () => {
+    const slugs = GAMES.map((g) => g.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const slug of slugs) {
+      expect(slug).toMatch(/^[a-z0-9-]+$/);
+      expect(slug).not.toMatch(/^game-\d+$/); // spec: descriptive, never numbered
+    }
+  });
+
+  it("every entry has complete card copy", () => {
+    for (const g of GAMES) {
+      expect(g.title.length).toBeGreaterThan(0);
+      expect(g.tagline.length).toBeGreaterThan(0);
+      expect(g.description.length).toBeGreaterThan(20);
+      expect(g.thumbnail.length).toBeGreaterThan(0);
+      expect(["live", "coming-soon"]).toContain(g.status);
+    }
+  });
+
+  it("getGame misses return undefined", () => {
+    expect(getGame("not-a-game")).toBeUndefined();
+  });
+
+  it("liveGames filters by status", () => {
+    for (const g of liveGames()) expect(g.status).toBe("live");
+  });
+});

--- a/apps/web/src/__tests__/proxy-games-host.test.ts
+++ b/apps/web/src/__tests__/proxy-games-host.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy, gamesHostRewrite } from "@/proxy";
+
+const req = (path: string, headers: Record<string, string>) =>
+  new NextRequest(`http://localhost:3000${path}`, { headers });
+
+const GAMES_HOST = { host: "games.seazn.club" };
+
+describe("games subdomain host rewrite", () => {
+  it("rewrites / to /games", () => {
+    expect(gamesHostRewrite(req("/", GAMES_HOST))?.pathname).toBe("/games");
+  });
+
+  it("rewrites /chess-quest to /games/chess-quest", () => {
+    expect(gamesHostRewrite(req("/chess-quest", GAMES_HOST))?.pathname).toBe(
+      "/games/chess-quest",
+    );
+  });
+
+  it("never double-prefixes /games paths", () => {
+    expect(gamesHostRewrite(req("/games", GAMES_HOST))).toBeNull();
+    expect(gamesHostRewrite(req("/games/chess-quest", GAMES_HOST))).toBeNull();
+  });
+
+  it("does not rewrite API calls", () => {
+    expect(gamesHostRewrite(req("/api/v1/public/discovery", GAMES_HOST))).toBeNull();
+  });
+
+  it("ignores non-games hosts (incl. lookalike paths)", () => {
+    expect(gamesHostRewrite(req("/", { host: "seazn.club" }))).toBeNull();
+    expect(gamesHostRewrite(req("/gamesfoo", GAMES_HOST))?.pathname).toBe("/games/gamesfoo");
+  });
+
+  it("prefers x-forwarded-host (Fly) over host", () => {
+    const r = req("/", { host: "internal:3000", "x-forwarded-host": "games.seazn.club" });
+    expect(gamesHostRewrite(r)?.pathname).toBe("/games");
+  });
+
+  it("strips ports before matching", () => {
+    expect(gamesHostRewrite(req("/", { host: "games.localhost:3000" }))?.pathname).toBe("/games");
+  });
+
+  it("proxy() rewrites and still stamps CSP", () => {
+    const res = proxy(req("/chess-quest", GAMES_HOST));
+    const rewrite = res.headers.get("x-middleware-rewrite");
+    expect(rewrite).toContain("/games/chess-quest");
+    expect(
+      res.headers.get("Content-Security-Policy-Report-Only") ??
+        res.headers.get("Content-Security-Policy"),
+    ).toContain("default-src 'self'");
+  });
+
+  it("proxy() leaves normal hosts alone", () => {
+    const res = proxy(req("/pricing", { host: "seazn.club" }));
+    expect(res.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/proxy-games-host.test.ts
+++ b/apps/web/src/__tests__/proxy-games-host.test.ts
@@ -27,6 +27,16 @@ describe("games subdomain host rewrite", () => {
     expect(gamesHostRewrite(req("/api/v1/public/discovery", GAMES_HOST))).toBeNull();
   });
 
+  it("leaves shared assets and non-page trees alone (found in browser demo)", () => {
+    // Public files: layout links /site.webmanifest on every page.
+    expect(gamesHostRewrite(req("/site.webmanifest", GAMES_HOST))).toBeNull();
+    expect(gamesHostRewrite(req("/brand/logo-wide.png", GAMES_HOST))).toBeNull();
+    // PostHog reverse proxy (next.config rewrites /ingest/* upstream).
+    expect(gamesHostRewrite(req("/ingest/array/phc_x/config.js", GAMES_HOST))).toBeNull();
+    // Multi-segment paths have no games route — pass through to 404 as-is.
+    expect(gamesHostRewrite(req("/chess-quest/deep/path", GAMES_HOST))).toBeNull();
+  });
+
   it("ignores non-games hosts (incl. lookalike paths)", () => {
     expect(gamesHostRewrite(req("/", { host: "seazn.club" }))).toBeNull();
     expect(gamesHostRewrite(req("/gamesfoo", GAMES_HOST))?.pathname).toBe("/games/gamesfoo");

--- a/apps/web/src/app/games/[slug]/game-player.tsx
+++ b/apps/web/src/app/games/[slug]/game-player.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { PLAYER_MAP } from "@/games/player-map";
+
+export function GamePlayer({ slug }: { slug: string }) {
+  const Game = PLAYER_MAP[slug];
+  // A live registry entry without a PLAYER_MAP entry is a wiring bug —
+  // the games-player-map unit test guards it; render nothing rather than crash.
+  if (!Game) return null;
+  return <Game />;
+}

--- a/apps/web/src/app/games/[slug]/page.tsx
+++ b/apps/web/src/app/games/[slug]/page.tsx
@@ -37,6 +37,12 @@ export default async function GamePage({ params }: { params: Promise<Params> }) 
         </Link>
         <span className="text-sm text-slate-300">|</span>
         <h1 className="mk-display text-base font-bold text-purple-950">{game.title}</h1>
+        <Link
+          href="/"
+          className="ml-auto text-xs text-slate-400 hover:text-purple-600"
+        >
+          Powered by <span className="font-semibold">Seazn Club</span>
+        </Link>
       </header>
       <main className="min-h-0 flex-1">
         {game.status === "live" ? (

--- a/apps/web/src/app/games/[slug]/page.tsx
+++ b/apps/web/src/app/games/[slug]/page.tsx
@@ -1,0 +1,59 @@
+// /games/<slug> — game player page. Slim chrome (no marketing footer):
+// header bar + full-height game area. Coming-soon games get a teaser panel.
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getGame } from "@/games/registry";
+import { GamePlayer } from "./game-player";
+
+type Params = { slug: string };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const game = getGame(slug);
+  if (!game) return {};
+  return {
+    title: `${game.title} — play free | Seazn Club`,
+    description: game.description,
+    // Canonical always on the apex domain so games.seazn.club doesn't split SEO.
+    alternates: { canonical: `https://seazn.club/games/${slug}` },
+  };
+}
+
+export default async function GamePage({ params }: { params: Promise<Params> }) {
+  const { slug } = await params;
+  const game = getGame(slug);
+  if (!game) notFound();
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-white">
+      <header className="flex items-center gap-3 border-b border-slate-200 px-4 py-2">
+        <Link href="/games" className="text-sm font-medium text-purple-600 hover:text-purple-800">
+          ← Games
+        </Link>
+        <span className="text-sm text-slate-300">|</span>
+        <h1 className="mk-display text-base font-bold text-purple-950">{game.title}</h1>
+      </header>
+      <main className="min-h-0 flex-1">
+        {game.status === "live" ? (
+          <GamePlayer slug={game.slug} />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+            <div className="text-6xl">{game.thumbnail}</div>
+            <h2 className="mk-display text-2xl font-bold text-purple-950">
+              {game.title} is coming soon
+            </h2>
+            <p className="max-w-md text-sm text-slate-500">{game.description}</p>
+            <Link href="/games" className="btn btn-ghost mt-2">
+              Browse other games
+            </Link>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/games/page.tsx
+++ b/apps/web/src/app/games/page.tsx
@@ -1,0 +1,59 @@
+// /games — Seazn Games listing. Cards come straight from the registry;
+// coming-soon games render as non-clickable cards with a badge.
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { GAMES } from "@/games/registry";
+
+export const metadata: Metadata = {
+  title: "Games — free browser games | Seazn Club",
+  description:
+    "Play free browser games by Seazn Club. Learn-to-play quests and quick challenges — no install, no sign-up.",
+  alternates: { canonical: "https://seazn.club/games" },
+};
+
+export default function GamesPage() {
+  return (
+    <MarketingShell>
+      <main className="mx-auto max-w-5xl px-4 py-12">
+        <h1 className="mk-display text-4xl font-bold text-purple-950">Games</h1>
+        <p className="mt-3 max-w-2xl text-lg text-slate-600">
+          Free games in your browser — pick one and play. No install, no sign-up.
+        </p>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {GAMES.map((g) =>
+            g.status === "live" ? (
+              <Link
+                key={g.slug}
+                href={`/games/${g.slug}`}
+                className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-purple-300 hover:shadow-md"
+              >
+                <div className="text-5xl">{g.thumbnail}</div>
+                <h2 className="mk-display mt-3 text-xl font-bold text-purple-950 group-hover:text-purple-700">
+                  {g.title}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">{g.tagline}</p>
+                <span className="mt-3 inline-block text-sm font-medium text-purple-600">
+                  Play →
+                </span>
+              </Link>
+            ) : (
+              <div
+                key={g.slug}
+                className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-5"
+              >
+                <div className="text-5xl opacity-60">{g.thumbnail}</div>
+                <h2 className="mk-display mt-3 text-xl font-bold text-slate-500">{g.title}</h2>
+                <p className="mt-1 text-sm text-slate-400">{g.tagline}</p>
+                <span className="mt-3 inline-block rounded-full bg-slate-200 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                  Coming soon
+                </span>
+              </div>
+            ),
+          )}
+        </div>
+      </main>
+    </MarketingShell>
+  );
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { listPublicSitemapEntries } from "@/server/public-site/data";
 import { listDiscoverySports } from "@/server/public-site/discovery";
+import { liveGames } from "@/games/registry";
 
 const BASE = "https://seazn.club";
 
@@ -11,6 +12,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE}/discover`, lastModified: now, changeFrequency: "hourly", priority: 0.9 },
     { url: `${BASE}/live`, lastModified: now, changeFrequency: "hourly", priority: 0.8 },
     { url: `${BASE}/pricing`, lastModified: now, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE}/games`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    ...liveGames().map((g) => ({
+      url: `${BASE}/games/${g.slug}`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    })),
     { url: `${BASE}/use-cases/clubs`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE}/use-cases/events`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: `${BASE}/use-cases/schools`, lastModified: now, changeFrequency: "monthly", priority: 0.8 },

--- a/apps/web/src/games/chess-quest/chess-quest.css
+++ b/apps/web/src/games/chess-quest/chess-quest.css
@@ -1,0 +1,135 @@
+/* Chess Quest board + game animations. Scoped with cq- prefixes; layout and
+   typography around the board stay Tailwind. */
+
+.cq-board {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  width: 100%;
+  max-width: 480px;
+  aspect-ratio: 1;
+  border: 2px solid var(--color-purple-950, #3b0764);
+  border-radius: 10px;
+  overflow: hidden;
+  touch-action: manipulation;
+}
+
+.cq-sq {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  cursor: pointer;
+  font-size: clamp(20px, 5.5vmin, 38px);
+  line-height: 1;
+}
+.cq-light {
+  background: #faf5ff; /* purple-50 */
+}
+.cq-dark {
+  background: #e9d5ff; /* purple-200 */
+}
+
+.cq-hl-sel {
+  box-shadow: inset 0 0 0 3px #9333ea; /* purple-600 */
+}
+.cq-hl-move::after {
+  content: "";
+  position: absolute;
+  width: 26%;
+  height: 26%;
+  border-radius: 9999px;
+  background: rgba(147, 51, 234, 0.45);
+}
+.cq-hl-cap {
+  box-shadow: inset 0 0 0 3px #f43f5e; /* rose-500 */
+}
+.cq-hl-hint {
+  box-shadow: inset 0 0 0 3px #f59e0b; /* amber-500 */
+  animation: cq-hint-pulse 0.9s ease-in-out infinite;
+}
+
+.cq-pc {
+  pointer-events: none;
+}
+.cq-pc-w {
+  color: #ffffff;
+  text-shadow:
+    0 0 2px #581c87,
+    0 1px 2px rgba(59, 7, 100, 0.6);
+}
+.cq-pc-b {
+  color: #1e1b4b; /* indigo-950 */
+}
+
+.cq-coin {
+  width: 40%;
+  height: 40%;
+  border-radius: 9999px;
+  background: radial-gradient(circle at 35% 30%, #fde68a, #f59e0b 70%);
+  box-shadow: 0 1px 3px rgba(120, 53, 15, 0.5);
+}
+
+/* rank number on the a-file, file letter on rank 1 */
+.cq-sq[data-rank]::before {
+  content: attr(data-rank);
+  position: absolute;
+  top: 2px;
+  left: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #7e22ce;
+  opacity: 0.7;
+}
+.cq-sq[data-file]::before {
+  content: attr(data-file);
+  position: absolute;
+  bottom: 1px;
+  right: 3px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #7e22ce;
+  opacity: 0.7;
+}
+.cq-sq[data-rank][data-file]::before {
+  content: attr(data-rank) " " attr(data-file);
+}
+
+.cq-pop {
+  animation: cq-pop 0.3s ease-out;
+}
+@keyframes cq-pop {
+  0% {
+    transform: scale(1.35);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.cq-shake {
+  animation: cq-shake 0.3s ease-in-out;
+}
+@keyframes cq-shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
+}
+
+@keyframes cq-hint-pulse {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 3px #f59e0b;
+  }
+  50% {
+    box-shadow: inset 0 0 0 5px #f59e0b;
+  }
+}

--- a/apps/web/src/games/chess-quest/chess-quest.css
+++ b/apps/web/src/games/chess-quest/chess-quest.css
@@ -131,3 +131,111 @@
     box-shadow: inset 0 0 0 5px #f59e0b;
   }
 }
+
+/* ---------- printable certificate ---------- */
+/* Hidden on screen; @media print hides the whole app and shows only the cert.
+   Print palette is hardcoded so a dark viewer never prints a dark sheet. */
+.cq-cert-sheet {
+  display: none;
+}
+
+@media print {
+  @page {
+    margin: 1.2cm;
+  }
+  body {
+    background: #ffffff !important;
+  }
+  /* Hide everything, then reveal only the certificate. */
+  body * {
+    visibility: hidden;
+  }
+  .cq-cert-sheet,
+  .cq-cert-sheet * {
+    visibility: visible;
+  }
+  .cq-cert-sheet {
+    display: block !important;
+    position: absolute;
+    inset: 0;
+  }
+  .cq-cert-frame {
+    border: 4px solid #2f7d52;
+    outline: 2px solid #c9971f;
+    outline-offset: 6px;
+    padding: 48px 40px 40px;
+    margin: 18px;
+    text-align: center;
+    color: #22301f;
+    font-family: Georgia, "Times New Roman", serif;
+  }
+  .cq-cert-crest {
+    font-size: 64px;
+    line-height: 1;
+    color: #2f7d52;
+  }
+  .cq-cert-brand {
+    font-weight: 800;
+    font-size: 14px;
+    letter-spacing: 0.35em;
+    text-transform: uppercase;
+    color: #c9971f;
+    margin-top: 10px;
+  }
+  .cq-cert-title {
+    font-size: 40px;
+    font-weight: 800;
+    margin: 14px 0 4px;
+    color: #22301f;
+  }
+  .cq-cert-lede {
+    font-style: italic;
+    font-size: 15px;
+    margin: 18px 0 6px;
+    color: #5f6e5c;
+  }
+  .cq-cert-name {
+    font-size: 44px;
+    font-weight: 700;
+    color: #2f7d52;
+    border-bottom: 2px solid #c9971f;
+    display: inline-block;
+    padding: 0 34px 6px;
+    margin: 4px 0 14px;
+    min-width: 40%;
+  }
+  .cq-cert-line {
+    font-size: 17px;
+    max-width: 60ch;
+    margin: 0 auto 18px;
+    line-height: 1.6;
+  }
+  .cq-cert-stats {
+    font-size: 15px;
+    color: #5f6e5c;
+    margin-bottom: 44px;
+  }
+  .cq-cert-foot {
+    display: flex;
+    justify-content: space-around;
+    gap: 30px;
+    margin-top: 26px;
+  }
+  .cq-cert-sig {
+    font-size: 12px;
+    color: #5f6e5c;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .cq-cert-sigline {
+    display: block;
+    font-size: 17px;
+    color: #22301f;
+    text-transform: none;
+    letter-spacing: 0;
+    border-top: 1.5px solid #22301f;
+    padding: 6px 26px 4px;
+    margin-bottom: 4px;
+    font-family: Georgia, serif;
+  }
+}

--- a/apps/web/src/games/chess-quest/chess-quest.css
+++ b/apps/web/src/games/chess-quest/chess-quest.css
@@ -4,6 +4,7 @@
 .cq-board {
   display: grid;
   grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
   width: 100%;
   max-width: 480px;
   aspect-ratio: 1;
@@ -21,6 +22,9 @@
   padding: 0;
   border: 0;
   cursor: pointer;
+  min-width: 0;
+  min-height: 0;
+  aspect-ratio: 1;
   font-size: clamp(20px, 5.5vmin, 38px);
   line-height: 1;
 }
@@ -52,15 +56,9 @@
 
 .cq-pc {
   pointer-events: none;
-}
-.cq-pc-w {
-  color: #ffffff;
-  text-shadow:
-    0 0 2px #581c87,
-    0 1px 2px rgba(59, 7, 100, 0.6);
-}
-.cq-pc-b {
-  color: #1e1b4b; /* indigo-950 */
+  width: 84%;
+  height: 84%;
+  object-fit: contain;
 }
 
 .cq-coin {

--- a/apps/web/src/games/chess-quest/components/Board.tsx
+++ b/apps/web/src/games/chess-quest/components/Board.tsx
@@ -43,12 +43,12 @@ export function Board({
   popToken?: { idx: number; n: number } | null;
   shakeToken?: number;
 }) {
-  // Re-mount the popped piece span so the CSS animation restarts.
-  const [popping, setPopping] = useState<{ idx: number; n: number } | null>(null);
-  useEffect(() => {
-    if (popToken) setPopping(popToken);
-  }, [popToken]);
+  // popToken drives the pop animation directly: the popped piece's `key`
+  // includes popToken.n, so bumping it re-mounts that span and replays the
+  // CSS keyframes — no extra state needed.
+  const popping = popToken ?? null;
 
+  // Shake replays a CSS animation for ~320ms after each shakeToken change.
   const [shaking, setShaking] = useState(false);
   const firstShake = useRef(true);
   useEffect(() => {

--- a/apps/web/src/games/chess-quest/components/Board.tsx
+++ b/apps/web/src/games/chess-quest/components/Board.tsx
@@ -80,14 +80,15 @@ export function Board({
         onClick={onTap ? () => onTap(idx) : undefined}
       >
         {p !== "" ? (
-          <span
+          // Classic Cburnett SVG pieces (see public/games/chess-quest/pieces/LICENSE.md)
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
             key={popping?.idx === idx ? `pop-${popping.n}` : "pc"}
-            className={`cq-pc ${isWhitePiece(p) ? "cq-pc-w" : "cq-pc-b"}${
-              popping?.idx === idx ? " cq-pop" : ""
-            }`}
-          >
-            {GLYPH[p.toUpperCase()]}
-          </span>
+            src={`/games/chess-quest/pieces/${p.toLowerCase()}${isWhitePiece(p) ? "l" : "d"}.svg`}
+            alt=""
+            draggable={false}
+            className={`cq-pc${popping?.idx === idx ? " cq-pop" : ""}`}
+          />
         ) : coins?.has(idx) ? (
           <span className="cq-coin" />
         ) : null}

--- a/apps/web/src/games/chess-quest/components/Board.tsx
+++ b/apps/web/src/games/chess-quest/components/Board.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+// Tap-to-move chess board (React port of the original js/board.js).
+// Controlled: position/highlights/coins come in as props; taps go out.
+// pop/shake are token-driven so a parent can retrigger CSS animations.
+import { useEffect, useRef, useState } from "react";
+import { FILES, fileOf, isWhitePiece, rankRow, sqName } from "../engine";
+
+export const GLYPH: Record<string, string> = {
+  P: "♟",
+  N: "♞",
+  B: "♝",
+  R: "♜",
+  Q: "♛",
+  K: "♚",
+};
+
+const PIECE_NAMES: Record<string, string> = {
+  P: "pawn",
+  N: "knight",
+  B: "bishop",
+  R: "rook",
+  Q: "queen",
+  K: "king",
+};
+
+export type Highlight = "sel" | "move" | "cap" | "hint";
+
+export function Board({
+  position,
+  highlights,
+  coins,
+  labels = false,
+  onTap,
+  popToken,
+  shakeToken,
+}: {
+  position: string[];
+  highlights?: Partial<Record<number, Highlight>>;
+  coins?: ReadonlySet<number>;
+  labels?: boolean;
+  onTap?(idx: number): void;
+  popToken?: { idx: number; n: number } | null;
+  shakeToken?: number;
+}) {
+  // Re-mount the popped piece span so the CSS animation restarts.
+  const [popping, setPopping] = useState<{ idx: number; n: number } | null>(null);
+  useEffect(() => {
+    if (popToken) setPopping(popToken);
+  }, [popToken]);
+
+  const [shaking, setShaking] = useState(false);
+  const firstShake = useRef(true);
+  useEffect(() => {
+    if (firstShake.current) {
+      firstShake.current = false;
+      return;
+    }
+    setShaking(true);
+    const t = setTimeout(() => setShaking(false), 320);
+    return () => clearTimeout(t);
+  }, [shakeToken]);
+
+  const squares = [];
+  for (let idx = 0; idx < 64; idx++) {
+    const p = position[idx];
+    const name = sqName(idx);
+    const hl = highlights?.[idx];
+    const light = (fileOf(idx) + rankRow(idx)) % 2 === 0;
+    const label = p !== "" ? `${name} ${isWhitePiece(p) ? "white" : "black"} ${PIECE_NAMES[p.toUpperCase()]}` : name;
+    squares.push(
+      <button
+        key={idx}
+        type="button"
+        data-square={name}
+        aria-label={label}
+        data-rank={labels && fileOf(idx) === 0 ? 8 - rankRow(idx) : undefined}
+        data-file={labels && rankRow(idx) === 7 ? FILES[fileOf(idx)] : undefined}
+        className={`cq-sq ${light ? "cq-light" : "cq-dark"}${hl ? ` cq-hl-${hl}` : ""}`}
+        onClick={onTap ? () => onTap(idx) : undefined}
+      >
+        {p !== "" ? (
+          <span
+            key={popping?.idx === idx ? `pop-${popping.n}` : "pc"}
+            className={`cq-pc ${isWhitePiece(p) ? "cq-pc-w" : "cq-pc-b"}${
+              popping?.idx === idx ? " cq-pop" : ""
+            }`}
+          >
+            {GLYPH[p.toUpperCase()]}
+          </span>
+        ) : coins?.has(idx) ? (
+          <span className="cq-coin" />
+        ) : null}
+      </button>,
+    );
+  }
+
+  return <div className={`cq-board${shaking ? " cq-shake" : ""}`}>{squares}</div>;
+}

--- a/apps/web/src/games/chess-quest/components/GameShell.tsx
+++ b/apps/web/src/games/chess-quest/components/GameShell.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+// Shared chrome for every mini-game (replaces the original modal): title +
+// score header, coach bubble with rich status and answer chips, an extra
+// slot (puzzle dots / piece pickers), the board, and a controls row.
+import { Rich } from "./rich";
+
+export function GameShell({
+  title,
+  score,
+  status,
+  chips,
+  extra,
+  controls,
+  children,
+}: {
+  title: string;
+  score?: React.ReactNode;
+  status: string;
+  chips?: { label: string; onPick(): void }[];
+  extra?: React.ReactNode;
+  controls?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-3 px-4 py-4">
+      <header className="flex items-baseline justify-between gap-3">
+        <h2 className="mk-display text-2xl font-bold text-purple-950">{title}</h2>
+        {score ? <div className="text-sm font-medium text-slate-600">{score}</div> : null}
+      </header>
+
+      <div className="flex items-start gap-2">
+        <span aria-hidden className="mt-1 text-2xl">
+          ♞
+        </span>
+        <div className="min-h-14 flex-1 rounded-2xl rounded-tl-sm border border-purple-200 bg-purple-50 px-3 py-2">
+          <Rich html={status} className="text-sm text-purple-950 [&_strong]:font-bold" />
+          {chips && chips.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {chips.map((c) => (
+                <button
+                  key={c.label}
+                  type="button"
+                  onClick={c.onPick}
+                  className="rounded-full border border-purple-300 bg-white px-3 py-1 text-xs font-medium text-purple-800 hover:bg-purple-100"
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {extra}
+
+      <div className="flex justify-center">{children}</div>
+
+      {controls ? <div className="flex flex-wrap justify-center gap-2">{controls}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/CoinHop.tsx
+++ b/apps/web/src/games/chess-quest/components/games/CoinHop.tsx
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { applyMove, fileOf, pieceTargets, rankRow } from "../../engine";
 import { emptyBoard, randSquares } from "../../lib/rand";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
 import { STAR_RULES } from "../../lib/stars";
 import { useProgress } from "../../lib/progress";
@@ -64,7 +65,7 @@ export function CoinHop({ pieces = ["N"] }: { pieces?: string[] }) {
     const stars = STAR_RULES.coinHop(totalMoves, piece);
     progress.setGameStars("coinHop", stars);
     setStatus(`All coins collected in <strong>${totalMoves}</strong> moves! ${"★".repeat(stars)}`);
-    sfx.fanfare();
+    celebrate();
   }
 
   function onTap(idx: number) {

--- a/apps/web/src/games/chess-quest/components/games/CoinHop.tsx
+++ b/apps/web/src/games/chess-quest/components/games/CoinHop.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+// Coin Hop — collect all 6 coins in as few moves as you can. Port of
+// js/games.js coinHop (lines 197–286): piece picker chips, bishop coins stay
+// on its color, pawn never promotes here, slider/stepper star pars.
+import { useCallback, useEffect, useState } from "react";
+import { applyMove, fileOf, pieceTargets, rankRow } from "../../engine";
+import { emptyBoard, randSquares } from "../../lib/rand";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useProgress } from "../../lib/progress";
+import { Board, GLYPH, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+
+const NAMES: Record<string, string> = {
+  R: "Rook",
+  B: "Bishop",
+  N: "Knight",
+  Q: "Queen",
+  K: "King",
+  P: "Pawn",
+};
+
+export function CoinHop({ pieces = ["N"] }: { pieces?: string[] }) {
+  const progress = useProgress();
+  const [piece, setPiece] = useState(pieces[0]);
+  const [position, setPosition] = useState<string[]>(emptyBoard());
+  const [pieceAt, setPieceAt] = useState(-1);
+  const [coins, setCoins] = useState<Set<number>>(new Set());
+  const [moves, setMoves] = useState(0);
+  const [sel, setSel] = useState(false);
+  const [done, setDone] = useState(false);
+  const [status, setStatus] = useState("");
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [shake, setShake] = useState(0);
+
+  const setup = useCallback(
+    (p: string) => {
+      setDone(false);
+      setSel(false);
+      setMoves(0);
+      setHighlights({});
+      const arr = emptyBoard();
+      const at = 27 + Math.floor(Math.random() * 10); // around the middle
+      arr[at] = p;
+      const sameColor = (i: number) =>
+        (fileOf(i) + rankRow(i)) % 2 === (fileOf(at) + rankRow(at)) % 2;
+      const coinIdxs = randSquares(6, [at], p === "B" ? sameColor : null);
+      setPosition(arr);
+      setPieceAt(at);
+      setCoins(new Set(coinIdxs));
+      setStatus(
+        `Tap the ${NAMES[p].toLowerCase()}, then tap where it should go. Collect all 6 coins!`,
+      );
+    },
+    [],
+  );
+
+  useEffect(() => setup(piece), [piece, setup]);
+
+  function finish(totalMoves: number) {
+    setDone(true);
+    const stars = STAR_RULES.coinHop(totalMoves, piece);
+    progress.setGameStars("coinHop", stars);
+    setStatus(`All coins collected in <strong>${totalMoves}</strong> moves! ${"★".repeat(stars)}`);
+    sfx.fanfare();
+  }
+
+  function onTap(idx: number) {
+    if (done) return;
+    if (idx === pieceAt) {
+      setSel(true);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of pieceTargets(position, idx)) hl[t] = "move";
+      setHighlights(hl);
+      return;
+    }
+    if (sel && pieceTargets(position, pieceAt).includes(idx)) {
+      let next = applyMove(position, pieceAt, idx);
+      // keep a pawn a pawn even across the last rank in this game
+      if (piece === "P") {
+        next = next.slice();
+        next[idx] = "P";
+      }
+      const nMoves = moves + 1;
+      setPosition(next);
+      setPieceAt(idx);
+      setMoves(nMoves);
+      setSel(false);
+      setHighlights({});
+      setPop({ idx, n: nMoves });
+      if (coins.has(idx)) {
+        const left = new Set(coins);
+        left.delete(idx);
+        setCoins(left);
+        sfx.coin();
+        if (left.size === 0) finish(nMoves);
+      } else {
+        sfx.move();
+      }
+    } else if (sel) {
+      setShake((s) => s + 1);
+    }
+  }
+
+  return (
+    <GameShell
+      title="Coin Hop"
+      score={
+        <span>
+          🪙 {coins.size} left &nbsp; 👣 {moves} moves
+        </span>
+      }
+      status={status}
+      extra={
+        pieces.length > 1 ? (
+          <div className="flex flex-wrap gap-2">
+            {pieces.map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setPiece(p)}
+                className={`rounded-full border px-3 py-1 text-sm font-medium ${
+                  p === piece
+                    ? "border-purple-600 bg-purple-600 text-white"
+                    : "border-purple-300 bg-white text-purple-800 hover:bg-purple-50"
+                }`}
+              >
+                {GLYPH[p]} {NAMES[p]}
+              </button>
+            ))}
+          </div>
+        ) : null
+      }
+      controls={
+        <button type="button" className="btn btn-ghost" onClick={() => setup(piece)}>
+          New coins
+        </button>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        coins={coins}
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/HangingHunt.tsx
+++ b/apps/web/src/games/chess-quest/components/games/HangingHunt.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+// Piece Detective — tap the black piece that's free to take (attacked and
+// undefended). Port of js/games.js hangingHunt (810–926): targeted coaching
+// for wrong taps, tap-the-guard flow for defended pieces.
+import { useCallback, useEffect, useState } from "react";
+import {
+  attackSquares,
+  defendersOf,
+  isAttacked,
+  isWhitePiece,
+  parseFEN,
+  sqIdx,
+} from "../../engine";
+import { HUNTS } from "../../content/puzzles";
+import { useCopy } from "../../lib/copy";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+import { PuzzleDots } from "./PuzzleDots";
+
+function firstUnsolved(isHuntSolved: (i: number) => boolean) {
+  for (let i = 0; i < HUNTS.length; i++) if (!isHuntSolved(i)) return i;
+  return 0;
+}
+
+export function HangingHunt() {
+  const progress = useProgress();
+  const { isStory } = useCopy();
+  const { later, clearPending } = useLater();
+  const [cur, setCur] = useState(() => firstUnsolved(progress.isHuntSolved));
+  const [position, setPosition] = useState<string[]>(() => parseFEN(HUNTS[cur].fen).board);
+  const [busy, setBusy] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+  const [coachTap, setCoachTap] = useState<((idx: number) => void) | null>(null);
+
+  const prompt = useCallback(
+    (h: (typeof HUNTS)[number]) =>
+      `${isStory() ? `<em>${h.story}</em><br>` : ""}Tap the black piece that is <strong>free to take</strong> — attacked, and nobody guards it!`,
+    [isStory],
+  );
+
+  const [status, setStatus] = useState(() => prompt(HUNTS[cur]));
+
+  const load = useCallback(
+    (i: number) => {
+      clearPending();
+      setCur(i);
+      setPosition(parseFEN(HUNTS[i].fen).board);
+      setHighlights({});
+      setBusy(false);
+      setCoachTap(null);
+      setStatus(prompt(HUNTS[i]));
+    },
+    [clearPending, prompt],
+  );
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  function solved(i: number) {
+    progress.setHuntSolved(i);
+    const n = progress.huntCount();
+    progress.setGameStars("hangingHunt", STAR_RULES.hangingHunt(n));
+    setStatus("<strong>Found it!</strong> 🔍 Free stuff detected.");
+    sfx.coin();
+    setBusy(true);
+    later(() => {
+      if (n < HUNTS.length) load(firstUnsolved(progress.isHuntSolved));
+      else {
+        setStatus(
+          "<strong>All cases closed!</strong> Official Free-Stuff Detector badge earned. ★★★",
+        );
+        sfx.fanfare();
+      }
+    }, 1300);
+  }
+
+  function onTap(idx: number) {
+    if (coachTap) {
+      coachTap(idx);
+      return;
+    }
+    if (busy) return;
+    const h = HUNTS[cur];
+    if (idx === sqIdx(h.answer)) {
+      setHighlights({ [idx]: "hint" });
+      setPop({ idx, n: popN + 1 });
+      setPopN((v) => v + 1);
+      solved(cur);
+      return;
+    }
+    const pos = position;
+    const p = pos[idx];
+    if (p === "" || isWhitePiece(p)) {
+      setShake((s) => s + 1);
+      sfx.bad();
+      setStatus("Tap a <strong>black</strong> piece — we’re hunting black’s loose ones!");
+    } else if (p === "k") {
+      setShake((s) => s + 1);
+      sfx.bad();
+      setStatus("Kings can never be taken — only checkmated! Hunt for a piece.");
+    } else if (!isAttacked(pos, idx, true)) {
+      setShake((s) => s + 1);
+      sfx.bad();
+      setStatus("Is anything even <strong>attacking</strong> that one? Trace every white piece’s path…");
+    } else {
+      const guards = defendersOf(pos, idx);
+      sfx.bad();
+      setStatus("It IS attacked — but it has a bodyguard! <strong>Tap the guard.</strong>");
+      setCoachTap(() => (t: number) => {
+        setCoachTap(null);
+        if (guards.includes(t)) {
+          setHighlights({ [t]: "hint" });
+          sfx.good();
+          setStatus("That’s the bodyguard! Free stuff has <strong>no</strong> guards. Keep hunting!");
+        } else {
+          setHighlights(Object.fromEntries(guards.map((g) => [g, "hint" as Highlight])));
+          setStatus("The glowing one guards it. Free stuff has no guards — keep hunting!");
+        }
+      });
+    }
+  }
+
+  function hint() {
+    const pos = position;
+    const ans = sqIdx(HUNTS[cur].answer);
+    const hl: Partial<Record<number, Highlight>> = {};
+    for (let i = 0; i < 64; i++) {
+      const p = pos[i];
+      if (p !== "" && isWhitePiece(p) && attackSquares(pos, i).includes(ans)) hl[i] = "hint";
+    }
+    setHighlights(hl);
+    setStatus(
+      `${isStory() ? `<em>${HUNTS[cur].story}</em><br>` : ""}Follow the glowing piece — what can it grab for free?`,
+    );
+  }
+
+  return (
+    <GameShell
+      title="Piece Detective"
+      score={`🔍 ${progress.huntCount()} / ${HUNTS.length} cases`}
+      status={status}
+      extra={
+        <PuzzleDots
+          count={HUNTS.length}
+          current={cur}
+          isSolved={progress.isHuntSolved}
+          onPick={load}
+          label="Case"
+        />
+      }
+      controls={
+        <>
+          <button type="button" className="btn btn-ghost" onClick={hint}>
+            Hint
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={() => {
+              progress.resetHunts();
+              load(0);
+            }}
+          >
+            Start cases over
+          </button>
+        </>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/HangingHunt.tsx
+++ b/apps/web/src/games/chess-quest/components/games/HangingHunt.tsx
@@ -14,7 +14,9 @@ import {
 } from "../../engine";
 import { HUNTS } from "../../content/puzzles";
 import { useCopy } from "../../lib/copy";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
+import { voice } from "../../lib/voice";
 import { STAR_RULES } from "../../lib/stars";
 import { useLater } from "../../lib/use-later";
 import { useProgress } from "../../lib/progress";
@@ -68,6 +70,7 @@ export function HangingHunt() {
     const n = progress.huntCount();
     progress.setGameStars("hangingHunt", STAR_RULES.hangingHunt(n));
     setStatus("<strong>Found it!</strong> 🔍 Free stuff detected.");
+    voice.say("Found it! Free stuff detected!");
     sfx.coin();
     setBusy(true);
     later(() => {
@@ -76,7 +79,7 @@ export function HangingHunt() {
         setStatus(
           "<strong>All cases closed!</strong> Official Free-Stuff Detector badge earned. ★★★",
         );
-        sfx.fanfare();
+        celebrate();
       }
     }, 1300);
   }

--- a/apps/web/src/games/chess-quest/components/games/MateInOne.tsx
+++ b/apps/web/src/games/chess-quest/components/games/MateInOne.tsx
@@ -6,9 +6,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { applyMove, isMate, isWhitePiece, legalTargets, parseFEN, sqIdx } from "../../engine";
 import { MATE1 } from "../../content/puzzles";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
 import { STAR_RULES } from "../../lib/stars";
 import { useLater } from "../../lib/use-later";
+import { voice } from "../../lib/voice";
 import { useProgress } from "../../lib/progress";
 import { Board, Highlight } from "../Board";
 import { GameShell } from "../GameShell";
@@ -61,7 +63,8 @@ export function MateInOne() {
     const n = progress.solvedCount();
     progress.setGameStars("mateInOne", STAR_RULES.packStars(n));
     setStatus("<strong>Checkmate!</strong> 🎉 The king has nowhere to run.");
-    sfx.fanfare();
+    voice.say("Checkmate! The king has nowhere to run!");
+    celebrate();
     setBusy(true);
     later(() => {
       if (n < MATE1.length) load(firstUnsolved(progress.isSolved));

--- a/apps/web/src/games/chess-quest/components/games/MateInOne.tsx
+++ b/apps/web/src/games/chess-quest/components/games/MateInOne.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+// Mate in 1 — solve the pack, any legal mating move accepted. Port of
+// js/games.js mateInOne (431–538); completion copy uses MATE1.length (the
+// original hardcoded "12" but the pack has 18).
+import { useCallback, useEffect, useState } from "react";
+import { applyMove, isMate, isWhitePiece, legalTargets, parseFEN, sqIdx } from "../../engine";
+import { MATE1 } from "../../content/puzzles";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+import { PuzzleDots } from "./PuzzleDots";
+import { Chip, runMateMiss } from "./mate-miss-coach";
+
+function firstUnsolved(isSolved: (i: number) => boolean) {
+  for (let i = 0; i < MATE1.length; i++) if (!isSolved(i)) return i;
+  return 0;
+}
+
+export function MateInOne() {
+  const progress = useProgress();
+  const { later, clearPending } = useLater();
+  const [cur, setCur] = useState(() => firstUnsolved(progress.isSolved));
+  const [position, setPosition] = useState<string[]>(() => parseFEN(MATE1[cur].fen).board);
+  const [selIdx, setSelIdx] = useState(-1);
+  const [tries, setTries] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+  const [chips, setChips] = useState<Chip[]>([]);
+  const [coachTap, setCoachTap] = useState<((idx: number) => void) | null>(null);
+  const [status, setStatus] = useState(
+    () => `<strong>${MATE1[cur].name}</strong> — white moves and checkmates in one!`,
+  );
+
+  const load = useCallback(
+    (i: number) => {
+      clearPending();
+      setCur(i);
+      setPosition(parseFEN(MATE1[i].fen).board);
+      setHighlights({});
+      setSelIdx(-1);
+      setTries(0);
+      setBusy(false);
+      setChips([]);
+      setCoachTap(null);
+      setStatus(`<strong>${MATE1[i].name}</strong> — white moves and checkmates in one!`);
+    },
+    [clearPending],
+  );
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  function solved(i: number) {
+    progress.setSolved(i);
+    const n = progress.solvedCount();
+    progress.setGameStars("mateInOne", STAR_RULES.packStars(n));
+    setStatus("<strong>Checkmate!</strong> 🎉 The king has nowhere to run.");
+    sfx.fanfare();
+    setBusy(true);
+    later(() => {
+      if (n < MATE1.length) load(firstUnsolved(progress.isSolved));
+      else
+        setStatus(
+          `<strong>Pack complete!</strong> All ${MATE1.length} checkmates found. ★★★`,
+        );
+    }, 1400);
+  }
+
+  function onTap(idx: number) {
+    if (coachTap) {
+      coachTap(idx);
+      return;
+    }
+    if (busy) return;
+    const pos = position;
+    const p = pos[idx];
+    if (p !== "" && isWhitePiece(p)) {
+      setSelIdx(idx);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of legalTargets(pos, idx)) hl[t] = pos[t] === "" ? "move" : "cap";
+      setHighlights(hl);
+      return;
+    }
+    if (selIdx >= 0 && legalTargets(pos, selIdx).includes(idx)) {
+      const next = applyMove(pos, selIdx, idx);
+      setSelIdx(-1);
+      if (isMate(next, false)) {
+        setPosition(next);
+        setHighlights({});
+        setPop({ idx, n: popN + 1 });
+        setPopN((v) => v + 1);
+        solved(cur);
+      } else {
+        const t = tries + 1;
+        setTries(t);
+        setPosition(next);
+        setHighlights({});
+        setBusy(true);
+        runMateMiss({
+          next,
+          resetBoard: parseFEN(MATE1[cur].fen).board,
+          extraNudge: t >= 2 ? " (The Hint button is your friend!)" : "",
+          setStatus,
+          setChips,
+          setCoachTap: (fn) => setCoachTap(() => fn),
+          setPosition,
+          setHighlights,
+          bumpShake: () => setShake((s) => s + 1),
+          later,
+          unlock: () => setBusy(false),
+          bad: sfx.bad,
+          good: sfx.good,
+        });
+      }
+    } else if (selIdx >= 0) {
+      setShake((s) => s + 1);
+    }
+  }
+
+  function hint() {
+    const from = sqIdx(MATE1[cur].solution.slice(0, 2));
+    setHighlights({ [from]: "hint" });
+    setStatus(`<strong>${MATE1[cur].name}</strong> — ${MATE1[cur].hint}`);
+  }
+
+  return (
+    <GameShell
+      title="Mate in 1"
+      score={`🧩 ${progress.solvedCount()} / ${MATE1.length} solved`}
+      status={status}
+      chips={chips}
+      extra={
+        <PuzzleDots
+          count={MATE1.length}
+          current={cur}
+          isSolved={progress.isSolved}
+          onPick={load}
+        />
+      }
+      controls={
+        <>
+          <button type="button" className="btn btn-ghost" onClick={hint}>
+            Hint
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={() => {
+              progress.resetPuzzles();
+              load(0);
+            }}
+          >
+            Start pack over
+          </button>
+        </>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/MateInTwo.tsx
+++ b/apps/web/src/games/chess-quest/components/games/MateInTwo.tsx
@@ -19,7 +19,9 @@ import {
   sqName,
 } from "../../engine";
 import { MATE2 } from "../../content/puzzles";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
+import { voice } from "../../lib/voice";
 import { STAR_RULES } from "../../lib/stars";
 import { useLater } from "../../lib/use-later";
 import { useProgress } from "../../lib/progress";
@@ -86,7 +88,8 @@ export function MateInTwo() {
     const n = progress.solved2Count();
     progress.setGameStars("mateInTwo", STAR_RULES.packStars(n));
     setStatus(msg);
-    sfx.fanfare();
+    voice.say(msg);
+    celebrate();
     setBusy(true);
     later(() => {
       if (n < MATE2.length) load(firstUnsolved(progress.isSolved2));

--- a/apps/web/src/games/chess-quest/components/games/MateInTwo.tsx
+++ b/apps/web/src/games/chess-quest/components/games/MateInTwo.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+// Mate in 2 — two phases. Port of js/games.js mateInTwo (540–706): phase 1
+// accepts any move that forces mate in two (or an immediate mate), plays
+// black's toughest defense, then phase 2 asks for the finishing mate-in-1.
+import { useCallback, useEffect, useState } from "react";
+import {
+  allLegalMoves,
+  applyMove,
+  bestDefense,
+  hasMateIn1,
+  inCheck,
+  isMate,
+  isMateIn2After,
+  isWhitePiece,
+  legalTargets,
+  parseFEN,
+  sqIdx,
+  sqName,
+} from "../../engine";
+import { MATE2 } from "../../content/puzzles";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+import { PuzzleDots } from "./PuzzleDots";
+import { Chip, runMateMiss } from "./mate-miss-coach";
+
+function firstUnsolved(isSolved2: (i: number) => boolean) {
+  for (let i = 0; i < MATE2.length; i++) if (!isSolved2(i)) return i;
+  return 0;
+}
+
+export function MateInTwo() {
+  const progress = useProgress();
+  const { later, clearPending } = useLater();
+  const [cur, setCur] = useState(() => firstUnsolved(progress.isSolved2));
+  const [position, setPosition] = useState<string[]>(() => parseFEN(MATE2[cur].fen).board);
+  const [selIdx, setSelIdx] = useState(-1);
+  const [tries, setTries] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [phase, setPhase] = useState<1 | 2>(1);
+  const [midBoard, setMidBoard] = useState<string[] | null>(null);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+  const [chips, setChips] = useState<Chip[]>([]);
+  const [coachTap, setCoachTap] = useState<((idx: number) => void) | null>(null);
+  const [status, setStatus] = useState(
+    () =>
+      `<strong>${MATE2[cur].name}</strong> — white forces checkmate in <strong>two</strong> moves. Find move one!`,
+  );
+
+  const load = useCallback(
+    (i: number) => {
+      clearPending();
+      setCur(i);
+      setPosition(parseFEN(MATE2[i].fen).board);
+      setHighlights({});
+      setSelIdx(-1);
+      setTries(0);
+      setBusy(false);
+      setPhase(1);
+      setMidBoard(null);
+      setChips([]);
+      setCoachTap(null);
+      setStatus(
+        `<strong>${MATE2[i].name}</strong> — white forces checkmate in <strong>two</strong> moves. Find move one!`,
+      );
+    },
+    [clearPending],
+  );
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  function popAt(idx: number) {
+    setPop({ idx, n: popN + 1 });
+    setPopN((v) => v + 1);
+  }
+
+  function solved(i: number, msg: string) {
+    progress.setSolved2(i);
+    const n = progress.solved2Count();
+    progress.setGameStars("mateInTwo", STAR_RULES.packStars(n));
+    setStatus(msg);
+    sfx.fanfare();
+    setBusy(true);
+    later(() => {
+      if (n < MATE2.length) load(firstUnsolved(progress.isSolved2));
+      else
+        setStatus(
+          "<strong>Pack complete!</strong> Twelve forced mates — real chess player thinking. ★★★",
+        );
+    }, 1600);
+  }
+
+  // Black plays its toughest defense, then hands the mate-in-1 back.
+  function blackReplies(afterWhite: string[]) {
+    setBusy(true);
+    later(() => {
+      const d = bestDefense(afterWhite);
+      if (!d) {
+        solved(cur, "<strong>Checkmate!</strong> 🎉");
+        return;
+      }
+      const afterBlack = applyMove(afterWhite, d.from, d.to);
+      setPosition(afterBlack);
+      popAt(d.to);
+      sfx.move();
+      setMidBoard(afterBlack);
+      setPhase(2);
+      setBusy(false);
+      setStatus(
+        `Locked in! Black tries <strong>${sqName(d.from)}–${sqName(d.to)}</strong>… now finish it. <strong>Mate in one!</strong>`,
+      );
+    }, 750);
+  }
+
+  function onTap(idx: number) {
+    if (coachTap) {
+      coachTap(idx);
+      return;
+    }
+    if (busy) return;
+    const pos = position;
+    const p = pos[idx];
+    if (p !== "" && isWhitePiece(p)) {
+      setSelIdx(idx);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of legalTargets(pos, idx)) hl[t] = pos[t] === "" ? "move" : "cap";
+      setHighlights(hl);
+      return;
+    }
+    if (selIdx < 0 || !legalTargets(pos, selIdx).includes(idx)) {
+      if (selIdx >= 0) setShake((s) => s + 1);
+      return;
+    }
+
+    const next = applyMove(pos, selIdx, idx);
+    const from = selIdx;
+    setSelIdx(-1);
+
+    if (phase === 1) {
+      if (isMate(next, false)) {
+        setPosition(next);
+        setHighlights({});
+        popAt(idx);
+        solved(cur, "<strong>Checkmate — even faster than asked!</strong> 🎉");
+      } else if (isMateIn2After(pos, from, idx)) {
+        setPosition(next);
+        setHighlights({});
+        popAt(idx);
+        sfx.good();
+        setStatus("That's the squeeze — black has no good answer…");
+        blackReplies(next);
+      } else {
+        const t = tries + 1;
+        setTries(t);
+        setPosition(next);
+        setHighlights({});
+        setBusy(true);
+        sfx.bad();
+        const replies = allLegalMoves(next, false);
+        let saveMove: { from: number; to: number } | null = null;
+        for (const r of replies) {
+          if (!hasMateIn1(applyMove(next, r.from, r.to), true)) {
+            saveMove = r;
+            break;
+          }
+        }
+        const nudge = t >= 2 ? " (The Hint button is your friend!)" : "";
+        const escapeTxt = saveMove
+          ? `black plays <strong>${sqName(saveMove.from)}–${sqName(saveMove.to)}</strong> and there is no mate`
+          : "black slips away";
+        later(() => {
+          setPosition(parseFEN(MATE2[cur].fen).board);
+          setShake((s) => s + 1);
+          setBusy(false);
+          setStatus(
+            (inCheck(next, false)
+              ? `It's check — but ${escapeTxt}. Find the move that leaves <strong>no way out</strong>.`
+              : `Black gets a free turn: ${escapeTxt}. Move one must be a check or an unstoppable threat!`) +
+              nudge,
+          );
+        }, 900);
+      }
+    } else {
+      // phase 2: must be mate in one
+      if (isMate(next, false)) {
+        setPosition(next);
+        setHighlights({});
+        popAt(idx);
+        solved(cur, "<strong>Checkmate!</strong> 🎉 A forced mate in two — beautifully done.");
+      } else {
+        const t = tries + 1;
+        setTries(t);
+        setPosition(next);
+        setHighlights({});
+        setBusy(true);
+        runMateMiss({
+          next,
+          resetBoard: midBoard ?? parseFEN(MATE2[cur].fen).board,
+          extraNudge: t >= 2 ? " (The Hint button is your friend!)" : "",
+          setStatus,
+          setChips,
+          setCoachTap: (fn) => setCoachTap(() => fn),
+          setPosition,
+          setHighlights,
+          bumpShake: () => setShake((s) => s + 1),
+          later,
+          unlock: () => setBusy(false),
+          bad: sfx.bad,
+          good: sfx.good,
+        });
+      }
+    }
+  }
+
+  function hint() {
+    if (phase === 1) {
+      setHighlights({ [sqIdx(MATE2[cur].solution.slice(0, 2))]: "hint" });
+      setStatus(`<strong>${MATE2[cur].name}</strong> — ${MATE2[cur].hint}`);
+    } else if (midBoard) {
+      for (const m of allLegalMoves(midBoard, true)) {
+        if (isMate(applyMove(midBoard, m.from, m.to), false)) {
+          setHighlights({ [m.from]: "hint" });
+          break;
+        }
+      }
+    }
+  }
+
+  return (
+    <GameShell
+      title="Mate in 2"
+      score={`🧩 ${progress.solved2Count()} / ${MATE2.length} solved`}
+      status={status}
+      chips={chips}
+      extra={
+        <PuzzleDots
+          count={MATE2.length}
+          current={cur}
+          isSolved={progress.isSolved2}
+          onPick={load}
+        />
+      }
+      controls={
+        <>
+          <button type="button" className="btn btn-ghost" onClick={hint}>
+            Hint
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={() => {
+              progress.resetPuzzles2();
+              load(0);
+            }}
+          >
+            Start pack over
+          </button>
+        </>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/PawnWars.tsx
+++ b/apps/web/src/games/chess-quest/components/games/PawnWars.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../engine";
 import { emptyBoard } from "../../lib/rand";
 import { useCopy } from "../../lib/copy";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
 import { STAR_RULES } from "../../lib/stars";
 import { useProgress } from "../../lib/progress";
@@ -74,7 +75,7 @@ export function PawnWars() {
         whiteWon ? t("⬜ The kid wins", "⬜ White wins") : t("⬛ The grown-up wins", "⬛ Black wins")
       } — ${why} ${"★".repeat(stars)}`,
     );
-    sfx.fanfare();
+    celebrate();
   }
 
   function bump() {

--- a/apps/web/src/games/chess-quest/components/games/PawnWars.tsx
+++ b/apps/web/src/games/chess-quest/components/games/PawnWars.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+// Pawn Wars — hot-seat pawns-only race, first to promote wins. Port of
+// js/games.js pawnWars (288–384): legal-target hints, promotion / stuck win
+// conditions, and the coach interjection when the kid hangs a pawn for free.
+import { useState } from "react";
+import {
+  allLegalMoves,
+  applyMove,
+  defendersOf,
+  isAttacked,
+  isWhitePiece,
+  legalTargets,
+} from "../../engine";
+import { emptyBoard } from "../../lib/rand";
+import { useCopy } from "../../lib/copy";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+
+function startBoard(): string[] {
+  const arr = emptyBoard();
+  for (let f = 0; f < 8; f++) {
+    arr[8 + f] = "p";
+    arr[48 + f] = "P";
+  }
+  return arr;
+}
+
+type Chip = { label: string; onPick(): void };
+
+export function PawnWars() {
+  const progress = useProgress();
+  const { t } = useCopy();
+  const [position, setPosition] = useState<string[]>(startBoard);
+  const [whiteToMove, setWhiteToMove] = useState(true);
+  const [selIdx, setSelIdx] = useState(-1);
+  const [over, setOver] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [shake, setShake] = useState(0);
+  const [popN, setPopN] = useState(0);
+  const [chips, setChips] = useState<Chip[]>([]);
+
+  const turnStatus = (white: boolean) =>
+    white
+      ? t(
+          "⬜ <strong>Kid’s move</strong> — race a pawn to the top!",
+          "⬜ <strong>White to move</strong> — race a pawn to the top!",
+        )
+      : t("⬛ <strong>Grown-up’s move</strong>", "⬛ <strong>Black to move</strong>");
+
+  const [status, setStatus] = useState(() => turnStatus(true));
+
+  function fresh() {
+    setPosition(startBoard());
+    setWhiteToMove(true);
+    setSelIdx(-1);
+    setOver(false);
+    setHighlights({});
+    setChips([]);
+    setStatus(turnStatus(true));
+  }
+
+  function win(whiteWon: boolean, why: string) {
+    setOver(true);
+    const stars = STAR_RULES.pawnWars(whiteWon);
+    progress.setGameStars("pawnWars", stars);
+    setChips([]);
+    setStatus(
+      `${
+        whiteWon ? t("⬜ The kid wins", "⬜ White wins") : t("⬛ The grown-up wins", "⬛ Black wins")
+      } — ${why} ${"★".repeat(stars)}`,
+    );
+    sfx.fanfare();
+  }
+
+  function bump() {
+    const n = popN + 1;
+    setPopN(n);
+    return n;
+  }
+
+  function onTap(idx: number) {
+    if (over) return;
+    const pos = position;
+    const p = pos[idx];
+    const mine = p !== "" && isWhitePiece(p) === whiteToMove;
+
+    if (mine) {
+      setSelIdx(idx);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const target of legalTargets(pos, idx)) hl[target] = pos[target] === "" ? "move" : "cap";
+      setHighlights(hl);
+      return;
+    }
+    if (selIdx >= 0 && legalTargets(pos, selIdx).includes(idx)) {
+      const next = applyMove(pos, selIdx, idx);
+      setPosition(next);
+      setHighlights({});
+      setPop({ idx, n: bump() });
+      sfx.move();
+      setSelIdx(-1);
+
+      if (next[idx] === "Q") return win(true, "a pawn was crowned! 👑");
+      if (next[idx] === "q") return win(false, "a pawn was crowned! 👑");
+
+      const nextWhite = !whiteToMove;
+      if (allLegalMoves(next, nextWhite).length === 0) {
+        return win(!nextWhite, nextWhite ? "white is stuck!" : "black is stuck!");
+      }
+
+      // Coach interjects if the kid just hung her pawn — she decides.
+      if (!nextWhite && isAttacked(next, idx, false) && defendersOf(next, idx).length === 0) {
+        const snap = pos;
+        const after = next;
+        setStatus("⚠️ Hold on — can black <strong>snack that pawn for free</strong>? Think…");
+        setChips([
+          {
+            label: "Oops! Take back",
+            onPick: () => {
+              if (JSON.stringify(position) !== JSON.stringify(after)) {
+                setStatus("Too late — the game moved on!");
+                setChips([]);
+                return;
+              }
+              setPosition(snap);
+              setWhiteToMove(true);
+              setHighlights({});
+              setChips([]);
+              setStatus("Good save! Look before you move — champion habit. ⬜ Your move again.");
+            },
+          },
+          {
+            label: "It’s my plan 😏",
+            onPick: () => {
+              setChips([]);
+              setStatus("Brave! Sometimes a pawn is bait. ⬛ <strong>Grown-up’s move…</strong>");
+            },
+          },
+        ]);
+        setWhiteToMove(nextWhite);
+        return;
+      }
+
+      setWhiteToMove(nextWhite);
+      setStatus(turnStatus(nextWhite));
+    } else if (selIdx >= 0) {
+      setShake((s) => s + 1);
+    }
+  }
+
+  return (
+    <GameShell
+      title="Pawn Wars"
+      status={status}
+      chips={chips}
+      controls={
+        <button type="button" className="btn btn-ghost" onClick={fresh}>
+          Restart
+        </button>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/PuzzleDots.tsx
+++ b/apps/web/src/games/chess-quest/components/games/PuzzleDots.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+// Numbered progress dots shared by the puzzle games (mate-in-1/2, hunts,
+// tactics). Solved dots fill; the current one is ringed.
+export function PuzzleDots({
+  count,
+  current,
+  isSolved,
+  onPick,
+  label = "Puzzle",
+}: {
+  count: number;
+  current: number;
+  isSolved(i: number): boolean;
+  onPick(i: number): void;
+  label?: string;
+}) {
+  return (
+    <div className="flex flex-wrap justify-center gap-1.5">
+      {Array.from({ length: count }, (_, i) => {
+        const solved = isSolved(i);
+        const cur = i === current;
+        return (
+          <button
+            key={i}
+            type="button"
+            aria-label={`${label} ${i + 1}`}
+            onClick={() => onPick(i)}
+            className={`h-6 w-6 rounded-full border text-xs font-semibold ${
+              solved
+                ? "border-emerald-500 bg-emerald-500 text-white"
+                : "border-purple-300 bg-white text-purple-700"
+            } ${cur ? "ring-2 ring-purple-500 ring-offset-1" : ""}`}
+          >
+            {i + 1}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/RookMaze.tsx
+++ b/apps/web/src/games/chess-quest/components/games/RookMaze.tsx
@@ -6,7 +6,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { applyMove, pathDistances, pieceTargets } from "../../engine";
 import { emptyBoard, randSquares } from "../../lib/rand";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
+import { voice } from "../../lib/voice";
 import { STAR_RULES } from "../../lib/stars";
 import { useLater } from "../../lib/use-later";
 import { useProgress } from "../../lib/progress";
@@ -88,7 +90,8 @@ export function RookMaze({ pieces = ["R"] }: { pieces?: string[] }) {
         totalMoves <= maze.par ? " — the perfect path! " : ` (best possible was ${maze.par}). `
       }${"★".repeat(stars)}`,
     );
-    sfx.fanfare();
+    voice.say(`Caught in ${totalMoves} moves!${totalMoves <= maze.par ? " The perfect path!" : ""}`);
+    celebrate();
   }
 
   function onTap(idx: number) {

--- a/apps/web/src/games/chess-quest/components/games/RookMaze.tsx
+++ b/apps/web/src/games/chess-quest/components/games/RookMaze.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+// Rook Maze — slide around your own pawns to catch the hiding prey in as few
+// moves as the shortest path allows. Port of js/games.js rookMaze (708–808):
+// generator with a distance floor, par display, blocked-lane coaching.
+import { useCallback, useEffect, useState } from "react";
+import { applyMove, pathDistances, pieceTargets } from "../../engine";
+import { emptyBoard, randSquares } from "../../lib/rand";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { Board, GLYPH, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+
+const NAMES: Record<string, string> = { R: "rook", B: "bishop", Q: "queen" };
+const PREY: Record<string, string> = { q: "queen", r: "rook", b: "bishop", n: "knight" };
+
+type MazeState = {
+  position: string[];
+  at: number;
+  target: number;
+  par: number;
+};
+
+function generate(piece: string): MazeState {
+  for (let tries = 0; tries < 60; tries++) {
+    const arr = emptyBoard();
+    const at = 48 + Math.floor(Math.random() * 16); // start on ranks 1–2
+    arr[at] = piece;
+    for (const w of randSquares(9, [at], null)) arr[w] = "P";
+    const dist = pathDistances(arr, at);
+    const cand: number[] = [];
+    for (let i = 0; i < 64; i++) if (i !== at && arr[i] === "" && dist[i] >= 3) cand.push(i);
+    if (!cand.length) continue;
+    const target = cand[Math.floor(Math.random() * cand.length)];
+    const preyKeys = piece === "B" ? ["q", "r", "n"] : ["q", "b", "n"];
+    arr[target] = preyKeys[Math.floor(Math.random() * preyKeys.length)];
+    const d2 = pathDistances(arr, at);
+    if (d2[target] < 2) continue; // prey blocked its own lane — regenerate
+    return { position: arr, at, target, par: d2[target] };
+  }
+  // Fallback (extremely unlikely): open board, rook a1, prey h8.
+  const arr = emptyBoard();
+  arr[56] = piece;
+  arr[7] = "q";
+  return { position: arr, at: 56, target: 7, par: pathDistances(arr, 56)[7] };
+}
+
+export function RookMaze({ pieces = ["R"] }: { pieces?: string[] }) {
+  const progress = useProgress();
+  const { clearPending } = useLater();
+  const [piece, setPiece] = useState(pieces[0]);
+  const [maze, setMaze] = useState<MazeState>(() => generate(pieces[0]));
+  const [at, setAt] = useState(maze.at);
+  const [moves, setMoves] = useState(0);
+  const [sel, setSel] = useState(false);
+  const [done, setDone] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+
+  const promptFor = (m: MazeState) =>
+    `The cheeky <strong>${PREY[m.position[m.target]]}</strong> hides behind the walls! Your own pawns block the road — go <strong>around</strong> and catch her. Can you do it in ${m.par} moves?`;
+
+  const [status, setStatus] = useState(() => promptFor(maze));
+
+  const gen = useCallback((p: string) => {
+    const m = generate(p);
+    setMaze(m);
+    setAt(m.at);
+    setMoves(0);
+    setSel(false);
+    setDone(false);
+    setHighlights({});
+    setStatus(promptFor(m));
+  }, []);
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  function finish(totalMoves: number) {
+    setDone(true);
+    const stars = STAR_RULES.rookMaze(totalMoves, maze.par);
+    progress.setGameStars("rookMaze", stars);
+    setStatus(
+      `<strong>Caught!</strong> 🏁 ${totalMoves} moves${
+        totalMoves <= maze.par ? " — the perfect path! " : ` (best possible was ${maze.par}). `
+      }${"★".repeat(stars)}`,
+    );
+    sfx.fanfare();
+  }
+
+  function onTap(idx: number) {
+    if (done) return;
+    const pos = maze.position;
+    if (idx === at) {
+      setSel(true);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of pieceTargets(pos, idx)) hl[t] = pos[t] === "" ? "move" : "cap";
+      setHighlights(hl);
+      return;
+    }
+    if (sel && pieceTargets(pos, at).includes(idx)) {
+      const caught = idx === maze.target;
+      const next = applyMove(pos, at, idx);
+      setMaze({ ...maze, position: next });
+      setAt(idx);
+      const nMoves = moves + 1;
+      setMoves(nMoves);
+      setSel(false);
+      setHighlights({});
+      setPop({ idx, n: popN + 1 });
+      setPopN((v) => v + 1);
+      if (caught) finish(nMoves);
+      else sfx.move();
+    } else if (sel) {
+      setShake((s) => s + 1);
+      sfx.bad();
+      setStatus("The road is blocked there! Sliders can’t jump — find the <strong>open lane</strong>.");
+    }
+  }
+
+  return (
+    <GameShell
+      title="Rook Maze"
+      score={`👣 ${moves} moves · 🎯 best possible: ${maze.par}`}
+      status={status}
+      extra={
+        pieces.length > 1 ? (
+          <div className="flex flex-wrap justify-center gap-2">
+            {pieces.map((p) => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => {
+                  setPiece(p);
+                  gen(p);
+                }}
+                className={`rounded-full border px-3 py-1 text-sm font-medium ${
+                  p === piece
+                    ? "border-purple-600 bg-purple-600 text-white"
+                    : "border-purple-300 bg-white text-purple-800 hover:bg-purple-50"
+                }`}
+              >
+                {GLYPH[p]} {NAMES[p]}
+              </button>
+            ))}
+          </div>
+        ) : null
+      }
+      controls={
+        <button type="button" className="btn btn-ghost" onClick={() => gen(piece)}>
+          New maze
+        </button>
+      }
+    >
+      <Board
+        position={maze.position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/SquareRace.tsx
+++ b/apps/web/src/games/chess-quest/components/games/SquareRace.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+// Square Race — 60 seconds, tap the called-out square. Port of js/games.js
+// squareRace (lines 136–195): scoring flash, 5-streak celebration hook point,
+// best-score record, star thresholds from STAR_RULES.
+import { useEffect, useRef, useState } from "react";
+import { sqName } from "../../engine";
+import { emptyBoard } from "../../lib/rand";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+
+const EMPTY = emptyBoard();
+
+export function SquareRace() {
+  const progress = useProgress();
+  const { later, clearPending } = useLater();
+  const [running, setRunning] = useState(false);
+  const [score, setScore] = useState(0);
+  const [time, setTime] = useState(60);
+  const [target, setTarget] = useState(-1);
+  const [status, setStatus] = useState(
+    "Tap the square I call out. The little letters and numbers help!",
+  );
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [shake, setShake] = useState(0);
+  const scoreRef = useRef(0);
+
+  useEffect(() => {
+    if (!running) return;
+    const timer = setInterval(() => {
+      setTime((t) => t - 1);
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [running]);
+
+  useEffect(() => {
+    if (running && time <= 0) {
+      setRunning(false);
+      setHighlights({});
+      const s = scoreRef.current;
+      const stars = STAR_RULES.squareRace(s);
+      const record = progress.setBest("squareRace", s);
+      if (stars) progress.setGameStars("squareRace", stars);
+      setStatus(
+        `Time! You found <strong>${s}</strong> squares ${"★".repeat(stars)}${
+          record ? " — new record!" : ""
+        }<br><small>Best so far: ${progress.getBest("squareRace")}</small>`,
+      );
+    }
+    // progress is intentionally omitted: reading it here must not rearm the effect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [time, running]);
+
+  function newTarget() {
+    const t = Math.floor(Math.random() * 64);
+    setTarget(t);
+    setStatus(`Find <strong class="text-lg">${sqName(t)}</strong> !`);
+  }
+
+  function start() {
+    scoreRef.current = 0;
+    setScore(0);
+    setTime(60);
+    setRunning(true);
+    newTarget();
+  }
+
+  function onTap(idx: number) {
+    if (!running) return;
+    if (idx === target) {
+      scoreRef.current += 1;
+      setScore(scoreRef.current);
+      sfx.good();
+      setHighlights({ [idx]: "hint" });
+      later(() => setHighlights({}), 250);
+      newTarget();
+    } else {
+      setShake((s) => s + 1);
+      sfx.bad();
+    }
+  }
+
+  return (
+    <GameShell
+      title="Square Race"
+      score={
+        <span>
+          ⭐ {score} &nbsp; <span className="tabular-nums">⏱ {time}s</span>
+        </span>
+      }
+      status={status}
+      controls={
+        !running ? (
+          <button type="button" className="btn btn-primary" onClick={() => { clearPending(); start(); }}>
+            {score > 0 || time <= 0 ? "Play again" : "Start! (60 seconds)"}
+          </button>
+        ) : null
+      }
+    >
+      <Board position={EMPTY} labels highlights={highlights} shakeToken={shake} onTap={onTap} />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/SquareRace.tsx
+++ b/apps/web/src/games/chess-quest/components/games/SquareRace.tsx
@@ -3,7 +3,7 @@
 // Square Race — 60 seconds, tap the called-out square. Port of js/games.js
 // squareRace (lines 136–195): scoring flash, 5-streak celebration hook point,
 // best-score record, star thresholds from STAR_RULES.
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { sqName } from "../../engine";
 import { emptyBoard } from "../../lib/rand";
 import { sfx } from "../../lib/sfx";
@@ -28,32 +28,36 @@ export function SquareRace() {
   const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
   const [shake, setShake] = useState(0);
   const scoreRef = useRef(0);
+  const timeRef = useRef(60);
+
+  // finish runs from the interval callback (not the effect body), so its
+  // setState calls don't trip the cascading-render lint.
+  const finish = useCallback(() => {
+    setRunning(false);
+    setHighlights({});
+    const s = scoreRef.current;
+    const stars = STAR_RULES.squareRace(s);
+    const record = progress.setBest("squareRace", s);
+    if (stars) progress.setGameStars("squareRace", stars);
+    setStatus(
+      `Time! You found <strong>${s}</strong> squares ${"★".repeat(stars)}${
+        record ? " — new record!" : ""
+      }<br><small>Best so far: ${progress.getBest("squareRace")}</small>`,
+    );
+  }, [progress]);
 
   useEffect(() => {
     if (!running) return;
     const timer = setInterval(() => {
-      setTime((t) => t - 1);
+      timeRef.current -= 1;
+      setTime(timeRef.current);
+      if (timeRef.current <= 0) {
+        clearInterval(timer);
+        finish();
+      }
     }, 1000);
     return () => clearInterval(timer);
-  }, [running]);
-
-  useEffect(() => {
-    if (running && time <= 0) {
-      setRunning(false);
-      setHighlights({});
-      const s = scoreRef.current;
-      const stars = STAR_RULES.squareRace(s);
-      const record = progress.setBest("squareRace", s);
-      if (stars) progress.setGameStars("squareRace", stars);
-      setStatus(
-        `Time! You found <strong>${s}</strong> squares ${"★".repeat(stars)}${
-          record ? " — new record!" : ""
-        }<br><small>Best so far: ${progress.getBest("squareRace")}</small>`,
-      );
-    }
-    // progress is intentionally omitted: reading it here must not rearm the effect
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [time, running]);
+  }, [running, finish]);
 
   function newTarget() {
     const t = Math.floor(Math.random() * 64);
@@ -63,6 +67,7 @@ export function SquareRace() {
 
   function start() {
     scoreRef.current = 0;
+    timeRef.current = 60;
     setScore(0);
     setTime(60);
     setRunning(true);

--- a/apps/web/src/games/chess-quest/components/games/TacticTrainer.tsx
+++ b/apps/web/src/games/chess-quest/components/games/TacticTrainer.tsx
@@ -21,7 +21,9 @@ import {
 } from "../../engine";
 import { TACTICS, TACTICS2 } from "../../content/puzzles";
 import { useCopy } from "../../lib/copy";
+import { celebrate } from "../../lib/celebrate";
 import { sfx } from "../../lib/sfx";
+import { voice } from "../../lib/voice";
 import { STAR_RULES } from "../../lib/stars";
 import { useLater } from "../../lib/use-later";
 import { useProgress } from "../../lib/progress";
@@ -131,7 +133,8 @@ export function TacticTrainer({ pack: initialPack = "fork" }: { pack?: string })
       tier2 ? STAR_RULES.packStars(total) : STAR_RULES.tacticTier1(total),
     );
     setStatus(`<strong>${info.name}!</strong> 🎯 Beautifully done.`);
-    sfx.fanfare();
+    voice.say(`${info.name}! Beautifully done!`);
+    celebrate();
     setBusy(true);
     later(() => {
       const n = progress.tacticCount(pack);

--- a/apps/web/src/games/chess-quest/components/games/TacticTrainer.tsx
+++ b/apps/web/src/games/chess-quest/components/games/TacticTrainer.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+// Trick Shots — play a move that pulls off the pack's tactic. Port of
+// js/games.js tacticTrainer (928–1092), plus a free-play pack picker (the
+// hub has no curriculum context to choose a pack for us).
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  applyMove,
+  attackSquares,
+  attackersOf,
+  Board as BoardType,
+  isAttacked,
+  isDiscoveredAfter,
+  isForkAfter,
+  isPinAfter,
+  isSkewerAfter,
+  isWhitePiece,
+  legalTargets,
+  parseFEN,
+  sqIdx,
+} from "../../engine";
+import { TACTICS, TACTICS2 } from "../../content/puzzles";
+import { useCopy } from "../../lib/copy";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+import { PuzzleDots } from "./PuzzleDots";
+import { Chip } from "./mate-miss-coach";
+
+const PACK_INFO: Record<string, { name: string; ask: string }> = {
+  fork: { name: "The Fork", ask: "Play a move that attacks TWO things at once!" },
+  pin: { name: "The Pin", ask: "Play a move that freezes a piece to something precious behind it!" },
+  skewer: { name: "The Skewer", ask: "Attack the big one in front — grab what hides behind!" },
+  disco: { name: "Discovered Attack", ask: "Move one piece so the piece behind it attacks — surprise!" },
+  fork2: { name: "The Fork — Master", ask: "Fork two big pieces from a square nobody can punish!" },
+  pin2: { name: "The Pin — Master", ask: "Build the line of three: you, their piece, their treasure behind it." },
+  skewer2: { name: "The Skewer — Master", ask: "Poke the big one in front so it must run — collect what hides behind." },
+  disco2: { name: "Discovered Attack — Master", ask: "Move one piece, unleash another — make BOTH of them threaten something!" },
+};
+
+const DETECTOR: Record<string, (b: BoardType, to: number) => boolean> = {
+  fork: isForkAfter,
+  pin: isPinAfter,
+  skewer: isSkewerAfter,
+  disco: (b, to) => isDiscoveredAfter(b, to, true),
+};
+DETECTOR.fork2 = DETECTOR.fork;
+DETECTOR.pin2 = DETECTOR.pin;
+DETECTOR.skewer2 = DETECTOR.skewer;
+DETECTOR.disco2 = DETECTOR.disco;
+
+const TIER1 = ["fork", "pin", "skewer", "disco"];
+const TIER2 = ["fork2", "pin2", "skewer2", "disco2"];
+const PACK_GLYPH: Record<string, string> = {
+  fork: "🍴",
+  pin: "📌",
+  skewer: "🍢",
+  disco: "🎭",
+  fork2: "🍴",
+  pin2: "📌",
+  skewer2: "🍢",
+  disco2: "🎭",
+};
+
+function casesOf(pack: string) {
+  return (TACTICS as Record<string, { fen: string; solution: string; story: string }[]>)[pack] ??
+    (TACTICS2 as Record<string, { fen: string; solution: string; story: string }[]>)[pack];
+}
+
+export function TacticTrainer({ pack: initialPack = "fork" }: { pack?: string }) {
+  const progress = useProgress();
+  const { isStory } = useCopy();
+  const { later, clearPending } = useLater();
+  const [pack, setPack] = useState(initialPack);
+  const cases = useMemo(() => casesOf(pack), [pack]);
+  const info = PACK_INFO[pack];
+
+  const firstUnsolved = useCallback(() => {
+    for (let i = 0; i < cases.length; i++) if (!progress.isTacticSolved(pack, i)) return i;
+    return 0;
+  }, [cases.length, pack, progress]);
+
+  const [cur, setCur] = useState(() => firstUnsolved());
+  const [position, setPosition] = useState<string[]>(() => parseFEN(cases[cur].fen).board);
+  const [selIdx, setSelIdx] = useState(-1);
+  const [busy, setBusy] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+  const [chips, setChips] = useState<Chip[]>([]);
+  const [coachTap, setCoachTap] = useState<((idx: number) => void) | null>(null);
+
+  const prompt = useCallback(
+    (c: { story: string }) =>
+      `${isStory() ? `<em>${c.story}</em><br>` : ""}${info.ask}`,
+    [info.ask, isStory],
+  );
+
+  const [status, setStatus] = useState(() => prompt(cases[cur]));
+
+  const load = useCallback(
+    (p: string, i: number) => {
+      clearPending();
+      const cs = casesOf(p);
+      setPack(p);
+      setCur(i);
+      setPosition(parseFEN(cs[i].fen).board);
+      setHighlights({});
+      setSelIdx(-1);
+      setBusy(false);
+      setChips([]);
+      setCoachTap(null);
+      setStatus(`${isStory() ? `<em>${cs[i].story}</em><br>` : ""}${PACK_INFO[p].ask}`);
+    },
+    [clearPending, isStory],
+  );
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  function solved() {
+    progress.setTacticSolved(pack, cur);
+    const tier2 = pack.endsWith("2");
+    const keys = tier2 ? TIER2 : TIER1;
+    const total = keys.reduce((s, p) => s + progress.tacticCount(p), 0);
+    progress.setGameStars(
+      tier2 ? "tacticTrainer2" : "tacticTrainer",
+      tier2 ? STAR_RULES.packStars(total) : STAR_RULES.tacticTier1(total),
+    );
+    setStatus(`<strong>${info.name}!</strong> 🎯 Beautifully done.`);
+    sfx.fanfare();
+    setBusy(true);
+    later(() => {
+      const n = progress.tacticCount(pack);
+      if (n < cases.length) {
+        for (let i = 0; i < cases.length; i++)
+          if (!progress.isTacticSolved(pack, i)) {
+            load(pack, i);
+            return;
+          }
+      } else {
+        setStatus(`<strong>${info.name} mastered!</strong> Try the other tricks with the chips above.`);
+      }
+    }, 1400);
+  }
+
+  function onTap(idx: number) {
+    if (coachTap) {
+      coachTap(idx);
+      return;
+    }
+    if (busy) return;
+    const pos = position;
+    const p = pos[idx];
+    if (p !== "" && isWhitePiece(p)) {
+      setSelIdx(idx);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of legalTargets(pos, idx)) hl[t] = pos[t] === "" ? "move" : "cap";
+      setHighlights(hl);
+      return;
+    }
+    if (selIdx < 0 || !legalTargets(pos, selIdx).includes(idx)) {
+      if (selIdx >= 0) {
+        setShake((s) => s + 1);
+        sfx.bad();
+      }
+      return;
+    }
+
+    const next = applyMove(pos, selIdx, idx);
+    setSelIdx(-1);
+    if (DETECTOR[pack](next, idx)) {
+      setPosition(next);
+      setHighlights({});
+      setPop({ idx, n: popN + 1 });
+      setPopN((v) => v + 1);
+      solved();
+      return;
+    }
+
+    // Wrong move — pack-specific coaching, then reset the puzzle.
+    setPosition(next);
+    setHighlights({});
+    sfx.bad();
+    setBusy(true);
+    const resetFen = cases[cur].fen;
+    const backSoon = (msg: string) =>
+      later(() => {
+        setPosition(parseFEN(resetFen).board);
+        setShake((s) => s + 1);
+        setBusy(false);
+        setChips([]);
+        setCoachTap(null);
+        setStatus(msg);
+      }, 500);
+
+    if (pack === "fork" || pack === "fork2") {
+      const hits = attackSquares(next, idx).filter(
+        (t) => next[t] !== "" && !isWhitePiece(next[t]) && next[t] !== "p",
+      );
+      if (isAttacked(next, idx, false)) {
+        const eaters = attackersOf(next, idx, false);
+        setStatus(
+          "Uh-oh — that square is dangerous! <strong>Tap the enemy</strong> that could eat your piece there.",
+        );
+        setCoachTap(() => (t: number) => {
+          setCoachTap(null);
+          if (eaters.includes(t)) {
+            setHighlights({ [t]: "cap" });
+            sfx.good();
+            backSoon("You spotted it! A fork only works from a <strong>safe</strong> square. Try again.");
+          } else {
+            setHighlights(Object.fromEntries(eaters.map((e) => [e, "cap" as Highlight])));
+            backSoon("It was the glowing one! Safe square first, fork second. Go again.");
+          }
+        });
+      } else {
+        const n = hits.length;
+        setStatus("Count with me — how many big enemy pieces does it attack from there?");
+        setChips([
+          {
+            label: String(n),
+            onPick: () =>
+              backSoon(
+                `Yes — ${n === 1 ? "just one" : n}! A fork needs <strong>two at once</strong>. Hunt for the magic square!`,
+              ),
+          },
+          {
+            label: String(n === 2 ? 1 : 2),
+            onPick: () => backSoon(`Count slowly next time — it was ${n}. A fork needs two at once!`),
+          },
+        ]);
+      }
+    } else if (pack === "pin" || pack === "pin2") {
+      backSoon(
+        "A pin is a line of three: you → their piece → something <strong>precious hiding behind</strong>. Did your move build that line? Look for the stack!",
+      );
+    } else if (pack === "skewer" || pack === "skewer2") {
+      backSoon(
+        "A skewer pokes the <strong>big one in front</strong> so it must run. What treasure stands behind it? Find that line!",
+      );
+    } else {
+      backSoon(
+        "The magic piece is the one <strong>behind</strong>: step aside and let a hidden friend attack. Which of your pieces is blocking a friend?",
+      );
+    }
+  }
+
+  function hint() {
+    setHighlights({ [sqIdx(cases[cur].solution.slice(0, 2))]: "hint" });
+  }
+
+  const allPacks = [...TIER1, ...TIER2];
+
+  return (
+    <GameShell
+      title={`Trick Shots — ${info.name}`}
+      score={`🎯 ${progress.tacticCount(pack)} / ${cases.length}`}
+      status={status}
+      chips={chips}
+      extra={
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap justify-center gap-1.5">
+            {allPacks.map((pk) => (
+              <button
+                key={pk}
+                type="button"
+                onClick={() => load(pk, 0)}
+                className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+                  pk === pack
+                    ? "border-purple-600 bg-purple-600 text-white"
+                    : "border-purple-300 bg-white text-purple-800 hover:bg-purple-50"
+                }`}
+              >
+                {PACK_GLYPH[pk]} {PACK_INFO[pk].name}
+              </button>
+            ))}
+          </div>
+          <PuzzleDots
+            count={cases.length}
+            current={cur}
+            isSolved={(i) => progress.isTacticSolved(pack, i)}
+            onPick={(i) => load(pack, i)}
+          />
+        </div>
+      }
+      controls={
+        <>
+          <button type="button" className="btn btn-ghost" onClick={hint}>
+            Hint
+          </button>
+          <button
+            type="button"
+            className="btn btn-ghost"
+            onClick={() => {
+              progress.resetTactics(pack);
+              load(pack, 0);
+            }}
+          >
+            Start pack over
+          </button>
+        </>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/games/mate-miss-coach.ts
+++ b/apps/web/src/games/chess-quest/components/games/mate-miss-coach.ts
@@ -1,0 +1,87 @@
+// Drives the "why wasn't that mate?" coach flow for the mate games — a direct
+// port of js/games.js mateMissCoach (386–429). Given the board after a wrong
+// move and a set of game callbacks, it diagnoses no-check / escapable /
+// capturable and walks the player toward the fix, then resets.
+import { Board } from "../../engine";
+import { classifyMateMiss } from "../../lib/mate-miss";
+import { Highlight } from "../Board";
+
+export type Chip = { label: string; onPick(): void };
+
+export type MateMissCtx = {
+  next: Board; // board after the non-mating move
+  resetBoard: Board; // board to restore to
+  extraNudge: string;
+  setStatus(s: string): void;
+  setChips(c: Chip[]): void;
+  setCoachTap(fn: ((idx: number) => void) | null): void;
+  setPosition(b: Board): void;
+  setHighlights(h: Partial<Record<number, Highlight>>): void;
+  bumpShake(): void;
+  later(fn: () => void, ms: number): void;
+  unlock(): void;
+  bad(): void;
+  good(): void;
+};
+
+export function runMateMiss(ctx: MateMissCtx) {
+  ctx.bad();
+  const backSoon = (msg: string) =>
+    ctx.later(() => {
+      ctx.setPosition(ctx.resetBoard.slice());
+      ctx.bumpShake();
+      ctx.unlock();
+      ctx.setChips([]);
+      ctx.setCoachTap(null);
+      ctx.setStatus(msg + ctx.extraNudge);
+    }, 500);
+
+  const res = classifyMateMiss(ctx.next);
+
+  if (res.kind === "no-check") {
+    ctx.setStatus("Look at the black king… is he even in <strong>check</strong> after that?");
+    ctx.setChips([
+      {
+        label: "No, he isn’t!",
+        onPick: () =>
+          backSoon("Right! Checkmate always starts with CHECK. Find a move that shouts check!"),
+      },
+      {
+        label: "Hmm, yes?",
+        onPick: () => backSoon("Peek again — nothing attacks him. First job: give CHECK!"),
+      },
+    ]);
+    return;
+  }
+
+  if (res.kind === "escape") {
+    const escapes = res.escapes;
+    let miss = 0;
+    ctx.setStatus(
+      "It IS check — but the king wriggles free! <strong>Tap the square</strong> where he can escape.",
+    );
+    ctx.setChips([]);
+    ctx.setCoachTap((t) => {
+      if (escapes.includes(t)) {
+        ctx.setCoachTap(null);
+        ctx.setHighlights({ [t]: "hint" });
+        ctx.good();
+        backSoon("Exactly! Your next move must lock that door too. Go!");
+      } else if (++miss >= 2) {
+        ctx.setCoachTap(null);
+        ctx.setHighlights(Object.fromEntries(escapes.map((s) => [s, "hint" as Highlight])));
+        backSoon("There — the glowing doors! Find a move that locks them all.");
+      } else {
+        ctx.bad();
+        ctx.setStatus(
+          "Not that one — watch the king himself. Where can <strong>he</strong> step? Tap it.",
+        );
+      }
+    });
+    return;
+  }
+
+  backSoon(
+    "It’s check and the king is stuck — but black can <strong>capture or block</strong> your attacker. Sneaky! Try another move.",
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/Certificate.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/Certificate.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+// Printable certificate — hidden on screen, shown alone when printing (see
+// chess-quest.css @media print). Port of js/app.js printCertificate.
+import { LANDS } from "../../content/lands";
+import { certTitle } from "../../lib/cert";
+import { useProgress } from "../../lib/progress";
+
+export function Certificate() {
+  const progress = useProgress();
+  const name = progress.getName() || "This player";
+  const t1 = progress.trackDone(1);
+  const t2 = progress.trackDone(2);
+  const { title, line } = certTitle(t1, t2);
+  const landsDone = LANDS.filter((l) => progress.landDone(l)).length;
+  const date = new Date().toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return (
+    <div className="cq-cert-sheet" aria-hidden>
+      <div className="cq-cert-frame">
+        <div className="cq-cert-crest">♞</div>
+        <div className="cq-cert-brand">Chess Quest</div>
+        <h1 className="cq-cert-title">{title}</h1>
+        <p className="cq-cert-lede">This certificate proudly declares that</p>
+        <div className="cq-cert-name">{name}</div>
+        <p className="cq-cert-line">{line}.</p>
+        <div className="cq-cert-stats">
+          ⭐ {progress.totalStars()} stars &nbsp;·&nbsp; 🗓 {progress.activityDates().length} days of
+          play &nbsp;·&nbsp; 🏰 {landsDone} of {LANDS.length} lands
+        </div>
+        <div className="cq-cert-foot">
+          <span className="cq-cert-sig">
+            <span className="cq-cert-sigline">{date}</span>Date
+          </span>
+          <span className="cq-cert-sig">
+            <span className="cq-cert-sigline">Coach Pony ♞</span>Quest Coach
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/GrownUpsDrawer.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/GrownUpsDrawer.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+// Grown-ups / training-partner drawer — a disclosure with the register's
+// coaching guide. Port of js/app.js renderGrownUps (190–206).
+import { GROWN_UPS, GROWN_UPS_CLASSIC } from "../../content/grown-ups";
+import { useCopy } from "../../lib/copy";
+
+export function GrownUpsDrawer() {
+  const { t, isStory } = useCopy();
+  const g = isStory() ? GROWN_UPS : GROWN_UPS_CLASSIC;
+
+  return (
+    <details className="rounded-2xl border border-slate-200 bg-white p-4">
+      <summary className="cursor-pointer text-sm font-semibold text-purple-800">
+        {t("For grown-ups — how to run the quest", "Training guide — how to run the quest")}
+      </summary>
+      <div className="mt-3 flex flex-col gap-4 text-sm text-slate-600">
+        <section>
+          <h3 className="mk-display font-bold text-purple-950">Every session, same recipe</h3>
+          <div className="mt-2 flex flex-col gap-1">
+            {g.recipe.map(([time, what]) => (
+              <div key={time} className="flex gap-2">
+                <b className="w-14 shrink-0 text-purple-700">{time}</b>
+                <span>{what}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+        <section>
+          <h3 className="mk-display font-bold text-purple-950">
+            {t("Rules for the grown-up", "Rules of the road")}
+          </h3>
+          <ul className="mt-1 list-disc pl-5">
+            {g.rules.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h3 className="mk-display font-bold text-purple-950">Toolbox</h3>
+          <ul className="mt-1 list-disc pl-5">
+            {g.toolbox.map(([name, desc]) => (
+              <li key={name}>
+                <b>{name}</b> — {desc}
+              </li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h3 className="mk-display font-bold text-purple-950">
+            {t("If she gets stuck or bored", "If you get stuck or bored")}
+          </h3>
+          <ul className="mt-1 list-disc pl-5">
+            {g.stuck.map(([q, a]) => (
+              <li key={q}>
+                <b>{q}</b> {a}
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </details>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/LessonCard.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/LessonCard.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+// Lesson card — the selected day's Learn/Play/Tip, an optional diagram board,
+// a Play button that launches the lesson's mini-game, and a mark-done toggle.
+// Port of js/app.js renderCard (129–187).
+import { parseFEN, pieceTargets, sqIdx } from "../../engine";
+import { LANDS } from "../../content/lands";
+import { GameId, LESSONS } from "../../content/lessons";
+import { useCopy } from "../../lib/copy";
+import { useProgress } from "../../lib/progress";
+import { Board, Highlight } from "../Board";
+import { Rich } from "../rich";
+import { dayOf, GAME_LABEL, lessonCopy } from "./questData";
+
+export function LessonCard({
+  n,
+  onPlay,
+}: {
+  n: number;
+  onPlay(game: GameId, opts: Record<string, unknown>): void;
+}) {
+  const progress = useProgress();
+  const { t, isStory } = useCopy();
+  const wk = LESSONS[n - 1];
+  const land = LANDS[wk.land - 1];
+  const isDone = progress.isWeekDone(wk.n);
+  const isLast = wk.n === land.weeks[1];
+  const c = lessonCopy(wk, isStory());
+  const landCheck = !isStory() && land.checkClassic ? land.checkClassic : land.check;
+
+  let diagramHl: Partial<Record<number, Highlight>> | undefined;
+  let diagramPos: string[] | undefined;
+  if (wk.diagram) {
+    diagramPos = parseFEN(wk.diagram.fen).board;
+    if (wk.diagram.from) {
+      const from = sqIdx(wk.diagram.from);
+      diagramHl = { [from]: "sel" };
+      for (const tgt of pieceTargets(diagramPos, from)) diagramHl[tgt] = "move";
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5">
+      <span className="text-xs font-semibold uppercase tracking-wide text-purple-400">
+        {land.glyph} {land.name} · Day {dayOf(wk.n)}
+      </span>
+      <h2 className="mk-display mt-1 text-2xl font-bold text-purple-950">{wk.title}</h2>
+
+      <dl className="mt-3 flex flex-col gap-2 text-sm">
+        <div className="flex gap-3">
+          <dt className="w-12 shrink-0 font-bold text-purple-700">Learn</dt>
+          <dd className="text-slate-600">
+            <Rich html={c.learn} />
+          </dd>
+        </div>
+        <div className="flex gap-3">
+          <dt className="w-12 shrink-0 font-bold text-purple-700">Play</dt>
+          <dd className="text-slate-600">
+            <Rich html={c.play} />
+          </dd>
+        </div>
+        <div className="flex gap-3">
+          <dt className="w-12 shrink-0 font-bold text-amber-600">{t("Spark", "Tip")}</dt>
+          <dd className="text-slate-600">
+            <Rich html={c.spark} />
+          </dd>
+        </div>
+      </dl>
+
+      {wk.diagram && diagramPos ? (
+        <div className="mt-4">
+          <div className="mx-auto max-w-64">
+            <Board position={diagramPos} highlights={diagramHl} />
+          </div>
+          <p className="mt-1 text-center text-xs italic text-slate-500">{wk.diagram.caption}</p>
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {wk.game ? (
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => onPlay(wk.game as GameId, wk.gameOpts ?? {})}
+          >
+            {GAME_LABEL[wk.game]}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className={isDone ? "btn btn-ghost" : "btn btn-primary"}
+          onClick={() => progress.setWeekDone(wk.n, !isDone)}
+        >
+          {isDone ? "✓ Done — undo?" : "Mark day done ⭐"}
+        </button>
+      </div>
+
+      {isLast ? (
+        <p className="mt-4 rounded-lg bg-purple-50 p-3 text-sm text-purple-900">
+          <b>
+            {land.glyph} Level-up check:
+          </b>{" "}
+          {landCheck}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/LessonCard.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/LessonCard.tsx
@@ -6,8 +6,10 @@
 import { parseFEN, pieceTargets, sqIdx } from "../../engine";
 import { LANDS } from "../../content/lands";
 import { GameId, LESSONS } from "../../content/lessons";
+import { celebrate } from "../../lib/celebrate";
 import { useCopy } from "../../lib/copy";
 import { useProgress } from "../../lib/progress";
+import { sfx } from "../../lib/sfx";
 import { Board, Highlight } from "../Board";
 import { Rich } from "../rich";
 import { dayOf, GAME_LABEL, lessonCopy } from "./questData";
@@ -89,7 +91,14 @@ export function LessonCard({
         <button
           type="button"
           className={isDone ? "btn btn-ghost" : "btn btn-primary"}
-          onClick={() => progress.setWeekDone(wk.n, !isDone)}
+          onClick={(e) => {
+            const was = isDone;
+            progress.setWeekDone(wk.n, !was);
+            if (!was) {
+              sfx.chime();
+              if (progress.landDone(land)) celebrate(e.currentTarget);
+            }
+          }}
         >
           {isDone ? "✓ Done — undo?" : "Mark day done ⭐"}
         </button>

--- a/apps/web/src/games/chess-quest/components/quest/Modal.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/Modal.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+// Lightweight centered modal used by the profile and progress panels.
+import { useEffect } from "react";
+
+export function Modal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose(): void;
+  children: React.ReactNode;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="my-8 w-full max-w-lg rounded-2xl bg-white p-5 shadow-xl"
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="mk-display text-xl font-bold text-purple-950">{title}</h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded-full px-2 py-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="mt-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/ProfilePanel.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/ProfilePanel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+// Players panel — list / switch / delete profiles, add a new one, and set the
+// active player's name and copy register. Port of js/app.js renderProfilePanel.
+import { useState } from "react";
+import { Mode, useProgress } from "../../lib/progress";
+import { Modal } from "./Modal";
+
+export function ProfilePanel({ onClose }: { onClose(): void }) {
+  const progress = useProgress();
+  const [armedDelete, setArmedDelete] = useState<string | null>(null);
+  const [newName, setNewName] = useState("");
+  const [newMode, setNewMode] = useState<Mode>("classic");
+
+  const profiles = progress.profiles();
+  const activeId = progress.activeId();
+
+  return (
+    <Modal title="Players" onClose={onClose}>
+      <p className="text-xs text-slate-500">
+        Each player keeps their own progress, stars and streak.
+      </p>
+
+      <ul className="mt-3 flex flex-col gap-2">
+        {profiles.map((prof, i) => {
+          const active = prof.id === activeId;
+          return (
+            <li
+              key={prof.id}
+              className={`flex items-center gap-2 rounded-xl border p-2 ${
+                active ? "border-purple-400 bg-purple-50" : "border-slate-200"
+              }`}
+            >
+              <span className="flex-1 text-sm font-medium text-purple-950">
+                {prof.name || `Player ${i + 1}`}
+                <span className="ml-2 rounded-full bg-slate-100 px-1.5 py-0.5 text-xs text-slate-500">
+                  {prof.mode === "story" ? "Story" : "Classic"}
+                </span>
+                {active ? <span className="ml-2 text-xs text-purple-600">· active</span> : null}
+              </span>
+              {!active ? (
+                <button
+                  type="button"
+                  className="rounded-lg border border-purple-300 px-2 py-1 text-xs font-medium text-purple-700 hover:bg-purple-50"
+                  onClick={() => progress.switchProfile(prof.id)}
+                >
+                  Switch
+                </button>
+              ) : null}
+              {profiles.length > 1 ? (
+                <button
+                  type="button"
+                  className={`rounded-lg border px-2 py-1 text-xs font-medium ${
+                    armedDelete === prof.id
+                      ? "border-rose-500 bg-rose-500 text-white"
+                      : "border-rose-300 text-rose-600 hover:bg-rose-50"
+                  }`}
+                  onClick={() => {
+                    if (armedDelete === prof.id) {
+                      progress.removeProfile(prof.id);
+                      setArmedDelete(null);
+                    } else {
+                      setArmedDelete(prof.id);
+                    }
+                  }}
+                >
+                  {armedDelete === prof.id ? "Really delete?" : "Delete"}
+                </button>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Active player's settings */}
+      <div className="mt-5 border-t border-slate-100 pt-4">
+        <label className="text-xs font-semibold text-slate-600">This player’s name</label>
+        <input
+          type="text"
+          maxLength={16}
+          value={progress.getName()}
+          onChange={(e) => progress.setName(e.target.value)}
+          placeholder="Add a name"
+          className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+        />
+        <div className="mt-3 flex gap-2">
+          {(["story", "classic"] as Mode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => progress.setMode(m)}
+              className={`rounded-full border px-3 py-1 text-sm font-medium ${
+                progress.getMode() === m
+                  ? "border-purple-600 bg-purple-600 text-white"
+                  : "border-purple-300 bg-white text-purple-800 hover:bg-purple-50"
+              }`}
+            >
+              {m === "story" ? "Story (kids)" : "Classic (adult)"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Add a new player */}
+      <div className="mt-5 border-t border-slate-100 pt-4">
+        <label className="text-xs font-semibold text-slate-600">Add a player</label>
+        <div className="mt-1 flex flex-wrap gap-2">
+          <input
+            type="text"
+            maxLength={16}
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Name"
+            className="min-w-32 flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm"
+          />
+          <select
+            value={newMode}
+            onChange={(e) => setNewMode(e.target.value as Mode)}
+            className="rounded-lg border border-slate-300 px-2 py-2 text-sm"
+          >
+            <option value="classic">Classic</option>
+            <option value="story">Story</option>
+          </select>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => {
+              progress.addProfile(newName, newMode);
+              setNewName("");
+            }}
+          >
+            Add
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/ProgressPanel.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/ProgressPanel.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+// Progress panel — streak, stars, track bars, a 14-day activity strip and a
+// per-game stars table. Port of js/app.js renderProgressPanel (357–441).
+import { HUNTS, MATE1, MATE2 } from "../../content/puzzles";
+import { useCopy } from "../../lib/copy";
+import { last14Days } from "../../lib/last14";
+import { useProgress } from "../../lib/progress";
+import { Modal } from "./Modal";
+
+function todayISO() {
+  const d = new Date();
+  return (
+    d.getFullYear() +
+    "-" +
+    String(d.getMonth() + 1).padStart(2, "0") +
+    "-" +
+    String(d.getDate()).padStart(2, "0")
+  );
+}
+
+function Stars({ n }: { n: number }) {
+  return (
+    <span aria-label={`${n} of 3 stars`} className="text-amber-500">
+      {"★".repeat(n)}
+      <span className="text-slate-300">{"☆".repeat(3 - n)}</span>
+    </span>
+  );
+}
+
+function TrackBar({ label, done, total }: { label: string; done: number; total: number }) {
+  return (
+    <div>
+      <div className="flex justify-between text-xs text-slate-500">
+        <span>{label}</span>
+        <span>
+          {done} / {total}
+        </span>
+      </div>
+      <div className="mt-1 h-2 overflow-hidden rounded-full bg-purple-100">
+        <div className="h-full rounded-full bg-purple-500" style={{ width: `${(done / total) * 100}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function ProgressPanel({ onClose, onPrint }: { onClose(): void; onPrint(): void }) {
+  const progress = useProgress();
+  const { t, isStory } = useCopy();
+  const name = progress.getName() || "This player";
+  const t1 = ["fork", "pin", "skewer", "disco"].reduce((s, p) => s + progress.tacticCount(p), 0);
+  const t2 = ["fork2", "pin2", "skewer2", "disco2"].reduce((s, p) => s + progress.tacticCount(p), 0);
+  const puzzlesTotal =
+    progress.solvedCount() + progress.solved2Count() + progress.huntCount() + t1 + t2;
+  const streak = progress.streak();
+  const days = last14Days(progress.activityDates(), todayISO());
+
+  const rows: [string, string, string][] = [
+    [
+      "Square Race",
+      "squareRace",
+      progress.getBest("squareRace") ? `best: ${progress.getBest("squareRace")} squares` : "",
+    ],
+    ["Coin Hop", "coinHop", ""],
+    ["Rook Maze", "rookMaze", ""],
+    ["Pawn Wars", "pawnWars", ""],
+    ["Mate in 1", "mateInOne", `${progress.solvedCount()} / ${MATE1.length} puzzles`],
+    ["Mate in 2", "mateInTwo", `${progress.solved2Count()} / ${MATE2.length} puzzles`],
+    ["Piece Detective", "hangingHunt", `${progress.huntCount()} / ${HUNTS.length} cases`],
+    ["Trick Shots", "tacticTrainer", `${t1} / 13 tricks`],
+    ["Trick Shots — Master", "tacticTrainer2", `${t2} / 12 tricks`],
+  ];
+
+  const tile = (num: React.ReactNode, label: string) => (
+    <div className="flex flex-col items-center rounded-xl border border-slate-200 bg-slate-50 p-3">
+      <span className="text-xl font-bold text-purple-950">{num}</span>
+      <span className="text-xs text-slate-500">{label}</span>
+    </div>
+  );
+
+  return (
+    <Modal title="Progress" onClose={onClose}>
+      <p className="text-xs text-slate-500">
+        {name} · {isStory() ? "Story" : "Classic"} mode
+      </p>
+
+      <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {tile(streak, t("day streak 🔥", "day streak"))}
+        {tile(`⭐ ${progress.totalStars()}`, "total stars")}
+        {tile(puzzlesTotal, "puzzles solved")}
+        {tile(progress.activityDates().length, "days played")}
+      </div>
+
+      <h3 className="mk-display mt-5 font-bold text-purple-950">Quest tracks</h3>
+      <div className="mt-2 flex flex-col gap-2">
+        <TrackBar label="Track 1 · First Steps" done={progress.trackDone(1)} total={24} />
+        <TrackBar label="Track 2 · Rising Player" done={progress.trackDone(2)} total={24} />
+      </div>
+
+      <h3 className="mk-display mt-5 font-bold text-purple-950">Last 14 days</h3>
+      <div
+        role="img"
+        aria-label={`Played on ${days.filter((d) => d.on).length} of the last 14 days`}
+        className="mt-2 flex justify-between gap-1"
+      >
+        {days.map((d) => (
+          <span key={d.iso} title={`${d.iso}${d.on ? " — played" : ""}`} className="flex flex-col items-center gap-1">
+            <span
+              className={`h-4 w-4 rounded-full ${d.on ? "bg-emerald-500" : "bg-slate-200"}`}
+            />
+            <span className="text-[10px] text-slate-400">{d.wd}</span>
+          </span>
+        ))}
+      </div>
+
+      <h3 className="mk-display mt-5 font-bold text-purple-950">Games</h3>
+      <table className="mt-2 w-full text-sm">
+        <tbody>
+          {rows.map(([label, id, detail]) => (
+            <tr key={id} className="border-t border-slate-100">
+              <td className="py-1.5 text-slate-700">{label}</td>
+              <td className="py-1.5">
+                <Stars n={progress.gameStars(id)} />
+              </td>
+              <td className="py-1.5 text-right text-xs text-slate-400">{detail}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="mt-5">
+        <button type="button" className="btn btn-primary" onClick={onPrint}>
+          🖨 Print certificate
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/QuestHeader.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/QuestHeader.tsx
@@ -44,6 +44,28 @@ export function QuestHeader({
           >
             📊 Progress
           </button>
+          <button
+            type="button"
+            aria-label={progress.getMuted() ? "Unmute sounds" : "Mute sounds"}
+            aria-pressed={progress.getMuted()}
+            onClick={() => progress.setMuted(!progress.getMuted())}
+            className="rounded-full border border-purple-300 bg-white px-2 py-1 text-sm hover:bg-purple-50"
+          >
+            {progress.getMuted() ? "🔇" : "🔊"}
+          </button>
+          <button
+            type="button"
+            aria-label={progress.getVoiceOn() ? "Turn coach voice off" : "Turn coach voice on"}
+            aria-pressed={progress.getVoiceOn()}
+            onClick={() => progress.setVoiceOn(!progress.getVoiceOn())}
+            className={`rounded-full border px-2 py-1 text-sm ${
+              progress.getVoiceOn()
+                ? "border-purple-300 bg-white hover:bg-purple-50"
+                : "border-slate-200 bg-slate-100 opacity-50"
+            }`}
+          >
+            🗣
+          </button>
         </div>
       </div>
 

--- a/apps/web/src/games/chess-quest/components/quest/QuestHeader.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/QuestHeader.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+// Quest header HUD — title, player + progress buttons, star total, days
+// progress bar, land badges. Port of js/app.js renderHeader (45–75).
+import { LANDS } from "../../content/lands";
+import { LESSONS } from "../../content/lessons";
+import { useCopy } from "../../lib/copy";
+import { useProgress } from "../../lib/progress";
+
+export function QuestHeader({
+  onOpenProfiles,
+  onOpenProgress,
+}: {
+  onOpenProfiles(): void;
+  onOpenProgress(): void;
+}) {
+  const progress = useProgress();
+  const { t, isStory } = useCopy();
+  const name = progress.getName();
+  const done = progress.weeksDone();
+  const pct = (done / LESSONS.length) * 100;
+
+  return (
+    <header className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="mk-display text-2xl font-bold text-purple-950">
+          {name ? `${name}'s ` : ""}Chess Quest <span aria-hidden>♞</span>
+        </h2>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onOpenProfiles}
+            className="rounded-full border border-purple-300 bg-white px-3 py-1 text-sm font-medium text-purple-800 hover:bg-purple-50"
+          >
+            👥 {name || "Players"}{" "}
+            <span className="ml-1 rounded-full bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700">
+              {isStory() ? "Story" : "Classic"}
+            </span>
+          </button>
+          <button
+            type="button"
+            onClick={onOpenProgress}
+            className="rounded-full border border-purple-300 bg-white px-3 py-1 text-sm font-medium text-purple-800 hover:bg-purple-50"
+          >
+            📊 Progress
+          </button>
+        </div>
+      </div>
+
+      <p className="max-w-2xl text-sm text-slate-600">
+        {t(
+          "One small lesson every other day — Day 1, Day 3, Day 5… — from first square to first tournament, with real games to play right here.",
+          "One focused lesson every other day — Day 1, Day 3, Day 5… — from the empty board to confident club play, with drills to play right here.",
+        )}
+      </p>
+
+      <div className="flex flex-wrap items-center gap-4">
+        <span className="text-sm font-semibold text-amber-600">⭐ {progress.totalStars()}</span>
+        <div className="min-w-48 flex-1">
+          <div className="flex justify-between text-xs text-slate-500">
+            <span>Quest progress</span>
+            <span>
+              {done} / {LESSONS.length} days
+            </span>
+          </div>
+          <div className="mt-1 h-2 overflow-hidden rounded-full bg-purple-100">
+            <div className="h-full rounded-full bg-purple-500" style={{ width: `${pct}%` }} />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {LANDS.map((land) => {
+          const won = progress.landDone(land);
+          return (
+            <span
+              key={land.id}
+              title={`${land.name}${won ? " — complete!" : ""}`}
+              className={`flex h-8 w-8 items-center justify-center rounded-full border text-lg ${
+                won
+                  ? "border-emerald-500 bg-emerald-50"
+                  : "border-slate-200 bg-slate-50 opacity-50"
+              }`}
+            >
+              {land.glyph}
+            </span>
+          );
+        })}
+      </div>
+    </header>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/QuestMap.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/QuestMap.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+// Quest map — Track 1/2 sections, lands, day-numbered stops. Port of
+// js/app.js renderMap (78–126). ✓ = done, ♞ = current stop, else the day.
+import { LANDS } from "../../content/lands";
+import { LESSONS } from "../../content/lessons";
+import { useProgress } from "../../lib/progress";
+import { dayOf } from "./questData";
+
+export function QuestMap({
+  selected,
+  onSelect,
+}: {
+  selected: number;
+  onSelect(n: number): void;
+}) {
+  const progress = useProgress();
+  const current = progress.currentWeek(LESSONS.length);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {LANDS.map((land, idx) => {
+        const track = land.track ?? 1;
+        const prevTrack = idx > 0 ? (LANDS[idx - 1].track ?? 1) : 0;
+        const showTrackHead = track !== prevTrack;
+        const won = progress.landDone(land);
+        return (
+          <div key={land.id} className="flex flex-col gap-2">
+            {showTrackHead ? (
+              <div className="mt-1 flex items-baseline gap-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-purple-400">
+                  Track {track}
+                </span>
+                <span className="mk-display text-sm font-bold text-purple-900">
+                  {track === 1 ? "First Steps" : "Rising Player"}
+                </span>
+              </div>
+            ) : null}
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-3">
+              <div className="flex items-center gap-2">
+                <span className="text-xl">{land.glyph}</span>
+                <div className="flex flex-col leading-tight">
+                  <span className="text-xs text-slate-400">
+                    Days {dayOf(land.weeks[0])}–{dayOf(land.weeks[1])}
+                  </span>
+                  <span className="mk-display text-sm font-bold text-purple-950">{land.name}</span>
+                </div>
+                <span
+                  title={won ? "Badge earned!" : "Finish every day here to earn the badge"}
+                  className={`ml-auto text-lg ${won ? "" : "opacity-30 grayscale"}`}
+                >
+                  {land.glyph}
+                </span>
+              </div>
+
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {Array.from(
+                  { length: land.weeks[1] - land.weeks[0] + 1 },
+                  (_, k) => land.weeks[0] + k,
+                ).map((n) => {
+                  const isDone = progress.isWeekDone(n);
+                  const isCur = n === current && !isDone;
+                  const isSel = n === selected;
+                  return (
+                    <button
+                      key={n}
+                      type="button"
+                      aria-label={`Day ${dayOf(n)}: ${LESSONS[n - 1].title}`}
+                      onClick={() => onSelect(n)}
+                      className={`h-9 min-w-9 rounded-lg border px-1 text-sm font-semibold transition ${
+                        isDone
+                          ? "border-emerald-500 bg-emerald-500 text-white"
+                          : isCur
+                            ? "border-purple-500 bg-purple-100 text-purple-800"
+                            : "border-slate-200 bg-white text-slate-600"
+                      } ${isSel ? "ring-2 ring-purple-500 ring-offset-1" : ""}`}
+                    >
+                      {isDone ? "✓" : isCur ? "♞" : dayOf(n)}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/questData.ts
+++ b/apps/web/src/games/chess-quest/components/quest/questData.ts
@@ -1,0 +1,27 @@
+// Shared quest helpers/constants for the map + card.
+import { GameId, Lesson } from "../../content/lessons";
+
+// Lessons run every other day: lesson 1 = Day 1, lesson 2 = Day 3, …
+export function dayOf(n: number): number {
+  return 2 * n - 1;
+}
+
+export const GAME_LABEL: Record<GameId, string> = {
+  squareRace: "▶ Play Square Race",
+  coinHop: "▶ Play Coin Hop",
+  pawnWars: "▶ Play Pawn Wars",
+  mateInOne: "▶ Play Mate in 1",
+  mateInTwo: "▶ Play Mate in 2",
+  hangingHunt: "▶ Play Piece Detective",
+  tacticTrainer: "▶ Play Trick Shots",
+  rookMaze: "▶ Play Rook Maze",
+};
+
+// The active register's copy for a lesson.
+export function lessonCopy(lesson: Lesson, story: boolean): {
+  learn: string;
+  play: string;
+  spark: string;
+} {
+  return story ? { learn: lesson.learn, play: lesson.play, spark: lesson.spark } : lesson.classic;
+}

--- a/apps/web/src/games/chess-quest/components/rich.tsx
+++ b/apps/web/src/games/chess-quest/components/rich.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+// Renders coach/status copy that carries <strong>/<em> markup. Only our own
+// literal strings from content/ and game components flow through here —
+// never user input.
+export function Rich({ html, className }: { html: string; className?: string }) {
+  return <span className={className} dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts
+++ b/apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { parseFEN } from "../../engine";
+import { LANDS } from "../lands";
+import { LESSONS } from "../lessons";
+import { TACTICS, TACTICS2 } from "../puzzles";
+
+const GAME_IDS = [
+  "squareRace",
+  "coinHop",
+  "pawnWars",
+  "mateInOne",
+  "mateInTwo",
+  "hangingHunt",
+  "tacticTrainer",
+  "rookMaze",
+];
+
+describe("curriculum shape", () => {
+  it("48 lessons, numbered 1..48 in order", () => {
+    expect(LESSONS).toHaveLength(48);
+    LESSONS.forEach((l, i) => expect(l.n).toBe(i + 1));
+  });
+  it("9 lands tiling lessons 1..48 exactly once", () => {
+    expect(LANDS).toHaveLength(9);
+    const seen = new Array(49).fill(0);
+    for (const land of LANDS) {
+      for (let i = land.weeks[0]; i <= land.weeks[1]; i++) seen[i]++;
+    }
+    expect(seen.slice(1).every((c) => c === 1)).toBe(true);
+  });
+  it("every lesson's land id matches the land covering its number", () => {
+    for (const l of LESSONS) {
+      const land = LANDS.find((x) => l.n >= x.weeks[0] && l.n <= x.weeks[1]);
+      expect(land?.id, `lesson ${l.n}`).toBe(l.land);
+    }
+  });
+  it("track 2 lands cover lessons 25..48 only", () => {
+    for (const land of LANDS.filter((l) => l.track === 2)) {
+      expect(land.weeks[0]).toBeGreaterThanOrEqual(25);
+    }
+  });
+  it("every land has both check registers", () => {
+    for (const land of LANDS) {
+      expect(land.check.length).toBeGreaterThan(0);
+      expect(land.checkClassic.length).toBeGreaterThan(0);
+    }
+  });
+  it("every lesson has story + classic copy", () => {
+    for (const l of LESSONS) {
+      expect(l.learn.length).toBeGreaterThan(0);
+      expect(l.play.length).toBeGreaterThan(0);
+      expect(l.spark.length).toBeGreaterThan(0);
+      expect(l.classic.learn.length).toBeGreaterThan(0);
+      expect(l.classic.play.length).toBeGreaterThan(0);
+      expect(l.classic.spark.length).toBeGreaterThan(0);
+    }
+  });
+  it("every game id is real", () => {
+    for (const l of LESSONS) {
+      if (l.game !== null) expect(GAME_IDS).toContain(l.game);
+    }
+  });
+  it("all diagram FENs parse to 64 squares", () => {
+    for (const l of LESSONS) {
+      if (!l.diagram) continue;
+      expect(parseFEN(l.diagram.fen).board, `lesson ${l.n}`).toHaveLength(64);
+    }
+  });
+  it("tactic-trainer lessons point at existing packs", () => {
+    for (const l of LESSONS.filter((x) => x.game === "tacticTrainer")) {
+      const pack = l.gameOpts?.pack ?? "";
+      const exists = pack in TACTICS || pack in TACTICS2;
+      expect(exists, `lesson ${l.n} pack "${pack}"`).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/games/chess-quest/content/__tests__/puzzles.test.ts
+++ b/apps/web/src/games/chess-quest/content/__tests__/puzzles.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseFEN,
+  sqIdx,
+  sqName,
+  isWhitePiece,
+  isAttacked,
+  inCheck,
+  legalTargets,
+  applyMove,
+  isMate,
+  hasMateIn1,
+  isMateIn2After,
+  isForkAfter,
+  isPinAfter,
+  isSkewerAfter,
+  isDiscoveredAfter,
+} from "../../engine";
+import { MATE1, HUNTS, TACTICS, MATE2, TACTICS2 } from "../puzzles";
+
+const mv = (sol: string) => ({ from: sqIdx(sol.slice(0, 2)), to: sqIdx(sol.slice(2, 4)) });
+
+describe("MATE1: every solution is a legal mate-in-1", () => {
+  it.each(MATE1.map((p) => [p.name, p] as const))("%s", (_name, pz) => {
+    const { board } = parseFEN(pz.fen);
+    const { from, to } = mv(pz.solution);
+    expect(inCheck(board, false)).toBe(false); // black not already in check
+    expect(legalTargets(board, from)).toContain(to);
+    expect(isMate(applyMove(board, from, to), false)).toBe(true);
+  });
+});
+
+describe("HUNTS: exactly one hanging black piece, matching the answer", () => {
+  it.each(HUNTS.map((h) => [h.answer, h] as const))("hunt %s", (_a, h) => {
+    const { board } = parseFEN(h.fen);
+    const hanging: string[] = [];
+    for (let i = 0; i < 64; i++) {
+      const p = board[i];
+      if (p === "" || isWhitePiece(p) || p === "k") continue;
+      const attacked = isAttacked(board, i, true);
+      const probe = board.slice();
+      probe[i] = "P"; // stand-in white piece: can black recapture here?
+      const defended = isAttacked(probe, i, false);
+      if (attacked && !defended) hanging.push(sqName(i));
+    }
+    expect(hanging).toEqual([h.answer]);
+    expect(inCheck(board, false)).toBe(false);
+    expect(inCheck(board, true)).toBe(false);
+  });
+});
+
+const DETECTOR = {
+  fork: isForkAfter,
+  pin: isPinAfter,
+  skewer: isSkewerAfter,
+  disco: (b: string[], to: number) => isDiscoveredAfter(b, to, true),
+} as const;
+
+describe("TACTICS: every solution performs its named trick", () => {
+  for (const pack of ["fork", "pin", "skewer", "disco"] as const) {
+    it.each(TACTICS[pack].map((tc, i) => [`${pack} ${i + 1}`, tc] as const))(
+      "%s",
+      (_label, tc) => {
+        const { board } = parseFEN(tc.fen);
+        const { from, to } = mv(tc.solution);
+        expect(inCheck(board, false)).toBe(false);
+        expect(inCheck(board, true)).toBe(false);
+        expect(legalTargets(board, from)).toContain(to);
+        expect(DETECTOR[pack](applyMove(board, from, to), to)).toBe(true);
+      },
+    );
+  }
+});
+
+describe("MATE2: forced in exactly two, never one", () => {
+  it("has 12 puzzles", () => {
+    expect(MATE2).toHaveLength(12);
+  });
+  it.each(MATE2.map((p) => [p.name, p] as const))("%s", (_name, pz) => {
+    const { board } = parseFEN(pz.fen);
+    const { from, to } = mv(pz.solution);
+    expect(inCheck(board, false)).toBe(false);
+    expect(inCheck(board, true)).toBe(false);
+    expect(hasMateIn1(board, true)).toBe(false); // no hidden mate-in-1 (caught 2 bad puzzles before)
+    expect(legalTargets(board, from)).toContain(to);
+    expect(isMateIn2After(board, from, to)).toBe(true);
+  });
+});
+
+const DETECTOR2 = {
+  fork2: isForkAfter,
+  pin2: isPinAfter,
+  skewer2: isSkewerAfter,
+  disco2: (b: string[], to: number) => isDiscoveredAfter(b, to, true),
+} as const;
+
+describe("TACTICS2: tier-2 packs", () => {
+  it("has all four packs of 3", () => {
+    for (const pack of ["fork2", "pin2", "skewer2", "disco2"] as const) {
+      expect(TACTICS2[pack]).toHaveLength(3);
+    }
+  });
+  for (const pack of ["fork2", "pin2", "skewer2", "disco2"] as const) {
+    it.each(TACTICS2[pack].map((tc, i) => [`${pack} ${i + 1}`, tc] as const))(
+      "%s",
+      (_label, tc) => {
+        const { board } = parseFEN(tc.fen);
+        const { from, to } = mv(tc.solution);
+        expect(inCheck(board, false)).toBe(false);
+        expect(inCheck(board, true)).toBe(false);
+        expect(legalTargets(board, from)).toContain(to);
+        expect(DETECTOR2[pack](applyMove(board, from, to), to)).toBe(true);
+      },
+    );
+  }
+});

--- a/apps/web/src/games/chess-quest/content/grown-ups.ts
+++ b/apps/web/src/games/chess-quest/content/grown-ups.ts
@@ -1,0 +1,73 @@
+// Chess Quest grown-ups drawer — transcribed verbatim from the original app
+// (chess-quest js/curriculum.js GROWN_UPS / GROWN_UPS_CLASSIC). Story register
+// addresses the coaching parent; Classic register reads as self-coaching.
+
+export type GrownUps = {
+  recipe: [string, string][];
+  rules: string[];
+  toolbox: [string, string][];
+  stuck: [string, string][];
+};
+
+export const GROWN_UPS: GrownUps = {
+  recipe: [
+    ["3 min", "Warm-up: one puzzle or “show me how the knight moves”"],
+    ["7 min", "One new thing (today’s topic — never two)"],
+    ["10 min", "Play a game or mini-game together"],
+    ["1 min", "High-five + one thing she did well"],
+  ],
+  rules: [
+    "Let her win about half the time at first — losing every game kills the spark. Shrink the help slowly.",
+    "Praise the thinking, not the talent: “I love that you checked if your queen was safe.”",
+    "Mistakes are detective clues, never scoldings. Ask “what did that piece want to do?”",
+    "Every few days, she teaches you something from the plan. Explaining it is how it sticks.",
+    "Speed doesn’t matter. A lesson that takes three tries is still a win. Skip nothing, rush nothing.",
+  ],
+  toolbox: [
+    ["ChessKid", "Kid-safe app: lessons, puzzles, games vs. other kids. Worth the Gold upgrade."],
+    ["Lichess", "Free unlimited puzzles; enable kid mode."],
+    [
+      "Story Time Chess",
+      "Board game that teaches pieces through stories — great for the first lessons.",
+    ],
+    ["No Stress Chess", "Card-guided starter game, perfect bridge to real chess."],
+    ["“Chess Is Child’s Play”", "The parent’s handbook for teaching this age."],
+  ],
+  stuck: [
+    ["Stuck on a lesson?", "Repeat it with different mini-games. Never push forward on a shaky topic."],
+    ["Bored?", "More playing, less teaching. Add extra rest days before dropping to zero."],
+    ["Knight moves won’t click?", "Totally normal — five minutes of Coin Hop any day."],
+    ["Loves it?", "Add puzzles, not lectures. Then find her a club — kids her age are rocket fuel."],
+  ],
+};
+
+// Classic-mode replacement for the grown-ups drawer: the learner IS the
+// grown-up, so it reads as a self-coaching guide.
+export const GROWN_UPS_CLASSIC: GrownUps = {
+  recipe: [
+    ["3 min", "Warm-up: one puzzle from a pack you’ve already finished"],
+    ["7 min", "One new idea (today’s lesson — never two)"],
+    ["10 min", "Play: the mini-game here, or a real game"],
+    ["1 min", "Note one thing that worked and one thing to fix"],
+  ],
+  rules: [
+    "Consistency beats bulk: twenty focused minutes every other day outruns a weekend binge.",
+    "Blunder-check before every move — the highest-value habit below 1200.",
+    "Review every loss for five minutes: find the one move where it turned.",
+    "Play slightly stronger opposition. Comfort games don’t teach.",
+    "Repeat a lesson until it feels boring. Boring means learned.",
+  ],
+  toolbox: [
+    ["Lichess", "Free unlimited puzzles, analysis board, and rated games at every speed."],
+    ["Lichess studies", "Free interactive courses on every endgame and tactic in this quest."],
+    ["ChessKid", "If you’re coaching a child alongside your own training."],
+    ["A physical board", "Set the diagrams up for real — board vision transfers better from 3D."],
+    ["Your own games", "The only opening book that never lies. Save and review them."],
+  ],
+  stuck: [
+    ["Stuck on a lesson?", "Re-run it with the mini-game until you beat par, then move on."],
+    ["Bored?", "More playing, less theory. Add one rapid game after each session."],
+    ["Blundering pieces?", "Return to Day 33’s blunder-check for a week — it resets fast."],
+    ["Hooked?", "Join a club or an online arena. Real opponents are rocket fuel."],
+  ],
+};

--- a/apps/web/src/games/chess-quest/content/lands.ts
+++ b/apps/web/src/games/chess-quest/content/lands.ts
@@ -1,0 +1,107 @@
+// Chess Quest lands — transcribed verbatim from the original app
+// (chess-quest js/curriculum.js LANDS). 5 Track 1 lands + 4 Track 2 lands.
+
+export type Land = {
+  id: number;
+  glyph: string;
+  name: string;
+  weeks: [number, number]; // inclusive lesson range
+  goal: string;
+  check: string; // Story register
+  checkClassic: string; // Classic register
+  track?: 2; // present on Track 2 lands only
+};
+
+export const LANDS: Land[] = [
+  {
+    id: 1,
+    glyph: "♙",
+    name: "Pawn Meadow",
+    weeks: [1, 4],
+    goal: "The board becomes a familiar place and every piece becomes a character.",
+    check: "She sets up the board alone, moves every piece correctly, and wins Pawn Wars sometimes.",
+    checkClassic:
+      "You set up the board unaided, move every piece correctly, and win Pawn Wars regularly.",
+  },
+  {
+    id: 2,
+    glyph: "♘",
+    name: "Knight Forest",
+    weeks: [5, 8],
+    goal: "The moves become a real game: values, check, and how games actually end.",
+    check: "She plays a full legal game, castles without reminders, and calls check.",
+    checkClassic: "You play a full legal game, castle without prompting, and announce check.",
+  },
+  {
+    id: 3,
+    glyph: "♖",
+    name: "Rook Mountain",
+    weeks: [9, 12],
+    goal: "Most kids can start a game; few can finish one. This land is checkmate school.",
+    check: "She mates with two rooks and with the queen, and opens by the golden rules.",
+    checkClassic: "You mate with two rooks and with the queen, and open by the golden rules.",
+  },
+  {
+    id: 4,
+    glyph: "♕",
+    name: "Queen Castle",
+    weeks: [13, 17],
+    goal: "One tactic trick per lesson — every one feels like a magic move.",
+    check: "She names forks, pins and skewers, and rarely leaves big pieces hanging.",
+    checkClassic: "You name forks, pins and skewers on sight, and rarely hang material.",
+  },
+  {
+    id: 5,
+    glyph: "♔",
+    name: "King Peak",
+    weeks: [18, 24],
+    goal: "Everything comes together: her opening, real endgames, and games against other kids.",
+    check: "Full careful games with an opening, tactics and endgame finishes. Club-ready!",
+    checkClassic:
+      "Complete, careful games: an opening plan, tactical awareness, endgame technique. Club-ready.",
+  },
+  {
+    id: 6,
+    glyph: "♗",
+    name: "Combination Canyon",
+    weeks: [25, 30],
+    track: 2,
+    goal: "Single tricks become chains: forcing moves that plan two steps ahead.",
+    check: "She solves mate-in-2s before touching a piece, and her tricks start from safe squares.",
+    checkClassic:
+      "You solve mate-in-2s in your head and land tactics from squares nobody can punish.",
+  },
+  {
+    id: 7,
+    glyph: "♞",
+    name: "Opening Harbor",
+    weeks: [31, 36],
+    track: 2,
+    goal: "From memorized moves to real plans: why the Italian pieces go where they go.",
+    check: "She reaches a castled, developed position every game and shuts down the f7 raids.",
+    checkClassic:
+      "You reach a sound middlegame from the Italian every game, and defend the classic traps cold.",
+  },
+  {
+    id: 8,
+    glyph: "♜",
+    name: "Endgame Glacier",
+    weeks: [37, 42],
+    track: 2,
+    goal: "Cold, precise technique: the endings that decide every close game.",
+    check: "She wins K+P with the opposition, holds Philidor’s fence, and builds Lucena’s bridge.",
+    checkClassic:
+      "You convert K+P endings with the opposition and know both rook-ending walls by name.",
+  },
+  {
+    id: 9,
+    glyph: "♛",
+    name: "Strategy Summit",
+    weeks: [43, 48],
+    track: 2,
+    goal: "Positions without tactics still have answers: squares, files, structure, and a thinking method.",
+    check: "She picks moves from a candidate list, and her own games become her study book.",
+    checkClassic:
+      "You choose from candidate moves, exploit outposts and files, and mine every game you play for lessons.",
+  },
+];

--- a/apps/web/src/games/chess-quest/content/lessons.ts
+++ b/apps/web/src/games/chess-quest/content/lessons.ts
@@ -1,0 +1,915 @@
+// Chess Quest lessons — transcribed verbatim from the original app
+// (chess-quest js/curriculum.js WEEKS, renamed LESSONS). 48 lessons:
+// Track 1 = 1–24, Track 2 "Rising Player" = 25–48. Both copy registers
+// (Story for kids, Classic for adult learners) carried over unchanged.
+
+export type GameId =
+  | "squareRace"
+  | "coinHop"
+  | "pawnWars"
+  | "mateInOne"
+  | "mateInTwo"
+  | "hangingHunt"
+  | "tacticTrainer"
+  | "rookMaze";
+
+export type LessonCopy = { learn: string; play: string; spark: string };
+
+export type Lesson = {
+  n: number; // 1..48
+  land: number; // owning land id (1..9)
+  title: string;
+  game: GameId | null; // null = play on a real board
+  gameOpts?: { pieces?: string[]; pack?: string };
+  learn: string;
+  play: string;
+  spark: string; // Story register
+  classic: LessonCopy; // Classic register
+  diagram?: { fen: string; from?: string; caption: string };
+};
+
+export const LESSONS: Lesson[] = [
+  {
+    n: 1,
+    land: 1,
+    title: "Board Land",
+    game: "squareRace",
+    learn:
+      "Light and dark squares, files a–h, ranks 1–8, diagonals. Set up the board with “white square on the right.”",
+    play: "Square Race: someone calls “e4!” and she taps it fast. Then a board-setup race against the clock.",
+    spark:
+      "The board is a kingdom map. Let her name the four corner squares — they’re her watchtowers.",
+    classic: {
+      learn:
+        "Light and dark squares, files a–h, ranks 1–8, diagonals. Set up with “white square on the right”, queen on her own color.",
+      play: "Square Race until naming any square is instant, then a timed board-setup drill.",
+      spark:
+        "Coordinates are the language of every book, video and engine — make them automatic, not “pretty sure”.",
+    },
+  },
+  {
+    n: 2,
+    land: 1,
+    title: "Rooks & Bishops",
+    game: "rookMaze",
+    gameOpts: { pieces: ["R", "B"] },
+    learn:
+      "Rooks slide in straight lines; bishops slide diagonally and live on one color forever. Sliders can never jump over anything.",
+    play: "Rook Maze: the prize hides behind walls, so slide AROUND them and catch it in as few moves as you can. Bishop mode too!",
+    spark: "Rook is a tower on wheels; bishop is the zig-zag runner who can’t step off his color.",
+    classic: {
+      learn:
+        "Rooks move on files and ranks; bishops on diagonals, locked to one color forever. Sliders never jump.",
+      play: "Rook Maze in both modes — plan the whole detour before touching the piece.",
+      spark:
+        "Count controlled squares, not vibes: a rook on an open file and a bishop on a long diagonal are worth more than their price tags.",
+    },
+    diagram: {
+      fen: "8/8/8/3R4/8/8/8/8 w - - 0 1",
+      from: "d5",
+      caption: "Every square the rook can slide to — until a wall gets in the way.",
+    },
+  },
+  {
+    n: 3,
+    land: 1,
+    title: "Queen & Knight",
+    game: "coinHop",
+    gameOpts: { pieces: ["N", "Q"] },
+    learn:
+      "Queen = rook powers + bishop powers. Knight hops in an L and is the only piece that jumps. Count out loud: “one, two, turn.”",
+    play: "Knight Coin Hop — the pony collects every coin. Then queen vs. eight pawns on the real board.",
+    spark:
+      "The knight is a pony that jumps fences. Knights take the most practice — extra hops for a few days is normal.",
+    classic: {
+      learn:
+        "Queen = rook + bishop combined. The knight jumps in an L and is the only piece that leaps. Learn its eight-square wheel.",
+      play: "Coin Hop with knight, then queen — fewest moves wins.",
+      spark:
+        "Knight routes reward calculation: pick the target square first, then find the two-hop path backwards.",
+    },
+    diagram: {
+      fen: "8/8/8/4N3/8/8/8/8 w - - 0 1",
+      from: "e5",
+      caption: "The knight’s eight secret landing spots.",
+    },
+  },
+  {
+    n: 4,
+    land: 1,
+    title: "Pawns & the King",
+    game: "pawnWars",
+    learn:
+      "Pawns walk one step (two from home), capture diagonally, and promote at the end. The king steps one square and can never be captured.",
+    play: "Pawn Wars, lots of it: pawns only, first to promote wins. It secretly teaches captures, races and planning.",
+    spark:
+      "Every pawn dreams of becoming a queen. Cheer out loud the first time one of hers makes it.",
+    classic: {
+      learn:
+        "Pawns: one step (two from home), capture diagonally, promote on the last rank. The king steps one square and can never be captured.",
+      play: "Pawn Wars — races, captures, breakthroughs; first promotion wins.",
+      spark: "Pawn structure starts here. Every push is permanent, so push with a reason.",
+    },
+  },
+  {
+    n: 5,
+    land: 2,
+    title: "Piece Prices",
+    game: "coinHop",
+    gameOpts: { pieces: ["Q", "R", "B", "N", "K"] },
+    learn:
+      "Pawn 1, knight 3, bishop 3, rook 5, queen 9. A good trade wins points; a bad trade loses them.",
+    play: "Capture battles with mixed pieces on the real board. After every trade, count the points out loud together.",
+    spark:
+      "Pieces cost candy: never pay nine candies to get one. She’ll never forget the queen costs nine.",
+    classic: {
+      learn:
+        "Pawn 1, knight 3, bishop 3, rook 5, queen 9. Every trade is arithmetic — count before you take.",
+      play: "Mixed capture battles on a real board; total the material after every trade.",
+      spark: "Most club games are decided by one bad trade. Count, then move.",
+    },
+  },
+  {
+    n: 6,
+    land: 2,
+    title: "Check!",
+    game: null,
+    learn:
+      "Check means the king is attacked. Three escapes: run (move the king), shield (block), or fight (capture the attacker).",
+    play: "Set up check positions on the real board and let her find all the escapes. She announces “check!” politely in every game.",
+    spark: "Run, shield, or fight — let her pick which superhero move fits each puzzle.",
+    classic: {
+      learn:
+        "Check means the king is attacked. Three answers, always: move the king, block, or capture the attacker.",
+      play: "Set up check positions and enumerate every legal answer before choosing one.",
+      spark:
+        "Strong players test the three answers in the same order every time. Build the routine now.",
+    },
+  },
+  {
+    n: 7,
+    land: 2,
+    title: "Checkmate vs. the Sneaky Tie",
+    game: "mateInOne",
+    learn:
+      "Checkmate: the king is attacked and has no escape — game over. Stalemate: not in check but no legal moves — a draw that steals wins.",
+    play: "Her first mate-in-1 puzzles right here on this page, plus a “mate or stalemate?” quiz on the real board.",
+    spark: "Stalemate is the sneaky trap. Make her the trap detective who spots it before it happens.",
+    classic: {
+      learn:
+        "Checkmate: attacked with no legal answer. Stalemate: NOT attacked but no legal move — a draw that rescues lost positions.",
+      play: "The mate-in-1 pack here, plus a “mate or stalemate?” quiz on a real board.",
+      spark:
+        "When you're up huge material, stalemate is the only way to drop the half point. Leave the defending king one legal square until the net is closed.",
+    },
+  },
+  {
+    n: 8,
+    land: 2,
+    title: "Secret Moves + First Real Game",
+    game: "pawnWars",
+    learn:
+      "Castling — the king’s one-time safety jump with the rook. En passant, quickly and lightly. Promotion recap.",
+    play: "Her first full game, start to finish, with you playing gently. Castle in every game from now on.",
+    spark: "Take a photo of game #1 and start a post-game high-five ritual, win or lose.",
+    classic: {
+      learn:
+        "Castling — the one-time king-safety move, with both legality rules. En passant, briefly. Promotion recap.",
+      play: "A full slow game, start to finish. Castle by move ten in every game from now on.",
+      spark:
+        "Uncastled kings lose to the tactics coming in Land 4. Make castling a habit, not a decision.",
+    },
+  },
+  {
+    n: 9,
+    land: 3,
+    title: "The Lawnmower",
+    game: "mateInOne",
+    learn:
+      "The two-rook ladder mate: rooks take turns pushing the lonely king back, row by row, to the edge.",
+    play: "King + two rooks vs. king on the real board until it’s easy, then race a two-minute timer. Ladder puzzles here too.",
+    spark: "The rooks mow the lawn, one row at a time. Vroom.",
+    classic: {
+      learn: "The two-rook ladder: alternate rank cuts and walk the lone king to the edge.",
+      play: "K+2R vs K on a real board until it takes under a minute, then the ladder puzzles here.",
+      spark:
+        "When the king attacks a rook, shift that rook to the far side of the board — the ladder keeps working.",
+    },
+    diagram: {
+      fen: "7k/R7/1R6/8/8/8/8/6K1 w - - 0 1",
+      caption: "The ladder: one rook holds a row, the other pushes the king back.",
+    },
+  },
+  {
+    n: 10,
+    land: 3,
+    title: "The Queen’s Box",
+    game: "mateInOne",
+    learn:
+      "King + queen vs. king: the queen shrinks the box around the enemy king, her king walks over to help finish. Watch out for stalemate!",
+    play: "Repetitions from different corners. Bonus point every time she pauses to ask “is this stalemate?” before moving.",
+    spark: "The queen builds the fence; the king closes the gate.",
+    classic: {
+      learn:
+        "K+Q vs K: shrink the box, bring your king to help, mate on the edge — and know the stalemate trap.",
+      play: "Repetitions from all four corners. Ask “stalemate?” before every queen move.",
+      spark:
+        "Keep the queen a knight's move from the cornered king: perfect box, zero stalemate risk.",
+    },
+  },
+  {
+    n: 11,
+    land: 3,
+    title: "Puzzle Storm",
+    game: "mateInOne",
+    learn: "Mate-in-1 with every piece — queen, rook, bishop, knight, even a pawn.",
+    play: "Five to ten puzzles a day: the pack here, plus ChessKid or Lichess. Start a puzzle sticker chart.",
+    spark: "Beat-your-own-record days: how many puzzles solved by Sunday?",
+    classic: {
+      learn:
+        "Mate-in-1 with every piece — queen, rook, bishop, knight, pawn. Pattern speed is real strength.",
+      play: "Five to ten puzzles a day, here or on Lichess. Track the streak.",
+      spark:
+        "Volume beats difficulty right now: easy mates build the pattern library that hard combinations draw on later.",
+    },
+  },
+  {
+    n: 12,
+    land: 3,
+    title: "Five Golden Opening Rules",
+    game: "squareRace",
+    learn:
+      "1) Fight for the center. 2) Knights and bishops out. 3) Castle early. 4) Queen stays home early. 5) Don’t move the same piece twice.",
+    play: "Full games where every golden rule she follows scores a point — she can win the points even if she loses the game.",
+    spark: "“Wake up the whole army before the battle.” Sleeping bishops lose wars.",
+    classic: {
+      learn:
+        "1) Fight for the center. 2) Develop knights and bishops. 3) Castle early. 4) Keep the queen modest. 5) Don't move the same piece twice.",
+      play: "Play full games scored on rule-following, not results.",
+      spark: "Every opening you will ever study is these five rules with move orders attached.",
+    },
+  },
+  {
+    n: 13,
+    land: 4,
+    title: "The Fork",
+    game: "tacticTrainer",
+    gameOpts: { pack: "fork" },
+    learn: "One piece attacks two things at once — the opponent can only save one.",
+    play: "Fork puzzles, especially knight forks. Hunt for the famous “royal fork” — king and queen at the same time.",
+    spark: "The knight pokes two dinners with one fork. Which one gets eaten?",
+    classic: {
+      learn:
+        "One piece attacks two targets at once — only one can be saved. Knights fork best; pawns fork cheapest.",
+      play: "The fork pack here, then hunt double attacks in your own games.",
+      spark:
+        "Before each move ask: from its new square, what does this piece attack — one thing, or two?",
+    },
+    diagram: {
+      fen: "3q3k/8/4N3/8/8/8/8/6K1 w - - 0 1",
+      from: "e6",
+      caption: "Knight on e6 hits the king AND the queen. Royal fork!",
+    },
+  },
+  {
+    n: 14,
+    land: 4,
+    title: "The Pin",
+    game: "tacticTrainer",
+    gameOpts: { pack: "pin" },
+    learn:
+      "A piece can’t move because something more precious hides behind it. Pinned pieces are frozen.",
+    play: "Pin puzzles, then games where she shouts “frozen!” whenever she pins one of your pieces.",
+    spark: "Freeze tag, chess edition.",
+    classic: {
+      learn:
+        "A piece that can't move because something more valuable stands behind it. Absolute pins (king behind) are laws; relative pins are advice.",
+      play: "The pin pack, then pile attackers onto pinned pieces in your games — they can't run.",
+      spark: "A pinned piece is a fake defender: count it out when calculating captures.",
+    },
+  },
+  {
+    n: 15,
+    land: 4,
+    title: "The Skewer",
+    game: "tacticTrainer",
+    gameOpts: { pack: "skewer" },
+    learn:
+      "The pin’s big sister: attack the precious piece in front so it must run, then grab what was hiding behind it.",
+    play: "Skewer puzzles, plus “pin or skewer?” — she names which trick each position shows.",
+    spark: "A shish-kebab: two pieces on one stick.",
+    classic: {
+      learn:
+        "The pin reversed: attack the valuable piece in front so it must move, then take what stood behind it.",
+      play: "The skewer pack, plus “pin or skewer?” naming drills.",
+      spark: "King and queen on one line is a skewer alarm. Scan every check for what it exposes.",
+    },
+  },
+  {
+    n: 16,
+    land: 4,
+    title: "Discovered Attack",
+    game: "tacticTrainer",
+    gameOpts: { pack: "disco" },
+    learn:
+      "Move one piece and — surprise! — the piece behind it attacks. Two threats from one move.",
+    play: "Discovered attack and discovered check puzzles. These feel like actual magic.",
+    spark: "The curtain opens and the archer was hiding behind it all along.",
+    classic: {
+      learn:
+        "Move one piece and the piece behind it attacks — two threats in a single tempo. Discovered check is nearly unanswerable.",
+      play: "The discovery pack. The moving piece can go anywhere — send it to its most annoying square.",
+      spark:
+        "Batteries (rook+rook, bishop+queen) are stored discoveries. Build them and the tactic plays itself.",
+    },
+  },
+  {
+    n: 17,
+    land: 4,
+    title: "The Free-Stuff Detector",
+    game: "hangingHunt",
+    learn:
+      "Before every move, two questions: “Is my piece safe there?” and “Is anything free to take?” This habit beats everything else at this age.",
+    play: "Games with a slow-move rule: hand hovers, both questions out loud, then move.",
+    spark: "Award an official Free-Stuff Detector badge once she catches you hanging a piece.",
+    classic: {
+      learn:
+        "The blunder-check: after choosing a move — is my piece safe there? Did they just leave anything loose?",
+      play: "Slow games with a hover rule: both questions answered before the hand commits.",
+      spark:
+        "Below 1200 this routine is worth more rating points than any opening study. It is most of the game.",
+    },
+  },
+  {
+    n: 18,
+    land: 5,
+    title: "Stop the Four-Move Trick",
+    game: null,
+    learn:
+      "Scholar’s Mate — the four-move queen-and-bishop attack on f7 that beats every unprepared kid. See it coming, shut it down.",
+    play: "You try the four-move trick in every game until blocking it is automatic.",
+    spark:
+      "f7 is the castle’s weak gate. She’s the guard who never falls for it — a superpower at school chess club.",
+    classic: {
+      learn:
+        "Scholar's Mate — the four-move queen-and-bishop strike on f7 — and its calm refutations.",
+      play: "Defend against it until automatic, then punish the early queen with developing moves.",
+      spark:
+        "An early queen loses time. Chase her with development and you win the opening for free.",
+    },
+  },
+  {
+    n: 19,
+    land: 5,
+    title: "Her First Opening",
+    game: null,
+    learn:
+      "One recipe, both colors. White: e4, knight f3, bishop c4, castle (the Italian Game). Black against e4: mirror it.",
+    play: "The same opening in every game. No memorizing — just a familiar, safe start.",
+    spark: "Make her an illustrated “opening recipe card” to keep next to the board.",
+    classic: {
+      learn:
+        "One opening recipe, both colors. White: e4, Nf3, Bc4, castle — the Italian Game. Black vs e4: mirror it.",
+      play: "The same opening every game. Ideas over memorization: center, pressure on f7, king safety.",
+      spark: "One opening played fifty times teaches more than five openings played ten.",
+    },
+    diagram: {
+      fen: "r1bqk1nr/pppp1ppp/2n5/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1",
+      caption: "The Italian Game: both sides developed, ready to castle.",
+    },
+  },
+  {
+    n: 20,
+    land: 5,
+    title: "The Pawn Race",
+    game: "pawnWars",
+    learn:
+      "King + pawn vs. king: the king walks in front of his pawn as a bodyguard and escorts it to promotion. First taste of the kings’ staring contest (opposition).",
+    play: "King-and-pawn endings from both sides on the real board; Pawn Wars rematches here.",
+    spark: "The bodyguard king walks the little pawn all the way home to be crowned.",
+    classic: {
+      learn:
+        "K+P vs K: the king escorts from IN FRONT of its pawn; the opposition decides. Rook pawns draw.",
+      play: "Play both sides until conversion is automatic; Pawn Wars rematches here.",
+      spark:
+        "Opposition — kings facing, one square between, opponent to move — decides most pawn endings. Learn to count it.",
+    },
+  },
+  {
+    n: 21,
+    land: 5,
+    title: "Winning the Won Game",
+    game: "hangingHunt",
+    learn:
+      "When ahead in points: trade pieces, keep pawns, push the passed pawn. Simpler board = safer win.",
+    play: "Start positions where she’s up a rook and must convert the win. Being winning and actually winning are different skills.",
+    spark: "“You have a full wallet — stop shopping, walk to the checkout.”",
+    classic: {
+      learn:
+        "Ahead in material: trade pieces (not pawns), activate the king, push the passed pawn.",
+      play: "Start up a rook and convert against real resistance.",
+      spark:
+        "Won positions don't win themselves. Simplify into an ending you already mastered — ladder, box, or escort.",
+    },
+  },
+  {
+    n: 22,
+    land: 5,
+    title: "Think Like a Champ",
+    game: "mateInOne",
+    learn:
+      "The champion’s checklist before every move: Checks, Captures, Threats — mine and theirs. Plus simple notation, so she can write “e4!” like the pros.",
+    play: "One slow game with the checklist said out loud both ways. She writes her first scoresheet.",
+    spark: "Her own scorebook. Game #1 goes on the fridge.",
+    classic: {
+      learn:
+        "Checks, captures, threats — theirs and yours — before every move. Plus simple algebraic notation.",
+      play: "One notated slow game with the checklist spoken aloud both ways.",
+      spark: "Notation turns every game into study material. Your losses become your best textbook.",
+    },
+  },
+  {
+    n: 23,
+    land: 5,
+    title: "Game Day",
+    game: null,
+    learn:
+      "Tournament manners: handshake before and after, touch-move, no takebacks, gracious in victory and defeat.",
+    play: "Real games against other kids — ChessKid online, school chess club, or a local club’s kids’ night.",
+    spark:
+      "Pick a chess hero together — show her Judit Polgár, the girl who grew up to beat world champions.",
+    classic: {
+      learn:
+        "Tournament habits: touch-move, clocks, handshakes, recording results — and composure either way.",
+      play: "Real opponents: a club evening or online rapid games.",
+      spark: "Play up. Losing to stronger players teaches faster than beating weaker ones.",
+    },
+  },
+  {
+    n: 24,
+    land: 5,
+    title: "Boss Battle & Crown",
+    game: "mateInOne",
+    learn: "Review her favorite tricks from the whole quest — she picks the highlights.",
+    play: "A best-of-three match against you, playing honestly (spot her a piece if needed). Then celebrate, whatever the score.",
+    spark:
+      "Print a certificate: “Chess Quest Champion.” Then plan the next adventure — a rated tournament, club membership, or coaching.",
+    classic: {
+      learn:
+        "Review the whole track — assemble your personal highlight reel of patterns that won you games.",
+      play: "A best-of-three match, full rules, notated, then an honest review together.",
+      spark:
+        "Finish here, then start Track 2: the climb from “knows the moves” to “wins on purpose”.",
+    },
+  },
+
+  /* ---- Track 2: Rising Player (lessons 25–48, Days 49–95) ---- */
+  {
+    n: 25,
+    land: 6,
+    title: "Forcing Moves: Mate in 2",
+    game: "mateInTwo",
+    learn:
+      "A forcing move leaves the enemy almost no answers: checks first, captures second, big threats third. Mate-in-2 is forcing moves in a chain: your check, their only reply, your mate.",
+    play: "The new Mate in 2 pack. Say the whole plan out loud BEFORE touching a piece: “I check here, the king must go there, then I mate.”",
+    spark:
+      "You’re not finding a move anymore — you’re telling the future. Two moves ahead is real wizard stuff.",
+    classic: {
+      learn:
+        "Forcing moves — checks, captures, threats — cut the reply tree down to almost nothing. A mate-in-2 is a forced line: your move, every defense, your mate.",
+      play: "The Mate in 2 pack. Calculate the full line before touching a piece; moving first is guessing.",
+      spark:
+        "“I go here, he must go there, I mate” — that sentence, said before you move, is the core skill of all calculation.",
+    },
+  },
+  {
+    n: 26,
+    land: 6,
+    title: "The Back-Rank Story",
+    game: "mateInTwo",
+    learn:
+      "A castled king behind his own pawns is safe from everything — except a rook or queen crashing through the back door. Cut the row, then slam it.",
+    play: "Back-rank mates in the Mate in 2 pack, then real-board setups: when does the king need a “window” (a pawn moved to let him breathe)?",
+    spark: "The king’s pawn shield is also his prison. You’re the one holding the key.",
+    classic: {
+      learn:
+        "The castled king’s pawn shield is also a trap: back-rank mates win more club games than any other pattern. Learn both sides — attack it, and make luft in time.",
+      play: "Back-rank puzzles in the Mate in 2 pack, then check every game: does either king need luft right now?",
+      spark:
+        "Before simplifying into “safe” positions, count the defenders of the back rank. Most one-move blunders live there.",
+    },
+    diagram: {
+      fen: "6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1",
+      from: "e1",
+      caption: "The back door is wide open — the pawn shield became a prison.",
+    },
+  },
+  {
+    n: 27,
+    land: 6,
+    title: "Master Forks",
+    game: "tacticTrainer",
+    gameOpts: { pack: "fork2" },
+    learn:
+      "Level-2 forks: the fork square must be SAFE, the targets must be worth it, and sometimes the fork comes with check so nothing can be saved.",
+    play: "The master fork pack — every wrong square gets punished. Then hunt forks-with-check in your own games.",
+    spark: "A fork with check is a robbery where the police can’t even come.",
+    classic: {
+      learn:
+        "Advanced forks: verify the landing square is unguarded, the targets outweigh your piece, and prefer forks with check — they remove all counterplay.",
+      play: "The fork2 pack, where careless squares are punished. In games, scan every check for a double attack.",
+      spark:
+        "Strong players don’t “spot” forks — they generate candidate checks and captures, then test each for a second target.",
+    },
+  },
+  {
+    n: 28,
+    land: 6,
+    title: "Pins & the Fake Defender",
+    game: "tacticTrainer",
+    gameOpts: { pack: "pin2" },
+    learn:
+      "A pinned piece is frozen — so it defends NOTHING. Removing the defender: capture or chase the guard, then take what it was guarding.",
+    play: "The master pin pack, then real-board drills: find the piece that only PRETENDS to defend.",
+    spark: "The pinned bodyguard is a statue of a bodyguard. Walk right past him.",
+    classic: {
+      learn:
+        "Pinned pieces don’t defend. Combine with removing the defender: eliminate or deflect the guard, then collect. Count captures with pinned pieces excluded.",
+      play: "The pin2 pack, then find “fake defenders” in your own games — defenders that are pinned, overloaded, or chaseable.",
+      spark: "Recount every exchange with pinned defenders removed from the math. Positions transform.",
+    },
+  },
+  {
+    n: 29,
+    land: 6,
+    title: "Master Skewers",
+    game: "tacticTrainer",
+    gameOpts: { pack: "skewer2" },
+    learn:
+      "Level-2 skewers: force the big piece onto the bad line first — a check that MAKES the king step in front of his treasure.",
+    play: "The master skewer pack. Then a real-board game where every check you give, you ask: what does it expose?",
+    spark: "Sometimes you build the shish-kebab yourself: push the king onto the stick, then skewer.",
+    classic: {
+      learn:
+        "Skewers are often prepared: a forcing check drives king or queen onto the fatal line first. Every check you consider — ask what it exposes behind the moving piece.",
+      play: "The skewer2 pack, then review your last games for missed line-up moments.",
+      spark:
+        "Kings and queens drift onto shared lines constantly in time trouble. The skewer is the punishment clause.",
+    },
+  },
+  {
+    n: 30,
+    land: 6,
+    title: "Discovered Double Trouble",
+    game: "tacticTrainer",
+    gameOpts: { pack: "disco2" },
+    learn:
+      "The master discovery: the piece that steps aside ALSO attacks something. Two threats, one move — only one can be answered.",
+    play: "The master discovery pack, then build batteries on purpose in a real game: rook behind rook, bishop behind queen.",
+    spark: "The curtain opens AND the person opening it throws a pie. Nobody can stop both.",
+    classic: {
+      learn:
+        "The refined discovery: the unmasking piece makes its own threat, so one move creates two problems. Batteries are discoveries in storage.",
+      play: "The disco2 pack, then deliberately build one battery per game and watch what it generates.",
+      spark:
+        "When a discovery is available, calculate the unmasking piece’s BEST square, not its first safe one. That choice is free tempo.",
+    },
+  },
+
+  {
+    n: 31,
+    land: 7,
+    title: "The Italian, With a Plan",
+    game: null,
+    learn:
+      "You know the Italian moves — now the WHY: the bishop eyes f7, the knight guards e5, castling connects the rooks. Every move has a job.",
+    play: "Play the Italian and say each piece’s job out loud as it develops. Then swap colors and say black’s jobs.",
+    spark: "An opening isn’t a password — it’s a seating plan for your army before the battle starts.",
+    classic: {
+      learn:
+        "Beyond move orders: Bc4 pressures f7, Nf3 controls e5 and enables castling, d3/c3 builds the pawn duo. Plans: c3+d4 break, or a kingside build with Re1/Nbd2/Nf1/Ng3.",
+      play: "Play the Italian saying each move’s purpose aloud. Then play black and state the mirror logic.",
+      spark:
+        "When you know a move’s job, you know what to do when the opponent deviates — that’s the difference between theory and understanding.",
+    },
+    diagram: {
+      fen: "r1bqk1nr/pppp1ppp/2n5/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 0 1",
+      caption: "The Italian: every piece has a job — the bishop watches f7, the knight guards e5.",
+    },
+  },
+  {
+    n: 32,
+    land: 7,
+    title: "Develop Like Clockwork",
+    game: "coinHop",
+    gameOpts: { pieces: ["N", "B", "Q", "R"] },
+    learn:
+      "Development is a race you can count: minor pieces out, castle, connect rooks — about 7 moves. Every wasted move is a lap you gave away.",
+    play: "Coin Hop with all the pieces — fastest routes only. Then count development moves in a real game: who finished the race first?",
+    spark: "Count your sleeping pieces after move 10. Zero sleepers = you win the race.",
+    classic: {
+      learn:
+        "Development is countable: two minors, castle, queen connect — roughly seven moves. Compare “developed armies” after move 10 in any game and the better position is usually obvious.",
+      play: "Coin Hop for efficient piece routes, then audit development counts in your recent games.",
+      spark:
+        "Tempo is a currency. Recapture toward development, chase with developing moves, never move twice without a reason you can say aloud.",
+    },
+  },
+  {
+    n: 33,
+    land: 7,
+    title: "Guard the Gate: Trap Defense",
+    game: "hangingHunt",
+    learn:
+      "Every kid-beating trap aims at f7/f2: Scholar’s Mate, the Fried Liver raid. The cures are calm: develop, castle, don’t grab poisoned pawns.",
+    play: "Piece Detective to sharpen your threat-scanning, then a grown-up plays trap openings at you until none of them land.",
+    spark: "Traps only catch players who move fast. Your superpower is one slow look at f7 every turn.",
+    classic: {
+      learn:
+        "The classic raids — Scholar's Mate, Fried Liver patterns, early Ng5 — all target f7. Defense is principled: develop, castle early, decline suspicious gifts, meet Ng5 with d5.",
+      play: "Piece Detective for threat scanning, then have a partner play trap lines at you until each refutation is automatic.",
+      spark:
+        "You don’t memorize refutations — you learn the smell of a raid: early queen, repeated aim at f7, gifts that cost tempo to take.",
+    },
+  },
+  {
+    n: 34,
+    land: 7,
+    title: "Fight for the Center",
+    game: "pawnWars",
+    learn:
+      "The center squares e4-d4-e5-d5 are the hill in king-of-the-hill: pieces there see everything. Pawn breaks (c3+d4!) are how you claim it.",
+    play: "Pawn Wars with a new eye: watch how the middle pawns decide everything. Then play a real game where every move must touch the center somehow.",
+    spark: "A knight in the center sees 8 squares; in the corner, 2. Same pony, different kingdom.",
+    classic: {
+      learn:
+        "Central control is piece activity: a centralized knight covers 8 squares, a rim knight 2–4. Pawn breaks (c3-d4 in the Italian) convert development leads into space.",
+      play: "Pawn Wars focused on central files, then a game where every move must fight for a central square — directly or by supporting a break.",
+      spark:
+        "When you don’t know what to do, improve your worst piece toward the center. It’s never wrong by much.",
+    },
+  },
+  {
+    n: 35,
+    land: 7,
+    title: "Open Files & the Rook Lift",
+    game: "rookMaze",
+    learn:
+      "Rooks are useless behind their own pawns and monsters on open files. Find (or make) the open file, double up, invade the 7th row.",
+    play: "Rook Maze — feel how walls choke a rook. Then in a real game: get ONE rook to an open file before move 15.",
+    spark:
+      "A rook on the 7th row eats pawns like popcorn. Two rooks there is called “pigs on the seventh.” Really.",
+    classic: {
+      learn:
+        "Rook value is file-dependent. Plan: identify the file that will open, put a rook there FIRST, double, invade the 7th. Rook lifts (Re1-e3-g3) create attacks from quiet positions.",
+      play: "Rook Maze for pathing instinct, then in games: one rook to an open or opening file before move 15.",
+      spark:
+        "“Pigs on the seventh” — doubled rooks on the 7th rank — routinely outweigh a whole extra piece.",
+    },
+  },
+  {
+    n: 36,
+    land: 7,
+    title: "Punish Opening Mistakes",
+    game: "mateInOne",
+    learn:
+      "When the enemy breaks the golden rules — queen too early, king stuck in the middle, greedy pawn grabs — there’s usually a punishment. Open lines at the uncastled king!",
+    play: "Mate in 1 pack for finishing instincts, then real games where a grown-up deliberately breaks one opening rule — find the punishment.",
+    spark: "An uncastled king in an open middle is a boss fight with the shields down.",
+    classic: {
+      learn:
+        "Punishing deviations: open the center against uncastled kings, gain tempi on early queens, accept sound gambits and return material for development.",
+      play: "The Mate in 1 pack for killer instinct, then games where your partner deliberately violates one principle — find the refutation over the board.",
+      spark:
+        "The punishment for most opening crimes is the same: open lines faster than the offender can organize.",
+    },
+  },
+
+  {
+    n: 37,
+    land: 8,
+    title: "The Opposition",
+    game: null,
+    learn:
+      "Kings can never touch — so when they stand face to face with one square between, whoever must move LOSES ground. That staring contest is called the opposition.",
+    play: "Kings-only staring contests on the real board: take the opposition, force the other king backwards, feel the zugzwang.",
+    spark: "It’s the only fight in chess you win by standing still and saying “you first.”",
+    classic: {
+      learn:
+        "Opposition: kings face off, one square apart, and the side NOT to move controls the position. Direct, distant, and diagonal opposition all reduce to counting.",
+      play: "Kings-only drills: take the opposition, outflank, force passage. Then apply it to K+P endings from both sides.",
+      spark:
+        "Zugzwang — “your turn, unfortunately” — decides most pawn endings. Opposition is how you hand it to the opponent.",
+    },
+    diagram: {
+      fen: "4k3/8/4K3/8/8/8/8/8 b - - 0 1",
+      caption: "The staring contest: black must move — and lose ground. That’s the opposition.",
+    },
+  },
+  {
+    n: 38,
+    land: 8,
+    title: "Escort the Pawn Home",
+    game: "pawnWars",
+    learn:
+      "K+P vs K, mastered: king IN FRONT of the pawn, use the opposition, and know the draw zones — rook pawns and stubborn defending kings.",
+    play: "Pawn Wars rematches, then the full escort on a real board from ten different starting spots — both sides!",
+    spark: "The pawn is the little sibling walking to school; the king walks AHEAD checking every corner first.",
+    classic: {
+      learn:
+        "The complete K+P vs K map: king in front + opposition = win; king behind or rook pawn = draw. Key squares make it instant arithmetic.",
+      play: "Escort drills from varied positions, defending side too — knowing WHEN it’s drawn saves half-points.",
+      spark:
+        "Every trade you make from now on should be checked against this map: which pawn ending am I trading into?",
+    },
+  },
+  {
+    n: 39,
+    land: 8,
+    title: "Philidor’s Fence",
+    game: "rookMaze",
+    learn:
+      "Rook endings, the drawing wall: park your rook on the third row like a fence — the enemy king can’t cross. When the pawn steps in, chase the king with checks from behind.",
+    play: "Rook Maze to warm the rook up, then defend Philidor on the real board until the fence feels solid.",
+    spark: "You’re building an invisible electric fence. The king touches it — bzzt — checks forever.",
+    classic: {
+      learn:
+        "Philidor’s position: defending rook on the 3rd rank fences the king out; once the pawn advances, swing behind for endless checks. The most valuable half-point in chess.",
+      play: "Defend Philidor repeatedly against a motivated attacker until it’s mechanical.",
+      spark:
+        "Rook endings are the most common endings in real chess. Philidor + Lucena cover the majority of them.",
+    },
+    diagram: {
+      fen: "4k3/8/8/3KP3/8/r7/8/4R3 b - - 0 1",
+      caption: "The fence on the third row: the white king may not cross while the rook patrols.",
+    },
+  },
+  {
+    n: 40,
+    land: 8,
+    title: "Lucena’s Bridge",
+    game: null,
+    learn:
+      "The winning wall: your pawn is one step from queening but your king is stuck in front. Build a bridge — rook to the 4th row, king steps out, checks get blocked by the bridge.",
+    play: "Build the bridge on the real board from both colors until the four steps are automatic: rook up, king out, walk, block.",
+    spark: "Your rook literally becomes a bridge the king walks across while arrows (checks) bounce off it.",
+    classic: {
+      learn:
+        "Lucena: pawn on the 7th, king in front, defender checking. Technique: Rf1-f4 (“building the bridge”), king emerges, interpose at the right moment. Win every time.",
+      play: "Drill the bridge from both sides until the move sequence is reflex, then mix Lucena/Philidor positions and name which is which.",
+      spark:
+        "Lucena wins the won rook endings; Philidor saves the lost ones. Together they’re most of a rating class.",
+    },
+    diagram: {
+      fen: "1K1k4/1P6/8/8/8/8/r7/2R5 w - - 0 1",
+      caption: "Pawn on the 7th, king boxed in — time to build the bridge.",
+    },
+  },
+  {
+    n: 41,
+    land: 8,
+    title: "Queen vs the Runner Pawn",
+    game: "coinHop",
+    gameOpts: { pieces: ["Q"] },
+    learn:
+      "A queen can catch almost any runaway pawn: zigzag closer with checks, park in front, bring the king. The sneaky draws: bishop and rook pawns on the 7th.",
+    play: "Coin Hop in queen mode for zigzag feel, then queen-vs-pawn races on the real board — learn which pawns escape!",
+    spark: "The queen is a police helicopter chasing a getaway car. Only two streets in town lead to a hideout.",
+    classic: {
+      learn:
+        "Q vs P on the 7th: win by checking closer and occupying the promotion square, EXCEPT bishop/rook pawns where stalemate tricks draw. Know the two exceptions cold.",
+      play: "Queen maneuvering in Coin Hop, then Q vs P races across all four pawn types.",
+      spark:
+        "The stalemate defense (rook/bishop pawn) is one of few endgame facts that reverses results instantly. Check the pawn’s file before you relax.",
+    },
+  },
+  {
+    n: 42,
+    land: 8,
+    title: "Endgame Habits",
+    game: "mateInTwo",
+    learn:
+      "The endgame rulebook: activate the king (he’s a fighter now!), rooks BEHIND passed pawns, cut the enemy king off, and never rush.",
+    play: "Mate in 2 pack to keep the finishing sharp, then a full endgame from a real game replayed with the habit list next to the board.",
+    spark: "In the endgame the king takes off his crown and puts on boxing gloves.",
+    classic: {
+      learn:
+        "Endgame principles: king activity is worth a pawn, rooks belong behind passed pawns (yours AND theirs), cut off kings, push candidates first, don’t hurry.",
+      play: "The Mate in 2 pack for finishing, then replay one of your real endings against the principles list.",
+      spark:
+        "“Don’t hurry” is technical advice: improving every piece before committing wins endings without calculation.",
+    },
+  },
+
+  {
+    n: 43,
+    land: 9,
+    title: "Outposts: A Home for the Pony",
+    game: "coinHop",
+    gameOpts: { pieces: ["N"] },
+    learn:
+      "An outpost is a square in enemy land where no enemy pawn can ever kick you. A knight living there is worth a rook. Find it, escort him there, watch him rule.",
+    play: "Coin Hop knight mode for route-finding, then a real game with one mission: plant a knight on an outpost and keep him there.",
+    spark: "You’re building the pony a castle in enemy territory. He pays rent in checkmate threats.",
+    classic: {
+      learn:
+        "Outposts: squares no enemy pawn can attack, ideally protected by yours. Knights on 5th/6th-rank outposts dominate bishops and win games slowly. Create them by inducing pawn moves.",
+      play: "Knight-route drills in Coin Hop, then a game with one strategic mission: create and occupy an outpost.",
+      spark:
+        "You can CREATE outposts — every enemy pawn push leaves squares behind forever. Provoke, then occupy.",
+    },
+    diagram: {
+      fen: "6k1/8/8/3N4/8/8/8/6K1 w - - 0 1",
+      from: "d5",
+      caption: "A knight on a protected central outpost — eight squares of trouble, forever.",
+    },
+  },
+  {
+    n: 44,
+    land: 9,
+    title: "Files, Ranks & Pigs",
+    game: "rookMaze",
+    learn:
+      "The rook plan, complete: open the file (or trade onto it), double the rooks, invade the 7th. Two rooks on the 7th row win by themselves.",
+    play: "Rook Maze at speed, then replay a real game hunting one thing only: the moment a file opened and who grabbed it first.",
+    spark: "Files are highways. Whoever owns the highway delivers all the packages.",
+    classic: {
+      learn:
+        "The full rook program: provoke or force a file open, seize it first, double, invade. Doubled rooks on the 7th (“pigs”) generate perpetual threats and win material by themselves.",
+      play: "Speed Rook Maze, then audit a real game: every file that opened — who took it, and what did it cost?",
+      spark: "File control compounds like interest. One tempo spent claiming a file early pays material later.",
+    },
+    diagram: {
+      fen: "6k1/R7/8/8/8/8/8/6K1 w - - 0 1",
+      from: "a7",
+      caption: "The seventh rank: every enemy pawn lives there, and the king hides there.",
+    },
+  },
+  {
+    n: 45,
+    land: 9,
+    title: "Pawn Shapes",
+    game: "pawnWars",
+    learn:
+      "Pawns write the story of the position: passed pawns (heroes), isolated pawns (orphans), doubled pawns (twins in one bed), pawn chains (walls with a weak base).",
+    play: "Pawn Wars one more time — now NAME every shape as it appears. Then find each shape in one of your real games.",
+    spark: "Pawns can’t move backwards, so every pawn shape is a promise you can’t take back.",
+    classic: {
+      learn:
+        "Structures: passed (push it), isolated (blockade, then attack), doubled (target the front one), backward (park a knight in front), chains (attack the base).",
+      play: "Pawn Wars while naming every structure aloud, then classify the structures in your last three games.",
+      spark:
+        "Trade pieces when your structure is better; trade pawns when it’s worse. That one rule is half of strategy.",
+    },
+  },
+  {
+    n: 46,
+    land: 9,
+    title: "Candidate Moves",
+    game: "hangingHunt",
+    learn:
+      "Champions don’t look at one move — they list THREE candidates (checks, captures, threats first), peek one move deep into each, THEN choose.",
+    play: "Piece Detective for the scanning habit, then a slow game with the rule: say three candidate moves out loud before every single move.",
+    spark: "One idea is a guess. Three ideas is a choice. Champions always get to choose.",
+    classic: {
+      learn:
+        "The candidate-move discipline: generate 2–4 plausible moves (forcing ones first), calculate each briefly, compare landing positions, then commit. It prevents both blunders and autopilot.",
+      play: "Piece Detective for scan discipline, then a slow game verbalizing three candidates every move, with a partner auditing.",
+      spark: "Blunders happen on moves that were never compared to an alternative. The list IS the safety net.",
+    },
+  },
+  {
+    n: 47,
+    land: 9,
+    title: "Your Games, Your Textbook",
+    game: null,
+    learn:
+      "Every game you play hides three lessons: the move where it turned, the tactic someone missed, the habit that cracked. Finding them is called analysis — champions do it after EVERY game.",
+    play: "Replay your last real game from the scoresheet. Find the turning point together. One sentence: “next time I will…”",
+    spark: "Losing a game costs nothing if you keep the receipt. Analysis is the receipt.",
+    classic: {
+      learn:
+        "Post-game analysis, the method: replay without an engine first, mark the turning point, find the missed tactic for BOTH sides, extract one habit-level fix.",
+      play: "Analyze your most recent serious game: turning point, missed shots, one-sentence lesson. Only then check with an engine if you use one.",
+      spark: "One honestly analyzed loss teaches more than ten wins. The rating is downstream of the notebook.",
+    },
+  },
+  {
+    n: 48,
+    land: 9,
+    title: "Boss Battle: Rising Player",
+    game: "mateInTwo",
+    learn:
+      "Everything, together: opening plan, candidate moves, tactics from safe squares, a real endgame finish. This is the whole mountain in one game.",
+    play: "The final challenge: a best-of-three match, slow, notated, analyzed after. Then the Mate in 2 pack one last time — all twelve, no hints.",
+    spark:
+      "Print the Rising Player certificate. Then look up — club ladders, rated tournaments, the whole chess world is open now.",
+    classic: {
+      learn:
+        "Integration: opening plan into middlegame method into endgame technique, with the blunder-check running underneath the whole time.",
+      play: "A notated best-of-three at slow pace, fully analyzed afterwards. Then the Mate in 2 pack clean — no hints, no misses.",
+      spark:
+        "From here it’s rated games, a club, and a puzzle habit. The method you built is the same one titled players use — just add miles.",
+    },
+  },
+];

--- a/apps/web/src/games/chess-quest/content/puzzles.ts
+++ b/apps/web/src/games/chess-quest/content/puzzles.ts
@@ -1,0 +1,397 @@
+// Chess Quest puzzle packs — transcribed verbatim from the original app
+// (chess-quest js/puzzles.js). Every entry is machine-verified by
+// content/__tests__/puzzles.test.ts; do not edit data to make tests pass.
+
+export type MatePuzzle = { fen: string; solution: string; name: string; hint: string };
+export type HuntPuzzle = { fen: string; answer: string; story: string };
+export type TacticPuzzle = { fen: string; solution: string; story: string };
+
+// Mate-in-1 puzzle pack. White to move in every puzzle.
+// solution is the move we hint toward; the game accepts ANY legal move
+// that delivers checkmate.
+export const MATE1: MatePuzzle[] = [
+  {
+    fen: "6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1",
+    solution: "e1e8",
+    name: "Sneak down the hallway",
+    hint: "The back row is wide open — slide all the way!",
+  },
+  {
+    fen: "6k1/5ppp/8/8/8/8/8/3Q2K1 w - - 0 1",
+    solution: "d1d8",
+    name: "Queen takes the hallway",
+    hint: "Same trick, stronger piece.",
+  },
+  {
+    fen: "6k1/8/6K1/8/8/8/8/Q7 w - - 0 1",
+    solution: "a1a8",
+    name: "The queen's fence",
+    hint: "Lock the whole top row. Your king guards the doors.",
+  },
+  {
+    fen: "7k/R7/1R6/8/8/8/8/6K1 w - - 0 1",
+    solution: "b6b8",
+    name: "The lawnmower",
+    hint: "One rook holds the row — the other one finishes the job.",
+  },
+  {
+    fen: "k7/6R1/8/8/8/8/8/5K1R w - - 0 1",
+    solution: "h1h8",
+    name: "Lawnmower, other side",
+    hint: "Rooks take turns. Whose turn is it?",
+  },
+  {
+    fen: "7k/Q7/6K1/8/8/8/8/8 w - - 0 1",
+    solution: "a7g7",
+    name: "The royal hug",
+    hint: "The queen stands right next to the king — bodyguard behind her.",
+  },
+  {
+    fen: "7k/6p1/5N2/8/8/8/8/R5K1 w - - 0 1",
+    solution: "a1a8",
+    name: "Knight and rook team up",
+    hint: "The pony already guards the escape squares.",
+  },
+  {
+    fen: "6rk/6pp/8/6N1/8/8/8/6K1 w - - 0 1",
+    solution: "g5f7",
+    name: "The smother",
+    hint: "The king is trapped by his own friends. Who can jump in?",
+  },
+  {
+    fen: "kr6/p7/P7/1N6/8/8/8/6K1 w - - 0 1",
+    solution: "b5c7",
+    name: "Corner pony",
+    hint: "The king's own army boxes him in. One hop ends it.",
+  },
+  {
+    fen: "6rk/6p1/8/8/3Q4/8/8/6K1 w - - 0 1",
+    solution: "d4h4",
+    name: "The side door",
+    hint: "The h-file is a wide-open corridor.",
+  },
+  {
+    fen: "k7/p1K5/1P6/8/8/8/8/8 w - - 0 1",
+    solution: "b6b7",
+    name: "The little giant",
+    hint: "Even the smallest soldier can win the war.",
+  },
+  {
+    fen: "2k5/P7/2K5/8/8/8/8/8 w - - 0 1",
+    solution: "a7a8",
+    name: "Crowned!",
+    hint: "Walk one more step and the pawn becomes a queen — with checkmate!",
+  },
+  {
+    fen: "k7/p7/2K5/8/8/8/8/1Q6 w - - 0 1",
+    solution: "b1b7",
+    name: "The bodyguard queen",
+    hint: "Stand right next to the king — your own king protects you.",
+  },
+  {
+    fen: "5k2/8/5K2/8/8/8/8/7R w - - 0 1",
+    solution: "h1h8",
+    name: "Box on the edge",
+    hint: "Your king blocks the whole row below. Slide across the top!",
+  },
+  {
+    fen: "4k3/4p3/4K3/8/8/8/8/7R w - - 0 1",
+    solution: "h1h8",
+    name: "Trapped in the middle",
+    hint: "His own pawn is in the way — and your king does the rest.",
+  },
+  {
+    fen: "k7/8/8/8/7R/8/1R6/6K1 w - - 0 1",
+    solution: "h4a4",
+    name: "Ladder lying down",
+    hint: "The ladder works sideways too. One rook holds the b-file…",
+  },
+  {
+    fen: "3k4/8/3K4/8/8/8/8/Q7 w - - 0 1",
+    solution: "a1a8",
+    name: "Queen slam",
+    hint: "The kings are staring at each other. Slam the back row!",
+  },
+  {
+    fen: "6k1/6p1/6P1/8/8/8/8/R5K1 w - - 0 1",
+    solution: "a1a8",
+    name: "Pawn locks the gate",
+    hint: "Your little pawn guards both escape doors already.",
+  },
+];
+
+// Hanging-piece positions for the Piece Detective game. White to move;
+// exactly one black piece (never the king) is attacked and undefended.
+// Uniqueness is machine-verified by the tests.
+export const HUNTS: HuntPuzzle[] = [
+  {
+    fen: "6k1/3n1ppp/8/8/8/8/8/3Q2K1 w - - 0 1",
+    answer: "d7",
+    story: "The queen stares down the d-file. Someone forgot their bodyguard…",
+  },
+  {
+    fen: "6k1/1p2bppp/n7/8/8/8/8/4R1K1 w - - 0 1",
+    answer: "e7",
+    story: "One black piece has a friend nearby. The other is all alone.",
+  },
+  {
+    fen: "6k1/5ppp/8/1q6/8/2N5/8/6K1 w - - 0 1",
+    answer: "b5",
+    story: "Even a queen can be free stuff if nobody guards her!",
+  },
+  {
+    fen: "2r3k1/5ppp/8/8/8/7B/8/6K1 w - - 0 1",
+    answer: "c8",
+    story: "The bishop peeks all the way down the long diagonal.",
+  },
+  {
+    fen: "6k1/5ppp/8/3n4/2P5/8/8/6K1 w - - 0 1",
+    answer: "d5",
+    story: "The littlest attacker! Pawns love catching big ponies.",
+  },
+  {
+    fen: "6k1/5ppp/8/8/8/2r5/8/2R3K1 w - - 0 1",
+    answer: "c3",
+    story: "Two rooks on one road — but only one of them is safe.",
+  },
+  {
+    fen: "3b2k1/5ppp/8/8/8/8/3R4/3R2K1 w - - 0 1",
+    answer: "d8",
+    story: "Double trouble on the d-file. The bishop never saw it coming.",
+  },
+  {
+    fen: "6k1/5ppp/2n5/8/3N4/8/8/6K1 w - - 0 1",
+    answer: "c6",
+    story: "Pony vs. pony! One of them wandered too far from home.",
+  },
+];
+
+// Trick Shots packs. White to move; playing the solution (or any move that
+// pulls off the same trick — the engine judges) wins the case.
+export const TACTICS: Record<"fork" | "pin" | "skewer" | "disco", TacticPuzzle[]> = {
+  fork: [
+    {
+      fen: "r3k3/8/8/1N6/8/8/8/6K1 w - - 0 1",
+      solution: "b5c7",
+      story: "The pony sees the king AND the rook. One hop, two dinners!",
+    },
+    {
+      fen: "6k1/8/8/2n1n3/8/3P4/8/6K1 w - - 0 1",
+      solution: "d3d4",
+      story: "The littlest soldier can poke two ponies at once.",
+    },
+    {
+      fen: "6k1/1n6/8/8/8/8/8/3Q2K1 w - - 0 1",
+      solution: "d1d5",
+      story: "Find the magic square where the queen shouts CHECK and grabs the pony next turn.",
+    },
+    {
+      fen: "2k1q3/8/8/8/2N5/8/8/6K1 w - - 0 1",
+      solution: "c4d6",
+      story: "The royal family fork — king and queen on one fork. The fanciest trick in chess!",
+    },
+  ],
+  pin: [
+    {
+      fen: "4k3/8/2n5/8/8/8/8/5BK1 w - - 0 1",
+      solution: "f1b5",
+      story: "Freeze the pony! If it moves, the king behind it is in trouble.",
+    },
+    {
+      fen: "3k4/8/8/3q4/8/8/8/R3K3 w - - 0 1",
+      solution: "a1d1",
+      story: "Pin the queen to her king. If she takes you, your king takes her back!",
+    },
+    {
+      fen: "k7/8/2q5/8/2B2N2/8/8/6K1 w - - 0 1",
+      solution: "c4d5",
+      story: "The bishop lines up queen and king. Your pony guards the landing spot.",
+    },
+  ],
+  skewer: [
+    {
+      fen: "4r3/8/8/4k3/8/8/8/R5K1 w - - 0 1",
+      solution: "a1e1",
+      story: "Check! The king must step aside — and look what was hiding behind him.",
+    },
+    {
+      fen: "q7/8/8/3k4/8/8/4B3/6K1 w - - 0 1",
+      solution: "e2f3",
+      story: "A shish-kebab on the long diagonal: king in front, queen behind.",
+    },
+    {
+      fen: "4q3/8/4k3/8/8/8/8/3Q2K1 w - - 0 1",
+      solution: "d1e2",
+      story: "Queens face off — but their king is standing in the middle of the road.",
+    },
+  ],
+  disco: [
+    {
+      fen: "4k3/8/8/8/4N3/8/8/4R1K1 w - - 0 1",
+      solution: "e4d6",
+      story: "Move the pony and — surprise! — the rook behind him was aiming all along.",
+    },
+    {
+      fen: "3k4/8/8/3B4/8/8/8/3R2K1 w - - 0 1",
+      solution: "d5c6",
+      story: "The bishop steps off the road and the rook thunders down it.",
+    },
+    {
+      fen: "6k1/8/8/3P4/8/8/B7/6K1 w - - 0 1",
+      solution: "d5d6",
+      story: "Even a tiny pawn step can open the curtain for the archer.",
+    },
+  ],
+};
+
+// Mate-in-2 pack (Track 2). White to move; the engine accepts ANY move that
+// forces mate in two (isMateIn2After), then plays black's toughest defense.
+// Every entry is machine-verified: no mate-in-1 exists, and the solution
+// forces mate against every reply.
+export const MATE2: MatePuzzle[] = [
+  {
+    fen: "8/7k/R7/1R6/8/8/8/6K1 w - - 0 1",
+    solution: "b5b7",
+    name: "The ladder, one rung early",
+    hint: "Check on the 7th row first — then the back row slams shut.",
+  },
+  {
+    fen: "8/k7/7R/6R1/8/8/8/6K1 w - - 0 1",
+    solution: "g5g7",
+    name: "Ladder from the left",
+    hint: "Same ladder, other side. Which rook gives the check?",
+  },
+  {
+    fen: "8/7k/R7/1Q6/8/8/8/6K1 w - - 0 1",
+    solution: "b5b7",
+    name: "Queen joins the ladder",
+    hint: "The queen takes the 7th row — the rook finishes on the 8th.",
+  },
+  {
+    fen: "7k/8/8/4K3/8/8/6Q1/8 w - - 0 1",
+    solution: "e5f6",
+    name: "The king lends a hand",
+    hint: "A quiet king step first. Then the queen lands right next door.",
+  },
+  {
+    fen: "k7/8/2K5/8/8/8/4Q3/8 w - - 0 1",
+    solution: "c6b6",
+    name: "Walk, then strike",
+    hint: "March your king one step closer — the queen sweeps the back row.",
+  },
+  {
+    fen: "7k/5K2/6P1/6P1/8/8/8/8 w - - 0 1",
+    solution: "g6g7",
+    name: "Crowning with check",
+    hint: "Push! The brand-new queen arrives with checkmate — the little brother guards the exit.",
+  },
+  {
+    fen: "k7/2K5/1P6/1P6/8/8/8/8 w - - 0 1",
+    solution: "b6b7",
+    name: "Coronation corner",
+    hint: "One more pawn step. Where does the king have to go?",
+  },
+  {
+    fen: "4k3/8/8/8/8/8/1R6/R5K1 w - - 0 1",
+    solution: "b2b7",
+    name: "Cut, then slam",
+    hint: "First cut off the 7th row — no check needed. Then slam the 8th.",
+  },
+  {
+    fen: "8/2K5/8/8/1Q6/R7/7k/8 w - - 0 1",
+    solution: "b4b2",
+    name: "Ladder, going down",
+    hint: "The ladder works downhill too. Queen checks, rook finishes.",
+  },
+  {
+    fen: "7k/8/8/6K1/8/8/8/R7 w - - 0 1",
+    solution: "g5g6",
+    name: "Shoulder to shoulder",
+    hint: "Step your king up close first. Then the rook delivers the letter.",
+  },
+  {
+    fen: "k7/8/8/1K6/8/8/8/7R w - - 0 1",
+    solution: "b5b6",
+    name: "Cornered by teamwork",
+    hint: "King to b6 takes every door away. The rook does the rest.",
+  },
+  {
+    fen: "k7/2K5/8/1P5p/3B4/8/8/8 w - - 0 1",
+    solution: "b5b6",
+    name: "The quiet squeeze",
+    hint: "No check at all! Take away the last free square and wait one move.",
+  },
+];
+
+// Tier-2 Trick Shots (Track 2): same detectors, trickier boards — poisoned
+// squares, defended targets, double threats. Verified like TACTICS.
+export const TACTICS2: Record<"fork2" | "pin2" | "skewer2" | "disco2", TacticPuzzle[]> = {
+  fork2: [
+    {
+      fen: "4q1k1/5p1p/8/3N4/8/8/8/6K1 w - - 0 1",
+      solution: "d5f6",
+      story: "The pony leaps in with CHECK — and lands on the queen's fork too!",
+    },
+    {
+      fen: "r5k1/6pp/8/8/8/8/8/3Q2K1 w - - 0 1",
+      solution: "d1d5",
+      story: "One magic square sees two windows: the king down one diagonal, the rook down the other.",
+    },
+    {
+      fen: "4k3/8/8/6p1/R6b/8/8/6K1 w - - 0 1",
+      solution: "a4e4",
+      story: "Don't grab the guarded bishop — slide to the crossroads and fork it with the king!",
+    },
+  ],
+  pin2: [
+    {
+      fen: "1k6/pp6/3q4/8/7B/8/7P/6K1 w - - 0 1",
+      solution: "h4g3",
+      story: "Tuck the bishop behind your own pawn — now the queen is frozen to her king.",
+    },
+    {
+      fen: "q3k3/3p4/2n5/8/8/8/4B3/6K1 w - - 0 1",
+      solution: "e2f3",
+      story: "The long diagonal! Freeze the pony to the queen hiding in the corner.",
+    },
+    {
+      fen: "6k1/6pp/4r3/8/8/8/8/2Q3K1 w - - 0 1",
+      solution: "c1c4",
+      story: "Pin the rook from the side — it can't step off the king's diagonal.",
+    },
+  ],
+  skewer2: [
+    {
+      fen: "8/pr6/8/3k4/8/7B/8/6K1 w - - 0 1",
+      solution: "h3g2",
+      story: "Check from the corner pocket! The king must step aside — his rook was hiding behind.",
+    },
+    {
+      fen: "4r2k/7p/8/4q3/8/8/8/R4K2 w - - 0 1",
+      solution: "a1e1",
+      story: "Poke the queen down the open file. When she runs, grab what stood behind her.",
+    },
+    {
+      fen: "8/8/5kp1/8/8/8/1q6/6KQ w - - 0 1",
+      solution: "h1h8",
+      story: "The longest skewer in chess: corner to corner, king in front, queen behind.",
+    },
+  ],
+  disco2: [
+    {
+      fen: "6k1/3q1p1p/8/8/6N1/8/8/6RK w - - 0 1",
+      solution: "g4f6",
+      story: "The pony jumps away, the rook shouts CHECK — and the pony pokes the queen. Double magic!",
+    },
+    {
+      fen: "3k4/5p2/8/8/8/3B4/8/3Q2K1 w - - 0 1",
+      solution: "d3b5",
+      story: "Step the bishop aside with a threat — the queen was aiming down the road all along.",
+    },
+    {
+      fen: "3r2k1/7p/4P3/8/8/1B6/8/6K1 w - - 0 1",
+      solution: "e6e7",
+      story: "One tiny pawn step: the bishop checks the king AND the pawn attacks the rook!",
+    },
+  ],
+};

--- a/apps/web/src/games/chess-quest/engine/__tests__/board.test.ts
+++ b/apps/web/src/games/chess-quest/engine/__tests__/board.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { sqIdx, sqName, parseFEN, isWhitePiece, isBlackPiece } from "../board";
+
+describe("square mapping", () => {
+  it("a8 is index 0, h1 is 63", () => {
+    expect(sqIdx("a8")).toBe(0);
+    expect(sqIdx("h1")).toBe(63);
+  });
+  it("round-trips every square", () => {
+    for (let i = 0; i < 64; i++) expect(sqIdx(sqName(i))).toBe(i);
+  });
+});
+
+describe("pieces", () => {
+  it("classifies colors; empty is neither", () => {
+    expect(isWhitePiece("Q")).toBe(true);
+    expect(isBlackPiece("q")).toBe(true);
+    expect(isWhitePiece("")).toBe(false);
+    expect(isBlackPiece("")).toBe(false);
+  });
+});
+
+describe("parseFEN", () => {
+  it("start position: 64 squares, correct corners, white to move", () => {
+    const { board, whiteToMove } = parseFEN(
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    );
+    expect(board).toHaveLength(64);
+    expect(board[sqIdx("a8")]).toBe("r");
+    expect(board[sqIdx("e1")]).toBe("K");
+    expect(board[sqIdx("e4")]).toBe("");
+    expect(whiteToMove).toBe(true);
+  });
+  it("reads side to move; defaults to white", () => {
+    expect(parseFEN("8/8/8/8/8/8/8/8 b - - 0 1").whiteToMove).toBe(false);
+    expect(parseFEN("8/8/8/8/8/8/8/8").whiteToMove).toBe(true);
+  });
+});

--- a/apps/web/src/games/chess-quest/engine/__tests__/mate.test.ts
+++ b/apps/web/src/games/chess-quest/engine/__tests__/mate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx } from "../board";
+import { applyMove, legalTargets } from "../moves";
+import { isMate, isStalemate, hasMateIn1, isMateIn2After, bestDefense } from "../mate";
+
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("mate and stalemate", () => {
+  it("back-rank mate detected", () => {
+    const board = applyMove(b("6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1"), sqIdx("e1"), sqIdx("e8"));
+    expect(isMate(board, false)).toBe(true);
+  });
+  it("corner stalemate detected, and is not mate", () => {
+    const board = b("k7/2Q5/1K6/8/8/8/8/8 b - - 0 1");
+    expect(isStalemate(board, false)).toBe(true);
+    expect(isMate(board, false)).toBe(false);
+  });
+});
+
+describe("mate-in-2 verifier (ladder pattern)", () => {
+  // Kh7 vs Ra6+Rb5: Rb7+ forces Kg8/Kh8, then Ra8#.
+  const fen = "8/7k/R7/1R6/8/8/8/6K1 w - - 0 1";
+  it("no mate-in-1 here", () => {
+    expect(hasMateIn1(b(fen), true)).toBe(false);
+  });
+  it("Rb7+ is mate in 2; Rb6 is not", () => {
+    expect(isMateIn2After(b(fen), sqIdx("b5"), sqIdx("b7"))).toBe(true);
+    expect(isMateIn2After(b(fen), sqIdx("b5"), sqIdx("b6"))).toBe(false);
+  });
+  it("bestDefense returns a legal black king reply", () => {
+    const afterCheck = applyMove(b(fen), sqIdx("b5"), sqIdx("b7"));
+    const d = bestDefense(afterCheck);
+    expect(d).not.toBeNull();
+    expect(afterCheck[d!.from]).toBe("k");
+    expect(legalTargets(afterCheck, d!.from)).toContain(d!.to);
+  });
+});
+
+describe("mate-in-2 guardrails", () => {
+  it("an immediate mate is not mate-in-2", () => {
+    const board = b("6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1");
+    expect(hasMateIn1(board, true)).toBe(true);
+    expect(isMateIn2After(board, sqIdx("e1"), sqIdx("e8"))).toBe(false);
+  });
+  it("bare kings force nothing", () => {
+    const board = b("k7/8/8/8/8/8/8/K7 w - - 0 1");
+    expect(hasMateIn1(board, true)).toBe(false);
+    expect(isMateIn2After(board, sqIdx("a1"), sqIdx("a2"))).toBe(false);
+  });
+});

--- a/apps/web/src/games/chess-quest/engine/__tests__/moves.test.ts
+++ b/apps/web/src/games/chess-quest/engine/__tests__/moves.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx, sqName } from "../board";
+import { legalTargets, applyMove, inCheck, allLegalMoves } from "../moves";
+
+const names = (idxs: number[]) => idxs.map(sqName).sort();
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("knight moves", () => {
+  it("b1 knight in the corner region -> a3,c3,d2", () => {
+    expect(names(legalTargets(b("8/8/8/8/8/8/8/1N6 w - - 0 1"), sqIdx("b1")))).toEqual([
+      "a3",
+      "c3",
+      "d2",
+    ]);
+  });
+  it("e5 knight has 8 moves", () => {
+    expect(legalTargets(b("8/8/8/4N3/8/8/8/8 w - - 0 1"), sqIdx("e5"))).toHaveLength(8);
+  });
+});
+
+describe("pawn moves", () => {
+  it("e2 pawn -> e3,e4 (double from start)", () => {
+    expect(names(legalTargets(b("8/8/8/8/8/8/4P3/8 w - - 0 1"), sqIdx("e2")))).toEqual([
+      "e3",
+      "e4",
+    ]);
+  });
+  it("captures diagonally, both colors", () => {
+    const board = b("8/8/8/3p4/4P3/8/8/8 w - - 0 1");
+    expect(names(legalTargets(board, sqIdx("e4")))).toContain("d5");
+    expect(names(legalTargets(board, sqIdx("d5")))).toContain("e4");
+  });
+  it("promotion auto-queens", () => {
+    const after = applyMove(b("8/4P3/8/8/8/8/8/8 w - - 0 1"), sqIdx("e7"), sqIdx("e8"));
+    expect(after[sqIdx("e8")]).toBe("Q");
+  });
+  it("a-file pawn does not wrap to h-file", () => {
+    expect(names(legalTargets(b("8/8/8/8/8/7p/P7/8 w - - 0 1"), sqIdx("a2")))).not.toContain(
+      "h3",
+    );
+  });
+});
+
+describe("sliders", () => {
+  it("rook stops before own pawn", () => {
+    const t = names(legalTargets(b("8/8/8/3R4/8/3P4/8/8 w - - 0 1"), sqIdx("d5")));
+    expect(t).not.toContain("d3");
+    expect(t).toContain("d4");
+  });
+});
+
+describe("check and legality", () => {
+  it("pinned rook stays on the e-file but may capture the pinner", () => {
+    const t = names(legalTargets(b("4r3/8/8/8/4R3/8/8/4K3 w - - 0 1"), sqIdx("e4")));
+    expect(t.every((s) => s[0] === "e")).toBe(true);
+    expect(t).toContain("e8");
+  });
+  it("king in check must leave the file", () => {
+    const board = b("4r3/8/8/8/8/8/8/4K3 w - - 0 1");
+    expect(inCheck(board, true)).toBe(true);
+    expect(names(legalTargets(board, sqIdx("e1"))).every((s) => s[0] !== "e")).toBe(true);
+  });
+  it("allLegalMoves only yields the side's pieces", () => {
+    for (const m of allLegalMoves(b("4r3/8/8/8/8/8/8/4K3 w - - 0 1"), true)) {
+      expect(sqName(m.from)).toBe("e1");
+    }
+  });
+});

--- a/apps/web/src/games/chess-quest/engine/__tests__/paths.test.ts
+++ b/apps/web/src/games/chess-quest/engine/__tests__/paths.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx } from "../board";
+import { pathDistances } from "../paths";
+
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("pathDistances (rook maze)", () => {
+  it("detours around a wall: blocked a8 takes 3 moves", () => {
+    // rook a1; own wall pawns a2,b2,c2
+    const d = pathDistances(b("8/8/8/8/8/8/PPP5/R7 w - - 0 1"), sqIdx("a1"));
+    expect(d[sqIdx("a8")]).toBe(3);
+    expect(d[sqIdx("a2")]).toBe(-1); // own wall square unreachable
+    expect(d[sqIdx("h1")]).toBe(1); // open rank
+  });
+  it("capture square is reachable but not passable", () => {
+    // rook a1, enemy queen a4; a8 hides behind her
+    const d = pathDistances(b("8/8/8/8/q7/8/8/R7 w - - 0 1"), sqIdx("a1"));
+    expect(d[sqIdx("a4")]).toBe(1);
+    expect(d[sqIdx("a8")]).not.toBe(1);
+  });
+});

--- a/apps/web/src/games/chess-quest/engine/__tests__/tactics.test.ts
+++ b/apps/web/src/games/chess-quest/engine/__tests__/tactics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx, sqName } from "../board";
+import { applyMove } from "../moves";
+import {
+  pieceValue,
+  isForkAfter,
+  isPinAfter,
+  isSkewerAfter,
+  isDiscoveredAfter,
+  attackersOf,
+  defendersOf,
+} from "../tactics";
+
+const b = (fen: string) => parseFEN(fen).board;
+const names = (idxs: number[]) => idxs.map(sqName).sort();
+
+describe("piece values", () => {
+  it("standard values, case-insensitive, empty is 0", () => {
+    expect(pieceValue("Q")).toBe(9);
+    expect(pieceValue("n")).toBe(3);
+    expect(pieceValue("")).toBe(0);
+  });
+});
+
+describe("detectors", () => {
+  it("royal knight fork detected (knight on c7 hits king a8 and rook e8)", () => {
+    const board = applyMove(b("k3r3/8/2N5/8/8/8/8/6K1 w - - 0 1"), sqIdx("c6"), sqIdx("c7"));
+    expect(isForkAfter(board, sqIdx("c7"))).toBe(true);
+  });
+  it("pin detected: rook pins knight to the king behind it", () => {
+    // From e1 up the e-file: knight e5 in front, king e8 hides behind → pin.
+    const board = b("4k3/8/8/4n3/8/8/8/4R1K1 w - - 0 1");
+    expect(isPinAfter(board, sqIdx("e1"))).toBe(true);
+  });
+  it("skewer detected: king in front must run, queen behind falls", () => {
+    // From e1 up the e-file: king e6 in front, queen e8 behind → skewer.
+    const board = b("4q3/8/4k3/8/8/8/8/4R1K1 b - - 0 1");
+    expect(isSkewerAfter(board, sqIdx("e1"))).toBe(true);
+  });
+  it("discovered check: the mover is not the checker", () => {
+    // Bishop moves off the e-file, Re1 behind gives the check
+    const start = b("4k3/8/8/8/4B3/8/8/4R1K1 w - - 0 1");
+    const after = applyMove(start, sqIdx("e4"), sqIdx("c6"));
+    expect(isDiscoveredAfter(after, sqIdx("c6"), true)).toBe(true);
+  });
+});
+
+describe("coach helpers (attackers and bodyguards)", () => {
+  // black bishop e7 attacked by Re1; knight a6 guarded by pawn b7
+  const board = b("6k1/1p2bppp/n7/8/8/8/8/4R1K1 w - - 0 1");
+  it("attackersOf finds the rook", () => {
+    expect(names(attackersOf(board, sqIdx("e7"), true))).toEqual(["e1"]);
+  });
+  it("bishop e7 has no bodyguards", () => {
+    expect(defendersOf(board, sqIdx("e7"))).toHaveLength(0);
+  });
+  it("knight a6 guarded by the b7 pawn", () => {
+    expect(names(defendersOf(board, sqIdx("a6")))).toEqual(["b7"]);
+  });
+});

--- a/apps/web/src/games/chess-quest/engine/board.ts
+++ b/apps/web/src/games/chess-quest/engine/board.ts
@@ -1,0 +1,52 @@
+// Chess Quest engine — board representation.
+// Board: array of 64. Index 0 = a8 … 63 = h1 (FEN reading order).
+// Pieces: "PNBRQK" white, "pnbrqk" black, "" empty.
+// Scope: no castling or en passant — the mini-games and puzzle set never
+// need them. Pawn promotion is always to a queen (kid-simple).
+
+export type Piece = string;
+export type Board = Piece[];
+export type Move = { from: number; to: number };
+
+export const FILES = "abcdefgh";
+
+export function sqIdx(name: string): number {
+  const file = FILES.indexOf(name[0]);
+  const rank = parseInt(name[1], 10);
+  return (8 - rank) * 8 + file;
+}
+
+export function sqName(idx: number): string {
+  return FILES[idx % 8] + (8 - Math.floor(idx / 8));
+}
+
+export function fileOf(idx: number): number {
+  return idx % 8;
+}
+
+// 0 = rank 8, 7 = rank 1
+export function rankRow(idx: number): number {
+  return Math.floor(idx / 8);
+}
+
+export function isWhitePiece(p: Piece): boolean {
+  return p !== "" && p === p.toUpperCase();
+}
+
+export function isBlackPiece(p: Piece): boolean {
+  return p !== "" && p === p.toLowerCase();
+}
+
+export function parseFEN(fen: string): { board: Board; whiteToMove: boolean } {
+  const parts = fen.trim().split(/\s+/);
+  const board: Board = [];
+  for (const ch of parts[0]) {
+    if (ch === "/") continue;
+    if (/\d/.test(ch)) {
+      for (let i = 0; i < Number(ch); i++) board.push("");
+    } else {
+      board.push(ch);
+    }
+  }
+  return { board, whiteToMove: (parts[1] ?? "w") === "w" };
+}

--- a/apps/web/src/games/chess-quest/engine/index.ts
+++ b/apps/web/src/games/chess-quest/engine/index.ts
@@ -1,0 +1,6 @@
+// Public engine surface. Everything outside engine/ imports from here.
+export * from "./board";
+export * from "./moves";
+export * from "./mate";
+export * from "./tactics";
+export * from "./paths";

--- a/apps/web/src/games/chess-quest/engine/mate.ts
+++ b/apps/web/src/games/chess-quest/engine/mate.ts
@@ -1,0 +1,52 @@
+// Game-ending detection and the mate-in-2 verifier used to machine-check
+// the puzzle packs (and to judge moves in the Mate in 2 game).
+import { Board, Move, isWhitePiece } from "./board";
+import { allLegalMoves, applyMove, inCheck } from "./moves";
+
+export function isMate(board: Board, white: boolean): boolean {
+  return inCheck(board, white) && allLegalMoves(board, white).length === 0;
+}
+
+export function isStalemate(board: Board, white: boolean): boolean {
+  return !inCheck(board, white) && allLegalMoves(board, white).length === 0;
+}
+
+export function hasMateIn1(board: Board, white: boolean): boolean {
+  for (const m of allLegalMoves(board, white)) {
+    if (isMate(applyMove(board, m.from, m.to), !white)) return true;
+  }
+  return false;
+}
+
+// Forced mate in exactly two: after this move the enemy is NOT yet mated,
+// still has replies, and every one of them leaves us a mate-in-1.
+export function isMateIn2After(board: Board, from: number, to: number): boolean {
+  const white = isWhitePiece(board[from]);
+  const b1 = applyMove(board, from, to);
+  if (inCheck(b1, white)) return false;
+  if (isMate(b1, !white)) return false;
+  const replies = allLegalMoves(b1, !white);
+  if (replies.length === 0) return false; // stalemate
+  for (const r of replies) {
+    if (!hasMateIn1(applyMove(b1, r.from, r.to), white)) return false;
+  }
+  return true;
+}
+
+// Black's toughest reply: the one leaving white the fewest mating moves.
+export function bestDefense(board: Board): Move | null {
+  let best: Move | null = null;
+  let fewest = Infinity;
+  for (const r of allLegalMoves(board, false)) {
+    const after = applyMove(board, r.from, r.to);
+    let mates = 0;
+    for (const m of allLegalMoves(after, true)) {
+      if (isMate(applyMove(after, m.from, m.to), false)) mates++;
+    }
+    if (mates < fewest) {
+      fewest = mates;
+      best = r;
+    }
+  }
+  return best;
+}

--- a/apps/web/src/games/chess-quest/engine/moves.ts
+++ b/apps/web/src/games/chess-quest/engine/moves.ts
@@ -1,0 +1,164 @@
+// Attack generation, move legality, and board updates. Pure functions;
+// boards are never mutated (applyMove returns a copy).
+import { Board, Move, Piece, fileOf, isWhitePiece, rankRow } from "./board";
+
+const KNIGHT_OFFS = [
+  [1, 2],
+  [2, 1],
+  [2, -1],
+  [1, -2],
+  [-1, -2],
+  [-2, -1],
+  [-2, 1],
+  [-1, 2],
+] as const;
+const KING_OFFS = [
+  [1, 0],
+  [1, 1],
+  [0, 1],
+  [-1, 1],
+  [-1, 0],
+  [-1, -1],
+  [0, -1],
+  [1, -1],
+] as const;
+export const ROOK_DIRS = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+] as const;
+export const BISHOP_DIRS = [
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+] as const;
+
+type Dir = readonly [number, number];
+
+function onBoard(f: number, r: number): boolean {
+  return f >= 0 && f < 8 && r >= 0 && r < 8;
+}
+
+// Square reached from idx by (df files, dr rows), or -1 off-board.
+export function step(idx: number, df: number, dr: number): number {
+  const f = fileOf(idx) + df;
+  const r = rankRow(idx) + dr;
+  return onBoard(f, r) ? r * 8 + f : -1;
+}
+
+export function sliderDirs(type: string): readonly Dir[] {
+  if (type === "R") return ROOK_DIRS;
+  if (type === "B") return BISHOP_DIRS;
+  return [...ROOK_DIRS, ...BISHOP_DIRS];
+}
+
+// Squares the piece on idx attacks (check detection). Pawns attack
+// diagonally only; sliders stop at the first piece they meet.
+export function attackSquares(board: Board, idx: number): number[] {
+  const p = board[idx];
+  const white = isWhitePiece(p);
+  const type = p.toUpperCase();
+  const out: number[] = [];
+
+  if (type === "P") {
+    const dr = white ? -1 : 1; // white pawns move toward rank 8 (row 0)
+    for (const df of [-1, 1]) {
+      const t = step(idx, df, dr);
+      if (t >= 0) out.push(t);
+    }
+    return out;
+  }
+  if (type === "N" || type === "K") {
+    for (const [df, dr] of type === "N" ? KNIGHT_OFFS : KING_OFFS) {
+      const t = step(idx, df, dr);
+      if (t >= 0) out.push(t);
+    }
+    return out;
+  }
+  for (const [df, dr] of sliderDirs(type)) {
+    let t = step(idx, df, dr);
+    while (t >= 0) {
+      out.push(t);
+      if (board[t] !== "") break;
+      t = step(t, df, dr);
+    }
+  }
+  return out;
+}
+
+export function isAttacked(board: Board, sq: number, byWhite: boolean): boolean {
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (p === "" || isWhitePiece(p) !== byWhite) continue;
+    if (attackSquares(board, i).includes(sq)) return true;
+  }
+  return false;
+}
+
+export function findKing(board: Board, white: boolean): number {
+  return board.indexOf(white ? "K" : "k");
+}
+
+export function inCheck(board: Board, white: boolean): boolean {
+  const k = findKing(board, white);
+  return k >= 0 && isAttacked(board, k, !white);
+}
+
+// Pseudo-legal destinations: respects blockers and capture rules,
+// ignores king safety (legalTargets filters that).
+export function pieceTargets(board: Board, idx: number): number[] {
+  const p = board[idx];
+  if (p === "") return [];
+  const white = isWhitePiece(p);
+  const type = p.toUpperCase();
+
+  if (type === "P") {
+    const out: number[] = [];
+    const dr = white ? -1 : 1;
+    const one = step(idx, 0, dr);
+    if (one >= 0 && board[one] === "") {
+      out.push(one);
+      const startRow = white ? 6 : 1;
+      const two = step(idx, 0, 2 * dr);
+      if (rankRow(idx) === startRow && two >= 0 && board[two] === "") out.push(two);
+    }
+    for (const df of [-1, 1]) {
+      const t = step(idx, df, dr);
+      if (t >= 0 && board[t] !== "" && isWhitePiece(board[t]) !== white) out.push(t);
+    }
+    return out;
+  }
+
+  return attackSquares(board, idx).filter(
+    (t) => board[t] === "" || isWhitePiece(board[t]) !== white,
+  );
+}
+
+export function applyMove(board: Board, from: number, to: number): Board {
+  const next = board.slice();
+  let p: Piece = next[from];
+  if (p.toUpperCase() === "P") {
+    const lastRow = isWhitePiece(p) ? 0 : 7;
+    if (rankRow(to) === lastRow) p = isWhitePiece(p) ? "Q" : "q";
+  }
+  next[to] = p;
+  next[from] = "";
+  return next;
+}
+
+export function legalTargets(board: Board, idx: number): number[] {
+  const white = isWhitePiece(board[idx]);
+  return pieceTargets(board, idx).filter((t) => !inCheck(applyMove(board, idx, t), white));
+}
+
+export function allLegalMoves(board: Board, white: boolean): Move[] {
+  const out: Move[] = [];
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (p === "" || isWhitePiece(p) !== white) continue;
+    for (const t of legalTargets(board, i)) out.push({ from: i, to: t });
+  }
+  return out;
+}

--- a/apps/web/src/games/chess-quest/engine/paths.ts
+++ b/apps/web/src/games/chess-quest/engine/paths.ts
@@ -1,0 +1,25 @@
+// Fewest moves for the piece on `from` to reach each square (walls and
+// captures respected). -1 = unreachable. Used by the Rook Maze generator.
+import { Board } from "./board";
+import { pieceTargets } from "./moves";
+
+export function pathDistances(board: Board, from: number): number[] {
+  const piece = board[from];
+  const dist = new Array<number>(64).fill(-1);
+  dist[from] = 0;
+  const queue: number[] = [from];
+  while (queue.length) {
+    const s = queue.shift()!;
+    if (board[s] !== "" && s !== from) continue; // stop expanding past a capture
+    const b2 = board.slice();
+    b2[from] = "";
+    b2[s] = piece;
+    for (const t of pieceTargets(b2, s)) {
+      if (dist[t] === -1) {
+        dist[t] = dist[s] + 1;
+        queue.push(t);
+      }
+    }
+  }
+  return dist;
+}

--- a/apps/web/src/games/chess-quest/engine/tactics.ts
+++ b/apps/web/src/games/chess-quest/engine/tactics.ts
@@ -1,0 +1,98 @@
+// Tactic detectors (Trick Shots / Tactic Trainer judging) and the coach's
+// attacker/defender helpers.
+import { Board, Piece, isWhitePiece } from "./board";
+import { attackSquares, findKing, inCheck, isAttacked, sliderDirs, step } from "./moves";
+
+const VALUE: Record<string, number> = { P: 1, N: 3, B: 3, R: 5, Q: 9, K: 100 };
+
+export function pieceValue(p: Piece): number {
+  return VALUE[p.toUpperCase()] ?? 0;
+}
+
+// Fork: the piece that just landed on `to` attacks 2+ enemy non-pawn pieces
+// (king counts) and stands on a square no enemy piece attacks.
+export function isForkAfter(board: Board, to: number): boolean {
+  const p = board[to];
+  if (p === "") return false;
+  const white = isWhitePiece(p);
+  const targets = attackSquares(board, to).filter(
+    (t) => board[t] !== "" && isWhitePiece(board[t]) !== white && board[t].toUpperCase() !== "P",
+  );
+  return targets.length >= 2 && !isAttacked(board, to, !white);
+}
+
+// Walk each ray of the slider on `sq`; report the first two enemy pieces
+// stacked on one ray as {front, back}.
+function rayPairs(board: Board, sq: number): { front: number; back: number }[] {
+  const p = board[sq];
+  const type = p.toUpperCase();
+  if (type !== "B" && type !== "R" && type !== "Q") return [];
+  const white = isWhitePiece(p);
+  const pairs: { front: number; back: number }[] = [];
+  for (const [df, dr] of sliderDirs(type)) {
+    let t = step(sq, df, dr);
+    let front = -1;
+    while (t >= 0) {
+      if (board[t] !== "") {
+        if (isWhitePiece(board[t]) === white) break;
+        if (front < 0) {
+          front = t;
+        } else {
+          pairs.push({ front, back: t });
+          break;
+        }
+      }
+      t = step(t, df, dr);
+    }
+  }
+  return pairs;
+}
+
+// Pin: enemy piece in front is stuck because something bigger (or the king)
+// hides behind it. Skewer: the big one is in front and must run.
+export function isPinAfter(board: Board, to: number): boolean {
+  return rayPairs(board, to).some(
+    ({ front, back }) =>
+      board[back].toUpperCase() === "K" || pieceValue(board[back]) > pieceValue(board[front]),
+  );
+}
+
+export function isSkewerAfter(board: Board, to: number): boolean {
+  return rayPairs(board, to).some(
+    ({ front, back }) =>
+      board[front].toUpperCase() === "K" || pieceValue(board[front]) > pieceValue(board[back]),
+  );
+}
+
+// Discovered attack: after the move, the enemy king is in check from a piece
+// OTHER than the one that just moved.
+export function isDiscoveredAfter(board: Board, to: number, white: boolean): boolean {
+  const k = findKing(board, !white);
+  if (k < 0 || !inCheck(board, !white)) return false;
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (i !== to && p !== "" && isWhitePiece(p) === white && attackSquares(board, i).includes(k))
+      return true;
+  }
+  return false;
+}
+
+// Which pieces of `byWhite` attack this square? (the coach uses these)
+export function attackersOf(board: Board, sq: number, byWhite: boolean): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (p !== "" && isWhitePiece(p) === byWhite && attackSquares(board, i).includes(sq)) out.push(i);
+  }
+  return out;
+}
+
+// Which friends could recapture on this piece's square? (its bodyguards)
+export function defendersOf(board: Board, sq: number): number[] {
+  const p = board[sq];
+  if (p === "") return [];
+  const white = isWhitePiece(p);
+  const probe = board.slice();
+  probe[sq] = white ? "p" : "P"; // stand-in enemy piece
+  return attackersOf(probe, sq, white);
+}

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+// Phase A placeholder — proves the registry → player-map → lazy-load path.
+// Phase C replaces this with the real Chess Quest root component.
+export default function ChessQuest() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+      <div className="text-6xl">♟️</div>
+      <h2 className="mk-display text-2xl font-bold text-purple-950">Chess Quest</h2>
+      <p className="max-w-sm text-sm text-slate-500">
+        The quest is being prepared. Check back soon!
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -11,6 +11,8 @@ import { CoinHop } from "./components/games/CoinHop";
 import { PawnWars } from "./components/games/PawnWars";
 import { MateInOne } from "./components/games/MateInOne";
 import { MateInTwo } from "./components/games/MateInTwo";
+import { HangingHunt } from "./components/games/HangingHunt";
+import { TacticTrainer } from "./components/games/TacticTrainer";
 
 type GameEntry = {
   id: string;
@@ -55,6 +57,20 @@ const GAMES: GameEntry[] = [
     title: "Mate in 2",
     blurb: "Force checkmate in two — think a move ahead.",
     render: () => <MateInTwo />,
+  },
+  {
+    id: "hangingHunt",
+    emoji: "🔍",
+    title: "Piece Detective",
+    blurb: "Spot the piece that's free to take.",
+    render: () => <HangingHunt />,
+  },
+  {
+    id: "tacticTrainer",
+    emoji: "🎯",
+    title: "Trick Shots",
+    blurb: "Forks, pins, skewers, discovered attacks.",
+    render: () => <TacticTrainer pack="fork" />,
   },
 ];
 

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -9,6 +9,8 @@ import { ProgressProvider } from "./lib/progress";
 import { SquareRace } from "./components/games/SquareRace";
 import { CoinHop } from "./components/games/CoinHop";
 import { PawnWars } from "./components/games/PawnWars";
+import { MateInOne } from "./components/games/MateInOne";
+import { MateInTwo } from "./components/games/MateInTwo";
 
 type GameEntry = {
   id: string;
@@ -39,6 +41,20 @@ const GAMES: GameEntry[] = [
     title: "Pawn Wars",
     blurb: "Pawns only — first to crown a queen wins.",
     render: () => <PawnWars />,
+  },
+  {
+    id: "mateInOne",
+    emoji: "♚",
+    title: "Mate in 1",
+    blurb: "Deliver checkmate in a single move.",
+    render: () => <MateInOne />,
+  },
+  {
+    id: "mateInTwo",
+    emoji: "👑",
+    title: "Mate in 2",
+    blurb: "Force checkmate in two — think a move ahead.",
+    render: () => <MateInTwo />,
   },
 ];
 

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -8,6 +8,7 @@ import { CopyProvider } from "./lib/copy";
 import { ProgressProvider } from "./lib/progress";
 import { SquareRace } from "./components/games/SquareRace";
 import { CoinHop } from "./components/games/CoinHop";
+import { PawnWars } from "./components/games/PawnWars";
 
 type GameEntry = {
   id: string;
@@ -31,6 +32,13 @@ const GAMES: GameEntry[] = [
     title: "Coin Hop",
     blurb: "Collect every coin in as few moves as you can.",
     render: () => <CoinHop pieces={["N", "B", "R", "Q", "K"]} />,
+  },
+  {
+    id: "pawnWars",
+    emoji: "⚔️",
+    title: "Pawn Wars",
+    blurb: "Pawns only — first to crown a queen wins.",
+    render: () => <PawnWars />,
   },
 ];
 

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -13,6 +13,7 @@ import { MateInOne } from "./components/games/MateInOne";
 import { MateInTwo } from "./components/games/MateInTwo";
 import { HangingHunt } from "./components/games/HangingHunt";
 import { TacticTrainer } from "./components/games/TacticTrainer";
+import { RookMaze } from "./components/games/RookMaze";
 
 type GameEntry = {
   id: string;
@@ -71,6 +72,13 @@ const GAMES: GameEntry[] = [
     title: "Trick Shots",
     blurb: "Forks, pins, skewers, discovered attacks.",
     render: () => <TacticTrainer pack="fork" />,
+  },
+  {
+    id: "rookMaze",
+    emoji: "🧩",
+    title: "Rook Maze",
+    blurb: "Slide around the walls to catch the prey.",
+    render: () => <RookMaze pieces={["R", "B", "Q"]} />,
   },
 ];
 

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -1,35 +1,81 @@
 "use client";
 
-// Temporary Phase C2 preview: renders the Board inside GameShell to verify
-// the chrome in the browser. Task C7 replaces this with the game hub.
+// Chess Quest hub — pick a mini-game, play, come back. Games arrive here
+// task by task through Phase C; C7 finalizes the full 8-game grid.
 import "./chess-quest.css";
 import { useState } from "react";
-import { parseFEN, sqName } from "./engine";
-import { Board } from "./components/Board";
-import { GameShell } from "./components/GameShell";
+import { CopyProvider } from "./lib/copy";
+import { ProgressProvider } from "./lib/progress";
+import { SquareRace } from "./components/games/SquareRace";
+import { CoinHop } from "./components/games/CoinHop";
 
-const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+type GameEntry = {
+  id: string;
+  emoji: string;
+  title: string;
+  blurb: string;
+  render(): React.ReactNode;
+};
+
+const GAMES: GameEntry[] = [
+  {
+    id: "squareRace",
+    emoji: "🎯",
+    title: "Square Race",
+    blurb: "Name that square — how many in 60 seconds?",
+    render: () => <SquareRace />,
+  },
+  {
+    id: "coinHop",
+    emoji: "🪙",
+    title: "Coin Hop",
+    blurb: "Collect every coin in as few moves as you can.",
+    render: () => <CoinHop pieces={["N", "B", "R", "Q", "K"]} />,
+  },
+];
 
 export default function ChessQuest() {
-  const [last, setLast] = useState<string>("");
-  const [shake, setShake] = useState(0);
+  const [open, setOpen] = useState<GameEntry | null>(null);
+
   return (
-    <GameShell
-      title="Chess Quest"
-      score="board preview"
-      status={last ? `You tapped <strong>${last}</strong>` : "Tap any square."}
-      controls={
-        <button type="button" className="btn btn-ghost" onClick={() => setShake((s) => s + 1)}>
-          Shake
-        </button>
-      }
-    >
-      <Board
-        position={parseFEN(START).board}
-        labels
-        shakeToken={shake}
-        onTap={(idx) => setLast(sqName(idx))}
-      />
-    </GameShell>
+    <ProgressProvider>
+      <CopyProvider register="classic">
+        {open ? (
+          <div className="flex flex-col">
+            <div className="mx-auto w-full max-w-xl px-4 pt-3">
+              <button
+                type="button"
+                onClick={() => setOpen(null)}
+                className="text-sm font-medium text-purple-600 hover:text-purple-800"
+              >
+                ← All games
+              </button>
+            </div>
+            {open.render()}
+          </div>
+        ) : (
+          <div className="mx-auto w-full max-w-3xl px-4 py-8">
+            <h2 className="mk-display text-3xl font-bold text-purple-950">Chess Quest</h2>
+            <p className="mt-2 max-w-lg text-sm text-slate-600">
+              Eight mini-games that teach real chess skills — pick one and play.
+            </p>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {GAMES.map((g) => (
+                <button
+                  key={g.id}
+                  type="button"
+                  onClick={() => setOpen(g)}
+                  className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-purple-300 hover:shadow-md"
+                >
+                  <div className="text-3xl">{g.emoji}</div>
+                  <h3 className="mk-display mt-2 text-lg font-bold text-purple-950">{g.title}</h3>
+                  <p className="mt-1 text-xs text-slate-500">{g.blurb}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </CopyProvider>
+    </ProgressProvider>
   );
 }

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-// Chess Quest hub — pick a mini-game, play, come back. Games arrive here
-// task by task through Phase C; C7 finalizes the full 8-game grid.
+// Chess Quest — the quest journey (48 lessons over 9 lands) is the landing;
+// the eight mini-games are also reachable as a free-play arcade. Lessons launch
+// their game with the lesson's gameOpts; progress persists per player profile.
 import "./chess-quest.css";
 import { useState } from "react";
+import { GameId } from "./content/lessons";
 import { CopyProvider } from "./lib/copy";
-import { ProgressProvider } from "./lib/progress";
+import { ProgressProvider, useProgress } from "./lib/progress";
 import { SquareRace } from "./components/games/SquareRace";
 import { CoinHop } from "./components/games/CoinHop";
 import { PawnWars } from "./components/games/PawnWars";
@@ -14,116 +16,161 @@ import { MateInTwo } from "./components/games/MateInTwo";
 import { HangingHunt } from "./components/games/HangingHunt";
 import { TacticTrainer } from "./components/games/TacticTrainer";
 import { RookMaze } from "./components/games/RookMaze";
+import { Certificate } from "./components/quest/Certificate";
+import { GrownUpsDrawer } from "./components/quest/GrownUpsDrawer";
+import { LessonCard } from "./components/quest/LessonCard";
+import { ProfilePanel } from "./components/quest/ProfilePanel";
+import { ProgressPanel } from "./components/quest/ProgressPanel";
+import { QuestHeader } from "./components/quest/QuestHeader";
+import { QuestMap } from "./components/quest/QuestMap";
+import { LESSONS } from "./content/lessons";
 
-type GameEntry = {
-  id: string;
-  emoji: string;
-  title: string;
-  blurb: string;
-  render(): React.ReactNode;
-};
+type Opts = Record<string, unknown>;
 
-const GAMES: GameEntry[] = [
-  {
-    id: "squareRace",
-    emoji: "🎯",
-    title: "Square Race",
-    blurb: "Name that square — how many in 60 seconds?",
-    render: () => <SquareRace />,
-  },
-  {
-    id: "coinHop",
-    emoji: "🪙",
-    title: "Coin Hop",
-    blurb: "Collect every coin in as few moves as you can.",
-    render: () => <CoinHop pieces={["N", "B", "R", "Q", "K"]} />,
-  },
-  {
-    id: "pawnWars",
-    emoji: "⚔️",
-    title: "Pawn Wars",
-    blurb: "Pawns only — first to crown a queen wins.",
-    render: () => <PawnWars />,
-  },
-  {
-    id: "mateInOne",
-    emoji: "♚",
-    title: "Mate in 1",
-    blurb: "Deliver checkmate in a single move.",
-    render: () => <MateInOne />,
-  },
-  {
-    id: "mateInTwo",
-    emoji: "👑",
-    title: "Mate in 2",
-    blurb: "Force checkmate in two — think a move ahead.",
-    render: () => <MateInTwo />,
-  },
-  {
-    id: "hangingHunt",
-    emoji: "🔍",
-    title: "Piece Detective",
-    blurb: "Spot the piece that's free to take.",
-    render: () => <HangingHunt />,
-  },
-  {
-    id: "tacticTrainer",
-    emoji: "🎯",
-    title: "Trick Shots",
-    blurb: "Forks, pins, skewers, discovered attacks.",
-    render: () => <TacticTrainer pack="fork" />,
-  },
-  {
-    id: "rookMaze",
-    emoji: "🧩",
-    title: "Rook Maze",
-    blurb: "Slide around the walls to catch the prey.",
-    render: () => <RookMaze pieces={["R", "B", "Q"]} />,
-  },
+// Render a game by id, applying lesson gameOpts (falling back to the fuller
+// free-play defaults when a lesson passes none).
+function renderGame(game: GameId, opts: Opts) {
+  const pieces = (opts.pieces as string[] | undefined) ?? undefined;
+  const pack = (opts.pack as string | undefined) ?? undefined;
+  switch (game) {
+    case "squareRace":
+      return <SquareRace />;
+    case "coinHop":
+      return <CoinHop pieces={pieces ?? ["N", "B", "R", "Q", "K"]} />;
+    case "pawnWars":
+      return <PawnWars />;
+    case "mateInOne":
+      return <MateInOne />;
+    case "mateInTwo":
+      return <MateInTwo />;
+    case "hangingHunt":
+      return <HangingHunt />;
+    case "tacticTrainer":
+      return <TacticTrainer pack={pack ?? "fork"} />;
+    case "rookMaze":
+      return <RookMaze pieces={pieces ?? ["R", "B", "Q"]} />;
+  }
+}
+
+const ARCADE: { id: GameId; emoji: string; title: string; blurb: string; opts: Opts }[] = [
+  { id: "squareRace", emoji: "🎯", title: "Square Race", blurb: "Name that square — how many in 60 seconds?", opts: {} },
+  { id: "coinHop", emoji: "🪙", title: "Coin Hop", blurb: "Collect every coin in as few moves as you can.", opts: {} },
+  { id: "pawnWars", emoji: "⚔️", title: "Pawn Wars", blurb: "Pawns only — first to crown a queen wins.", opts: {} },
+  { id: "mateInOne", emoji: "♚", title: "Mate in 1", blurb: "Deliver checkmate in a single move.", opts: {} },
+  { id: "mateInTwo", emoji: "👑", title: "Mate in 2", blurb: "Force checkmate in two — think a move ahead.", opts: {} },
+  { id: "hangingHunt", emoji: "🔍", title: "Piece Detective", blurb: "Spot the piece that's free to take.", opts: {} },
+  { id: "tacticTrainer", emoji: "🎯", title: "Trick Shots", blurb: "Forks, pins, skewers, discovered attacks.", opts: { pack: "fork" } },
+  { id: "rookMaze", emoji: "🧩", title: "Rook Maze", blurb: "Slide around the walls to catch the prey.", opts: {} },
 ];
 
-export default function ChessQuest() {
-  const [open, setOpen] = useState<GameEntry | null>(null);
+function QuestApp() {
+  const progress = useProgress();
+  const [view, setView] = useState<"quest" | "arcade">("quest");
+  const [selected, setSelected] = useState(() => progress.currentWeek(LESSONS.length));
+  const [game, setGame] = useState<{ game: GameId; opts: Opts; back: "quest" | "arcade" } | null>(
+    null,
+  );
+  const [profilesOpen, setProfilesOpen] = useState(false);
+  const [progressOpen, setProgressOpen] = useState(false);
+
+  // A launched game takes the whole area with a back bar.
+  if (game) {
+    return (
+      <div className="flex flex-col">
+        <div className="mx-auto w-full max-w-xl px-4 pt-3">
+          <button
+            type="button"
+            onClick={() => setGame(null)}
+            className="text-sm font-medium text-purple-600 hover:text-purple-800"
+          >
+            {game.back === "quest" ? "← Back to quest" : "← All games"}
+          </button>
+        </div>
+        {renderGame(game.game, game.opts)}
+        <Certificate />
+      </div>
+    );
+  }
 
   return (
+    <div className="mx-auto w-full max-w-4xl px-4 py-6">
+      <div className="mb-4 inline-flex rounded-full border border-purple-200 bg-white p-1">
+        {(["quest", "arcade"] as const).map((v) => (
+          <button
+            key={v}
+            type="button"
+            onClick={() => setView(v)}
+            className={`rounded-full px-4 py-1 text-sm font-medium ${
+              view === v ? "bg-purple-600 text-white" : "text-purple-700 hover:bg-purple-50"
+            }`}
+          >
+            {v === "quest" ? "Quest" : "Free play"}
+          </button>
+        ))}
+      </div>
+
+      {view === "quest" ? (
+        <div className="flex flex-col gap-5">
+          <QuestHeader
+            onOpenProfiles={() => setProfilesOpen(true)}
+            onOpenProgress={() => setProgressOpen(true)}
+          />
+          <div className="grid gap-5 lg:grid-cols-2">
+            <QuestMap selected={selected} onSelect={setSelected} />
+            <div className="flex flex-col gap-4">
+              <LessonCard
+                n={selected}
+                onPlay={(g, opts) => setGame({ game: g, opts, back: "quest" })}
+              />
+              <GrownUpsDrawer />
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {ARCADE.map((a) => (
+            <button
+              key={a.id}
+              type="button"
+              onClick={() => setGame({ game: a.id, opts: a.opts, back: "arcade" })}
+              className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-purple-300 hover:shadow-md"
+            >
+              <div className="text-3xl">{a.emoji}</div>
+              <h3 className="mk-display mt-2 text-lg font-bold text-purple-950">{a.title}</h3>
+              <p className="mt-1 text-xs text-slate-500">{a.blurb}</p>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {profilesOpen ? <ProfilePanel onClose={() => setProfilesOpen(false)} /> : null}
+      {progressOpen ? (
+        <ProgressPanel
+          onClose={() => setProgressOpen(false)}
+          onPrint={() => {
+            if (typeof window !== "undefined") window.print();
+          }}
+        />
+      ) : null}
+      <Certificate />
+    </div>
+  );
+}
+
+function RegisterBridge() {
+  // Reads the active profile's mode so copy re-renders when it changes.
+  const progress = useProgress();
+  return (
+    <CopyProvider register={progress.getMode()}>
+      <QuestApp />
+    </CopyProvider>
+  );
+}
+
+export default function ChessQuest() {
+  return (
     <ProgressProvider>
-      <CopyProvider register="classic">
-        {open ? (
-          <div className="flex flex-col">
-            <div className="mx-auto w-full max-w-xl px-4 pt-3">
-              <button
-                type="button"
-                onClick={() => setOpen(null)}
-                className="text-sm font-medium text-purple-600 hover:text-purple-800"
-              >
-                ← All games
-              </button>
-            </div>
-            {open.render()}
-          </div>
-        ) : (
-          <div className="mx-auto w-full max-w-3xl px-4 py-8">
-            <h2 className="mk-display text-3xl font-bold text-purple-950">Chess Quest</h2>
-            <p className="mt-2 max-w-lg text-sm text-slate-600">
-              Eight mini-games that teach real chess skills — pick one and play.
-            </p>
-            <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {GAMES.map((g) => (
-                <button
-                  key={g.id}
-                  type="button"
-                  onClick={() => setOpen(g)}
-                  className="rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-purple-300 hover:shadow-md"
-                >
-                  <div className="text-3xl">{g.emoji}</div>
-                  <h3 className="mk-display mt-2 text-lg font-bold text-purple-950">{g.title}</h3>
-                  <p className="mt-1 text-xs text-slate-500">{g.blurb}</p>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-      </CopyProvider>
+      <RegisterBridge />
     </ProgressProvider>
   );
 }

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 import { GameId } from "./content/lessons";
 import { CopyProvider } from "./lib/copy";
 import { ProgressProvider, useProgress } from "./lib/progress";
+import { useDeviceAudio } from "./lib/use-device-audio";
 import { SquareRace } from "./components/games/SquareRace";
 import { CoinHop } from "./components/games/CoinHop";
 import { PawnWars } from "./components/games/PawnWars";
@@ -65,6 +66,7 @@ const ARCADE: { id: GameId; emoji: string; title: string; blurb: string; opts: O
 
 function QuestApp() {
   const progress = useProgress();
+  useDeviceAudio();
   const [view, setView] = useState<"quest" | "arcade">("quest");
   const [selected, setSelected] = useState(() => progress.currentWeek(LESSONS.length));
   const [game, setGame] = useState<{ game: GameId; opts: Opts; back: "quest" | "arcade" } | null>(

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -1,15 +1,35 @@
 "use client";
 
-// Phase A placeholder — proves the registry → player-map → lazy-load path.
-// Phase C replaces this with the real Chess Quest root component.
+// Temporary Phase C2 preview: renders the Board inside GameShell to verify
+// the chrome in the browser. Task C7 replaces this with the game hub.
+import "./chess-quest.css";
+import { useState } from "react";
+import { parseFEN, sqName } from "./engine";
+import { Board } from "./components/Board";
+import { GameShell } from "./components/GameShell";
+
+const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
 export default function ChessQuest() {
+  const [last, setLast] = useState<string>("");
+  const [shake, setShake] = useState(0);
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
-      <div className="text-6xl">♟️</div>
-      <h2 className="mk-display text-2xl font-bold text-purple-950">Chess Quest</h2>
-      <p className="max-w-sm text-sm text-slate-500">
-        The quest is being prepared. Check back soon!
-      </p>
-    </div>
+    <GameShell
+      title="Chess Quest"
+      score="board preview"
+      status={last ? `You tapped <strong>${last}</strong>` : "Tap any square."}
+      controls={
+        <button type="button" className="btn btn-ghost" onClick={() => setShake((s) => s + 1)}>
+          Shake
+        </button>
+      }
+    >
+      <Board
+        position={parseFEN(START).board}
+        labels
+        shakeToken={shake}
+        onTap={(idx) => setLast(sqName(idx))}
+      />
+    </GameShell>
   );
 }

--- a/apps/web/src/games/chess-quest/lib/__tests__/cert.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/cert.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { certTitle } from "../cert";
+
+describe("certTitle", () => {
+  it("both tracks complete → Champion", () => {
+    expect(certTitle(24, 24).title).toBe("Chess Quest Champion");
+  });
+  it("track 1 only → First Steps Champion", () => {
+    expect(certTitle(24, 5).title).toBe("First Steps Champion");
+  });
+  it("track 2 only → Rising Player Champion", () => {
+    expect(certTitle(0, 24).title).toBe("Rising Player Champion");
+  });
+  it("partial → Adventurer with the day count", () => {
+    const r = certTitle(3, 2);
+    expect(r.title).toBe("Chess Quest Adventurer");
+    expect(r.line).toContain("5 of 48");
+  });
+});

--- a/apps/web/src/games/chess-quest/lib/__tests__/last14.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/last14.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { last14Days } from "../last14";
+
+describe("last14Days", () => {
+  it("returns 14 entries ending on today", () => {
+    const days = last14Days([], "2026-07-14");
+    expect(days).toHaveLength(14);
+    expect(days[13].iso).toBe("2026-07-14");
+    expect(days[0].iso).toBe("2026-07-01");
+  });
+
+  it("flags days that appear in the activity set", () => {
+    const days = last14Days(["2026-07-14", "2026-07-10", "2026-06-01"], "2026-07-14");
+    const on = days.filter((d) => d.on).map((d) => d.iso);
+    expect(on).toEqual(["2026-07-10", "2026-07-14"]); // out-of-window date ignored
+  });
+
+  it("labels weekdays", () => {
+    const days = last14Days([], "2026-07-14"); // 2026-07-14 is a Tuesday
+    expect(days[13].wd).toBe("T");
+  });
+});

--- a/apps/web/src/games/chess-quest/lib/__tests__/mate-miss.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/mate-miss.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseFEN, sqIdx, sqName } from "../../engine";
+import { parseFEN, sqName } from "../../engine";
 import { classifyMateMiss } from "../mate-miss";
 
 const b = (fen: string) => parseFEN(fen).board;

--- a/apps/web/src/games/chess-quest/lib/__tests__/mate-miss.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/mate-miss.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx, sqName } from "../../engine";
+import { classifyMateMiss } from "../mate-miss";
+
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("classifyMateMiss (why a 'find the mate' move wasn't mate)", () => {
+  it("no-check: the move doesn't even attack the black king", () => {
+    // rook on b1 (not the a-file), black king a8 → not in check
+    const res = classifyMateMiss(b("k7/8/8/8/8/8/8/1R4K1 w - - 0 1"));
+    expect(res.kind).toBe("no-check");
+  });
+
+  it("escape: check but the king has a flight square", () => {
+    // Rook a1 checks Ka8 down the a-file; king can step to b7/b8 → escape
+    const checked = classifyMateMiss(b("k7/8/8/8/8/8/8/R6K w - - 0 1"));
+    expect(checked.kind).toBe("escape");
+    if (checked.kind === "escape") {
+      expect(checked.escapes.map(sqName)).toContain("b7");
+    }
+  });
+
+  it("capture-block: check, king stuck, but a black piece can interpose", () => {
+    // Rook e8 checks Kg8 along the 8th; king boxed by its own f7/g7/h7 pawns
+    // (f8/h8 covered by the rook), but the d7 knight can block on f8 → not mate.
+    const res = classifyMateMiss(b("4R1k1/3n1ppp/8/8/8/8/8/6K1 w - - 0 1"));
+    expect(res.kind).toBe("capture-block");
+  });
+});

--- a/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
@@ -202,4 +202,16 @@ describe("persistence", () => {
     expect(p.profiles()).toHaveLength(1);
     expect(p.getName()).toBe("");
   });
+
+  it("device audio settings default on and persist", () => {
+    const storage = fakeStorage();
+    const p = createProgressState(storage);
+    expect(p.getMuted()).toBe(false);
+    expect(p.getVoiceOn()).toBe(true);
+    p.setMuted(true);
+    p.setVoiceOn(false);
+    const reloaded = createProgressState(storage);
+    expect(reloaded.getMuted()).toBe(true);
+    expect(reloaded.getVoiceOn()).toBe(false);
+  });
 });

--- a/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
@@ -76,11 +76,11 @@ describe("progress store (session-only; Phase D swaps persistence)", () => {
 });
 
 describe("profiles store (Phase D)", () => {
-  it("starts with one story profile, empty name", () => {
+  it("starts with one classic profile, empty name", () => {
     const p = createProgressState();
     expect(p.profiles()).toHaveLength(1);
     expect(p.activeId()).toBe("p1");
-    expect(p.getMode()).toBe("story");
+    expect(p.getMode()).toBe("classic"); // public-site default
     expect(p.getName()).toBe("");
   });
 
@@ -116,7 +116,7 @@ describe("profiles store (Phase D)", () => {
   it("addProfile never mutates existing profiles", () => {
     const p = createProgressState();
     p.setName("Mila");
-    expect(p.getMode()).toBe("story");
+    p.setMode("story");
     p.addProfile("Dad", "classic");
     p.switchProfile("p1");
     expect(p.getMode()).toBe("story");
@@ -125,8 +125,8 @@ describe("profiles store (Phase D)", () => {
 
   it("setMode only touches the active profile", () => {
     const p = createProgressState();
-    p.setMode("classic");
-    expect(p.getMode()).toBe("classic");
+    p.setMode("story");
+    expect(p.getMode()).toBe("story");
   });
 });
 

--- a/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createProgressState } from "../progress";
+
+describe("progress store (session-only; Phase D swaps persistence)", () => {
+  it("mate-in-1 pack solve/count/reset", () => {
+    const p = createProgressState();
+    expect(p.isSolved(0)).toBe(false);
+    p.setSolved(0);
+    p.setSolved(5);
+    p.setSolved(5); // idempotent
+    expect(p.isSolved(0)).toBe(true);
+    expect(p.solvedCount()).toBe(2);
+    p.resetPuzzles();
+    expect(p.solvedCount()).toBe(0);
+  });
+  it("mate-in-2 pack is independent", () => {
+    const p = createProgressState();
+    p.setSolved(1);
+    p.setSolved2(1);
+    expect(p.solved2Count()).toBe(1);
+    p.resetPuzzles2();
+    expect(p.solved2Count()).toBe(0);
+    expect(p.solvedCount()).toBe(1);
+  });
+  it("hunts", () => {
+    const p = createProgressState();
+    p.setHuntSolved(3);
+    expect(p.isHuntSolved(3)).toBe(true);
+    expect(p.huntCount()).toBe(1);
+    p.resetHunts();
+    expect(p.huntCount()).toBe(0);
+  });
+  it("tactics per pack", () => {
+    const p = createProgressState();
+    p.setTacticSolved("fork", 0);
+    p.setTacticSolved("fork", 2);
+    p.setTacticSolved("pin2", 1);
+    expect(p.tacticCount("fork")).toBe(2);
+    expect(p.tacticCount("pin2")).toBe(1);
+    expect(p.isTacticSolved("fork", 2)).toBe(true);
+    p.resetTactics("fork");
+    expect(p.tacticCount("fork")).toBe(0);
+    expect(p.tacticCount("pin2")).toBe(1);
+  });
+  it("game stars keep the max", () => {
+    const p = createProgressState();
+    p.setGameStars("squareRace", 2);
+    p.setGameStars("squareRace", 1);
+    expect(p.gameStars("squareRace")).toBe(2);
+    p.setGameStars("squareRace", 3);
+    expect(p.gameStars("squareRace")).toBe(3);
+  });
+  it("bests: new record only on strict improvement", () => {
+    const p = createProgressState();
+    expect(p.setBest("squareRace", 5)).toBe(true);
+    expect(p.setBest("squareRace", 5)).toBe(false);
+    expect(p.setBest("squareRace", 4)).toBe(false);
+    expect(p.setBest("squareRace", 6)).toBe(true);
+    expect(p.getBest("squareRace")).toBe(6);
+  });
+});

--- a/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
 import { createProgressState } from "../progress";
 
+// Minimal in-memory Storage for the persistence tests.
+function fakeStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    key: (i) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k) => void map.delete(k),
+    setItem: (k, v) => void map.set(k, String(v)),
+  };
+}
+
 describe("progress store (session-only; Phase D swaps persistence)", () => {
   it("mate-in-1 pack solve/count/reset", () => {
     const p = createProgressState();
@@ -57,5 +72,134 @@ describe("progress store (session-only; Phase D swaps persistence)", () => {
     expect(p.setBest("squareRace", 4)).toBe(false);
     expect(p.setBest("squareRace", 6)).toBe(true);
     expect(p.getBest("squareRace")).toBe(6);
+  });
+});
+
+describe("profiles store (Phase D)", () => {
+  it("starts with one story profile, empty name", () => {
+    const p = createProgressState();
+    expect(p.profiles()).toHaveLength(1);
+    expect(p.activeId()).toBe("p1");
+    expect(p.getMode()).toBe("story");
+    expect(p.getName()).toBe("");
+  });
+
+  it("add / switch / isolation / remove", () => {
+    const p = createProgressState();
+    p.setName("Mila");
+    p.setWeekDone(1, true);
+    const id2 = p.addProfile("Dad", "classic");
+    expect(p.activeId()).toBe(id2);
+    expect(p.getName()).toBe("Dad");
+    expect(p.getMode()).toBe("classic");
+    expect(p.isWeekDone(1)).toBe(false); // isolated
+    p.switchProfile("p1");
+    expect(p.getName()).toBe("Mila");
+    expect(p.isWeekDone(1)).toBe(true);
+    expect(p.profiles()).toHaveLength(2);
+    // remove non-active
+    expect(p.removeProfile(id2)).toBe(true);
+    expect(p.profiles()).toHaveLength(1);
+    // refuses to remove the only one
+    expect(p.removeProfile("p1")).toBe(false);
+  });
+
+  it("removing the active profile switches to a survivor", () => {
+    const p = createProgressState();
+    const id2 = p.addProfile("Dad", "classic");
+    expect(p.activeId()).toBe(id2);
+    p.removeProfile(id2);
+    expect(p.activeId()).toBe("p1");
+    expect(p.profiles()).toHaveLength(1);
+  });
+
+  it("addProfile never mutates existing profiles", () => {
+    const p = createProgressState();
+    p.setName("Mila");
+    expect(p.getMode()).toBe("story");
+    p.addProfile("Dad", "classic");
+    p.switchProfile("p1");
+    expect(p.getMode()).toBe("story");
+    expect(p.getName()).toBe("Mila");
+  });
+
+  it("setMode only touches the active profile", () => {
+    const p = createProgressState();
+    p.setMode("classic");
+    expect(p.getMode()).toBe("classic");
+  });
+});
+
+describe("lessons + tracks", () => {
+  it("weeks done, current stop, land + track counts", () => {
+    const p = createProgressState();
+    expect(p.weeksDone()).toBe(0);
+    expect(p.currentWeek(48)).toBe(1);
+    p.setWeekDone(1, true);
+    p.setWeekDone(2, true);
+    p.setWeekDone(25, true);
+    expect(p.weeksDone()).toBe(3);
+    expect(p.currentWeek(48)).toBe(26); // highest done (25) + 1
+    expect(p.landDone({ weeks: [1, 4] })).toBe(false);
+    expect(p.trackDone(1)).toBe(2);
+    expect(p.trackDone(2)).toBe(1);
+    p.setWeekDone(2, false);
+    expect(p.isWeekDone(2)).toBe(false);
+    expect(p.weeksDone()).toBe(2);
+  });
+
+  it("totalStars = weeks done + game stars", () => {
+    const p = createProgressState();
+    p.setWeekDone(1, true);
+    p.setGameStars("coinHop", 3);
+    p.setGameStars("squareRace", 2);
+    expect(p.totalStars()).toBe(1 + 3 + 2);
+  });
+});
+
+describe("activity + streak", () => {
+  it("empty streak is 0; markActivity dedupes", () => {
+    const p = createProgressState();
+    expect(p.streak("2026-07-12")).toBe(0);
+    p.markActivity("2026-07-12");
+    p.markActivity("2026-07-12");
+    expect(p.activityDates()).toHaveLength(1);
+  });
+
+  it("chain with <=2-day gaps counts; dies after 3 quiet days", () => {
+    const p = createProgressState();
+    p.markActivity("2026-07-08");
+    p.markActivity("2026-07-10");
+    p.markActivity("2026-07-12");
+    expect(p.streak("2026-07-12")).toBe(3);
+    expect(p.streak("2026-07-14")).toBe(3); // still alive 2 days later
+    expect(p.streak("2026-07-15")).toBe(0); // dead after 3 quiet days
+  });
+});
+
+describe("persistence", () => {
+  it("survives a reload against the same storage", () => {
+    const storage = fakeStorage();
+    const p = createProgressState(storage);
+    p.setName("Dad");
+    p.setWeekDone(3, true);
+    p.setGameStars("mateInOne", 2);
+    const id2 = p.addProfile("Kid", "story");
+
+    const reloaded = createProgressState(storage);
+    expect(reloaded.activeId()).toBe(id2);
+    expect(reloaded.profiles()).toHaveLength(2);
+    reloaded.switchProfile("p1");
+    expect(reloaded.getName()).toBe("Dad");
+    expect(reloaded.isWeekDone(3)).toBe(true);
+    expect(reloaded.gameStars("mateInOne")).toBe(2);
+  });
+
+  it("recovers from a corrupt blob", () => {
+    const storage = fakeStorage();
+    storage.setItem("seazn-games:chess-quest:v1", "{not json");
+    const p = createProgressState(storage);
+    expect(p.profiles()).toHaveLength(1);
+    expect(p.getName()).toBe("");
   });
 });

--- a/apps/web/src/games/chess-quest/lib/__tests__/rand.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/rand.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { randSquares } from "../rand";
+
+describe("randSquares", () => {
+  it("returns n distinct squares avoiding exclusions", () => {
+    for (let run = 0; run < 20; run++) {
+      const out = randSquares(6, [10, 20, 30]);
+      expect(out).toHaveLength(6);
+      expect(new Set(out).size).toBe(6);
+      for (const i of out) {
+        expect([10, 20, 30]).not.toContain(i);
+        expect(i).toBeGreaterThanOrEqual(0);
+        expect(i).toBeLessThan(64);
+      }
+    }
+  });
+  it("honors the allowed filter", () => {
+    const even = (i: number) => i % 2 === 0;
+    for (let run = 0; run < 20; run++) {
+      for (const i of randSquares(5, [], even)) expect(i % 2).toBe(0);
+    }
+  });
+  it("caps at the pool size", () => {
+    const only3 = (i: number) => i < 3;
+    expect(randSquares(10, [], only3)).toHaveLength(3);
+  });
+});

--- a/apps/web/src/games/chess-quest/lib/__tests__/stars.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/stars.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { STAR_RULES } from "../stars";
+
+describe("star formulas (ported thresholds)", () => {
+  it("squareRace", () => {
+    expect(STAR_RULES.squareRace(12)).toBe(3);
+    expect(STAR_RULES.squareRace(11)).toBe(2);
+    expect(STAR_RULES.squareRace(7)).toBe(2);
+    expect(STAR_RULES.squareRace(6)).toBe(1);
+    expect(STAR_RULES.squareRace(3)).toBe(1);
+    expect(STAR_RULES.squareRace(2)).toBe(0);
+  });
+  it("coinHop — easy sliders vs hard steppers", () => {
+    expect(STAR_RULES.coinHop(9, "Q")).toBe(3);
+    expect(STAR_RULES.coinHop(10, "Q")).toBe(2);
+    expect(STAR_RULES.coinHop(13, "R")).toBe(2);
+    expect(STAR_RULES.coinHop(14, "B")).toBe(1);
+    expect(STAR_RULES.coinHop(14, "N")).toBe(3);
+    expect(STAR_RULES.coinHop(15, "N")).toBe(2);
+    expect(STAR_RULES.coinHop(20, "K")).toBe(2);
+    expect(STAR_RULES.coinHop(21, "P")).toBe(1);
+  });
+  it("pawnWars", () => {
+    expect(STAR_RULES.pawnWars(true)).toBe(3);
+    expect(STAR_RULES.pawnWars(false)).toBe(1);
+  });
+  it("packStars (mate packs, tier-2 tactics)", () => {
+    expect(STAR_RULES.packStars(12)).toBe(3);
+    expect(STAR_RULES.packStars(11)).toBe(2);
+    expect(STAR_RULES.packStars(8)).toBe(2);
+    expect(STAR_RULES.packStars(7)).toBe(1);
+    expect(STAR_RULES.packStars(4)).toBe(1);
+    expect(STAR_RULES.packStars(3)).toBe(0);
+  });
+  it("hangingHunt", () => {
+    expect(STAR_RULES.hangingHunt(8)).toBe(3);
+    expect(STAR_RULES.hangingHunt(7)).toBe(2);
+    expect(STAR_RULES.hangingHunt(5)).toBe(2);
+    expect(STAR_RULES.hangingHunt(4)).toBe(1);
+    expect(STAR_RULES.hangingHunt(3)).toBe(1);
+    expect(STAR_RULES.hangingHunt(2)).toBe(0);
+  });
+  it("tacticTier1 (13 cases total)", () => {
+    expect(STAR_RULES.tacticTier1(13)).toBe(3);
+    expect(STAR_RULES.tacticTier1(12)).toBe(2);
+    expect(STAR_RULES.tacticTier1(8)).toBe(2);
+    expect(STAR_RULES.tacticTier1(7)).toBe(1);
+    expect(STAR_RULES.tacticTier1(4)).toBe(1);
+    expect(STAR_RULES.tacticTier1(3)).toBe(0);
+  });
+  it("rookMaze vs par", () => {
+    expect(STAR_RULES.rookMaze(5, 5)).toBe(3);
+    expect(STAR_RULES.rookMaze(6, 5)).toBe(2);
+    expect(STAR_RULES.rookMaze(7, 5)).toBe(1);
+  });
+});

--- a/apps/web/src/games/chess-quest/lib/celebrate.ts
+++ b/apps/web/src/games/chess-quest/lib/celebrate.ts
@@ -1,0 +1,9 @@
+// A win: fanfare + confetti. Games call this instead of sfx.fanfare() so the
+// two always fire together (and confetti stays reduced-motion aware).
+import { burst } from "./fx";
+import { sfx } from "./sfx";
+
+export function celebrate(originEl?: Element | null): void {
+  sfx.fanfare();
+  burst(originEl);
+}

--- a/apps/web/src/games/chess-quest/lib/cert.ts
+++ b/apps/web/src/games/chess-quest/lib/cert.ts
@@ -1,0 +1,25 @@
+// Certificate title/line by tracks completed (port of js/app.js printCertificate).
+export function certTitle(t1: number, t2: number): { title: string; line: string } {
+  if (t1 === 24 && t2 === 24) {
+    return {
+      title: "Chess Quest Champion",
+      line: "has completed the entire Chess Quest — all 48 lessons, from the first square to Rising Player strength",
+    };
+  }
+  if (t1 === 24) {
+    return {
+      title: "First Steps Champion",
+      line: "has completed Track 1 “First Steps” — 24 lessons, from the empty board to full, careful games",
+    };
+  }
+  if (t2 === 24) {
+    return {
+      title: "Rising Player Champion",
+      line: "has completed Track 2 “Rising Player” — 24 lessons of combinations, openings, endgames and strategy",
+    };
+  }
+  return {
+    title: "Chess Quest Adventurer",
+    line: `has bravely conquered ${t1 + t2} of 48 quest days — and the journey continues`,
+  };
+}

--- a/apps/web/src/games/chess-quest/lib/copy.tsx
+++ b/apps/web/src/games/chess-quest/lib/copy.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// Copy register: Story (kid voice) vs Classic (adult coaching voice).
+// Defaults to Classic on the public site; Phase D's profiles add the toggle.
+import { createContext, useContext, useMemo } from "react";
+
+export type Register = "story" | "classic";
+
+const CopyCtx = createContext<Register>("classic");
+
+export function CopyProvider({
+  register = "classic",
+  children,
+}: {
+  register?: Register;
+  children: React.ReactNode;
+}) {
+  return <CopyCtx.Provider value={register}>{children}</CopyCtx.Provider>;
+}
+
+export function useCopy(): { t(story: string, classic: string): string; isStory(): boolean } {
+  const register = useContext(CopyCtx);
+  return useMemo(
+    () => ({
+      t: (story: string, classic: string) => (register === "story" ? story : classic),
+      isStory: () => register === "story",
+    }),
+    [register],
+  );
+}

--- a/apps/web/src/games/chess-quest/lib/fx.ts
+++ b/apps/web/src/games/chess-quest/lib/fx.ts
@@ -1,0 +1,76 @@
+// Confetti burst on a throwaway fullscreen canvas. Skipped under reduced
+// motion. Port of the standalone app's FX.
+const COLORS = ["#58B586", "#F2C14E", "#E8734A", "#7BB3E0", "#C77FC9", "#F6F1E3"];
+
+function reduced(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    !!window.matchMedia &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+export function burst(originEl?: Element | null, count = 90): void {
+  if (typeof window === "undefined" || reduced()) return;
+
+  const canvas = document.createElement("canvas");
+  canvas.style.cssText = "position:fixed;inset:0;z-index:60;pointer-events:none";
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    canvas.remove();
+    return;
+  }
+
+  let x = window.innerWidth / 2;
+  let y = window.innerHeight / 2.5;
+  const r = originEl?.getBoundingClientRect();
+  if (r) {
+    x = r.left + r.width / 2;
+    y = r.top + r.height / 2;
+  }
+
+  const parts = Array.from({ length: count }, (_, i) => {
+    const a = Math.random() * Math.PI * 2;
+    const v = 4 + Math.random() * 7;
+    return {
+      x,
+      y,
+      vx: Math.cos(a) * v,
+      vy: Math.sin(a) * v - 4,
+      s: 4 + Math.random() * 5,
+      c: COLORS[i % COLORS.length],
+      r: Math.random() * Math.PI,
+      vr: (Math.random() - 0.5) * 0.3,
+      life: 60 + Math.random() * 30,
+    };
+  });
+
+  let frame = 0;
+  const tick = () => {
+    frame++;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    let alive = 0;
+    for (const p of parts) {
+      if (frame > p.life) continue;
+      alive++;
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vy += 0.25;
+      p.vx *= 0.99;
+      p.r += p.vr;
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.r);
+      ctx.fillStyle = p.c;
+      ctx.globalAlpha = Math.max(0, 1 - frame / p.life);
+      ctx.fillRect(-p.s / 2, -p.s / 2, p.s, p.s * 0.6);
+      ctx.restore();
+    }
+    if (alive > 0) requestAnimationFrame(tick);
+    else canvas.remove();
+  };
+  tick();
+}

--- a/apps/web/src/games/chess-quest/lib/last14.ts
+++ b/apps/web/src/games/chess-quest/lib/last14.ts
@@ -1,0 +1,22 @@
+// The 14-day activity strip for the progress panel (port of js/app.js
+// last14Days). Pure: caller passes the activity dates and "today".
+export function last14Days(
+  activity: string[],
+  todayISO: string,
+): { iso: string; wd: string; on: boolean }[] {
+  const played = new Set(activity);
+  const out: { iso: string; wd: string; on: boolean }[] = [];
+  const d = new Date(todayISO + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() - 13);
+  for (let i = 0; i < 14; i++) {
+    const iso =
+      d.getUTCFullYear() +
+      "-" +
+      String(d.getUTCMonth() + 1).padStart(2, "0") +
+      "-" +
+      String(d.getUTCDate()).padStart(2, "0");
+    out.push({ iso, wd: "SMTWTFS"[d.getUTCDay()], on: played.has(iso) });
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return out;
+}

--- a/apps/web/src/games/chess-quest/lib/mate-miss.ts
+++ b/apps/web/src/games/chess-quest/lib/mate-miss.ts
@@ -1,0 +1,18 @@
+// Diagnose WHY a "find the checkmate" move failed, so the coach can nudge the
+// player toward the right idea (port of js/games.js mateMissCoach, 386–429).
+// Pure classification; the game component renders the matching coach flow.
+import { Board, allLegalMoves, inCheck } from "../engine";
+
+export type MateMiss =
+  | { kind: "no-check" } // the move doesn't even give check
+  | { kind: "escape"; escapes: number[] } // check, but the king can step away
+  | { kind: "capture-block" }; // check, king stuck, but the checker can be met
+
+export function classifyMateMiss(next: Board): MateMiss {
+  if (!inCheck(next, false)) return { kind: "no-check" };
+  const escapes = allLegalMoves(next, false)
+    .filter((m) => next[m.from] === "k")
+    .map((m) => m.to);
+  if (escapes.length) return { kind: "escape", escapes };
+  return { kind: "capture-block" };
+}

--- a/apps/web/src/games/chess-quest/lib/progress.tsx
+++ b/apps/web/src/games/chess-quest/lib/progress.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+// Session progress store. Phase C keeps it in memory; Phase D swaps the
+// provider internals for localStorage-backed profiles. The Progress API is
+// the contract — game components must not reach around it.
+import { createContext, useContext, useMemo, useRef, useState } from "react";
+
+export type Progress = {
+  isSolved(i: number): boolean;
+  setSolved(i: number): void;
+  solvedCount(): number;
+  resetPuzzles(): void;
+  isSolved2(i: number): boolean;
+  setSolved2(i: number): void;
+  solved2Count(): number;
+  resetPuzzles2(): void;
+  isHuntSolved(i: number): boolean;
+  setHuntSolved(i: number): void;
+  huntCount(): number;
+  resetHunts(): void;
+  isTacticSolved(pack: string, i: number): boolean;
+  setTacticSolved(pack: string, i: number): void;
+  tacticCount(pack: string): number;
+  resetTactics(pack: string): void;
+  setGameStars(gameId: string, stars: number): void; // keep-max semantics
+  gameStars(gameId: string): number;
+  setBest(gameId: string, score: number): boolean; // true = new record
+  getBest(gameId: string): number;
+};
+
+export function createProgressState(): Progress {
+  const solved = new Set<number>();
+  const solved2 = new Set<number>();
+  const hunts = new Set<number>();
+  const tactics: Record<string, Set<number>> = {};
+  const stars: Record<string, number> = {};
+  const bests: Record<string, number> = {};
+  const packOf = (pack: string) => (tactics[pack] ??= new Set());
+
+  return {
+    isSolved: (i) => solved.has(i),
+    setSolved: (i) => void solved.add(i),
+    solvedCount: () => solved.size,
+    resetPuzzles: () => solved.clear(),
+    isSolved2: (i) => solved2.has(i),
+    setSolved2: (i) => void solved2.add(i),
+    solved2Count: () => solved2.size,
+    resetPuzzles2: () => solved2.clear(),
+    isHuntSolved: (i) => hunts.has(i),
+    setHuntSolved: (i) => void hunts.add(i),
+    huntCount: () => hunts.size,
+    resetHunts: () => hunts.clear(),
+    isTacticSolved: (pack, i) => packOf(pack).has(i),
+    setTacticSolved: (pack, i) => void packOf(pack).add(i),
+    tacticCount: (pack) => packOf(pack).size,
+    resetTactics: (pack) => packOf(pack).clear(),
+    setGameStars: (id, s) => {
+      stars[id] = Math.max(stars[id] ?? 0, s);
+    },
+    gameStars: (id) => stars[id] ?? 0,
+    setBest: (id, score) => {
+      if (score > (bests[id] ?? 0)) {
+        bests[id] = score;
+        return true;
+      }
+      return false;
+    },
+    getBest: (id) => bests[id] ?? 0,
+  };
+}
+
+const ProgressCtx = createContext<Progress | null>(null);
+
+// Mutators bump a version counter so consumers re-render on writes.
+const MUTATORS = [
+  "setSolved",
+  "resetPuzzles",
+  "setSolved2",
+  "resetPuzzles2",
+  "setHuntSolved",
+  "resetHunts",
+  "setTacticSolved",
+  "resetTactics",
+  "setGameStars",
+  "setBest",
+] as const;
+
+export function ProgressProvider({ children }: { children: React.ReactNode }) {
+  const ref = useRef<Progress | null>(null);
+  ref.current ??= createProgressState();
+  const [, setVersion] = useState(0);
+
+  const value = useMemo(() => {
+    const inner = ref.current!;
+    const wrapped = { ...inner };
+    for (const m of MUTATORS) {
+      const fn = inner[m] as (...args: never[]) => unknown;
+      (wrapped as Record<string, unknown>)[m] = (...args: never[]) => {
+        const out = fn(...args);
+        setVersion((v) => v + 1);
+        return out;
+      };
+    }
+    return wrapped as Progress;
+  }, []);
+
+  return <ProgressCtx.Provider value={value}>{children}</ProgressCtx.Provider>;
+}
+
+export function useProgress(): Progress {
+  const ctx = useContext(ProgressCtx);
+  if (!ctx) throw new Error("useProgress needs a ProgressProvider");
+  return ctx;
+}

--- a/apps/web/src/games/chess-quest/lib/progress.tsx
+++ b/apps/web/src/games/chess-quest/lib/progress.tsx
@@ -97,7 +97,9 @@ function dayNum(iso: string): number {
 function blankProfile(): Profile {
   return {
     name: "",
-    mode: "story",
+    // Public site skews adult, so the first profile reads Classic; a kid
+    // profile can be switched to Story per-player (spec 2026-07-14).
+    mode: "classic",
     weeks: {},
     stars: {},
     best: {},
@@ -348,8 +350,11 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
   const [inner] = useState<Progress>(() =>
     createProgressState(typeof window !== "undefined" ? window.localStorage : undefined),
   );
-  const [, setVersion] = useState(0);
+  const [version, setVersion] = useState(0);
 
+  // `version` is a dep so each mutation produces a NEW value object — pure
+  // context consumers (e.g. the lesson card) only re-render when the value
+  // identity changes, and the store mutates in place behind a stable `inner`.
   const value = useMemo(() => {
     const wrapped = { ...inner };
     for (const m of MUTATORS) {
@@ -361,7 +366,8 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
       };
     }
     return wrapped as Progress;
-  }, [inner]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inner, version]);
 
   return <ProgressCtx.Provider value={value}>{children}</ProgressCtx.Provider>;
 }

--- a/apps/web/src/games/chess-quest/lib/progress.tsx
+++ b/apps/web/src/games/chess-quest/lib/progress.tsx
@@ -26,7 +26,13 @@ type Profile = {
   created: string;
 };
 
-type Blob = { active: string; seq: number; profiles: Record<string, Profile> };
+type Blob = {
+  active: string;
+  seq: number;
+  muted: boolean;
+  voiceOff: boolean;
+  profiles: Record<string, Profile>;
+};
 
 export type Progress = {
   // puzzle packs (Phase C contract — unchanged)
@@ -77,6 +83,12 @@ export type Progress = {
   addProfile(name: string, mode: Mode): string;
   switchProfile(id: string): boolean;
   removeProfile(id: string): boolean;
+
+  // device settings (shared across profiles)
+  getMuted(): boolean;
+  setMuted(m: boolean): void;
+  getVoiceOn(): boolean;
+  setVoiceOn(on: boolean): void;
 };
 
 function todayISO(): string {
@@ -113,7 +125,7 @@ function blankProfile(): Profile {
 }
 
 function freshBlob(): Blob {
-  return { active: "p1", seq: 1, profiles: { p1: blankProfile() } };
+  return { active: "p1", seq: 1, muted: false, voiceOff: false, profiles: { p1: blankProfile() } };
 }
 
 function loadBlob(storage?: Storage): Blob {
@@ -318,6 +330,17 @@ export function createProgressState(storage?: Storage): Progress {
       save();
       return true;
     },
+
+    getMuted: () => !!data.muted,
+    setMuted: (m) => {
+      data.muted = !!m;
+      save();
+    },
+    getVoiceOn: () => !data.voiceOff,
+    setVoiceOn: (on) => {
+      data.voiceOff = !on;
+      save();
+    },
   };
 }
 
@@ -342,6 +365,8 @@ const MUTATORS = [
   "addProfile",
   "switchProfile",
   "removeProfile",
+  "setMuted",
+  "setVoiceOn",
 ] as const;
 
 export function ProgressProvider({ children }: { children: React.ReactNode }) {

--- a/apps/web/src/games/chess-quest/lib/progress.tsx
+++ b/apps/web/src/games/chess-quest/lib/progress.tsx
@@ -1,11 +1,35 @@
 "use client";
 
-// Session progress store. Phase C keeps it in memory; Phase D swaps the
-// provider internals for localStorage-backed profiles. The Progress API is
-// the contract — game components must not reach around it.
+// Chess Quest progress — localStorage-backed player profiles. Each profile
+// keeps its own lessons, stars, puzzle progress, activity streak and copy
+// register. Ported from the standalone app's Store (chess-quest js/store.js),
+// minus the v1 migration (Seazn is a fresh origin, so key + data start clean).
+// The game-facing members (isSolved/setGameStars/setBest/…) match Phase C so
+// the eight mini-games keep working unchanged.
 import { createContext, useContext, useMemo, useState } from "react";
 
+const KEY = "seazn-games:chess-quest:v1";
+
+export type Mode = "story" | "classic";
+
+type Profile = {
+  name: string;
+  mode: Mode;
+  weeks: Record<number, boolean>;
+  stars: Record<string, number>;
+  best: Record<string, number>;
+  solved: number[];
+  solved2: number[];
+  hunts: number[];
+  tactics: Record<string, number[]>;
+  activity: string[];
+  created: string;
+};
+
+type Blob = { active: string; seq: number; profiles: Record<string, Profile> };
+
 export type Progress = {
+  // puzzle packs (Phase C contract — unchanged)
   isSolved(i: number): boolean;
   setSolved(i: number): void;
   solvedCount(): number;
@@ -22,56 +46,282 @@ export type Progress = {
   setTacticSolved(pack: string, i: number): void;
   tacticCount(pack: string): number;
   resetTactics(pack: string): void;
-  setGameStars(gameId: string, stars: number): void; // keep-max semantics
+  setGameStars(gameId: string, stars: number): void;
   gameStars(gameId: string): number;
-  setBest(gameId: string, score: number): boolean; // true = new record
+  setBest(gameId: string, score: number): boolean;
   getBest(gameId: string): number;
+
+  // lessons
+  isWeekDone(n: number): boolean;
+  setWeekDone(n: number, done: boolean): void;
+  weeksDone(): number;
+  currentWeek(total: number): number;
+  landDone(land: { weeks: [number, number] }): boolean;
+  trackDone(track: 1 | 2): number;
+
+  // activity / streak
+  markActivity(dateISO?: string): void;
+  activityDates(): string[];
+  streak(todayISO?: string): number;
+
+  // identity + register
+  getName(): string;
+  setName(n: string): void;
+  getMode(): Mode;
+  setMode(m: Mode): void;
+  totalStars(): number;
+
+  // profiles
+  profiles(): { id: string; name: string; mode: Mode }[];
+  activeId(): string;
+  addProfile(name: string, mode: Mode): string;
+  switchProfile(id: string): boolean;
+  removeProfile(id: string): boolean;
 };
 
-export function createProgressState(): Progress {
-  const solved = new Set<number>();
-  const solved2 = new Set<number>();
-  const hunts = new Set<number>();
-  const tactics: Record<string, Set<number>> = {};
-  const stars: Record<string, number> = {};
-  const bests: Record<string, number> = {};
-  const packOf = (pack: string) => (tactics[pack] ??= new Set());
+function todayISO(): string {
+  const d = new Date();
+  return (
+    d.getFullYear() +
+    "-" +
+    String(d.getMonth() + 1).padStart(2, "0") +
+    "-" +
+    String(d.getDate()).padStart(2, "0")
+  );
+}
+
+function dayNum(iso: string): number {
+  return Math.round(Date.parse(iso + "T00:00:00Z") / 86400000);
+}
+
+function blankProfile(): Profile {
+  return {
+    name: "",
+    mode: "story",
+    weeks: {},
+    stars: {},
+    best: {},
+    solved: [],
+    solved2: [],
+    hunts: [],
+    tactics: {},
+    activity: [],
+    created: todayISO(),
+  };
+}
+
+function freshBlob(): Blob {
+  return { active: "p1", seq: 1, profiles: { p1: blankProfile() } };
+}
+
+function loadBlob(storage?: Storage): Blob {
+  if (!storage) return freshBlob();
+  let data: Blob | null = null;
+  try {
+    const raw = storage.getItem(KEY);
+    if (raw) data = JSON.parse(raw) as Blob;
+  } catch {
+    console.warn("[chess-quest] discarding corrupt progress blob");
+  }
+  if (!data || !data.profiles) return freshBlob();
+  // Backfill any missing fields on older blobs.
+  for (const id in data.profiles) {
+    data.profiles[id] = { ...blankProfile(), ...data.profiles[id] };
+  }
+  if (!data.profiles[data.active]) data.active = Object.keys(data.profiles)[0];
+  return data;
+}
+
+export function createProgressState(storage?: Storage): Progress {
+  const data = loadBlob(storage);
+  const P = () => data.profiles[data.active];
+
+  function save() {
+    if (!storage) return;
+    try {
+      storage.setItem(KEY, JSON.stringify(data));
+    } catch {
+      /* private mode — run without persistence */
+    }
+  }
+
+  // Any real play counts toward today's streak.
+  function touch() {
+    const d = todayISO();
+    if (!P().activity.includes(d)) P().activity.push(d);
+  }
+
+  const packOf = (pack: string) => (P().tactics[pack] ??= []);
 
   return {
-    isSolved: (i) => solved.has(i),
-    setSolved: (i) => void solved.add(i),
-    solvedCount: () => solved.size,
-    resetPuzzles: () => solved.clear(),
-    isSolved2: (i) => solved2.has(i),
-    setSolved2: (i) => void solved2.add(i),
-    solved2Count: () => solved2.size,
-    resetPuzzles2: () => solved2.clear(),
-    isHuntSolved: (i) => hunts.has(i),
-    setHuntSolved: (i) => void hunts.add(i),
-    huntCount: () => hunts.size,
-    resetHunts: () => hunts.clear(),
-    isTacticSolved: (pack, i) => packOf(pack).has(i),
-    setTacticSolved: (pack, i) => void packOf(pack).add(i),
-    tacticCount: (pack) => packOf(pack).size,
-    resetTactics: (pack) => packOf(pack).clear(),
-    setGameStars: (id, s) => {
-      stars[id] = Math.max(stars[id] ?? 0, s);
+    isSolved: (i) => P().solved.includes(i),
+    setSolved: (i) => {
+      if (!P().solved.includes(i)) {
+        P().solved.push(i);
+        touch();
+        save();
+      }
     },
-    gameStars: (id) => stars[id] ?? 0,
+    solvedCount: () => P().solved.length,
+    resetPuzzles: () => {
+      P().solved = [];
+      save();
+    },
+    isSolved2: (i) => P().solved2.includes(i),
+    setSolved2: (i) => {
+      if (!P().solved2.includes(i)) {
+        P().solved2.push(i);
+        touch();
+        save();
+      }
+    },
+    solved2Count: () => P().solved2.length,
+    resetPuzzles2: () => {
+      P().solved2 = [];
+      save();
+    },
+    isHuntSolved: (i) => P().hunts.includes(i),
+    setHuntSolved: (i) => {
+      if (!P().hunts.includes(i)) {
+        P().hunts.push(i);
+        touch();
+        save();
+      }
+    },
+    huntCount: () => P().hunts.length,
+    resetHunts: () => {
+      P().hunts = [];
+      save();
+    },
+    isTacticSolved: (pack, i) => packOf(pack).includes(i),
+    setTacticSolved: (pack, i) => {
+      if (!packOf(pack).includes(i)) {
+        packOf(pack).push(i);
+        touch();
+        save();
+      }
+    },
+    tacticCount: (pack) => packOf(pack).length,
+    resetTactics: (pack) => {
+      P().tactics[pack] = [];
+      save();
+    },
+    setGameStars: (id, s) => {
+      if (s > (P().stars[id] ?? 0)) P().stars[id] = s;
+      touch();
+      save();
+    },
+    gameStars: (id) => P().stars[id] ?? 0,
     setBest: (id, score) => {
-      if (score > (bests[id] ?? 0)) {
-        bests[id] = score;
+      if (score > (P().best[id] ?? 0)) {
+        P().best[id] = score;
+        touch();
+        save();
         return true;
       }
       return false;
     },
-    getBest: (id) => bests[id] ?? 0,
+    getBest: (id) => P().best[id] ?? 0,
+
+    isWeekDone: (n) => !!P().weeks[n],
+    setWeekDone: (n, done) => {
+      if (done) {
+        P().weeks[n] = true;
+        touch();
+      } else {
+        delete P().weeks[n];
+      }
+      save();
+    },
+    weeksDone: () => Object.keys(P().weeks).length,
+    currentWeek: (total) => {
+      let cur = 1;
+      for (let i = 1; i <= total; i++) if (P().weeks[i]) cur = Math.min(i + 1, total);
+      return cur;
+    },
+    landDone: (land) => {
+      for (let i = land.weeks[0]; i <= land.weeks[1]; i++) if (!P().weeks[i]) return false;
+      return true;
+    },
+    trackDone: (track) => {
+      const lo = track === 2 ? 25 : 1;
+      const hi = track === 2 ? 48 : 24;
+      let n = 0;
+      for (let i = lo; i <= hi; i++) if (P().weeks[i]) n++;
+      return n;
+    },
+
+    markActivity: (dateISO) => {
+      const d = dateISO || todayISO();
+      if (!P().activity.includes(d)) {
+        P().activity.push(d);
+        save();
+      }
+    },
+    activityDates: () => P().activity.slice(),
+    // Streak of play-days: alive while gaps stay ≤ 2 days (the quest runs
+    // every other day, so one rest day never breaks it).
+    streak: (todayStr) => {
+      const t = dayNum(todayStr || todayISO());
+      const days = [...new Set(P().activity)].map(dayNum).sort((a, b) => b - a);
+      if (!days.length || t - days[0] > 2) return 0;
+      let n = 1;
+      for (let i = 1; i < days.length && days[i - 1] - days[i] <= 2; i++) n++;
+      return n;
+    },
+
+    getName: () => P().name || "",
+    setName: (n) => {
+      P().name = String(n || "").trim().slice(0, 16);
+      save();
+    },
+    getMode: () => P().mode,
+    setMode: (m) => {
+      P().mode = m === "classic" ? "classic" : "story";
+      save();
+    },
+    totalStars: () => {
+      let s = Object.keys(P().weeks).length;
+      for (const k in P().stars) s += P().stars[k];
+      return s;
+    },
+
+    profiles: () =>
+      Object.keys(data.profiles).map((id) => ({
+        id,
+        name: data.profiles[id].name,
+        mode: data.profiles[id].mode,
+      })),
+    activeId: () => data.active,
+    addProfile: (name, mode) => {
+      const id = "p" + ++data.seq;
+      const prof = blankProfile();
+      prof.name = String(name || "").trim().slice(0, 16);
+      prof.mode = mode === "classic" ? "classic" : "story";
+      data.profiles[id] = prof;
+      data.active = id;
+      save();
+      return id;
+    },
+    switchProfile: (id) => {
+      if (!data.profiles[id]) return false;
+      data.active = id;
+      save();
+      return true;
+    },
+    removeProfile: (id) => {
+      if (!data.profiles[id] || Object.keys(data.profiles).length <= 1) return false;
+      delete data.profiles[id];
+      if (data.active === id) data.active = Object.keys(data.profiles)[0];
+      save();
+      return true;
+    },
   };
 }
 
 const ProgressCtx = createContext<Progress | null>(null);
 
-// Mutators bump a version counter so consumers re-render on writes.
+// Every mutator bumps a version counter so consumers re-render on writes.
 const MUTATORS = [
   "setSolved",
   "resetPuzzles",
@@ -83,10 +333,21 @@ const MUTATORS = [
   "resetTactics",
   "setGameStars",
   "setBest",
+  "setWeekDone",
+  "markActivity",
+  "setName",
+  "setMode",
+  "addProfile",
+  "switchProfile",
+  "removeProfile",
 ] as const;
 
 export function ProgressProvider({ children }: { children: React.ReactNode }) {
-  const [inner] = useState(createProgressState);
+  // The whole chess-quest tree loads via next/dynamic({ ssr: false }), so this
+  // only ever renders in the browser — safe to read localStorage at init.
+  const [inner] = useState<Progress>(() =>
+    createProgressState(typeof window !== "undefined" ? window.localStorage : undefined),
+  );
   const [, setVersion] = useState(0);
 
   const value = useMemo(() => {

--- a/apps/web/src/games/chess-quest/lib/progress.tsx
+++ b/apps/web/src/games/chess-quest/lib/progress.tsx
@@ -3,7 +3,7 @@
 // Session progress store. Phase C keeps it in memory; Phase D swaps the
 // provider internals for localStorage-backed profiles. The Progress API is
 // the contract — game components must not reach around it.
-import { createContext, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useContext, useMemo, useState } from "react";
 
 export type Progress = {
   isSolved(i: number): boolean;
@@ -86,12 +86,10 @@ const MUTATORS = [
 ] as const;
 
 export function ProgressProvider({ children }: { children: React.ReactNode }) {
-  const ref = useRef<Progress | null>(null);
-  ref.current ??= createProgressState();
+  const [inner] = useState(createProgressState);
   const [, setVersion] = useState(0);
 
   const value = useMemo(() => {
-    const inner = ref.current!;
     const wrapped = { ...inner };
     for (const m of MUTATORS) {
       const fn = inner[m] as (...args: never[]) => unknown;
@@ -102,7 +100,7 @@ export function ProgressProvider({ children }: { children: React.ReactNode }) {
       };
     }
     return wrapped as Progress;
-  }, []);
+  }, [inner]);
 
   return <ProgressCtx.Provider value={value}>{children}</ProgressCtx.Provider>;
 }

--- a/apps/web/src/games/chess-quest/lib/rand.ts
+++ b/apps/web/src/games/chess-quest/lib/rand.ts
@@ -1,0 +1,22 @@
+// Random square picking for game generators (port of js/games.js randSquares).
+export function randSquares(
+  n: number,
+  exclude: number[],
+  allowed?: ((i: number) => boolean) | null,
+): number[] {
+  const pool: number[] = [];
+  for (let i = 0; i < 64; i++) {
+    if (exclude.includes(i)) continue;
+    if (allowed && !allowed(i)) continue;
+    pool.push(i);
+  }
+  const out: number[] = [];
+  while (out.length < n && pool.length) {
+    out.push(pool.splice(Math.floor(Math.random() * pool.length), 1)[0]);
+  }
+  return out;
+}
+
+export function emptyBoard(): string[] {
+  return new Array(64).fill("");
+}

--- a/apps/web/src/games/chess-quest/lib/sfx.ts
+++ b/apps/web/src/games/chess-quest/lib/sfx.ts
@@ -1,11 +1,70 @@
-// Sound effects — call sites are wired now; real WebAudio lands in Phase E.
-// Keeping the object shape stable means Phase E only edits this file.
+// Tiny WebAudio sound effects — no audio files. The AudioContext is created
+// lazily on the first play (autoplay policy). Port of the standalone app's
+// SFX; muted state is driven from the store via setMuted().
+let ctx: AudioContext | null = null;
+let muted = false;
+
+type WindowWithWebkitAudio = Window & { webkitAudioContext?: typeof AudioContext };
+
+function ac(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (!ctx) {
+    const AC = window.AudioContext ?? (window as WindowWithWebkitAudio).webkitAudioContext;
+    if (!AC) return null;
+    ctx = new AC();
+  }
+  if (ctx.state === "suspended") void ctx.resume();
+  return ctx;
+}
+
+function tone(freq: number, dur: number, type: OscillatorType = "sine", delay = 0, vol = 0.12) {
+  const a = ac();
+  if (!a || muted) return;
+  const t0 = a.currentTime + delay;
+  const osc = a.createOscillator();
+  const gain = a.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, t0);
+  gain.gain.setValueAtTime(0, t0);
+  gain.gain.linearRampToValueAtTime(vol, t0 + 0.012);
+  gain.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(gain).connect(a.destination);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.05);
+}
 
 export const sfx = {
-  tap(): void {},
-  good(): void {},
-  bad(): void {},
-  move(): void {},
-  coin(): void {},
-  fanfare(): void {},
+  setMuted(m: boolean): void {
+    muted = m;
+  },
+  isMuted(): boolean {
+    return muted;
+  },
+  tap(): void {
+    tone(500, 0.06, "sine");
+  },
+  move(): void {
+    tone(240, 0.09, "triangle", 0, 0.16);
+  },
+  coin(): void {
+    tone(880, 0.09, "sine");
+    tone(1320, 0.12, "sine", 0.07);
+  },
+  good(): void {
+    tone(523, 0.1, "sine");
+    tone(659, 0.12, "sine", 0.06);
+  },
+  bad(): void {
+    tone(160, 0.18, "triangle", 0, 0.08);
+  },
+  chime(): void {
+    tone(659, 0.12, "sine");
+    tone(988, 0.22, "sine", 0.1);
+  },
+  fanfare(): void {
+    tone(523, 0.12, "triangle");
+    tone(659, 0.12, "triangle", 0.11);
+    tone(784, 0.12, "triangle", 0.22);
+    tone(1047, 0.3, "triangle", 0.33, 0.14);
+  },
 };

--- a/apps/web/src/games/chess-quest/lib/sfx.ts
+++ b/apps/web/src/games/chess-quest/lib/sfx.ts
@@ -1,0 +1,11 @@
+// Sound effects — call sites are wired now; real WebAudio lands in Phase E.
+// Keeping the object shape stable means Phase E only edits this file.
+
+export const sfx = {
+  tap(): void {},
+  good(): void {},
+  bad(): void {},
+  move(): void {},
+  coin(): void {},
+  fanfare(): void {},
+};

--- a/apps/web/src/games/chess-quest/lib/stars.ts
+++ b/apps/web/src/games/chess-quest/lib/stars.ts
@@ -1,0 +1,32 @@
+// Star formulas — ported 1:1 from the original games (chess-quest js/games.js).
+// Pure so thresholds stay pinned by lib/__tests__/stars.test.ts.
+
+export const STAR_RULES = {
+  squareRace(score: number): number {
+    return score >= 12 ? 3 : score >= 7 ? 2 : score >= 3 ? 1 : 0;
+  },
+  // Sliders (R/B/Q) reach coins fast; steppers (N/K/P) get looser pars.
+  coinHop(moves: number, piece: string): number {
+    const easy = piece !== "N" && piece !== "K" && piece !== "P";
+    const s3 = easy ? 9 : 14;
+    const s2 = easy ? 13 : 20;
+    return moves <= s3 ? 3 : moves <= s2 ? 2 : 1;
+  },
+  pawnWars(whiteWon: boolean): number {
+    return whiteWon ? 3 : 1;
+  },
+  // Mate-in-1, Mate-in-2 and tier-2 tactics all award on solved count.
+  packStars(solved: number): number {
+    return solved >= 12 ? 3 : solved >= 8 ? 2 : solved >= 4 ? 1 : 0;
+  },
+  hangingHunt(solved: number): number {
+    return solved >= 8 ? 3 : solved >= 5 ? 2 : solved >= 3 ? 1 : 0;
+  },
+  // Tier-1 tactics: total across fork+pin+skewer+disco (13 cases).
+  tacticTier1(total: number): number {
+    return total >= 13 ? 3 : total >= 8 ? 2 : total >= 4 ? 1 : 0;
+  },
+  rookMaze(moves: number, par: number): number {
+    return moves <= par ? 3 : moves <= par + 1 ? 2 : 1;
+  },
+};

--- a/apps/web/src/games/chess-quest/lib/use-device-audio.ts
+++ b/apps/web/src/games/chess-quest/lib/use-device-audio.ts
@@ -1,0 +1,20 @@
+"use client";
+
+// Keep the sfx/voice singletons in sync with the active device settings so
+// the header toggles take effect everywhere.
+import { useEffect } from "react";
+import { useProgress } from "./progress";
+import { sfx } from "./sfx";
+import { voice } from "./voice";
+
+export function useDeviceAudio(): void {
+  const progress = useProgress();
+  const muted = progress.getMuted();
+  const voiceOn = progress.getVoiceOn();
+  useEffect(() => {
+    sfx.setMuted(muted);
+  }, [muted]);
+  useEffect(() => {
+    voice.setEnabled(voiceOn);
+  }, [voiceOn]);
+}

--- a/apps/web/src/games/chess-quest/lib/use-later.ts
+++ b/apps/web/src/games/chess-quest/lib/use-later.ts
@@ -1,0 +1,26 @@
+"use client";
+
+// Timer registry: every delayed game callback goes through later() so
+// unmounting (or switching games) can never fire a stale callback into the
+// next game's UI — the bug class the original app hit with raw setTimeout.
+import { useCallback, useEffect, useRef } from "react";
+
+export function useLater(): {
+  later(fn: () => void, ms: number): void;
+  clearPending(): void;
+} {
+  const pending = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  const clearPending = useCallback(() => {
+    pending.current.forEach(clearTimeout);
+    pending.current = [];
+  }, []);
+
+  const later = useCallback((fn: () => void, ms: number) => {
+    pending.current.push(setTimeout(fn, ms));
+  }, []);
+
+  useEffect(() => clearPending, [clearPending]);
+
+  return { later, clearPending };
+}

--- a/apps/web/src/games/chess-quest/lib/voice.ts
+++ b/apps/web/src/games/chess-quest/lib/voice.ts
@@ -1,0 +1,53 @@
+// Coach voice via the browser's built-in speech synthesis — offline, no
+// network. Port of the standalone app's Voice; enabled state comes from the
+// store. say() takes rich/plain strings and strips markup + emoji first.
+let enabled = true;
+let voice: SpeechSynthesisVoice | null = null;
+
+function pickVoice() {
+  if (typeof window === "undefined" || !window.speechSynthesis) return;
+  const all = speechSynthesis.getVoices();
+  voice =
+    all.find((v) => /Samantha|Google US English|Zira/i.test(v.name)) ??
+    all.find((v) => v.lang?.startsWith("en")) ??
+    null;
+}
+
+if (typeof window !== "undefined" && window.speechSynthesis) {
+  pickVoice();
+  speechSynthesis.addEventListener("voiceschanged", pickVoice);
+}
+
+function plain(html: string): string {
+  const text = html.replace(/<[^>]*>/g, " ");
+  // Drop emoji/symbols the voice would read out; collapse whitespace.
+  return text
+    .replace(/[^\p{L}\p{N}\p{P}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export const voice = {
+  setEnabled(on: boolean): void {
+    enabled = on;
+    if (!on && typeof window !== "undefined" && window.speechSynthesis) speechSynthesis.cancel();
+  },
+  isEnabled(): boolean {
+    return enabled;
+  },
+  say(html: string): void {
+    if (!enabled || typeof window === "undefined" || !window.speechSynthesis) return;
+    const text = plain(html);
+    if (!text) return;
+    speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    if (voice) u.voice = voice;
+    u.rate = 0.95;
+    u.pitch = 1.1;
+    u.volume = 0.9;
+    speechSynthesis.speak(u);
+  },
+  stop(): void {
+    if (typeof window !== "undefined" && window.speechSynthesis) speechSynthesis.cancel();
+  },
+};

--- a/apps/web/src/games/chess-quest/lib/voice.ts
+++ b/apps/web/src/games/chess-quest/lib/voice.ts
@@ -2,12 +2,12 @@
 // network. Port of the standalone app's Voice; enabled state comes from the
 // store. say() takes rich/plain strings and strips markup + emoji first.
 let enabled = true;
-let voice: SpeechSynthesisVoice | null = null;
+let chosenVoice: SpeechSynthesisVoice | null = null;
 
 function pickVoice() {
   if (typeof window === "undefined" || !window.speechSynthesis) return;
   const all = speechSynthesis.getVoices();
-  voice =
+  chosenVoice =
     all.find((v) => /Samantha|Google US English|Zira/i.test(v.name)) ??
     all.find((v) => v.lang?.startsWith("en")) ??
     null;
@@ -41,7 +41,7 @@ export const voice = {
     if (!text) return;
     speechSynthesis.cancel();
     const u = new SpeechSynthesisUtterance(text);
-    if (voice) u.voice = voice;
+    if (chosenVoice) u.voice = chosenVoice;
     u.rate = 0.95;
     u.pitch = 1.1;
     u.volume = 0.9;

--- a/apps/web/src/games/player-map.tsx
+++ b/apps/web/src/games/player-map.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+// slug → lazily loaded game component. Lives apart from registry.ts so the
+// registry stays pure data that server code (sitemap, metadata) can import;
+// next/dynamic keeps each game's bundle out of every other page.
+import dynamic from "next/dynamic";
+import type { ComponentType } from "react";
+
+const loading = () => (
+  <div className="flex h-full items-center justify-center text-sm text-slate-400">
+    Loading game…
+  </div>
+);
+
+export const PLAYER_MAP: Record<string, ComponentType> = {
+  "chess-quest": dynamic(() => import("./chess-quest"), { ssr: false, loading }),
+};

--- a/apps/web/src/games/registry.ts
+++ b/apps/web/src/games/registry.ts
@@ -1,0 +1,34 @@
+// Seazn Games registry — the single source of truth for what games exist.
+// Pure data: server code (sitemap, pages) imports this, so no client
+// components here. Game React components are wired in player-map.tsx.
+// Adding a game = new src/games/<slug>/ folder + one entry here
+// (+ a player-map entry once it is playable).
+
+export type GameMeta = {
+  slug: string; // URL segment: /games/<slug>
+  title: string;
+  tagline: string; // one-liner for the listing card
+  description: string; // longer copy for SEO/meta
+  thumbnail: string; // emoji for the card art
+  status: "live" | "coming-soon";
+};
+
+export const GAMES: GameMeta[] = [
+  {
+    slug: "chess-quest",
+    title: "Chess Quest",
+    tagline: "Learn chess from first move to checkmate — one quest at a time.",
+    description:
+      "A free chess learning adventure: 48 bite-size lessons across two tracks, from how the pieces move to mate-in-two tactics. Play mini-games, earn stars, and track your streak — right in the browser.",
+    thumbnail: "♟️",
+    status: "coming-soon",
+  },
+];
+
+export function getGame(slug: string): GameMeta | undefined {
+  return GAMES.find((g) => g.slug === slug);
+}
+
+export function liveGames(): GameMeta[] {
+  return GAMES.filter((g) => g.status === "live");
+}

--- a/apps/web/src/games/registry.ts
+++ b/apps/web/src/games/registry.ts
@@ -21,7 +21,7 @@ export const GAMES: GameMeta[] = [
     description:
       "A free chess learning adventure: 48 bite-size lessons across two tracks, from how the pieces move to mate-in-two tactics. Play mini-games, earn stars, and track your streak — right in the browser.",
     thumbnail: "♟️",
-    status: "coming-soon",
+    status: "live",
   },
 ];
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -78,14 +78,21 @@ export function requestHostname(request: NextRequest): string {
  * games.* hosts serve the /games route tree: games.seazn.club/ is the games
  * listing, games.seazn.club/<slug> plays a game. Any `games.`-prefixed host
  * matches so staging (games.stg…) and local (games.localhost) work unchanged.
- * Returns the rewritten URL, or null when no rewrite applies (wrong host,
- * API call, or already inside /games — never double-prefix).
+ * Returns the rewritten URL, or null when no rewrite applies.
+ *
+ * Only "/" and single-segment slug paths ("/chess-quest") rewrite — the games
+ * tree has no deeper URLs. Everything else (API, /ingest PostHog proxy,
+ * public files like /site.webmanifest or /brand/*, and /games itself — never
+ * double-prefix) passes through untouched so shared assets keep working on
+ * the subdomain.
  */
+const GAMES_SLUG_PATH = /^\/[a-z0-9-]+$/;
+
 export function gamesHostRewrite(request: NextRequest): URL | null {
   if (!requestHostname(request).startsWith("games.")) return null;
   const { pathname } = request.nextUrl;
-  if (pathname.startsWith("/api/")) return null;
-  if (pathname === "/games" || pathname.startsWith("/games/")) return null;
+  if (pathname !== "/" && !GAMES_SLUG_PATH.test(pathname)) return null;
+  if (pathname === "/games") return null;
   const url = request.nextUrl.clone();
   url.pathname = pathname === "/" ? "/games" : `/games${pathname}`;
   return url;

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -58,6 +58,40 @@ function cspHeader(nonce: string, opts: { forceReportOnly?: boolean } = {}): { n
 }
 
 /**
+ * Bare hostname for the request: prefer X-Forwarded-Host (Fly.io / reverse
+ * proxy; Next dev also sets it — WITH a port), fall back to Host. Ports are
+ * stripped; URL parsing handles IPv6 hosts like "[::1]:3000" correctly.
+ */
+export function requestHostname(request: NextRequest): string {
+  const rawHost =
+    request.headers.get("x-forwarded-host")?.split(",")[0].trim() ??
+    request.headers.get("host") ??
+    request.nextUrl.hostname;
+  try {
+    return new URL(`http://${rawHost}`).hostname;
+  } catch {
+    return rawHost.split(":")[0];
+  }
+}
+
+/**
+ * games.* hosts serve the /games route tree: games.seazn.club/ is the games
+ * listing, games.seazn.club/<slug> plays a game. Any `games.`-prefixed host
+ * matches so staging (games.stg…) and local (games.localhost) work unchanged.
+ * Returns the rewritten URL, or null when no rewrite applies (wrong host,
+ * API call, or already inside /games — never double-prefix).
+ */
+export function gamesHostRewrite(request: NextRequest): URL | null {
+  if (!requestHostname(request).startsWith("games.")) return null;
+  const { pathname } = request.nextUrl;
+  if (pathname.startsWith("/api/")) return null;
+  if (pathname === "/games" || pathname.startsWith("/games/")) return null;
+  const url = request.nextUrl.clone();
+  url.pathname = pathname === "/" ? "/games" : `/games${pathname}`;
+  return url;
+}
+
+/**
  * CSRF protection: for every mutating API call, the Origin header must match
  * the app host. Browsers always send Origin on cross-origin requests, so a
  * mismatch means a third-party site is trying to trigger an action on behalf
@@ -82,21 +116,7 @@ export function proxy(request: NextRequest) {
       // any cross-origin request that somehow carries credentials.
       // Absent Origin (same-origin fetch in some browsers/curl) → allow through.
       if (origin) {
-        // Prefer X-Forwarded-Host (Fly.io / reverse proxy; Next dev also sets
-        // it — WITH a port, e.g. "localhost:3000"). Fall back to Host. Strip
-        // the port from either so we compare bare hostnames.
-        const rawHost =
-          request.headers.get("x-forwarded-host")?.split(",")[0].trim() ??
-          request.headers.get("host") ??
-          request.nextUrl.hostname;
-        // URL parsing handles IPv6 hosts like "[::1]:3000" correctly.
-        const appHost = (() => {
-          try {
-            return new URL(`http://${rawHost}`).hostname;
-          } catch {
-            return rawHost.split(":")[0];
-          }
-        })();
+        const appHost = requestHostname(request);
         try {
           const originHostname = new URL(origin).hostname;
           if (originHostname !== appHost) {
@@ -124,7 +144,10 @@ export function proxy(request: NextRequest) {
     requestHeaders.set(csp.name, csp.value);
   }
 
-  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  const rewriteUrl = gamesHostRewrite(request);
+  const response = rewriteUrl
+    ? NextResponse.rewrite(rewriteUrl, { request: { headers: requestHeaders } })
+    : NextResponse.next({ request: { headers: requestHeaders } });
   response.headers.set(csp.name, csp.value);
   return response;
 }

--- a/docs/superpowers/plans/2026-07-14-games-platform-phase-a.md
+++ b/docs/superpowers/plans/2026-07-14-games-platform-phase-a.md
@@ -1,0 +1,773 @@
+# Seazn Games Platform — Phase A (Platform Shell) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the games surface end-to-end: `/games` listing, `/games/[slug]` player page, `games.seazn.club` host rewrite, sitemap entries — with Chess Quest registered as `coming-soon`.
+
+**Architecture:** A pure-data games registry (`src/games/registry.ts`) drives a server-rendered listing page and a dynamic player route. Game components load client-side via a separate `player-map.tsx` (keeps the registry importable from server code like `sitemap.ts`). The existing `src/proxy.ts` gains a host rewrite so any `games.*` host maps into the `/games` route tree.
+
+**Tech Stack:** Next.js 16.2.9 App Router (repo warning: differs from training data — `params` is a `Promise`, copy repo patterns, e.g. `src/app/discover/[sport]/page.tsx`), React 19, Tailwind CSS v4, Vitest (node env, `@` → `src` alias), Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-seazn-games-chess-quest-design.md` (this plan = Phase A only; Phases B–E get their own plans later).
+
+## Global Constraints
+
+- Branch: `games-platform` (already exists, spec committed on it). Work from `~/GitHub/seazn.club`.
+- All app code under `apps/web`. Run commands from `apps/web` unless the command shows another cwd.
+- No database access for games — the registry is static data.
+- Registry slugs: `^[a-z0-9-]+$`, descriptive (`chess-quest`), never numbered.
+- Canonical URLs always point at `https://seazn.club/games/...` (never the subdomain).
+- `src/games/registry.ts` must stay free of client-component imports (server code imports it).
+- Follow existing public-page styling: `MarketingShell`, `mk-display` display face, purple/slate palette, `btn btn-primary` / `btn btn-ghost` (see `src/app/discover/[sport]/page.tsx`).
+- Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
+- One deviation from spec locked here: no `generateStaticParams` — the CSP nonce in `src/proxy.ts` forces per-request rendering anyway, and no existing dynamic public route uses it.
+
+---
+
+### Task 1: Games registry
+
+**Files:**
+- Create: `apps/web/src/games/registry.ts`
+- Test: `apps/web/src/__tests__/games-registry.test.ts`
+
+**Interfaces:**
+- Produces: `type GameMeta = { slug: string; title: string; tagline: string; description: string; thumbnail: string; status: "live" | "coming-soon" }`; `const GAMES: GameMeta[]`; `function getGame(slug: string): GameMeta | undefined`; `function liveGames(): GameMeta[]`. Consumed by Tasks 2–6.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/__tests__/games-registry.test.ts
+import { describe, expect, it } from "vitest";
+import { GAMES, getGame, liveGames } from "@/games/registry";
+
+describe("games registry", () => {
+  it("has at least chess-quest", () => {
+    expect(getGame("chess-quest")).toMatchObject({ title: "Chess Quest" });
+  });
+
+  it("slugs are unique, url-safe, descriptive", () => {
+    const slugs = GAMES.map((g) => g.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const slug of slugs) {
+      expect(slug).toMatch(/^[a-z0-9-]+$/);
+      expect(slug).not.toMatch(/^game-\d+$/); // spec: descriptive, never numbered
+    }
+  });
+
+  it("every entry has complete card copy", () => {
+    for (const g of GAMES) {
+      expect(g.title.length).toBeGreaterThan(0);
+      expect(g.tagline.length).toBeGreaterThan(0);
+      expect(g.description.length).toBeGreaterThan(20);
+      expect(g.thumbnail.length).toBeGreaterThan(0);
+      expect(["live", "coming-soon"]).toContain(g.status);
+    }
+  });
+
+  it("getGame misses return undefined", () => {
+    expect(getGame("not-a-game")).toBeUndefined();
+  });
+
+  it("liveGames filters by status", () => {
+    for (const g of liveGames()) expect(g.status).toBe("live");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `apps/web`): `npx vitest run src/__tests__/games-registry.test.ts`
+Expected: FAIL — `Cannot find module '@/games/registry'` (or equivalent resolve error).
+
+- [ ] **Step 3: Write the registry**
+
+```ts
+// apps/web/src/games/registry.ts
+// Seazn Games registry — the single source of truth for what games exist.
+// Pure data: server code (sitemap, pages) imports this, so no client
+// components here. Game React components are wired in player-map.tsx.
+// Adding a game = new src/games/<slug>/ folder + one entry here
+// (+ a player-map entry once it is playable).
+
+export type GameMeta = {
+  slug: string; // URL segment: /games/<slug>
+  title: string;
+  tagline: string; // one-liner for the listing card
+  description: string; // longer copy for SEO/meta
+  thumbnail: string; // emoji for the card art
+  status: "live" | "coming-soon";
+};
+
+export const GAMES: GameMeta[] = [
+  {
+    slug: "chess-quest",
+    title: "Chess Quest",
+    tagline: "Learn chess from first move to checkmate — one quest at a time.",
+    description:
+      "A free chess learning adventure: 48 bite-size lessons across two tracks, from how the pieces move to mate-in-two tactics. Play mini-games, earn stars, and track your streak — right in the browser.",
+    thumbnail: "♟️",
+    status: "coming-soon",
+  },
+];
+
+export function getGame(slug: string): GameMeta | undefined {
+  return GAMES.find((g) => g.slug === slug);
+}
+
+export function liveGames(): GameMeta[] {
+  return GAMES.filter((g) => g.status === "live");
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/games-registry.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/registry.ts apps/web/src/__tests__/games-registry.test.ts
+git commit -m "feat(games): games registry with chess-quest entry
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Player map + Chess Quest placeholder component
+
+**Files:**
+- Create: `apps/web/src/games/player-map.tsx`
+- Create: `apps/web/src/games/chess-quest/index.tsx`
+- Test: `apps/web/src/__tests__/games-player-map.test.ts`
+
+**Interfaces:**
+- Consumes: `liveGames()` from `@/games/registry` (Task 1).
+- Produces: `PLAYER_MAP: Record<string, ComponentType>` (client module) — Task 4's `GamePlayer` reads it. `src/games/chess-quest/index.tsx` default-exports the game's root client component (Phase C replaces its body).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/__tests__/games-player-map.test.ts
+import { describe, expect, it } from "vitest";
+import { liveGames } from "@/games/registry";
+import { PLAYER_MAP } from "@/games/player-map";
+
+describe("games player map", () => {
+  it("every live game has a playable component", () => {
+    for (const g of liveGames()) {
+      expect(PLAYER_MAP[g.slug], `missing PLAYER_MAP entry for ${g.slug}`).toBeDefined();
+    }
+  });
+
+  it("chess-quest is wired (ready for the Phase C status flip)", () => {
+    expect(PLAYER_MAP["chess-quest"]).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/games-player-map.test.ts`
+Expected: FAIL — cannot resolve `@/games/player-map`.
+
+- [ ] **Step 3: Write placeholder component and player map**
+
+```tsx
+// apps/web/src/games/chess-quest/index.tsx
+"use client";
+
+// Phase A placeholder — proves the registry → player-map → lazy-load path.
+// Phase C replaces this with the real Chess Quest root component.
+export default function ChessQuest() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+      <div className="text-6xl">♟️</div>
+      <h2 className="mk-display text-2xl font-bold text-purple-950">Chess Quest</h2>
+      <p className="max-w-sm text-sm text-slate-500">
+        The quest is being prepared. Check back soon!
+      </p>
+    </div>
+  );
+}
+```
+
+```tsx
+// apps/web/src/games/player-map.tsx
+"use client";
+
+// slug → lazily loaded game component. Lives apart from registry.ts so the
+// registry stays pure data that server code (sitemap, metadata) can import;
+// next/dynamic keeps each game's bundle out of every other page.
+import dynamic from "next/dynamic";
+import type { ComponentType } from "react";
+
+const loading = () => (
+  <div className="flex h-full items-center justify-center text-sm text-slate-400">
+    Loading game…
+  </div>
+);
+
+export const PLAYER_MAP: Record<string, ComponentType> = {
+  "chess-quest": dynamic(() => import("./chess-quest"), { ssr: false, loading }),
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/__tests__/games-player-map.test.ts`
+Expected: PASS (2 tests). If vitest chokes on the `"use client"` directive or `next/dynamic`, it is a transform config issue — check that the file extension is `.tsx` and rerun; do not move the map into the registry.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/player-map.tsx apps/web/src/games/chess-quest/index.tsx apps/web/src/__tests__/games-player-map.test.ts
+git commit -m "feat(games): player map + chess-quest placeholder component
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: /games listing page
+
+**Files:**
+- Create: `apps/web/src/app/games/page.tsx`
+
+**Interfaces:**
+- Consumes: `GAMES` from `@/games/registry`; `MarketingShell` from `@/components/marketing/marketing-shell`.
+- Produces: the `/games` route (later rewritten-to by the subdomain, Task 5).
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+// apps/web/src/app/games/page.tsx
+// /games — Seazn Games listing. Cards come straight from the registry;
+// coming-soon games render as non-clickable cards with a badge.
+import type { Metadata } from "next";
+import Link from "next/link";
+import { MarketingShell } from "@/components/marketing/marketing-shell";
+import { GAMES } from "@/games/registry";
+
+export const metadata: Metadata = {
+  title: "Games — free browser games | Seazn Club",
+  description:
+    "Play free browser games by Seazn Club. Learn-to-play quests and quick challenges — no install, no sign-up.",
+  alternates: { canonical: "https://seazn.club/games" },
+};
+
+export default function GamesPage() {
+  return (
+    <MarketingShell>
+      <main className="mx-auto max-w-5xl px-4 py-12">
+        <h1 className="mk-display text-4xl font-bold text-purple-950">Games</h1>
+        <p className="mt-3 max-w-2xl text-lg text-slate-600">
+          Free games in your browser — pick one and play. No install, no sign-up.
+        </p>
+
+        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {GAMES.map((g) =>
+            g.status === "live" ? (
+              <Link
+                key={g.slug}
+                href={`/games/${g.slug}`}
+                className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-purple-300 hover:shadow-md"
+              >
+                <div className="text-5xl">{g.thumbnail}</div>
+                <h2 className="mk-display mt-3 text-xl font-bold text-purple-950 group-hover:text-purple-700">
+                  {g.title}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">{g.tagline}</p>
+                <span className="mt-3 inline-block text-sm font-medium text-purple-600">
+                  Play →
+                </span>
+              </Link>
+            ) : (
+              <div
+                key={g.slug}
+                className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-5"
+              >
+                <div className="text-5xl opacity-60">{g.thumbnail}</div>
+                <h2 className="mk-display mt-3 text-xl font-bold text-slate-500">{g.title}</h2>
+                <p className="mt-1 text-sm text-slate-400">{g.tagline}</p>
+                <span className="mt-3 inline-block rounded-full bg-slate-200 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                  Coming soon
+                </span>
+              </div>
+            ),
+          )}
+        </div>
+      </main>
+    </MarketingShell>
+  );
+}
+```
+
+- [ ] **Step 2: Verify in the dev server**
+
+Run (from `apps/web`): `npm run dev` (background), then:
+
+```bash
+curl -s http://localhost:3000/games | grep -o "Chess Quest" | head -1
+curl -s http://localhost:3000/games | grep -o "Coming soon" | head -1
+```
+
+Expected: both grep hits. (Page-level e2e assertion lands in Task 7.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/games/page.tsx
+git commit -m "feat(games): /games listing page
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: /games/[slug] player page
+
+**Files:**
+- Create: `apps/web/src/app/games/[slug]/page.tsx`
+- Create: `apps/web/src/app/games/[slug]/game-player.tsx`
+
+**Interfaces:**
+- Consumes: `getGame` from `@/games/registry`; `PLAYER_MAP` from `@/games/player-map`.
+- Produces: the `/games/<slug>` route. `GamePlayer` (client) is internal to this route.
+
+- [ ] **Step 1: Write the client player wrapper**
+
+```tsx
+// apps/web/src/app/games/[slug]/game-player.tsx
+"use client";
+
+import { PLAYER_MAP } from "@/games/player-map";
+
+export function GamePlayer({ slug }: { slug: string }) {
+  const Game = PLAYER_MAP[slug];
+  // A live registry entry without a PLAYER_MAP entry is a wiring bug —
+  // the games-player-map unit test guards it; render nothing rather than crash.
+  if (!Game) return null;
+  return <Game />;
+}
+```
+
+- [ ] **Step 2: Write the server page**
+
+Note Next 16 convention: `params` is a `Promise` — `await` it (pattern: `src/app/discover/[sport]/page.tsx`).
+
+```tsx
+// apps/web/src/app/games/[slug]/page.tsx
+// /games/<slug> — game player page. Slim chrome (no marketing footer):
+// header bar + full-height game area. Coming-soon games get a teaser panel.
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getGame } from "@/games/registry";
+import { GamePlayer } from "./game-player";
+
+type Params = { slug: string };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const game = getGame(slug);
+  if (!game) return {};
+  return {
+    title: `${game.title} — play free | Seazn Club`,
+    description: game.description,
+    // Canonical always on the apex domain so games.seazn.club doesn't split SEO.
+    alternates: { canonical: `https://seazn.club/games/${slug}` },
+  };
+}
+
+export default async function GamePage({ params }: { params: Promise<Params> }) {
+  const { slug } = await params;
+  const game = getGame(slug);
+  if (!game) notFound();
+
+  return (
+    <div className="flex min-h-dvh flex-col bg-white">
+      <header className="flex items-center gap-3 border-b border-slate-200 px-4 py-2">
+        <Link href="/games" className="text-sm font-medium text-purple-600 hover:text-purple-800">
+          ← Games
+        </Link>
+        <span className="text-sm text-slate-300">|</span>
+        <h1 className="mk-display text-base font-bold text-purple-950">{game.title}</h1>
+      </header>
+      <main className="min-h-0 flex-1">
+        {game.status === "live" ? (
+          <GamePlayer slug={game.slug} />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+            <div className="text-6xl">{game.thumbnail}</div>
+            <h2 className="mk-display text-2xl font-bold text-purple-950">
+              {game.title} is coming soon
+            </h2>
+            <p className="max-w-md text-sm text-slate-500">{game.description}</p>
+            <Link href="/games" className="btn btn-ghost mt-2">
+              Browse other games
+            </Link>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify in the dev server**
+
+```bash
+curl -s http://localhost:3000/games/chess-quest | grep -o "coming soon" | head -1
+curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/games/not-a-game
+```
+
+Expected: `coming soon` and `404`.
+
+Then flip the wiring check (do NOT commit this change): in `registry.ts` set chess-quest `status: "live"`, reload `http://localhost:3000/games/chess-quest` in the browser — the ♟️ placeholder from Task 2 must render (proves registry → player-map → dynamic import). Revert to `"coming-soon"` and confirm `git diff apps/web/src/games/registry.ts` is clean before committing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/web/src/app/games/[slug]/page.tsx" "apps/web/src/app/games/[slug]/game-player.tsx"
+git commit -m "feat(games): /games/[slug] player page with coming-soon teaser
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: games.* host rewrite in the proxy
+
+**Files:**
+- Modify: `apps/web/src/proxy.ts` (CSRF host block ~lines 84–108; page branch ~lines 114–129)
+- Test: `apps/web/src/__tests__/proxy-games-host.test.ts`
+
+**Interfaces:**
+- Consumes: existing `proxy(request)` in `src/proxy.ts`.
+- Produces: exported `gamesHostRewrite(request: NextRequest): URL | null` (exported for tests) and `requestHostname(request: NextRequest): string` (extracted helper reused by the CSRF block).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/__tests__/proxy-games-host.test.ts
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy, gamesHostRewrite } from "@/proxy";
+
+const req = (path: string, headers: Record<string, string>) =>
+  new NextRequest(`http://localhost:3000${path}`, { headers });
+
+const GAMES_HOST = { host: "games.seazn.club" };
+
+describe("games subdomain host rewrite", () => {
+  it("rewrites / to /games", () => {
+    expect(gamesHostRewrite(req("/", GAMES_HOST))?.pathname).toBe("/games");
+  });
+
+  it("rewrites /chess-quest to /games/chess-quest", () => {
+    expect(gamesHostRewrite(req("/chess-quest", GAMES_HOST))?.pathname).toBe(
+      "/games/chess-quest",
+    );
+  });
+
+  it("never double-prefixes /games paths", () => {
+    expect(gamesHostRewrite(req("/games", GAMES_HOST))).toBeNull();
+    expect(gamesHostRewrite(req("/games/chess-quest", GAMES_HOST))).toBeNull();
+  });
+
+  it("does not rewrite API calls", () => {
+    expect(gamesHostRewrite(req("/api/v1/public/discovery", GAMES_HOST))).toBeNull();
+  });
+
+  it("ignores non-games hosts (incl. lookalike paths)", () => {
+    expect(gamesHostRewrite(req("/", { host: "seazn.club" }))).toBeNull();
+    expect(gamesHostRewrite(req("/gamesfoo", GAMES_HOST))?.pathname).toBe("/games/gamesfoo");
+  });
+
+  it("prefers x-forwarded-host (Fly) over host", () => {
+    const r = req("/", { host: "internal:3000", "x-forwarded-host": "games.seazn.club" });
+    expect(gamesHostRewrite(r)?.pathname).toBe("/games");
+  });
+
+  it("strips ports before matching", () => {
+    expect(gamesHostRewrite(req("/", { host: "games.localhost:3000" }))?.pathname).toBe("/games");
+  });
+
+  it("proxy() rewrites and still stamps CSP", () => {
+    const res = proxy(req("/chess-quest", GAMES_HOST));
+    const rewrite = res.headers.get("x-middleware-rewrite");
+    expect(rewrite).toContain("/games/chess-quest");
+    expect(
+      res.headers.get("Content-Security-Policy-Report-Only") ??
+        res.headers.get("Content-Security-Policy"),
+    ).toContain("default-src 'self'");
+  });
+
+  it("proxy() leaves normal hosts alone", () => {
+    const res = proxy(req("/pricing", { host: "seazn.club" }));
+    expect(res.headers.get("x-middleware-rewrite")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/__tests__/proxy-games-host.test.ts`
+Expected: FAIL — `gamesHostRewrite` is not exported.
+
+- [ ] **Step 3: Implement in proxy.ts**
+
+Three edits.
+
+**(a)** Add the hostname helper + rewrite function above `proxy()` (after `cspHeader`):
+
+```ts
+/**
+ * Bare hostname for the request: prefer X-Forwarded-Host (Fly.io / reverse
+ * proxy; Next dev also sets it — WITH a port), fall back to Host. Ports are
+ * stripped; URL parsing handles IPv6 hosts like "[::1]:3000" correctly.
+ */
+export function requestHostname(request: NextRequest): string {
+  const rawHost =
+    request.headers.get("x-forwarded-host")?.split(",")[0].trim() ??
+    request.headers.get("host") ??
+    request.nextUrl.hostname;
+  try {
+    return new URL(`http://${rawHost}`).hostname;
+  } catch {
+    return rawHost.split(":")[0];
+  }
+}
+
+/**
+ * games.* hosts serve the /games route tree: games.seazn.club/ is the games
+ * listing, games.seazn.club/<slug> plays a game. Any `games.`-prefixed host
+ * matches so staging (games.stg…) and local (games.localhost) work unchanged.
+ * Returns the rewritten URL, or null when no rewrite applies (wrong host,
+ * API call, or already inside /games — never double-prefix).
+ */
+export function gamesHostRewrite(request: NextRequest): URL | null {
+  if (!requestHostname(request).startsWith("games.")) return null;
+  const { pathname } = request.nextUrl;
+  if (pathname.startsWith("/api/")) return null;
+  if (pathname === "/games" || pathname.startsWith("/games/")) return null;
+  const url = request.nextUrl.clone();
+  url.pathname = pathname === "/" ? "/games" : `/games${pathname}`;
+  return url;
+}
+```
+
+**(b)** In the CSRF block inside `proxy()`, replace the inline host derivation with the helper. Replace:
+
+```ts
+        // Prefer X-Forwarded-Host (Fly.io / reverse proxy; Next dev also sets
+        // it — WITH a port, e.g. "localhost:3000"). Fall back to Host. Strip
+        // the port from either so we compare bare hostnames.
+        const rawHost =
+          request.headers.get("x-forwarded-host")?.split(",")[0].trim() ??
+          request.headers.get("host") ??
+          request.nextUrl.hostname;
+        // URL parsing handles IPv6 hosts like "[::1]:3000" correctly.
+        const appHost = (() => {
+          try {
+            return new URL(`http://${rawHost}`).hostname;
+          } catch {
+            return rawHost.split(":")[0];
+          }
+        })();
+```
+
+with:
+
+```ts
+        const appHost = requestHostname(request);
+```
+
+**(c)** In the page branch at the bottom of `proxy()`, route through the rewrite when it applies. Replace:
+
+```ts
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set(csp.name, csp.value);
+  return response;
+```
+
+with:
+
+```ts
+  const rewriteUrl = gamesHostRewrite(request);
+  const response = rewriteUrl
+    ? NextResponse.rewrite(rewriteUrl, { request: { headers: requestHeaders } })
+    : NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set(csp.name, csp.value);
+  return response;
+```
+
+- [ ] **Step 4: Run tests to verify pass (new + existing proxy suite)**
+
+Run: `npx vitest run src/__tests__/proxy-games-host.test.ts src/__tests__/proxy-csp.test.ts`
+Expected: PASS, both files (9 + 5 tests). The CSP suite guards the refactor of the CSRF block.
+
+- [ ] **Step 5: Verify against the dev server**
+
+```bash
+curl -s -H "Host: games.localhost" http://localhost:3000/ | grep -o "Chess Quest" | head -1
+curl -s -H "Host: games.localhost" http://localhost:3000/chess-quest | grep -o "coming soon" | head -1
+```
+
+Expected: both grep hits (dev server forwards Host as x-forwarded-host).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/proxy.ts apps/web/src/__tests__/proxy-games-host.test.ts
+git commit -m "feat(games): games.* host rewrite into /games tree
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Sitemap entries
+
+**Files:**
+- Modify: `apps/web/src/app/sitemap.ts` (staticEntries array, ~line 9)
+
+**Interfaces:**
+- Consumes: `liveGames()` from `@/games/registry`.
+
+- [ ] **Step 1: Add /games + live games to the sitemap**
+
+Add the import at the top of `src/app/sitemap.ts`:
+
+```ts
+import { liveGames } from "@/games/registry";
+```
+
+Add to the `staticEntries` array (after the `/pricing` entry):
+
+```ts
+    { url: `${BASE}/games`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    ...liveGames().map((g) => ({
+      url: `${BASE}/games/${g.slug}`,
+      lastModified: now,
+      changeFrequency: "monthly" as const,
+      priority: 0.7,
+    })),
+```
+
+(Coming-soon games stay out — nothing playable to index yet; entries appear automatically at the Phase C status flip.)
+
+- [ ] **Step 2: Verify**
+
+```bash
+curl -s http://localhost:3000/sitemap.xml | grep -o "seazn.club/games" | head -1
+```
+
+Expected: `seazn.club/games`. Also confirm no `/games/chess-quest` entry yet (status is coming-soon):
+
+```bash
+curl -s http://localhost:3000/sitemap.xml | grep -c "games/chess-quest"
+```
+
+Expected: `0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/sitemap.ts
+git commit -m "feat(games): sitemap entries for /games and live games
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: E2E smoke + full verification
+
+**Files:**
+- Create: `apps/web/e2e/games.spec.ts`
+
+**Interfaces:**
+- Consumes: routes from Tasks 3–5.
+
+- [ ] **Step 1: Write the e2e spec**
+
+```ts
+// apps/web/e2e/games.spec.ts
+import { test, expect } from "@playwright/test";
+
+// Seazn Games surface (Phase A): listing, player page, 404s, subdomain
+// rewrite. No fixtures needed — the registry is static data.
+
+test("games listing renders registry cards", async ({ page }) => {
+  await page.goto("/games");
+  await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
+  await expect(page.getByText("Chess Quest")).toBeVisible();
+  await expect(page.getByText("Coming soon")).toBeVisible();
+});
+
+test("coming-soon game shows teaser, not a dead page", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await expect(page.getByText("Chess Quest is coming soon")).toBeVisible();
+  await expect(page.getByRole("link", { name: "← Games" })).toBeVisible();
+});
+
+test("unknown game slug 404s", async ({ page }) => {
+  const res = await page.goto("/games/not-a-game");
+  expect(res?.status()).toBe(404);
+});
+
+test("games.* host serves the games tree", async ({ browser }) => {
+  // The proxy prefers x-forwarded-host, which is what Fly sets in production.
+  const ctx = await browser.newContext({
+    extraHTTPHeaders: { "x-forwarded-host": "games.seazn.club" },
+  });
+  const page = await ctx.newPage();
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "Games", exact: true })).toBeVisible();
+  await page.goto("/chess-quest");
+  await expect(page.getByText("Chess Quest is coming soon")).toBeVisible();
+  await ctx.close();
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+Run (from `apps/web`, dev server up on :3000): `npx playwright test e2e/games.spec.ts`
+Expected: 4 passed. If the auth setup project runs first and fails on a cold DB, run with `--project=parallel` (public pages need no auth) or per the repo's e2e README.
+
+- [ ] **Step 3: Full verification**
+
+Run from repo root:
+
+```bash
+npm run lint --workspace apps/web
+npm run test --workspace apps/web
+npm run build --workspace apps/web
+```
+
+Expected: lint clean, all vitest suites pass (incl. the 3 new files), build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/e2e/games.spec.ts
+git commit -m "test(games): e2e smoke for listing, player page, subdomain rewrite
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Post-plan (user actions, not tasks)
+
+- DNS: CNAME `games.seazn.club` → the Fly app hostname.
+- Certs: `fly certs add games.seazn.club` (repeat on staging app for `games.stg…` if wanted).
+- PR: branch `games-platform` → main through the normal PR flow.
+- Phase B plan (engine + content) is the next planning session.

--- a/docs/superpowers/plans/2026-07-14-games-platform-phase-b.md
+++ b/docs/superpowers/plans/2026-07-14-games-platform-phase-b.md
@@ -1,0 +1,1242 @@
+# Seazn Games — Phase B (Chess Quest Engine + Content) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pure TypeScript chess engine + fully transcribed, machine-verified curriculum/puzzle content for Chess Quest — zero UI, fully green under vitest.
+
+**Architecture:** `apps/web/src/games/chess-quest/engine/` — five focused pure modules (board, moves, mate, tactics, paths) with a barrel index; `content/` — typed data transcribed from the original `~/GitHub/chess-quest` app plus a verification suite that machine-checks every puzzle and the curriculum shape (the original caught 2 bad puzzles this way; keep that rigor).
+
+**Tech Stack:** TypeScript (strict), Vitest (node env, `@` → `src` alias). No React, no DOM, no DB in this phase.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-seazn-games-chess-quest-design.md` (Phase B). Phase A landed on branch `games-platform` (PR #92).
+
+## Global Constraints
+
+- Branch: `games-platform` (continue on it while PR #92 is open).
+- Everything in this phase lives under `apps/web/src/games/chess-quest/{engine,content}/`.
+- Engine is pure: no imports outside these folders, no `window`, no side effects.
+- Board model (locked, matches original so content transcribes 1:1): `Board = string[]` of 64; index 0 = a8 … 63 = h1 (FEN reading order); pieces `"PNBRQK"` white / `"pnbrqk"` black / `""` empty; **no castling, no en passant; promotion always auto-queens** (curriculum never needs more).
+- Content is **transcribed, not re-authored** from `~/GitHub/chess-quest/js/puzzles.js` and `js/curriculum.js` — FEN strings, solutions, names, hints, lesson copy (both Story and Classic registers) copied verbatim; only the container syntax becomes typed TS. Original repo stays untouched.
+- Tests co-located per repo pattern: `engine/__tests__/*.test.ts`, `content/__tests__/*.test.ts` (like `src/server/usecases/__tests__/`).
+- Test commands run from `apps/web`; use `rtk proxy npx vitest run <path>` (plain `npx vitest` output gets truncated by the rtk hook).
+- Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer.
+
+---
+
+### Task 1: Board module — squares, pieces, FEN
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/engine/board.ts`
+- Test: `apps/web/src/games/chess-quest/engine/__tests__/board.test.ts`
+
+**Interfaces:**
+- Produces (all later tasks consume): `type Piece = string`, `type Board = Piece[]`, `type Move = { from: number; to: number }`, `const FILES = "abcdefgh"`, `sqIdx(name: string): number`, `sqName(idx: number): string`, `fileOf(idx: number): number`, `rankRow(idx: number): number`, `isWhitePiece(p: Piece): boolean`, `isBlackPiece(p: Piece): boolean`, `parseFEN(fen: string): { board: Board; whiteToMove: boolean }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/games/chess-quest/engine/__tests__/board.test.ts
+import { describe, expect, it } from "vitest";
+import { sqIdx, sqName, parseFEN, isWhitePiece, isBlackPiece } from "../board";
+
+describe("square mapping", () => {
+  it("a8 is index 0, h1 is 63", () => {
+    expect(sqIdx("a8")).toBe(0);
+    expect(sqIdx("h1")).toBe(63);
+  });
+  it("round-trips every square", () => {
+    for (let i = 0; i < 64; i++) expect(sqIdx(sqName(i))).toBe(i);
+  });
+});
+
+describe("pieces", () => {
+  it("classifies colors; empty is neither", () => {
+    expect(isWhitePiece("Q")).toBe(true);
+    expect(isBlackPiece("q")).toBe(true);
+    expect(isWhitePiece("")).toBe(false);
+    expect(isBlackPiece("")).toBe(false);
+  });
+});
+
+describe("parseFEN", () => {
+  it("start position: 64 squares, correct corners, white to move", () => {
+    const { board, whiteToMove } = parseFEN(
+      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+    );
+    expect(board).toHaveLength(64);
+    expect(board[sqIdx("a8")]).toBe("r");
+    expect(board[sqIdx("e1")]).toBe("K");
+    expect(board[sqIdx("e4")]).toBe("");
+    expect(whiteToMove).toBe(true);
+  });
+  it("reads side to move; defaults to white", () => {
+    expect(parseFEN("8/8/8/8/8/8/8/8 b - - 0 1").whiteToMove).toBe(false);
+    expect(parseFEN("8/8/8/8/8/8/8/8").whiteToMove).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `apps/web`): `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/board.test.ts`
+Expected: FAIL — cannot resolve `../board`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/web/src/games/chess-quest/engine/board.ts
+// Chess Quest engine — board representation.
+// Board: array of 64. Index 0 = a8 … 63 = h1 (FEN reading order).
+// Pieces: "PNBRQK" white, "pnbrqk" black, "" empty.
+// Scope: no castling or en passant — the mini-games and puzzle set never
+// need them. Pawn promotion is always to a queen (kid-simple).
+
+export type Piece = string;
+export type Board = Piece[];
+export type Move = { from: number; to: number };
+
+export const FILES = "abcdefgh";
+
+export function sqIdx(name: string): number {
+  const file = FILES.indexOf(name[0]);
+  const rank = parseInt(name[1], 10);
+  return (8 - rank) * 8 + file;
+}
+
+export function sqName(idx: number): string {
+  return FILES[idx % 8] + (8 - Math.floor(idx / 8));
+}
+
+export function fileOf(idx: number): number {
+  return idx % 8;
+}
+
+// 0 = rank 8, 7 = rank 1
+export function rankRow(idx: number): number {
+  return Math.floor(idx / 8);
+}
+
+export function isWhitePiece(p: Piece): boolean {
+  return p !== "" && p === p.toUpperCase();
+}
+
+export function isBlackPiece(p: Piece): boolean {
+  return p !== "" && p === p.toLowerCase();
+}
+
+export function parseFEN(fen: string): { board: Board; whiteToMove: boolean } {
+  const parts = fen.trim().split(/\s+/);
+  const board: Board = [];
+  for (const ch of parts[0]) {
+    if (ch === "/") continue;
+    if (/\d/.test(ch)) {
+      for (let i = 0; i < Number(ch); i++) board.push("");
+    } else {
+      board.push(ch);
+    }
+  }
+  return { board, whiteToMove: (parts[1] ?? "w") === "w" };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/board.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/engine/
+git commit -m "feat(chess-quest): engine board module — squares, pieces, FEN
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Moves module — attacks, legality, apply
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/engine/moves.ts`
+- Test: `apps/web/src/games/chess-quest/engine/__tests__/moves.test.ts`
+
+**Interfaces:**
+- Consumes: everything from `./board` (Task 1).
+- Produces: `attackSquares(board, idx): number[]`, `isAttacked(board, sq, byWhite): boolean`, `findKing(board, white): number`, `inCheck(board, white): boolean`, `pieceTargets(board, idx): number[]`, `applyMove(board, from, to): Board`, `legalTargets(board, idx): number[]`, `allLegalMoves(board, white): Move[]`. Tasks 3–5 and all content verification consume these.
+
+- [ ] **Step 1: Write the failing test** (ports the original suite's intent: knight edge/center, pawn push/capture/promotion/no-wrap, slider blocking, pins, king-in-check legality)
+
+```ts
+// apps/web/src/games/chess-quest/engine/__tests__/moves.test.ts
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx, sqName } from "../board";
+import { legalTargets, applyMove, inCheck, allLegalMoves } from "../moves";
+
+const names = (idxs: number[]) => idxs.map(sqName).sort();
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("knight moves", () => {
+  it("b1 knight in the corner region -> a3,c3,d2", () => {
+    expect(names(legalTargets(b("8/8/8/8/8/8/8/1N6 w - - 0 1"), sqIdx("b1")))).toEqual([
+      "a3",
+      "c3",
+      "d2",
+    ]);
+  });
+  it("e5 knight has 8 moves", () => {
+    expect(legalTargets(b("8/8/8/4N3/8/8/8/8 w - - 0 1"), sqIdx("e5"))).toHaveLength(8);
+  });
+});
+
+describe("pawn moves", () => {
+  it("e2 pawn -> e3,e4 (double from start)", () => {
+    expect(names(legalTargets(b("8/8/8/8/8/8/4P3/8 w - - 0 1"), sqIdx("e2")))).toEqual([
+      "e3",
+      "e4",
+    ]);
+  });
+  it("captures diagonally, both colors", () => {
+    const board = b("8/8/8/3p4/4P3/8/8/8 w - - 0 1");
+    expect(names(legalTargets(board, sqIdx("e4")))).toContain("d5");
+    expect(names(legalTargets(board, sqIdx("d5")))).toContain("e4");
+  });
+  it("promotion auto-queens", () => {
+    const after = applyMove(b("8/4P3/8/8/8/8/8/8 w - - 0 1"), sqIdx("e7"), sqIdx("e8"));
+    expect(after[sqIdx("e8")]).toBe("Q");
+  });
+  it("a-file pawn does not wrap to h-file", () => {
+    expect(names(legalTargets(b("8/8/8/8/8/7p/P7/8 w - - 0 1"), sqIdx("a2")))).not.toContain(
+      "h3",
+    );
+  });
+});
+
+describe("sliders", () => {
+  it("rook stops before own pawn", () => {
+    const t = names(legalTargets(b("8/8/8/3R4/8/3P4/8/8 w - - 0 1"), sqIdx("d5")));
+    expect(t).not.toContain("d3");
+    expect(t).toContain("d4");
+  });
+});
+
+describe("check and legality", () => {
+  it("pinned rook stays on the e-file but may capture the pinner", () => {
+    const t = names(legalTargets(b("4r3/8/8/8/4R3/8/8/4K3 w - - 0 1"), sqIdx("e4")));
+    expect(t.every((s) => s[0] === "e")).toBe(true);
+    expect(t).toContain("e8");
+  });
+  it("king in check must leave the file", () => {
+    const board = b("4r3/8/8/8/8/8/8/4K3 w - - 0 1");
+    expect(inCheck(board, true)).toBe(true);
+    expect(names(legalTargets(board, sqIdx("e1"))).every((s) => s[0] !== "e")).toBe(true);
+  });
+  it("allLegalMoves only yields the side's pieces", () => {
+    for (const m of allLegalMoves(b("4r3/8/8/8/8/8/8/4K3 w - - 0 1"), true)) {
+      expect(sqName(m.from)).toBe("e1");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/moves.test.ts`
+Expected: FAIL — cannot resolve `../moves`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/web/src/games/chess-quest/engine/moves.ts
+// Attack generation, move legality, and board updates. Pure functions;
+// boards are never mutated (applyMove returns a copy).
+import { Board, Move, Piece, fileOf, isWhitePiece, rankRow } from "./board";
+
+const KNIGHT_OFFS = [
+  [1, 2],
+  [2, 1],
+  [2, -1],
+  [1, -2],
+  [-1, -2],
+  [-2, -1],
+  [-2, 1],
+  [-1, 2],
+] as const;
+const KING_OFFS = [
+  [1, 0],
+  [1, 1],
+  [0, 1],
+  [-1, 1],
+  [-1, 0],
+  [-1, -1],
+  [0, -1],
+  [1, -1],
+] as const;
+export const ROOK_DIRS = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+] as const;
+export const BISHOP_DIRS = [
+  [1, 1],
+  [1, -1],
+  [-1, 1],
+  [-1, -1],
+] as const;
+
+type Dir = readonly [number, number];
+
+function onBoard(f: number, r: number): boolean {
+  return f >= 0 && f < 8 && r >= 0 && r < 8;
+}
+
+// Square reached from idx by (df files, dr rows), or -1 off-board.
+export function step(idx: number, df: number, dr: number): number {
+  const f = fileOf(idx) + df;
+  const r = rankRow(idx) + dr;
+  return onBoard(f, r) ? r * 8 + f : -1;
+}
+
+export function sliderDirs(type: string): readonly Dir[] {
+  if (type === "R") return ROOK_DIRS;
+  if (type === "B") return BISHOP_DIRS;
+  return [...ROOK_DIRS, ...BISHOP_DIRS];
+}
+
+// Squares the piece on idx attacks (check detection). Pawns attack
+// diagonally only; sliders stop at the first piece they meet.
+export function attackSquares(board: Board, idx: number): number[] {
+  const p = board[idx];
+  const white = isWhitePiece(p);
+  const type = p.toUpperCase();
+  const out: number[] = [];
+
+  if (type === "P") {
+    const dr = white ? -1 : 1; // white pawns move toward rank 8 (row 0)
+    for (const df of [-1, 1]) {
+      const t = step(idx, df, dr);
+      if (t >= 0) out.push(t);
+    }
+    return out;
+  }
+  if (type === "N" || type === "K") {
+    for (const [df, dr] of type === "N" ? KNIGHT_OFFS : KING_OFFS) {
+      const t = step(idx, df, dr);
+      if (t >= 0) out.push(t);
+    }
+    return out;
+  }
+  for (const [df, dr] of sliderDirs(type)) {
+    let t = step(idx, df, dr);
+    while (t >= 0) {
+      out.push(t);
+      if (board[t] !== "") break;
+      t = step(t, df, dr);
+    }
+  }
+  return out;
+}
+
+export function isAttacked(board: Board, sq: number, byWhite: boolean): boolean {
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (p === "" || isWhitePiece(p) !== byWhite) continue;
+    if (attackSquares(board, i).includes(sq)) return true;
+  }
+  return false;
+}
+
+export function findKing(board: Board, white: boolean): number {
+  return board.indexOf(white ? "K" : "k");
+}
+
+export function inCheck(board: Board, white: boolean): boolean {
+  const k = findKing(board, white);
+  return k >= 0 && isAttacked(board, k, !white);
+}
+
+// Pseudo-legal destinations: respects blockers and capture rules,
+// ignores king safety (legalTargets filters that).
+export function pieceTargets(board: Board, idx: number): number[] {
+  const p = board[idx];
+  if (p === "") return [];
+  const white = isWhitePiece(p);
+  const type = p.toUpperCase();
+
+  if (type === "P") {
+    const out: number[] = [];
+    const dr = white ? -1 : 1;
+    const one = step(idx, 0, dr);
+    if (one >= 0 && board[one] === "") {
+      out.push(one);
+      const startRow = white ? 6 : 1;
+      const two = step(idx, 0, 2 * dr);
+      if (rankRow(idx) === startRow && two >= 0 && board[two] === "") out.push(two);
+    }
+    for (const df of [-1, 1]) {
+      const t = step(idx, df, dr);
+      if (t >= 0 && board[t] !== "" && isWhitePiece(board[t]) !== white) out.push(t);
+    }
+    return out;
+  }
+
+  return attackSquares(board, idx).filter(
+    (t) => board[t] === "" || isWhitePiece(board[t]) !== white,
+  );
+}
+
+export function applyMove(board: Board, from: number, to: number): Board {
+  const next = board.slice();
+  let p: Piece = next[from];
+  if (p.toUpperCase() === "P") {
+    const lastRow = isWhitePiece(p) ? 0 : 7;
+    if (rankRow(to) === lastRow) p = isWhitePiece(p) ? "Q" : "q";
+  }
+  next[to] = p;
+  next[from] = "";
+  return next;
+}
+
+export function legalTargets(board: Board, idx: number): number[] {
+  const white = isWhitePiece(board[idx]);
+  return pieceTargets(board, idx).filter((t) => !inCheck(applyMove(board, idx, t), white));
+}
+
+export function allLegalMoves(board: Board, white: boolean): Move[] {
+  const out: Move[] = [];
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (p === "" || isWhitePiece(p) !== white) continue;
+    for (const t of legalTargets(board, i)) out.push({ from: i, to: t });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/moves.test.ts`
+Expected: PASS (9 tests). Also rerun board.test.ts — still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/engine/
+git commit -m "feat(chess-quest): engine moves module — attacks, legality, apply
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Mate module — mate, stalemate, mate-in-1/2, best defense
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/engine/mate.ts`
+- Test: `apps/web/src/games/chess-quest/engine/__tests__/mate.test.ts`
+
+**Interfaces:**
+- Consumes: `./board`, `./moves`.
+- Produces: `isMate(board, white): boolean`, `isStalemate(board, white): boolean`, `hasMateIn1(board, white): boolean`, `isMateIn2After(board, from, to): boolean`, `bestDefense(board): Move | null`. Content verification (Task 6) and the Phase C MateInTwo game consume these.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/games/chess-quest/engine/__tests__/mate.test.ts
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx } from "../board";
+import { applyMove, legalTargets } from "../moves";
+import { isMate, isStalemate, hasMateIn1, isMateIn2After, bestDefense } from "../mate";
+
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("mate and stalemate", () => {
+  it("back-rank mate detected", () => {
+    const board = applyMove(b("6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1"), sqIdx("e1"), sqIdx("e8"));
+    expect(isMate(board, false)).toBe(true);
+  });
+  it("corner stalemate detected, and is not mate", () => {
+    const board = b("k7/2Q5/1K6/8/8/8/8/8 b - - 0 1");
+    expect(isStalemate(board, false)).toBe(true);
+    expect(isMate(board, false)).toBe(false);
+  });
+});
+
+describe("mate-in-2 verifier (ladder pattern)", () => {
+  // Kh7 vs Ra6+Rb5: Rb7+ forces Kg8/Kh8, then Ra8#.
+  const fen = "8/7k/R7/1R6/8/8/8/6K1 w - - 0 1";
+  it("no mate-in-1 here", () => {
+    expect(hasMateIn1(b(fen), true)).toBe(false);
+  });
+  it("Rb7+ is mate in 2; Rb6 is not", () => {
+    expect(isMateIn2After(b(fen), sqIdx("b5"), sqIdx("b7"))).toBe(true);
+    expect(isMateIn2After(b(fen), sqIdx("b5"), sqIdx("b6"))).toBe(false);
+  });
+  it("bestDefense returns a legal black king reply", () => {
+    const afterCheck = applyMove(b(fen), sqIdx("b5"), sqIdx("b7"));
+    const d = bestDefense(afterCheck);
+    expect(d).not.toBeNull();
+    expect(afterCheck[d!.from]).toBe("k");
+    expect(legalTargets(afterCheck, d!.from)).toContain(d!.to);
+  });
+});
+
+describe("mate-in-2 guardrails", () => {
+  it("an immediate mate is not mate-in-2", () => {
+    const board = b("6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1");
+    expect(hasMateIn1(board, true)).toBe(true);
+    expect(isMateIn2After(board, sqIdx("e1"), sqIdx("e8"))).toBe(false);
+  });
+  it("bare kings force nothing", () => {
+    const board = b("k7/8/8/8/8/8/8/K7 w - - 0 1");
+    expect(hasMateIn1(board, true)).toBe(false);
+    expect(isMateIn2After(board, sqIdx("a1"), sqIdx("a2"))).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/mate.test.ts`
+Expected: FAIL — cannot resolve `../mate`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/web/src/games/chess-quest/engine/mate.ts
+// Game-ending detection and the mate-in-2 verifier used to machine-check
+// the puzzle packs (and to judge moves in the Mate in 2 game).
+import { Board, Move, isWhitePiece } from "./board";
+import { allLegalMoves, applyMove, inCheck } from "./moves";
+
+export function isMate(board: Board, white: boolean): boolean {
+  return inCheck(board, white) && allLegalMoves(board, white).length === 0;
+}
+
+export function isStalemate(board: Board, white: boolean): boolean {
+  return !inCheck(board, white) && allLegalMoves(board, white).length === 0;
+}
+
+export function hasMateIn1(board: Board, white: boolean): boolean {
+  for (const m of allLegalMoves(board, white)) {
+    if (isMate(applyMove(board, m.from, m.to), !white)) return true;
+  }
+  return false;
+}
+
+// Forced mate in exactly two: after this move the enemy is NOT yet mated,
+// still has replies, and every one of them leaves us a mate-in-1.
+export function isMateIn2After(board: Board, from: number, to: number): boolean {
+  const white = isWhitePiece(board[from]);
+  const b1 = applyMove(board, from, to);
+  if (inCheck(b1, white)) return false;
+  if (isMate(b1, !white)) return false;
+  const replies = allLegalMoves(b1, !white);
+  if (replies.length === 0) return false; // stalemate
+  for (const r of replies) {
+    if (!hasMateIn1(applyMove(b1, r.from, r.to), white)) return false;
+  }
+  return true;
+}
+
+// Black's toughest reply: the one leaving white the fewest mating moves.
+export function bestDefense(board: Board): Move | null {
+  let best: Move | null = null;
+  let fewest = Infinity;
+  for (const r of allLegalMoves(board, false)) {
+    const after = applyMove(board, r.from, r.to);
+    let mates = 0;
+    for (const m of allLegalMoves(after, true)) {
+      if (isMate(applyMove(after, m.from, m.to), false)) mates++;
+    }
+    if (mates < fewest) {
+      fewest = mates;
+      best = r;
+    }
+  }
+  return best;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/mate.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/engine/
+git commit -m "feat(chess-quest): engine mate module — mate/stalemate, mate-in-2 verifier
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Tactics module — values, fork/pin/skewer/discovered, coach helpers
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/engine/tactics.ts`
+- Test: `apps/web/src/games/chess-quest/engine/__tests__/tactics.test.ts`
+
+**Interfaces:**
+- Consumes: `./board`, `./moves` (incl. exported `step`, `sliderDirs`).
+- Produces: `pieceValue(p): number`, `isForkAfter(board, to): boolean`, `isPinAfter(board, to): boolean`, `isSkewerAfter(board, to): boolean`, `isDiscoveredAfter(board, to, white): boolean`, `attackersOf(board, sq, byWhite): number[]`, `defendersOf(board, sq): number[]`. Content verification and Phase C TacticTrainer/HangingHunt/coach consume these.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/games/chess-quest/engine/__tests__/tactics.test.ts
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx, sqName } from "../board";
+import { applyMove } from "../moves";
+import {
+  pieceValue,
+  isForkAfter,
+  isPinAfter,
+  isSkewerAfter,
+  isDiscoveredAfter,
+  attackersOf,
+  defendersOf,
+} from "../tactics";
+
+const b = (fen: string) => parseFEN(fen).board;
+const names = (idxs: number[]) => idxs.map(sqName).sort();
+
+describe("piece values", () => {
+  it("standard values, case-insensitive, empty is 0", () => {
+    expect(pieceValue("Q")).toBe(9);
+    expect(pieceValue("n")).toBe(3);
+    expect(pieceValue("")).toBe(0);
+  });
+});
+
+describe("detectors", () => {
+  it("royal knight fork detected (knight on c7 hits king a8 and rook e8)", () => {
+    const board = applyMove(b("k3r3/8/2N5/8/8/8/8/6K1 w - - 0 1"), sqIdx("c6"), sqIdx("c7"));
+    expect(isForkAfter(board, sqIdx("c7"))).toBe(true);
+  });
+  it("pin detected: rook pins knight to the king behind it", () => {
+    // From e1 up the e-file: knight e5 in front, king e8 hides behind → pin.
+    const board = b("4k3/8/8/4n3/8/8/8/4R1K1 w - - 0 1");
+    expect(isPinAfter(board, sqIdx("e1"))).toBe(true);
+  });
+  it("skewer detected: king in front must run, queen behind falls", () => {
+    // From e1 up the e-file: king e6 in front, queen e8 behind → skewer.
+    const board = b("4q3/8/4k3/8/8/8/8/4R1K1 b - - 0 1");
+    expect(isSkewerAfter(board, sqIdx("e1"))).toBe(true);
+  });
+  it("discovered check: the mover is not the checker", () => {
+    // Bishop moves off the e-file, Re1 behind gives the check
+    const start = b("4k3/8/8/8/4B3/8/8/4R1K1 w - - 0 1");
+    const after = applyMove(start, sqIdx("e4"), sqIdx("c6"));
+    expect(isDiscoveredAfter(after, sqIdx("c6"), true)).toBe(true);
+  });
+});
+
+describe("coach helpers (attackers and bodyguards)", () => {
+  // black bishop e7 attacked by Re1; knight a6 guarded by pawn b7
+  const board = b("6k1/1p2bppp/n7/8/8/8/8/4R1K1 w - - 0 1");
+  it("attackersOf finds the rook", () => {
+    expect(names(attackersOf(board, sqIdx("e7"), true))).toEqual(["e1"]);
+  });
+  it("bishop e7 has no bodyguards", () => {
+    expect(defendersOf(board, sqIdx("e7"))).toHaveLength(0);
+  });
+  it("knight a6 guarded by the b7 pawn", () => {
+    expect(names(defendersOf(board, sqIdx("a6")))).toEqual(["b7"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/tactics.test.ts`
+Expected: FAIL — cannot resolve `../tactics`.
+
+If a detector fixture turns out chess-wrong when the module exists (e.g. the fork FEN doesn't actually fork), fix the FEN, not the detector — the detector definitions below are the contract. Verify fixtures by hand against the definitions in the comments.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/web/src/games/chess-quest/engine/tactics.ts
+// Tactic detectors (Trick Shots / Tactic Trainer judging) and the coach's
+// attacker/defender helpers.
+import { Board, Piece, isWhitePiece } from "./board";
+import { attackSquares, findKing, inCheck, isAttacked, sliderDirs, step } from "./moves";
+
+const VALUE: Record<string, number> = { P: 1, N: 3, B: 3, R: 5, Q: 9, K: 100 };
+
+export function pieceValue(p: Piece): number {
+  return VALUE[p.toUpperCase()] ?? 0;
+}
+
+// Fork: the piece that just landed on `to` attacks 2+ enemy non-pawn pieces
+// (king counts) and stands on a square no enemy piece attacks.
+export function isForkAfter(board: Board, to: number): boolean {
+  const p = board[to];
+  if (p === "") return false;
+  const white = isWhitePiece(p);
+  const targets = attackSquares(board, to).filter(
+    (t) => board[t] !== "" && isWhitePiece(board[t]) !== white && board[t].toUpperCase() !== "P",
+  );
+  return targets.length >= 2 && !isAttacked(board, to, !white);
+}
+
+// Walk each ray of the slider on `sq`; report the first two enemy pieces
+// stacked on one ray as {front, back}.
+function rayPairs(board: Board, sq: number): { front: number; back: number }[] {
+  const p = board[sq];
+  const type = p.toUpperCase();
+  if (type !== "B" && type !== "R" && type !== "Q") return [];
+  const white = isWhitePiece(p);
+  const pairs: { front: number; back: number }[] = [];
+  for (const [df, dr] of sliderDirs(type)) {
+    let t = step(sq, df, dr);
+    let front = -1;
+    while (t >= 0) {
+      if (board[t] !== "") {
+        if (isWhitePiece(board[t]) === white) break;
+        if (front < 0) {
+          front = t;
+        } else {
+          pairs.push({ front, back: t });
+          break;
+        }
+      }
+      t = step(t, df, dr);
+    }
+  }
+  return pairs;
+}
+
+// Pin: enemy piece in front is stuck because something bigger (or the king)
+// hides behind it. Skewer: the big one is in front and must run.
+export function isPinAfter(board: Board, to: number): boolean {
+  return rayPairs(board, to).some(
+    ({ front, back }) =>
+      board[back].toUpperCase() === "K" || pieceValue(board[back]) > pieceValue(board[front]),
+  );
+}
+
+export function isSkewerAfter(board: Board, to: number): boolean {
+  return rayPairs(board, to).some(
+    ({ front, back }) =>
+      board[front].toUpperCase() === "K" || pieceValue(board[front]) > pieceValue(board[back]),
+  );
+}
+
+// Discovered attack: after the move, the enemy king is in check from a piece
+// OTHER than the one that just moved.
+export function isDiscoveredAfter(board: Board, to: number, white: boolean): boolean {
+  const k = findKing(board, !white);
+  if (k < 0 || !inCheck(board, !white)) return false;
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (i !== to && p !== "" && isWhitePiece(p) === white && attackSquares(board, i).includes(k))
+      return true;
+  }
+  return false;
+}
+
+// Which pieces of `byWhite` attack this square? (the coach uses these)
+export function attackersOf(board: Board, sq: number, byWhite: boolean): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < 64; i++) {
+    const p = board[i];
+    if (p !== "" && isWhitePiece(p) === byWhite && attackSquares(board, i).includes(sq)) out.push(i);
+  }
+  return out;
+}
+
+// Which friends could recapture on this piece's square? (its bodyguards)
+export function defendersOf(board: Board, sq: number): number[] {
+  const p = board[sq];
+  if (p === "") return [];
+  const white = isWhitePiece(p);
+  const probe = board.slice();
+  probe[sq] = white ? "p" : "P"; // stand-in enemy piece
+  return attackersOf(probe, sq, white);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/tactics.test.ts`
+Expected: PASS (8 tests). If a detector test fails, hand-check the FEN fixture against the detector definition first (see Step 2 note) before touching the module.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/engine/
+git commit -m "feat(chess-quest): engine tactics module — detectors + coach helpers
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Paths module + engine barrel
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/engine/paths.ts`
+- Create: `apps/web/src/games/chess-quest/engine/index.ts`
+- Test: `apps/web/src/games/chess-quest/engine/__tests__/paths.test.ts`
+
+**Interfaces:**
+- Consumes: `./board`, `./moves`.
+- Produces: `pathDistances(board, from): number[]` (BFS move counts, -1 unreachable — Rook Maze generator); `engine/index.ts` re-exports every public symbol from board, moves, mate, tactics, paths. Content tests and Phase C import from `../engine` (the barrel) only.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/games/chess-quest/engine/__tests__/paths.test.ts
+import { describe, expect, it } from "vitest";
+import { parseFEN, sqIdx } from "../board";
+import { pathDistances } from "../paths";
+
+const b = (fen: string) => parseFEN(fen).board;
+
+describe("pathDistances (rook maze)", () => {
+  it("detours around a wall: blocked a8 takes 3 moves", () => {
+    // rook a1; own wall pawns a2,b2,c2
+    const d = pathDistances(b("8/8/8/8/8/8/PPP5/R7 w - - 0 1"), sqIdx("a1"));
+    expect(d[sqIdx("a8")]).toBe(3);
+    expect(d[sqIdx("a2")]).toBe(-1); // own wall square unreachable
+    expect(d[sqIdx("h1")]).toBe(1); // open rank
+  });
+  it("capture square is reachable but not passable", () => {
+    // rook a1, enemy queen a4; a8 hides behind her
+    const d = pathDistances(b("8/8/8/8/q7/8/8/R7 w - - 0 1"), sqIdx("a1"));
+    expect(d[sqIdx("a4")]).toBe(1);
+    expect(d[sqIdx("a8")]).not.toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine/__tests__/paths.test.ts`
+Expected: FAIL — cannot resolve `../paths`.
+
+- [ ] **Step 3: Implement paths + barrel**
+
+```ts
+// apps/web/src/games/chess-quest/engine/paths.ts
+// Fewest moves for the piece on `from` to reach each square (walls and
+// captures respected). -1 = unreachable. Used by the Rook Maze generator.
+import { Board } from "./board";
+import { pieceTargets } from "./moves";
+
+export function pathDistances(board: Board, from: number): number[] {
+  const piece = board[from];
+  const dist = new Array<number>(64).fill(-1);
+  dist[from] = 0;
+  const queue: number[] = [from];
+  while (queue.length) {
+    const s = queue.shift()!;
+    if (board[s] !== "" && s !== from) continue; // stop expanding past a capture
+    const b2 = board.slice();
+    b2[from] = "";
+    b2[s] = piece;
+    for (const t of pieceTargets(b2, s)) {
+      if (dist[t] === -1) {
+        dist[t] = dist[s] + 1;
+        queue.push(t);
+      }
+    }
+  }
+  return dist;
+}
+```
+
+```ts
+// apps/web/src/games/chess-quest/engine/index.ts
+// Public engine surface. Everything outside engine/ imports from here.
+export * from "./board";
+export * from "./moves";
+export * from "./mate";
+export * from "./tactics";
+export * from "./paths";
+```
+
+- [ ] **Step 4: Run the whole engine suite**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/engine`
+Expected: PASS — 5 files (board, moves, mate, tactics, paths), ~30 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/engine/
+git commit -m "feat(chess-quest): engine paths module + public barrel
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Puzzle content — transcription + machine verification
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/content/puzzles.ts`
+- Test: `apps/web/src/games/chess-quest/content/__tests__/puzzles.test.ts`
+
+**Interfaces:**
+- Consumes: engine barrel.
+- Produces (Phase C games consume): `type MatePuzzle = { fen: string; solution: string; name: string; hint: string }`, `type HuntPuzzle = { fen: string; answer: string }`, `type TacticPuzzle = { fen: string; solution: string }`, `MATE1: MatePuzzle[]`, `HUNTS: HuntPuzzle[]`, `TACTICS: Record<"fork" | "pin" | "skewer" | "disco", TacticPuzzle[]>`, `MATE2: MatePuzzle[]`, `TACTICS2: Record<"fork2" | "pin2" | "skewer2" | "disco2", TacticPuzzle[]>`.
+
+**Source of truth:** `~/GitHub/chess-quest/js/puzzles.js` — read it in full and transcribe **every entry verbatim** (fen, solution, name, hint, answer strings unchanged). Rename `PUZZLES` → `MATE1`; all other collection names keep their original names. Example of the target shape (first MATE1 entry, copied from source):
+
+```ts
+export const MATE1: MatePuzzle[] = [
+  {
+    fen: "6k1/5ppp/8/8/8/8/8/4R1K1 w - - 0 1",
+    solution: "e1e8",
+    name: "Sneak down the hallway",
+    hint: "The back row is wide open — slide all the way!",
+  },
+  // … every remaining entry from js/puzzles.js, verbatim …
+];
+```
+
+The verification suite below is the acceptance gate: if transcription drops or mangles an entry, a test fails naming the puzzle. Do not edit puzzle data to make tests pass — a failure means a transcription error (the source set is already machine-verified in the original repo).
+
+- [ ] **Step 1: Write the verification suite first** (fails until puzzles.ts exists; ports the original acceptance checks 1:1)
+
+```ts
+// apps/web/src/games/chess-quest/content/__tests__/puzzles.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  parseFEN,
+  sqIdx,
+  sqName,
+  isWhitePiece,
+  isAttacked,
+  inCheck,
+  legalTargets,
+  applyMove,
+  isMate,
+  hasMateIn1,
+  isMateIn2After,
+  isForkAfter,
+  isPinAfter,
+  isSkewerAfter,
+  isDiscoveredAfter,
+} from "../../engine";
+import { MATE1, HUNTS, TACTICS, MATE2, TACTICS2 } from "../puzzles";
+
+const mv = (sol: string) => ({ from: sqIdx(sol.slice(0, 2)), to: sqIdx(sol.slice(2, 4)) });
+
+describe("MATE1: every solution is a legal mate-in-1", () => {
+  it.each(MATE1.map((p) => [p.name, p] as const))("%s", (_name, pz) => {
+    const { board } = parseFEN(pz.fen);
+    const { from, to } = mv(pz.solution);
+    expect(inCheck(board, false)).toBe(false); // black not already in check
+    expect(legalTargets(board, from)).toContain(to);
+    expect(isMate(applyMove(board, from, to), false)).toBe(true);
+  });
+});
+
+describe("HUNTS: exactly one hanging black piece, matching the answer", () => {
+  it.each(HUNTS.map((h) => [h.answer, h] as const))("hunt %s", (_a, h) => {
+    const { board } = parseFEN(h.fen);
+    const hanging: string[] = [];
+    for (let i = 0; i < 64; i++) {
+      const p = board[i];
+      if (p === "" || isWhitePiece(p) || p === "k") continue;
+      const attacked = isAttacked(board, i, true);
+      const probe = board.slice();
+      probe[i] = "P"; // stand-in white piece: can black recapture here?
+      const defended = isAttacked(probe, i, false);
+      if (attacked && !defended) hanging.push(sqName(i));
+    }
+    expect(hanging).toEqual([h.answer]);
+    expect(inCheck(board, false)).toBe(false);
+    expect(inCheck(board, true)).toBe(false);
+  });
+});
+
+const DETECTOR = {
+  fork: isForkAfter,
+  pin: isPinAfter,
+  skewer: isSkewerAfter,
+  disco: (b: string[], to: number) => isDiscoveredAfter(b, to, true),
+} as const;
+
+describe("TACTICS: every solution performs its named trick", () => {
+  for (const pack of ["fork", "pin", "skewer", "disco"] as const) {
+    it.each(TACTICS[pack].map((tc, i) => [`${pack} ${i + 1}`, tc] as const))(
+      "%s",
+      (_label, tc) => {
+        const { board } = parseFEN(tc.fen);
+        const { from, to } = mv(tc.solution);
+        expect(inCheck(board, false)).toBe(false);
+        expect(inCheck(board, true)).toBe(false);
+        expect(legalTargets(board, from)).toContain(to);
+        expect(DETECTOR[pack](applyMove(board, from, to), to)).toBe(true);
+      },
+    );
+  }
+});
+
+describe("MATE2: forced in exactly two, never one", () => {
+  it("has 12 puzzles", () => {
+    expect(MATE2).toHaveLength(12);
+  });
+  it.each(MATE2.map((p) => [p.name, p] as const))("%s", (_name, pz) => {
+    const { board } = parseFEN(pz.fen);
+    const { from, to } = mv(pz.solution);
+    expect(inCheck(board, false)).toBe(false);
+    expect(inCheck(board, true)).toBe(false);
+    expect(hasMateIn1(board, true)).toBe(false); // no hidden mate-in-1 (caught 2 bad puzzles before)
+    expect(legalTargets(board, from)).toContain(to);
+    expect(isMateIn2After(board, from, to)).toBe(true);
+  });
+});
+
+const DETECTOR2 = {
+  fork2: isForkAfter,
+  pin2: isPinAfter,
+  skewer2: isSkewerAfter,
+  disco2: (b: string[], to: number) => isDiscoveredAfter(b, to, true),
+} as const;
+
+describe("TACTICS2: tier-2 packs", () => {
+  it("has all four packs of 3", () => {
+    for (const pack of ["fork2", "pin2", "skewer2", "disco2"] as const) {
+      expect(TACTICS2[pack]).toHaveLength(3);
+    }
+  });
+  for (const pack of ["fork2", "pin2", "skewer2", "disco2"] as const) {
+    it.each(TACTICS2[pack].map((tc, i) => [`${pack} ${i + 1}`, tc] as const))(
+      "%s",
+      (_label, tc) => {
+        const { board } = parseFEN(tc.fen);
+        const { from, to } = mv(tc.solution);
+        expect(inCheck(board, false)).toBe(false);
+        expect(inCheck(board, true)).toBe(false);
+        expect(legalTargets(board, from)).toContain(to);
+        expect(DETECTOR2[pack](applyMove(board, from, to), to)).toBe(true);
+      },
+    );
+  }
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/content/__tests__/puzzles.test.ts`
+Expected: FAIL — cannot resolve `../puzzles`.
+
+- [ ] **Step 3: Transcribe puzzles.ts**
+
+Read `~/GitHub/chess-quest/js/puzzles.js` in full. Create `content/puzzles.ts` with the type declarations from the Interfaces block and all five collections transcribed verbatim (every fen/solution/name/hint/answer string byte-identical; ~63 FENs total). Keep the original file's section comments.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/content/__tests__/puzzles.test.ts`
+Expected: PASS — every named puzzle green. A single red test = transcription typo in that entry; re-check against the source line.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/content/
+git commit -m "feat(chess-quest): puzzle packs transcribed + machine-verified
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Curriculum content — lands + lessons + shape verification
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/content/lands.ts`
+- Create: `apps/web/src/games/chess-quest/content/lessons.ts`
+- Test: `apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts`
+
+**Interfaces:**
+- Consumes: engine barrel (FEN validation in tests); `./puzzles` (pack references).
+- Produces (Phase C/D consume):
+
+```ts
+// lands.ts
+export type Land = {
+  id: number;
+  glyph: string;
+  name: string;
+  weeks: [number, number]; // inclusive lesson range
+  goal: string;
+  check: string; // Story register
+  checkClassic: string; // Classic register
+  track?: 2; // present on Track 2 lands only (original data shape)
+};
+export const LANDS: Land[]; // 9 lands: 5 Track 1 + 4 Track 2
+
+// lessons.ts
+export type GameId =
+  | "squareRace"
+  | "coinHop"
+  | "pawnWars"
+  | "mateInOne"
+  | "mateInTwo"
+  | "hangingHunt"
+  | "tacticTrainer"
+  | "rookMaze";
+export type LessonCopy = { learn: string; play: string; spark: string };
+export type Lesson = {
+  n: number; // 1..48
+  title?: string; // verify against source — add/require fields to match js/curriculum.js exactly
+  learn: string;
+  play: string;
+  spark: string; // Story register
+  classic: LessonCopy; // Classic register
+  game: GameId | null; // null = play on a real board
+  gameOpts?: Record<string, unknown>;
+  diagram?: { fen: string; caption?: string };
+};
+export const LESSONS: Lesson[]; // 48, ordered
+```
+
+**Source of truth:** `~/GitHub/chess-quest/js/curriculum.js` (`LANDS` and `WEEKS` exports). Transcribe verbatim — every copy string in both registers, every `gameOpts`, every diagram FEN. `WEEKS` renames to `LESSONS`; field names otherwise unchanged. If a source lesson has fields beyond the type above, add them to the type rather than dropping data.
+
+- [ ] **Step 1: Write the shape verification suite** (ports original curriculum checks 1:1)
+
+```ts
+// apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts
+import { describe, expect, it } from "vitest";
+import { parseFEN } from "../../engine";
+import { LANDS } from "../lands";
+import { LESSONS } from "../lessons";
+import { TACTICS, TACTICS2 } from "../puzzles";
+
+const GAME_IDS = [
+  "squareRace",
+  "coinHop",
+  "pawnWars",
+  "mateInOne",
+  "mateInTwo",
+  "hangingHunt",
+  "tacticTrainer",
+  "rookMaze",
+];
+
+describe("curriculum shape", () => {
+  it("48 lessons, numbered 1..48 in order", () => {
+    expect(LESSONS).toHaveLength(48);
+    LESSONS.forEach((l, i) => expect(l.n).toBe(i + 1));
+  });
+  it("9 lands tiling lessons 1..48 exactly once", () => {
+    expect(LANDS).toHaveLength(9);
+    const seen = new Array(49).fill(0);
+    for (const land of LANDS) {
+      for (let i = land.weeks[0]; i <= land.weeks[1]; i++) seen[i]++;
+    }
+    expect(seen.slice(1).every((c) => c === 1)).toBe(true);
+  });
+  it("track 2 lands cover lessons 25..48 only", () => {
+    for (const land of LANDS.filter((l) => l.track === 2)) {
+      expect(land.weeks[0]).toBeGreaterThanOrEqual(25);
+    }
+  });
+  it("every land has both check registers", () => {
+    for (const land of LANDS) {
+      expect(land.check.length).toBeGreaterThan(0);
+      expect(land.checkClassic.length).toBeGreaterThan(0);
+    }
+  });
+  it("every lesson has story + classic copy", () => {
+    for (const l of LESSONS) {
+      expect(l.learn.length).toBeGreaterThan(0);
+      expect(l.play.length).toBeGreaterThan(0);
+      expect(l.spark.length).toBeGreaterThan(0);
+      expect(l.classic.learn.length).toBeGreaterThan(0);
+      expect(l.classic.play.length).toBeGreaterThan(0);
+      expect(l.classic.spark.length).toBeGreaterThan(0);
+    }
+  });
+  it("every game id is real", () => {
+    for (const l of LESSONS) {
+      if (l.game !== null) expect(GAME_IDS).toContain(l.game);
+    }
+  });
+  it("all diagram FENs parse to 64 squares", () => {
+    for (const l of LESSONS) {
+      if (!l.diagram) continue;
+      expect(parseFEN(l.diagram.fen).board, `lesson ${l.n}`).toHaveLength(64);
+    }
+  });
+  it("tactic-trainer lessons point at existing packs", () => {
+    for (const l of LESSONS.filter((x) => x.game === "tacticTrainer")) {
+      const pack = (l.gameOpts as { pack?: string } | undefined)?.pack ?? "";
+      const exists =
+        pack in TACTICS || pack in TACTICS2;
+      expect(exists, `lesson ${l.n} pack "${pack}"`).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/content/__tests__/curriculum.test.ts`
+Expected: FAIL — cannot resolve `../lands` / `../lessons`.
+
+- [ ] **Step 3: Transcribe lands.ts and lessons.ts**
+
+Read `~/GitHub/chess-quest/js/curriculum.js` in full (it is ~47K — read in chunks). Transcribe `LANDS` → `content/lands.ts` and `WEEKS` → `content/lessons.ts` (renamed `LESSONS`), types as declared in Interfaces. All strings verbatim, both copy registers, all `gameOpts` and `diagram` blocks. Keep the original section comments per land.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/content`
+Expected: PASS — puzzles + curriculum suites both green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/content/
+git commit -m "feat(chess-quest): curriculum transcribed (9 lands, 48 lessons) + shape checks
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full verification
+
+**Files:** none new.
+
+- [ ] **Step 1: Whole chess-quest tree**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest`
+Expected: PASS — 7 test files (5 engine + 2 content), zero failures.
+
+- [ ] **Step 2: Full workspace suites + lint + build**
+
+```bash
+cd apps/web
+rtk proxy npx vitest run 2>&1 | tail -5      # all green (skipped DB suites are normal)
+rtk proxy npx eslint src/games 2>&1 | tail -5 # zero problems in games tree
+rtk proxy npm run build 2>&1 | tail -5        # compiles clean
+```
+
+Expected: no regressions; games tree lints clean (repo has one pre-existing error in `verify-email.tsx` on main — ignore, out of scope).
+
+- [ ] **Step 3: Push**
+
+```bash
+git push
+```
+
+(Continues PR #92; or if it has merged by then, open a Phase B PR from the branch per the finishing-a-development-branch skill.)
+
+---
+
+### Out of scope (later phases)
+
+- Board/game React components, GameShell, coach UI — Phase C.
+- QuestMap, profiles, localStorage store, progress, certificate — Phase D.
+- Sfx/voice hooks, status flip to `live`, SEO polish — Phase C/E.

--- a/docs/superpowers/plans/2026-07-14-games-platform-phase-c.md
+++ b/docs/superpowers/plans/2026-07-14-games-platform-phase-c.md
@@ -1,0 +1,228 @@
+# Seazn Games — Phase C (Board + Mini-Games, Chess Quest Goes Live) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Interactive Board + all 8 mini-games as React components with a free-play hub; flip Chess Quest's registry status to `live` so `/games/chess-quest` is playable.
+
+**Architecture:** Client components under `src/games/chess-quest/components/`, consuming the Phase B engine barrel and content. Shared infrastructure first (GameShell with coach bubble, timer registry hook, in-memory progress context whose API Phase D swaps for localStorage, copy-register context), then one component per mini-game porting the original mechanics 1:1 from `~/GitHub/chess-quest/js/games.js` (the normative reference — line refs per task), re-skinned Seazn (Tailwind + one scoped `chess-quest.css` for board grid/animations).
+
+**Tech Stack:** React 19 client components, Tailwind v4 + scoped CSS, Vitest for pure logic, Playwright for flows. No DB, no localStorage yet (Phase D).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-seazn-games-chess-quest-design.md` (Phase C). Branch `games-platform` (PR #92).
+
+## Global Constraints
+
+- All new files under `apps/web/src/games/chess-quest/` except e2e; every component file starts with `"use client"`.
+- Engine imports ONLY from `../engine` barrel; content from `../content/*`.
+- **Mechanics are ports, not redesigns.** Normative source: `~/GitHub/chess-quest/js/games.js` (read the referenced lines before implementing each game). Keep: star formulas, coach dialogue flows, timing delays (250/500/750/900/1300/1400/1600 ms), tap-tap move selection, board-reset-on-wrong-answer behavior. Copy strings carried verbatim (both registers via `t(story, classic)`).
+- Known source quirk to fix while porting: mateInOne completion text hardcodes "All 12 checkmates" but MATE1 has 18 puzzles — use `MATE1.length` in copy.
+- **SFX/FX deferred to Phase E:** `lib/sfx.ts` ships as a typed no-op object (`tap/good/bad/move/coin/fanfare`) so call sites are wired now; confetti `FX.burst` is replaced by the piece `pop` animation + ★ text until E.
+- **Progress is session-only in C:** `ProgressProvider` holds Store-shaped state in React state. Phase D swaps the provider internals for localStorage profiles; the consumer API below is the contract — don't deviate from it.
+- Copy register: default `"classic"` (public site, adult visitor); Story strings still ported and reachable via the register toggle Phase D adds. `t(story, classic)` picks by register; `isStory()` gates the italic story leads in hunts/tactics.
+- Coach/status copy may contain `<strong>`/`<em>` — render via a `Rich` helper using `dangerouslySetInnerHTML` on our own literal strings only (never user input).
+- Timers: every delayed callback goes through `useLater()` (auto-cleared on unmount and via `clearPending()` on game switch) — the original's stale-timer bug class stays dead.
+- Board colors: Seazn palette — light squares `bg-purple-50`, dark `bg-purple-200`, selection/move/capture/hint tints in `chess-quest.css` with `cq-` prefixed classes; pieces are the filled glyphs `♟♞♝♜♛♚` colored white/slate like the original's w/b classes.
+- Tests: pure logic in `lib/*.ts` gets vitest coverage (star formulas, generators, progress store); interactive flows get Playwright e2e; browser-verify each game during its task (dev server + click through once).
+- Conventional commits with the `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>` trailer; run suites with `rtk proxy npx vitest run …`.
+
+---
+
+### Task C1: Shared foundations — sfx stub, timers, progress store, copy register
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/lib/sfx.ts`
+- Create: `apps/web/src/games/chess-quest/lib/use-later.ts`
+- Create: `apps/web/src/games/chess-quest/lib/progress.tsx`
+- Create: `apps/web/src/games/chess-quest/lib/copy.tsx`
+- Create: `apps/web/src/games/chess-quest/lib/stars.ts`
+- Test: `apps/web/src/games/chess-quest/lib/__tests__/stars.test.ts`
+- Test: `apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts`
+
+**Interfaces (the Phase D contract — later tasks and Phase D consume exactly this):**
+
+```ts
+// sfx.ts — no-op until Phase E
+export const sfx: { tap(): void; good(): void; bad(): void; move(): void; coin(): void; fanfare(): void };
+
+// use-later.ts
+export function useLater(): { later(fn: () => void, ms: number): void; clearPending(): void };
+// clearPending also runs automatically on unmount.
+
+// progress.tsx  (context provider + hook; in-memory in Phase C)
+export type Progress = {
+  isSolved(i: number): boolean; setSolved(i: number): void; solvedCount(): number; resetPuzzles(): void;
+  isSolved2(i: number): boolean; setSolved2(i: number): void; solved2Count(): number; resetPuzzles2(): void;
+  isHuntSolved(i: number): boolean; setHuntSolved(i: number): void; huntCount(): number; resetHunts(): void;
+  isTacticSolved(pack: string, i: number): boolean; setTacticSolved(pack: string, i: number): void;
+  tacticCount(pack: string): number; resetTactics(pack: string): void;
+  setGameStars(gameId: string, stars: number): void; // keep-max semantics
+  gameStars(gameId: string): number;
+  setBest(gameId: string, score: number): boolean; // true = new record
+  getBest(gameId: string): number;
+};
+export function ProgressProvider({ children }: { children: React.ReactNode }): JSX.Element;
+export function useProgress(): Progress;
+
+// copy.tsx
+export type Register = "story" | "classic";
+export function CopyProvider({ register = "classic", children }): JSX.Element;
+export function useCopy(): { t(story: string, classic: string): string; isStory(): boolean };
+
+// stars.ts — every star formula, pure (ported from js/games.js; tested)
+export const STAR_RULES: {
+  squareRace(score: number): number;             // ≥12→3, ≥7→2, ≥3→1, else 0
+  coinHop(moves: number, piece: string): number; // easy (R/B/Q): ≤9→3, ≤13→2, else 1; hard (N/K/P): ≤14→3, ≤20→2, else 1
+  pawnWars(whiteWon: boolean): number;           // 3 / 1
+  packStars(solved: number): number;             // mateInOne, mateInTwo, tier-2 tactics: ≥12→3, ≥8→2, ≥4→1, else 0
+  hangingHunt(solved: number): number;           // ≥8→3, ≥5→2, ≥3→1, else 0
+  tacticTier1(total: number): number;            // across fork+pin+skewer+disco (13 cases): ≥13→3, ≥8→2, ≥4→1, else 0
+  rookMaze(moves: number, par: number): number;  // ≤par→3, ≤par+1→2, else 1
+};
+```
+
+- [ ] **Step 1: Write failing tests** — `stars.test.ts` asserts every threshold above at its boundary values (e.g. `squareRace(12)===3`, `squareRace(11)===2`, `coinHop(9,"Q")===3`, `coinHop(10,"Q")===2`, `coinHop(14,"N")===3`, `rookMaze(5,5)===3`, `rookMaze(6,5)===2`, `rookMaze(7,5)===1`, `packStars(11)===2`, `tacticTier1(13)===3`). `progress.test.ts` exercises the Progress object created by the provider's internal factory (export `createProgressState()` for testability): solve/count/reset per pack family, keep-max `setGameStars`, `setBest` returns true only on strict improvement.
+- [ ] **Step 2: Run to verify failure** — `rtk proxy npx vitest run src/games/chess-quest/lib` → cannot resolve modules.
+- [ ] **Step 3: Implement all five modules** per the interfaces (progress state: plain objects `{ solved: Set<number>, solved2: Set<number>, hunts: Set<number>, tactics: Record<string, Set<number>>, stars: Record<string, number>, bests: Record<string, number> }` behind `useState` + stable callbacks).
+- [ ] **Step 4: Run to verify pass**, then commit `feat(chess-quest): shared game foundations — progress, copy, timers, star rules`.
+
+---
+
+### Task C2: Board component + game chrome
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/Board.tsx`
+- Create: `apps/web/src/games/chess-quest/components/GameShell.tsx`
+- Create: `apps/web/src/games/chess-quest/components/rich.tsx`
+- Create: `apps/web/src/games/chess-quest/chess-quest.css`
+
+**Interfaces:**
+
+```tsx
+// Board.tsx — controlled, tap-driven (port of js/board.js)
+export const GLYPH: Record<string, string>; // { P:"♟", N:"♞", B:"♝", R:"♜", Q:"♛", K:"♚" }
+export type Highlight = "sel" | "move" | "cap" | "hint";
+export function Board(props: {
+  position: string[];                       // 64-array, engine convention
+  highlights?: Partial<Record<number, Highlight>>;
+  coins?: ReadonlySet<number>;              // rendered on empty squares
+  labels?: boolean;                         // file letters on rank 1, rank numbers on a-file
+  onTap?(idx: number): void;
+  popToken?: { idx: number; n: number } | null; // n change triggers pop animation on idx
+  shakeToken?: number;                      // change triggers board shake
+}): JSX.Element;
+// Each square renders as a <button> with data-square="e4" and
+// aria-label "e4" (+ piece name when occupied) — e2e and a11y hook.
+
+// GameShell.tsx — replaces the modal: header (title + score), coach bubble
+// (status rich text + chip buttons), extra slot (dots/pickers), board slot, controls slot.
+export function GameShell(props: {
+  title: string;
+  score?: React.ReactNode;
+  status: string;                            // rich HTML string (own literals only)
+  chips?: { label: string; onPick(): void }[];
+  extra?: React.ReactNode;
+  controls?: React.ReactNode;
+  children: React.ReactNode;                 // the board
+}): JSX.Element;
+
+// rich.tsx
+export function Rich({ html, className }: { html: string; className?: string }): JSX.Element;
+```
+
+- `chess-quest.css`: `.cq-board` 8×8 grid (aspect-square, max 480px), square colors, `.cq-hl-sel/-move/-cap/-hint` tints, `.cq-coin` dot, `@keyframes cq-pop` (scale 1.35→1, 300ms) and `cq-shake` (translate ±4px, 300ms), rank/file label pseudo-elements. Import once from the hub root.
+- Coach bubble: ♞ face + purple-tinted bubble, chips as small rounded buttons — Seazn styling of the original coach-row.
+- [ ] **Step 1: Implement** all four files (no unit tests — node-env vitest can't render; verified in browser next step and by every game task after).
+- [ ] **Step 2: Browser-verify** with a temporary render: point `player-map.tsx`'s placeholder at a scratch page that mounts `<Board position={parseFEN(START).board} labels />` inside `GameShell` — confirm grid, glyphs, labels, tap logging, pop/shake animations in the dev server, then revert the scratch wiring.
+- [ ] **Step 3: Commit** `feat(chess-quest): Board component + GameShell chrome`.
+
+---
+
+### Task C3: Square Race + Coin Hop
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/games/SquareRace.tsx` (source: games.js:136–195)
+- Create: `apps/web/src/games/chess-quest/components/games/CoinHop.tsx` (source: games.js:197–286)
+- Create: `apps/web/src/games/chess-quest/lib/rand.ts` — `randSquares(n, exclude, allowed?)` port (games.js:122–134) + test in `lib/__tests__/rand.test.ts` (count, exclusion, allowed-filter honored, no duplicates).
+
+**Behavior contracts (port exactly):**
+- SquareRace: empty board, labels on; Start → 60s countdown (interval, cleared on unmount), random target square announced as `Find <strong>e4</strong>!`; correct tap: score++, brief hint flash 250ms, new target; wrong: shake. Finish: stars via `STAR_RULES.squareRace`, `setBest("squareRace", score)` record flag in copy, `setGameStars`, Play-again button. HUD `⭐ n · ⏱ ts`.
+- CoinHop: `pieces` prop (default `["N"]`), chip picker when >1 (games.js drawPicker); piece placed `27 + rand(10)`; 6 coins via `randSquares`, bishop restricted to same-color squares; tap piece → show `pieceTargets` (pseudo-legal — intentional, no kings here); move: coins collected shrink set, pawn never promotes in this game (re-set "P"), moves++; all collected → stars via `STAR_RULES.coinHop(moves, piece)`. HUD `🪙 left · 👣 moves`. "New coins" control.
+- [ ] **Step 1: rand.ts + failing test, run, implement, pass.**
+- [ ] **Step 2: Implement both game components.**
+- [ ] **Step 3: Browser-verify each** (temporary hub wiring acceptable — Task C7 makes it permanent): play one Square Race round ≥3 score, one full Coin Hop clear.
+- [ ] **Step 4: Commit** `feat(chess-quest): Square Race + Coin Hop mini-games`.
+
+---
+
+### Task C4: Pawn Wars + shared mate-miss coach
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/games/PawnWars.tsx` (source: games.js:288–384)
+- Create: `apps/web/src/games/chess-quest/lib/mate-miss.ts` (source: games.js:386–429) — returns the coach interaction plan for a non-mating attempt: given `next` board, produces one of three flows (`no-check` chips / `escape` tap-the-square with 2-miss fallback / `capture-block` plain reset) as data the game component renders via GameShell chips/tap handler. Test `lib/__tests__/mate-miss.test.ts`: classify each flow from three fixture boards (no-check move, check-with-escape incl. escape list, check-stuck-but-capturable).
+
+**Behavior contracts:**
+- PawnWars: 8 white pawns rank 2 vs 8 black rank 7, hot-seat (white = "Kid"/"White" per register, black = "Grown-up"/"Black"); tap-select shows legal targets (`hl-move`/`hl-cap`); win on promotion (board piece becomes Q/q) or opponent stuck (`allLegalMoves` empty → mover of last move wins); stars 3/1 via `STAR_RULES.pawnWars`; hanging-pawn coach interjection after a white move that leaves the moved pawn attacked and undefended — chips "Oops! Take back" (restores snapshot only if board unchanged) / "It's my plan 😏" (verbatim flows, games.js:355–374).
+- [ ] **Step 1: mate-miss failing test → implement → pass.**
+- [ ] **Step 2: Implement PawnWars, browser-verify** one game incl. triggering the take-back coach.
+- [ ] **Step 3: Commit** `feat(chess-quest): Pawn Wars + shared mate-miss coach`.
+
+---
+
+### Task C5: Mate in 1 + Mate in 2
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/games/MateInOne.tsx` (source: games.js:431–538)
+- Create: `apps/web/src/games/chess-quest/components/games/MateInTwo.tsx` (source: games.js:540–706)
+- Create: `apps/web/src/games/chess-quest/components/games/PuzzleDots.tsx` — shared numbered dot-row (solved/current states, aria-labels), used by both + hunts + tactics.
+
+**Behavior contracts:**
+- MateInOne: MATE1 pack; auto-advance to first unsolved (all solved → index 0); dots navigation; Hint highlights solution's from-square + shows `pz.hint`; correct = any legal move where `isMate(next,false)` (accepts alternates); wrong → `mate-miss` flow with board reset to puzzle FEN and `(The Hint button is your friend!)` nudge after 2 tries; solved: `setSolved`, pack stars `packStars(solvedCount)`, 1400ms then next unsolved; completion copy uses `MATE1.length` (18 — fixes source's hardcoded "12"). "Start pack over" resets.
+- MateInTwo: MATE2 pack, two phases. Phase 1: immediate mate accepted ("even faster than asked"); `isMateIn2After` accepted → status "That's the squeeze…", 750ms → `bestDefense` reply animates, phase 2 ("Black tries e7–e8… now finish it. Mate in one!"); wrong phase-1 move → diagnostic: find black's saving reply (first reply after which `hasMateIn1` false), 900ms reset with check/no-check-specific coaching (games.js:659–679 verbatim). Phase 2: must mate, else `mate-miss` against `midBoard`. Hint: phase 1 = solution from-square + hint text; phase 2 = from-square of an actual mating move found by search. Solved flow like MateInOne (1600ms, 12 puzzles, `packStars`).
+- [ ] **Step 1: Implement PuzzleDots + MateInOne, browser-verify** (solve puzzle 1: e1→e8; then a deliberate wrong move → coach flow).
+- [ ] **Step 2: Implement MateInTwo, browser-verify** (solve ladder puzzle 1: b5→b7, watch black defense, finish mate; and one wrong-move diagnostic).
+- [ ] **Step 3: Commit** `feat(chess-quest): Mate in 1 + Mate in 2 puzzle games`.
+
+---
+
+### Task C6: Piece Detective + Trick Shots
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/games/HangingHunt.tsx` (source: games.js:810–926)
+- Create: `apps/web/src/games/chess-quest/components/games/TacticTrainer.tsx` (source: games.js:928–1092)
+
+**Behavior contracts:**
+- HangingHunt: HUNTS cases; story lead (italic) only when `isStory()`; tap the hanging piece = solved (hint flash, 1300ms advance, `STAR_RULES.hangingHunt`); wrong taps get targeted coaching: empty/white square → "tap a black piece"; king → "kings can never be taken"; unattacked → "is anything even attacking…"; attacked-but-defended → tap-the-guard interaction using `defendersOf` (games.js:905–919). Hint lights white attackers of the answer square.
+- TacticTrainer: `pack` prop; **plus a pack chip picker** (all 8 packs, current highlighted — free-play addition, same chip pattern as CoinHop's piece picker) since the hub has no curriculum context; PACK_INFO names/asks verbatim (games.js:929–938); solve = any legal white move passing the pack's detector on the landing square; fork-specific miss coaching (unsafe square → tap-the-eater; safe but <2 targets → count chips), pin/skewer/disco one-line resets (games.js:1048–1081); stars: tier-1 total across 4 packs via `tacticTier1`, tier-2 via `packStars` stored under `tacticTrainer2`.
+- [ ] **Step 1: Implement HangingHunt, browser-verify** (solve case 1 d7; trigger guard-tap coaching on a defended piece).
+- [ ] **Step 2: Implement TacticTrainer, browser-verify** (fork 1 b5→c7 solve; one wrong fork square → counting chips; switch pack via chips).
+- [ ] **Step 3: Commit** `feat(chess-quest): Piece Detective + Trick Shots trainers`.
+
+---
+
+### Task C7: Hub, go-live flip, e2e
+
+**Files:**
+- Modify: `apps/web/src/games/chess-quest/index.tsx` — placeholder becomes the hub: providers (`ProgressProvider`, `CopyProvider`), css import, game picker grid (8 cards: emoji, title, one-liner), selected game renders full-area with "← All games" back within the hub; game defaults `coinHop {pieces:["N","B","R","Q","K"]}`, `rookMaze {pieces:["R","B","Q"]}`, `tacticTrainer {pack:"fork"}`.
+- Create: `apps/web/src/games/chess-quest/components/games/RookMaze.tsx` (source: games.js:708–808 — slotted here to keep C6 balanced): generator loop (piece on ranks 1–2, 9 wall pawns, target with `pathDistances ≥ 3` pre-prey and `≥ 2` post-prey else regenerate, 60 attempts), par display, `pieceTargets` movement, blocked-tap coaching line, `STAR_RULES.rookMaze`.
+- Modify: `apps/web/src/games/registry.ts` — chess-quest `status: "live"`.
+- Modify: `apps/web/e2e/games.spec.ts` — replace coming-soon expectations: listing card shows "Play →"; `/games/chess-quest` shows hub with 8 game cards; deterministic play-through: open "Mate in 1", tap e1 then e8, expect "Checkmate!"; subdomain test now expects the hub.
+- [ ] **Step 1: RookMaze + hub implementation.**
+- [ ] **Step 2: Flip registry to live** — sitemap gains `/games/chess-quest` automatically (assert via curl).
+- [ ] **Step 3: Update + run e2e:** `rtk proxy npx playwright test e2e/games.spec.ts --project=parallel --no-deps` → all pass.
+- [ ] **Step 4: Commit** `feat(chess-quest): free-play hub + Rook Maze; chess quest goes live`.
+
+---
+
+### Task C8: Full verification + demo
+
+- [ ] **Step 1:** `rtk proxy npx vitest run` (all green), `rtk proxy npx eslint src/games` (exit 0), `rtk proxy npm run build` (clean, routes emitted).
+- [ ] **Step 2: Browser demo pass:** every one of the 8 games opened and one interaction each on `/games/chess-quest`; screenshot hub + one game.
+- [ ] **Step 3: Push** (PR #92 or successor per finishing-a-development-branch).
+
+---
+
+### Out of scope (Phase D/E)
+
+- localStorage persistence, profiles, register toggle UI (D — swaps `ProgressProvider`/`CopyProvider` internals only).
+- QuestMap/lesson launching with curriculum `gameOpts` (D).
+- Real sounds, voice, confetti (E).

--- a/docs/superpowers/plans/2026-07-14-games-platform-phase-d.md
+++ b/docs/superpowers/plans/2026-07-14-games-platform-phase-d.md
@@ -1,0 +1,190 @@
+# Seazn Games — Phase D (Quest Map, Profiles, Progress, Certificate) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the free-play arcade into the full Chess Quest journey — a 48-lesson map over 9 lands (Day 1→95) that launches each lesson's mini-game, backed by localStorage profiles with streaks, a progress panel, and a printable certificate.
+
+**Architecture:** Rewrite the in-memory `lib/progress` into a localStorage-backed **profiles store** (the Phase C `Progress` API is preserved and extended). New components under `components/quest/`: `QuestMap`, `LessonCard`, `QuestHeader`, `ProfilePanel`, `ProgressPanel`, `Certificate`, `GrownUpsDrawer`. The hub landing becomes the quest; the 8-game arcade stays reachable as "Free play". Lessons launch the existing Phase C game components with their `gameOpts`.
+
+**Tech Stack:** React 19 client components, Tailwind v4 + the existing `chess-quest.css`, Vitest (localStorage shim for the store, like the original `store.test.mjs`), Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-seazn-games-chess-quest-design.md` (Phase D). Branch `games-platform` (PR #92). Normative source for behavior/copy: `~/GitHub/chess-quest/js/{store,app}.js` and `css/style.css` (read the referenced lines per task).
+
+## Global Constraints
+
+- All new code under `apps/web/src/games/chess-quest/`; every component file starts with `"use client"`. Engine from `../engine`, content from `../content/*`.
+- **localStorage key `seazn-games:chess-quest:v1`** (namespaced; **no migration** from the standalone app's `chess-quest-v2` — different origin, fresh start per spec).
+- **The Phase C `Progress` API stays byte-compatible** — all 8 game components already call `isSolved/setGameStars/setBest/...`. Phase D only *adds* methods (weeks, activity/streak, name/mode, profiles, totalStars) and swaps the provider's internals for persistence. Do not rename or change existing signatures.
+- **SSR safety:** the whole chess-quest tree already loads via `next/dynamic({ ssr: false })` (player-map), but still guard every `localStorage`/`window` access with `typeof window !== "undefined"`, and hydrate the store in an effect after mount so first render is deterministic.
+- Copy register comes from the **active profile's mode** (`story`/`classic`), not a static prop — `CopyProvider` reads it from the store. Default new profiles to `classic` on the public site.
+- Lessons run every other day: `dayOf(n) = 2*n - 1` (Day 1, 3, 5…). Streak: activity-date chain alive while gaps ≤ 2 days.
+- Rich copy (`<strong>`, `<em>`, lesson HTML from content) renders via the existing `Rich` helper — our own literal/content strings only.
+- Star/best/solved semantics unchanged from Phase C (keep-max stars, strict-improvement best).
+- Run suites with `rtk proxy npx vitest run …`. Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task D1: Persistent profiles store
+
+**Files:**
+- Rewrite: `apps/web/src/games/chess-quest/lib/progress.tsx`
+- Test: `apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts` (extend)
+
+**Interfaces (extends the Phase C `Progress` — additions only):**
+
+```ts
+// Existing (unchanged, still consumed by the 8 games):
+//   isSolved/setSolved/solvedCount/resetPuzzles, ...Solved2..., ...Hunt...,
+//   isTacticSolved/setTacticSolved/tacticCount/resetTactics,
+//   setGameStars/gameStars, setBest/getBest
+
+export type Progress = {
+  /* …all Phase C members unchanged… */
+
+  // lessons
+  isWeekDone(n: number): boolean;
+  setWeekDone(n: number, done: boolean): void;
+  weeksDone(): number;
+  currentWeek(total: number): number;          // highest done + 1, clamped
+  landDone(land: { weeks: [number, number] }): boolean;
+  trackDone(track: 1 | 2): number;             // lessons done in that track's 24
+
+  // activity / streak
+  markActivity(dateISO?: string): void;
+  activityDates(): string[];
+  streak(todayISO?: string): number;           // gaps ≤ 2 days keep it alive
+
+  // identity + register
+  getName(): string;
+  setName(n: string): void;
+  getMode(): "story" | "classic";
+  setMode(m: "story" | "classic"): void;
+  totalStars(): number;                        // weeksDone + Σ game stars
+
+  // profiles
+  profiles(): { id: string; name: string; mode: "story" | "classic" }[];
+  activeId(): string;
+  addProfile(name: string, mode: "story" | "classic"): string;  // switches to it
+  switchProfile(id: string): boolean;
+  removeProfile(id: string): boolean;          // refuses to remove the last one
+};
+
+// Testable factory (no React) — persists through an injected storage.
+export function createProgressState(storage?: Storage): Progress;
+export function ProgressProvider(props): JSX.Element;   // loads/saves localStorage
+export function useProgress(): Progress;
+```
+
+- Persistence model (port `store.js`): one blob `{ active, seq, profiles: { [id]: Profile } }`; `Profile = { name, mode, weeks:{}, stars:{}, best:{}, solved:[], solved2:[], hunts:[], tactics:{}, activity:[], created }`. Every mutation calls a private `save()` (writes JSON, guarded try/catch for private mode). `touch()` adds today to activity on any real play (setWeekDone(true), setGameStars, setBest, setSolved*, setHuntSolved, setTacticSolved) — matches source.
+- Corrupt/unparseable blob → discard, start one blank profile (console.warn, no Sentry).
+- `ProgressProvider`: `createProgressState()` bound to `window.localStorage` after mount; version-bump on mutation (Phase C pattern) so consumers re-render. Before hydration (SSR/first paint) render children against a fresh in-memory state; swap to the persisted one in a mount effect.
+
+- [ ] **Step 1: Extend the failing test** — add, alongside the Phase C cases, a localStorage-shim suite porting `store.test.mjs` intent (no v1 migration): default single profile, add/switch/isolation/remove (refuses last), `setMode` on active only + never touches other profiles, weeks done/current/landDone/trackDone, activity dedupe + streak (`streak("2026-07-12")===3` for a ≤2-gap chain; alive 2 days after; dead after 3), `totalStars`, persistence across a fresh `createProgressState(sameStorage)` reload. Use a `Map`-backed fake `Storage`.
+- [ ] **Step 2: Run → fail** (`rtk proxy npx vitest run src/games/chess-quest/lib/__tests__/progress.test.ts`).
+- [ ] **Step 3: Implement** the profiles store + provider.
+- [ ] **Step 4: Run → pass**; also rerun the 8-game lib deps quickly (nothing else imports progress internals).
+- [ ] **Step 5: Commit** `feat(chess-quest): localStorage profiles store — lessons, streak, identity`.
+
+---
+
+### Task D2: Copy register from store + Quest header
+
+**Files:**
+- Modify: `apps/web/src/games/chess-quest/lib/copy.tsx` (register from a prop the hub feeds from `getMode()`, still overridable)
+- Create: `apps/web/src/games/chess-quest/components/quest/QuestHeader.tsx`
+
+**Interfaces:**
+- `QuestHeader` (port `renderHeader`, app.js:45–75): title (`{name}'s Chess Quest ♞`), a Players button (name + Story/Classic tag) that opens the profile panel (callback prop), a Progress button (callback), `⭐ {totalStars}`, `{weeksDone} / 48 days` with a fill bar, and the 9 land badges (glyph, `badge-won` when `landDone`). Taglines/footlines by register (verbatim).
+- `CopyProvider` gains no new API surface for games; the hub passes `register={progress.getMode()}` so switching a profile re-renders copy.
+
+- [ ] **Step 1: Implement** `QuestHeader` (Tailwind, Seazn palette; reuse `Rich` where copy has markup). No unit test (visual) — verified in D7.
+- [ ] **Step 2: Commit** `feat(chess-quest): quest header HUD + register wired to active profile`.
+
+---
+
+### Task D3: Quest map + lesson card
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/quest/QuestMap.tsx` (port `renderMap`, app.js:78–126)
+- Create: `apps/web/src/games/chess-quest/components/quest/LessonCard.tsx` (port `renderCard`, app.js:129–187)
+
+**Behavior contracts:**
+- `QuestMap`: Track 1/Track 2 headers ("First Steps" / "Rising Player"); per land a header (glyph, `Days {dayOf(lo)}–{dayOf(hi)}`, name, medal when `landDone`); stops for each lesson showing `✓` when done, a ♞ pony on the current stop (`currentWeek`, not done), else the day number; selected stop highlighted. Tapping a stop selects it (calls `onSelect(n)`).
+- `LessonCard`: for the selected lesson, render eyebrow (`{glyph} {land} · Day {dayOf(n)}`), title, Learn/Play/`Spark`|`Tip` rows (copy via `useCopy().t`, classic block when present), optional **diagram mini-board** (`<Board>` small, non-interactive, from `diagram.fen`, highlighting `diagram.from` + its `pieceTargets` when present), a **Play button** that launches the lesson's game (`gameOpts`) via an `onPlay(game, gameOpts)` prop, a **Mark-day-done** toggle (`setWeekDone`), and on the land's last lesson a "Level-up check" line (`land.check`/`checkClassic`). `GAME_LABEL` map (port app.js — e.g. squareRace → "Play Square Race", tacticTrainer → "Play Trick Shots", null game → no button).
+- [ ] **Step 1: Implement** `GAME_LABEL` + both components.
+- [ ] **Step 2: Browser-verify** in D7 (needs the hub wiring). No unit test.
+- [ ] **Step 3: Commit** `feat(chess-quest): quest map + lesson card`.
+
+---
+
+### Task D4: Profile panel + grown-ups drawer
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/quest/ProfilePanel.tsx` (port `renderProfilePanel`, app.js ~246–320)
+- Create: `apps/web/src/games/chess-quest/components/quest/GrownUpsDrawer.tsx` (port `renderGrownUps`, app.js:190–206)
+
+**Behavior contracts:**
+- `ProfilePanel` (modal): list profiles (name or "Player N", mode tag, active marker), Switch/Delete per row (Delete two-step "armed" confirm; refuses when only one remains), an add form (name input max 16 chars + Story/Classic choice → `addProfile`), a Story/Classic toggle for the active profile (`setMode`), and a name field (`setName`). Each write re-renders the hub (provider version bump). Hint line "Each player keeps their own progress, stars and streak."
+- `GrownUpsDrawer`: a `<details>` disclosure; content from `content/grown-ups.ts` (`GROWN_UPS`/`GROWN_UPS_CLASSIC` by register) — recipe steps, rules, toolbox, stuck — with the register-varied headings (verbatim).
+- [ ] **Step 1: Implement** both.
+- [ ] **Step 2: Commit** `feat(chess-quest): profile panel + grown-ups drawer`.
+
+---
+
+### Task D5: Progress panel
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/quest/ProgressPanel.tsx` (port `renderProgressPanel` + `last14Days`, app.js:357–441)
+
+**Behavior contract:** modal showing — stat tiles (day streak, `⭐ totalStars`, total puzzles solved = `solvedCount+solved2Count+huntCount+tacticTier1+tacticTier2`, days played); two track bars (Track 1 / Track 2, x/24); a 14-day dot strip (`last14Days`, filled where an activity date matches, weekday letters); a games table (9 rows: the 8 games + Trick Shots-Master, each with `starsGlyph(gameStars)` ★/☆ out of 3 and a detail cell — e.g. Mate in 1 `{solvedCount} / {MATE1.length}`, Trick Shots `{t1} / 13`, Square Race best). A "🖨 Print certificate" button (calls into D6). Content constants (MATE1/MATE2/HUNTS lengths) from `content/puzzles`.
+- [ ] **Step 1: Implement** `ProgressPanel` (+ a small pure `last14Days(todayISO?)` helper in `lib/` with a unit test: returns 14 entries, correct `on` flags for supplied activity dates).
+- [ ] **Step 2: Run the helper test → pass.**
+- [ ] **Step 3: Commit** `feat(chess-quest): progress panel with streak, tracks, 14-day strip`.
+
+---
+
+### Task D6: Printable certificate
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/quest/Certificate.tsx` (port `printCertificate`, app.js:445–483)
+- Modify: `apps/web/src/games/chess-quest/chess-quest.css` (add the `@media print` cert styles, port `css/style.css:490–531`)
+
+**Behavior contract:** a normally-hidden `.cq-cert-sheet`; `@media print` hides the app and shows only the certificate (hardcoded light palette). Title + line vary by tracks completed (both 24 → "Chess Quest Champion"; Track 1 only → "First Steps Champion"; Track 2 only → "Rising Player Champion"; else "Chess Quest Adventurer" with `{total} of 48`). Stats line (`⭐ totalStars · 🗓 days · 🏰 lands done/9`), date, "Coach Pony ♞". A `printCertificate()` populates it and calls `window.print()`. Determine title via a pure `certTitle(t1, t2)` helper (unit-tested for all four branches).
+- [ ] **Step 1: `certTitle` failing test → implement → pass.**
+- [ ] **Step 2: Implement** the component + print CSS.
+- [ ] **Step 3: Commit** `feat(chess-quest): printable quest certificate`.
+
+---
+
+### Task D7: Quest hub wiring + arcade tab + e2e
+
+**Files:**
+- Rewrite: `apps/web/src/games/chess-quest/index.tsx` — the quest becomes the landing.
+- Modify: `apps/web/e2e/games.spec.ts`
+
+**Hub structure:**
+- Providers: `ProgressProvider` wrapping a `CopyProvider register={progress.getMode()}`.
+- Two views toggled by a segmented control: **Quest** (default) and **Free play**.
+  - Quest view: `QuestHeader` (opens `ProfilePanel` / `ProgressPanel` modals) + a two-column layout — `QuestMap` (select a lesson) beside `LessonCard` for the selected lesson (single column on mobile) + `GrownUpsDrawer` below. `LessonCard.onPlay(game, gameOpts)` opens the matching Phase C game component full-screen with a "← Back to quest" bar; closing it returns to the map (progress persisted).
+  - Free play view: the existing 8-card arcade grid from Phase C (unchanged), each launching its game.
+- A single `GAME_COMPONENTS` registry maps game id → component so both the arcade and lesson launches share one wiring; lesson launches pass `gameOpts` (pieces/pack). Games not needing opts ignore them.
+- [ ] **Step 1: Rewrite `index.tsx`** with providers, Quest/Free-play toggle, modals, lesson→game launching, back navigation.
+- [ ] **Step 2: Browser-verify** end to end: pick a profile name + Classic; select Day 1 (Square Race) → Play → back; **Mark day done** → the stop shows ✓, header "1 / 48 days", star total up; open Progress → streak 1, Track 1 1/24; switch to Free play → arcade still works; add a second profile → its map is empty (isolation); reload the page → first profile's progress survives.
+- [ ] **Step 3: Update e2e** (`--project=parallel --no-deps`): quest landing shows the map + Day 1 card; clicking "Mark day done" flips the header day count and the stop to ✓ (assert persisted via a `page.reload()`); a lesson "Play" launches its game (e.g. Day 7 → Mate in 1, solve e1→e8→Checkmate); the Free-play toggle shows the 8-card arcade. (localStorage persists within the browser context across reloads.)
+- [ ] **Step 4: Run e2e → pass. Commit** `feat(chess-quest): quest hub — map, lessons launch games, profiles; arcade as free play`.
+
+---
+
+### Task D8: Full verification + demo
+
+- [ ] **Step 1:** `rtk proxy npx vitest run` (all green), `rtk proxy npx eslint src/games` (0 errors), `rtk proxy npm run build` (clean).
+- [ ] **Step 2: Browser demo:** screenshot the quest map (with a couple of days done + a land badge earned), a lesson card with its diagram, the progress panel (streak + 14-day strip), and a print-preview of the certificate.
+- [ ] **Step 3: Push** (PR #92 / successor per finishing-a-development-branch).
+
+---
+
+### Out of scope (Phase E)
+
+- Real sounds, speech voice, confetti (the `lib/sfx` no-op and text ★ stay until E).
+- Account-linked (Postgres) progress sync — still deferred; the localStorage key is namespaced so a later sync layer can migrate it.
+- Minimax play-vs-computer opponent.

--- a/docs/superpowers/specs/2026-07-14-seazn-games-chess-quest-design.md
+++ b/docs/superpowers/specs/2026-07-14-seazn-games-chess-quest-design.md
@@ -1,0 +1,176 @@
+# Seazn Games platform + Chess Quest — design
+
+**Date:** 2026-07-14
+**Status:** Approved (design review 2026-07-14)
+
+## Goal
+
+Add a games surface to seazn.club: a branded listing of playable browser games at
+`seazn.club/games` (also served as `games.seazn.club`), each game playable at
+`seazn.club/games/<slug>`. First game: **Chess Quest**, a ground-up TypeScript/React
+rewrite of the standalone chess-learning PWA (`~/GitHub/chess-quest`), re-skinned to
+the Seazn design language. The platform must make adding future games cheap: one
+folder + one registry entry.
+
+Decisions locked during design review:
+
+| Decision | Choice |
+|----------|--------|
+| Integration approach | Ground-up React rewrite inside `apps/web` (no iframe, no vendored static bundle) |
+| URL slugs | Descriptive (`/games/chess-quest`), not numbered |
+| Progress storage | localStorage v1 (account/Postgres sync is a later phase) |
+| Visual identity | Seazn design language (Tailwind v4, existing tokens), not the original Chess Quest theme |
+| Content | Code is new; curriculum/puzzle **content** (48 lessons, 2 tracks, 9 lands, puzzle FENs, Story/Classic copy) is carried over from chess-quest data files, re-typed in TS |
+| PWA | None for games v1 — no service worker, no separate manifest (SW staleness burned us in chess-quest dev) |
+| Original repo | `~/GitHub/chess-quest` and the kid's play copy stay untouched; this is a fork-by-rewrite |
+
+## Architecture
+
+### 1. Games platform (`apps/web/src/games/`)
+
+New top-level folder inside the web app. Everything game-related lives here except
+the two route files.
+
+- **`src/games/registry.ts`** — the single source of truth for what games exist.
+  ```ts
+  type GameMeta = {
+    slug: string;          // URL segment: /games/<slug>
+    title: string;
+    tagline: string;       // one-liner for the listing card
+    description: string;   // longer copy for SEO/meta
+    thumbnail: string;     // emoji or /public path for the card art
+    status: "live" | "coming-soon";
+  };
+  ```
+  Each entry pairs `GameMeta` with a lazy component loader
+  (`() => import("./chess-quest")`) so game code is code-split per game and the
+  listing page ships none of it. Adding a game later = new `src/games/<slug>/`
+  folder + one registry entry.
+
+- **`app/(public)/games/page.tsx`** — listing page. Seazn-branded card grid from the
+  registry (server component; metadata for SEO). `coming-soon` games render as
+  non-clickable cards.
+
+- **`app/(public)/games/[slug]/page.tsx`** — player page. Server shell resolves the
+  slug against the registry (404 on miss via `notFound()`), renders a slim header
+  bar ("← Games", game title) above a full-viewport client component loaded via the
+  registry's lazy loader. `generateStaticParams` from the registry;
+  `generateMetadata` from `GameMeta`.
+
+- **Note:** repo `AGENTS.md` warns this Next.js version differs from training data —
+  read `node_modules/next/dist/docs/` for routing/metadata conventions before
+  writing the route files.
+
+### 2. Subdomain wiring (`src/proxy.ts`)
+
+Host-based rewrite added to the existing proxy:
+
+- Requests with host `games.seazn.club` (and `games.` + staging host) rewrite into
+  the `/games` tree: `/` → `/games`, `/<slug>` → `/games/<slug>`. Static/_next asset
+  requests pass through untouched (matcher already excludes them).
+- Guard against double-prefixing (`games.seazn.club/games/x` must not become
+  `/games/games/x`).
+- Canonical URLs on both routes point at `https://seazn.club/games/...` so the
+  subdomain doesn't split SEO.
+- CSRF check in the proxy compares Origin host to app host — verify a
+  `games.seazn.club` page never posts to `/api/*`; games v1 makes no API calls, so
+  no change needed, but the e2e smoke should confirm pages render on the subdomain.
+- `sitemap.ts` gains `/games` + one entry per live game.
+- **Manual infra (user action, not code):** DNS CNAME `games.seazn.club` → Fly app;
+  `fly certs add games.seazn.club` (staging likewise if desired).
+
+CSP needs no carve-out: these are normal React pages and get the per-request nonce
+like every other route.
+
+### 3. Chess Quest (`src/games/chess-quest/`)
+
+Ground-up rewrite, organized so each unit is independently testable:
+
+- **`engine/`** — pure TS, zero DOM. Board representation (64-array, same square
+  indexing as the original for content compatibility), move generation per piece,
+  legality (own-king safety), check/checkmate/stalemate detection, and the puzzle
+  verifiers: `hasMateIn1`, `isMateIn2After` (move → every reply → mate-in-1),
+  `bestDefense` (reply minimizing mating continuations). Castling/en passant/
+  promotion to the extent the curriculum needs them (original engine scope).
+- **`content/`** — typed data modules: `lands.ts` (9 lands incl. Track 2: ♗
+  Combination Canyon, ♞ Opening Harbor, ♜ Endgame Glacier, ♛ Strategy Summit),
+  `lessons.ts` (48 lessons, Track 1 = 1–24, Track 2 = 25–48, each with `game` id +
+  `gameOpts`), `puzzles.ts` (MATE1, MATE2 — 12 puzzles, TACTICS fork/pin/skewer/
+  discovered incl. the 2-move variants), `copy.ts` (Story vs Classic register — the
+  kid voice and adult coaching voice — with a `t()`-style lookup). Content is
+  transcribed from the chess-quest data files, not re-authored.
+- **`components/`** — React, Tailwind v4 with Seazn tokens (reference
+  `app/globals.css` + existing public pages for palette/spacing/typography):
+  - `Board` — interactive chessboard (tap-tap move selection like the original;
+    drag optional later), legal-move hints, last-move + check highlights.
+  - Eight mini-games, one component each, sharing a `GameShell` (status line,
+    coach messages, star award, next/retry): `SquareRace`, `CoinHop`, `PawnWars`,
+    `MateInOne`, `MateInTwo` (two-phase: forcing move → auto black best-defense →
+    finish mate; accepts any verified forcing move), `HangingHunt`,
+    `TacticTrainer`, `RookMaze`.
+  - `QuestMap` — lesson map with Track 1/Track 2 section headers, land groupings,
+    stars, lock/unlock state.
+  - `ProgressPanel` — streak (activity-date chain, gaps ≤ 2 days), stat tiles,
+    track progress bars, 14-day dot strip, stars/packs table.
+  - `ProfileSwitcher` — create/select/rename profiles; per-profile copy register
+    (Story/Classic).
+  - `Certificate` — printable; print CSS swaps the page for a light-palette cert
+    sheet; title varies by tracks completed.
+- **`store/`** — localStorage persistence under key `seazn-games:chess-quest:v1`
+  (fresh key — no migration from the standalone app; different origin anyway).
+  Profiles, per-profile progress (stars, completed lessons, activity dates),
+  settings. Exposed to React through a context + `useQuestStore()` hook; writes are
+  synchronous on state change; boot hydration guarded for SSR (`typeof window`).
+- **Timers:** all game timers (solve-advance delays, black-reply delays, coach
+  resets) live inside components via `useEffect` cleanup — the original's leaked-
+  setTimeout bug class is structurally prevented; no shared timer registry needed.
+- **Audio/voice:** small `useSfx` (WebAudio beeps) + `useVoice`
+  (speechSynthesis) hooks, both no-op when unavailable. CSP-safe (no external
+  fetches).
+
+### 4. Error handling
+
+- Unknown slug → `notFound()`.
+- Corrupt/unparseable localStorage → discard and start fresh (v1 key only; log to
+  console, no Sentry noise).
+- Engine verifier failures on content are build-time concerns caught by tests, not
+  runtime paths.
+
+### 5. Testing
+
+- **Vitest (apps/web already configured):**
+  - `engine` unit tests — move gen per piece, legality, check/mate/stalemate,
+    mate-in-1/2 verifiers (port the *intent* of `chess-quest/test/engine.test.mjs`).
+  - **Content verification suite** — every MATE1 puzzle has ≥1 mate-in-1; every
+    MATE2/TACTICS2 puzzle passes `isMateIn2After` with **no hidden mate-in-1**
+    (this check caught two bad promotion puzzles before); curriculum shape (48
+    lessons, ids unique, every `game` id exists in the mini-game set).
+  - `store` tests — profiles, streak chain (≤2-day gaps), corrupt-state recovery
+    (localStorage shim like the original store tests).
+  - Registry/route tests — every registry slug resolves a component; metadata
+    complete.
+- **Playwright e2e (repo already has a suite):** smoke — `/games` lists Chess
+  Quest; `/games/chess-quest` boots to profile/map; host-rewrite check for the
+  subdomain (Playwright `extraHTTPHeaders` Host or local hosts mapping, matching
+  however existing e2e handles hosts).
+
+### 6. Phased delivery
+
+| Phase | Scope | Ships |
+|-------|-------|-------|
+| A | Platform shell: registry, `/games` listing, `/games/[slug]` player chrome, proxy host rewrite, sitemap; Chess Quest registered as `coming-soon` | Listing live end-to-end incl. subdomain |
+| B | Engine + content + verification tests | Pure logic, fully green |
+| C | Board + the 8 mini-games (free-play entry from a simple menu) | Chess Quest flips to `live` |
+| D | Quest map, profiles, store, progress panel, certificate | Full quest experience |
+| E | Sfx/voice, SEO polish, e2e smoke, listing card art | Launch quality |
+
+Each phase lands as a normal PR through the repo's usual checks.
+
+## Out of scope (v1)
+
+- Account-linked progress in Postgres (explicitly deferred; localStorage key is
+  namespaced so a later sync layer can migrate it).
+- PWA/offline for games.
+- Minimax play-vs-computer opponent (was "next candidate" in chess-quest; still
+  future).
+- Any change to the standalone chess-quest repo.


### PR DESCRIPTION
Adds a games surface to seazn.club and integrates Chess Quest as the first game — a ground-up TypeScript/React rewrite of the standalone chess-learning app, re-skinned to Seazn.

## What's here (phases A–E)
- **Platform** — `/games` listing + `/games/[slug]` player, a pure-data registry (new game = one folder + one entry), `games.seazn.club` host rewrite, sitemap, "Powered by Seazn Club" link. Canonicals stay on the apex domain.
- **Engine + content** — pure TS chess engine (moves, mate-in-2 verifier, tactic detectors) and every puzzle/lesson transcribed verbatim from the original and **machine-verified** (65 puzzle checks, incl. no-hidden-mate-in-1).
- **8 mini-games** — Square Race, Coin Hop, Pawn Wars, Mate in 1, Mate in 2 (two-phase), Piece Detective, Trick Shots, Rook Maze — classic Cburnett SVG pieces (CC BY-SA 3.0).
- **The 48-day quest** — quest map over 9 lands, lesson cards that launch each lesson's game via its `gameOpts`, localStorage **player profiles** (streak, stars, Story/Classic register), progress panel, printable certificate. Free-play arcade as a second tab.
- **Polish** — real WebAudio sfx, offline speech-synthesis coach voice, confetti on wins, device mute/voice toggles.

## Test plan
- [x] Vitest: 813 passing (engine, content verification, store/profiles/streak, star rules, helpers)
- [x] Playwright: `e2e/games.spec.ts` — listing, quest map, mark-done persistence across reload, lesson launches game, free-play solve (e1→e8→Checkmate), subdomain rewrite
- [x] `npm run build` clean; browser-verified all 8 games, the quest flow, profiles, progress, certificate, audio
- Pre-existing lint error in `verify-email.tsx` (on main) is unrelated; games tree lints clean but for one tolerated Board shake-animation warning

## Post-merge (manual infra)
- DNS CNAME `games.seazn.club` → Fly app
- `fly certs add games.seazn.club`

Specs + phase plans under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)