### PR TITLE
feat(games): add Games link to the site footer

### DIFF
--- a/apps/web/src/components/marketing-footer.tsx
+++ b/apps/web/src/components/marketing-footer.tsx
@@ -9,6 +9,7 @@ const COLS: Array<{ head: string; links: Array<{ label: string; href: string }> 
       { label: "Scheduling", href: "/scheduling" },
       { label: "Pricing", href: "/pricing" },
       { label: "Live now", href: "/discover" },
+      { label: "Games", href: "/games" },
     ],
   },
   {


### PR DESCRIPTION
Surfaces the new games section from the site footer for discoverability — adds **Games** → `/games` under the Product column, next to Live now.

## Test plan
- [x] eslint clean
- One-line link addition; renders in the shared `MarketingFooter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)