### PR TITLE
feat(games): Chess Quest Track 3 — Opening Trainer + playable opening lessons

### DIFF
--- a/apps/web/e2e/games.spec.ts
+++ b/apps/web/e2e/games.spec.ts
@@ -47,6 +47,19 @@ test("free-play arcade lists the eight games and one solves", async ({ page }) =
   await expect(page.getByText(/Checkmate/)).toBeVisible();
 });
 
+test("an Opening Trainer lesson launches and takes the first move", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
+  await page.reload();
+  await page.getByRole("button", { name: "Free play" }).click();
+  await page.getByRole("button", { name: /Opening Trainer/ }).click();
+  await expect(page.getByText(/The Italian Game/)).toBeVisible();
+  // First learner move in the Italian: e2–e4.
+  await page.locator('[data-square="e2"]').click();
+  await page.locator('[data-square="e4"]').click();
+  await expect(page.locator('[data-square="e4"]')).toHaveAttribute("aria-label", /white pawn/);
+});
+
 test("unknown game slug 404s", async ({ page }) => {
   const res = await page.goto("/games/not-a-game");
   expect(res?.status()).toBe(404);

--- a/apps/web/src/app/games/[slug]/page.tsx
+++ b/apps/web/src/app/games/[slug]/page.tsx
@@ -31,16 +31,14 @@ export default async function GamePage({ params }: { params: Promise<Params> }) 
 
   return (
     <div className="flex min-h-dvh flex-col bg-white">
-      <header className="flex items-center gap-3 border-b border-slate-200 px-4 py-2">
+      <header className="flex flex-wrap items-center justify-center gap-3 border-b border-slate-200 px-4 py-2">
         <Link href="/games" className="text-sm font-medium text-purple-600 hover:text-purple-800">
           ← Games
         </Link>
         <span className="text-sm text-slate-300">|</span>
         <h1 className="mk-display text-base font-bold text-purple-950">{game.title}</h1>
-        <Link
-          href="/"
-          className="ml-auto text-xs text-slate-400 hover:text-purple-600"
-        >
+        <span className="text-sm text-slate-300">|</span>
+        <Link href="/" className="text-xs text-slate-400 hover:text-purple-600">
           Powered by <span className="font-semibold">Seazn Club</span>
         </Link>
       </header>

--- a/apps/web/src/components/marketing-footer.tsx
+++ b/apps/web/src/components/marketing-footer.tsx
@@ -9,6 +9,7 @@ const COLS: Array<{ head: string; links: Array<{ label: string; href: string }> 
       { label: "Scheduling", href: "/scheduling" },
       { label: "Pricing", href: "/pricing" },
       { label: "Live now", href: "/discover" },
+      { label: "Games", href: "/games" },
     ],
   },
   {

--- a/apps/web/src/games/chess-quest/components/games/OpeningTrainer.tsx
+++ b/apps/web/src/games/chess-quest/components/games/OpeningTrainer.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+// Opening Trainer — play a named opening move by move. The trainer auto-plays
+// the book replies; you play your side's moves until the line is complete.
+// Repetition builds the opening into muscle memory ("play it fifty times").
+import { useCallback, useEffect, useState } from "react";
+import { applyMove, isWhitePiece, legalTargets, parseFEN, sqIdx } from "../../engine";
+import { OPENINGS } from "../../content/openings";
+import { celebrate } from "../../lib/celebrate";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { voice } from "../../lib/voice";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+
+const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+export function OpeningTrainer({ opening }: { opening: string }) {
+  const op = OPENINGS[opening] ?? OPENINGS.italian;
+  const progress = useProgress();
+  const { later, clearPending } = useLater();
+
+  const learnerPly = useCallback(
+    (i: number) => (i % 2 === 0) === (op.learnerSide === "white"),
+    [op.learnerSide],
+  );
+
+  const promptFor = useCallback(
+    (i: number) => {
+      if (i >= op.line.length) return `<strong>${op.name}</strong> — line complete!`;
+      return learnerPly(i)
+        ? `Your move: play <strong>${op.line[i].san}</strong>. Tap the glowing piece, then its square.`
+        : `<strong>${op.name}</strong> — watch the reply…`;
+    },
+    [op, learnerPly],
+  );
+
+  const [position, setPosition] = useState<string[]>(() => parseFEN(START).board);
+  const [ply, setPly] = useState(0);
+  const [selIdx, setSelIdx] = useState(-1);
+  const [mistakes, setMistakes] = useState(0);
+  const [done, setDone] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+  const [status, setStatus] = useState(() => promptFor(0));
+
+  const learnerMovesTotal = op.line.filter((_, i) => learnerPly(i)).length;
+
+  // "Play again" / "Restart" — each launch is a fresh mount, so this only runs
+  // from the button.
+  const reset = useCallback(() => {
+    clearPending();
+    setPosition(parseFEN(START).board);
+    setPly(0);
+    setSelIdx(-1);
+    setMistakes(0);
+    setDone(false);
+    setHighlights({});
+    setStatus(promptFor(0));
+  }, [clearPending, promptFor]);
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  // Auto-play opponent moves; glow the learner's from-square on their turn.
+  useEffect(() => {
+    if (done || ply >= op.line.length) return;
+    if (!learnerPly(ply)) {
+      later(() => {
+        const mv = op.line[ply];
+        setPosition((pos) => applyMove(pos, sqIdx(mv.from), sqIdx(mv.to)));
+        setPop({ idx: sqIdx(mv.to), n: popN + 1 });
+        setPopN((v) => v + 1);
+        sfx.move();
+        setPly((p) => p + 1);
+      }, 550);
+    } else {
+      setHighlights({ [sqIdx(op.line[ply].from)]: "hint" });
+      setStatus(promptFor(ply));
+    }
+    // ply drives the sequence; the setters/refs are stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ply, done]);
+
+  function finish() {
+    setDone(true);
+    setHighlights({});
+    const stars = STAR_RULES.openingTrainer(mistakes);
+    progress.setGameStars("openingTrainer", stars);
+    setStatus(`<strong>${op.name}</strong> — you played the whole line! ${"★".repeat(stars)}`);
+    voice.say(`${op.name}. You played the whole line!`);
+    celebrate();
+  }
+
+  function onLearnerMove(from: number, to: number) {
+    const mv = op.line[ply];
+    if (from === sqIdx(mv.from) && to === sqIdx(mv.to)) {
+      setPosition(applyMove(position, from, to));
+      setPop({ idx: to, n: popN + 1 });
+      setPopN((v) => v + 1);
+      sfx.move();
+      setSelIdx(-1);
+      const nextPly = ply + 1;
+      setPly(nextPly);
+      if (nextPly >= op.line.length) finish();
+    } else {
+      setSelIdx(-1);
+      setMistakes((x) => x + 1);
+      setShake((s) => s + 1);
+      sfx.bad();
+      setStatus(
+        `Not the book move — the ${op.name} plays <strong>${mv.san}</strong> here. Follow the glowing piece.`,
+      );
+      setHighlights({ [sqIdx(mv.from)]: "hint" });
+    }
+  }
+
+  function onTap(idx: number) {
+    if (done || ply >= op.line.length || !learnerPly(ply)) return;
+    const pos = position;
+    const p = pos[idx];
+    const mine = p !== "" && isWhitePiece(p) === (op.learnerSide === "white");
+    if (mine) {
+      setSelIdx(idx);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of legalTargets(pos, idx)) hl[t] = pos[t] === "" ? "move" : "cap";
+      hl[sqIdx(op.line[ply].from)] = "hint";
+      setHighlights(hl);
+      return;
+    }
+    if (selIdx >= 0 && legalTargets(pos, selIdx).includes(idx)) {
+      onLearnerMove(selIdx, idx);
+    } else if (selIdx >= 0) {
+      setShake((s) => s + 1);
+    }
+  }
+
+  const doneLearnerMoves = op.line.slice(0, ply).filter((_, i) => learnerPly(i)).length;
+
+  return (
+    <GameShell
+      title={`Opening Trainer — ${op.name}`}
+      score={`move ${doneLearnerMoves}/${learnerMovesTotal}`}
+      status={status}
+      extra={<p className="text-center text-xs italic text-slate-500">{op.idea}</p>}
+      controls={
+        <button type="button" className="btn btn-ghost" onClick={reset}>
+          {done ? "Play again" : "Restart"}
+        </button>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}

--- a/apps/web/src/games/chess-quest/components/quest/Certificate.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/Certificate.tsx
@@ -11,7 +11,8 @@ export function Certificate() {
   const name = progress.getName() || "This player";
   const t1 = progress.trackDone(1);
   const t2 = progress.trackDone(2);
-  const { title, line } = certTitle(t1, t2);
+  const t3 = progress.trackDone(3);
+  const { title, line } = certTitle(t1, t2, t3);
   const landsDone = LANDS.filter((l) => progress.landDone(l)).length;
   const date = new Date().toLocaleDateString(undefined, {
     year: "numeric",

--- a/apps/web/src/games/chess-quest/components/quest/ProgressPanel.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/ProgressPanel.tsx
@@ -95,6 +95,7 @@ export function ProgressPanel({ onClose, onPrint }: { onClose(): void; onPrint()
       <div className="mt-2 flex flex-col gap-2">
         <TrackBar label="Track 1 · First Steps" done={progress.trackDone(1)} total={24} />
         <TrackBar label="Track 2 · Rising Player" done={progress.trackDone(2)} total={24} />
+        <TrackBar label="Track 3 · Opening Range" done={progress.trackDone(3)} total={5} />
       </div>
 
       <h3 className="mk-display mt-5 font-bold text-purple-950">Last 14 days</h3>

--- a/apps/web/src/games/chess-quest/components/quest/QuestMap.tsx
+++ b/apps/web/src/games/chess-quest/components/quest/QuestMap.tsx
@@ -32,7 +32,7 @@ export function QuestMap({
                   Track {track}
                 </span>
                 <span className="mk-display text-sm font-bold text-purple-900">
-                  {track === 1 ? "First Steps" : "Rising Player"}
+                  {track === 1 ? "First Steps" : track === 2 ? "Rising Player" : "Opening Range"}
                 </span>
               </div>
             ) : null}

--- a/apps/web/src/games/chess-quest/components/quest/questData.ts
+++ b/apps/web/src/games/chess-quest/components/quest/questData.ts
@@ -15,6 +15,7 @@ export const GAME_LABEL: Record<GameId, string> = {
   hangingHunt: "▶ Play Piece Detective",
   tacticTrainer: "▶ Play Trick Shots",
   rookMaze: "▶ Play Rook Maze",
+  openingTrainer: "▶ Play the opening",
 };
 
 // The active register's copy for a lesson.

--- a/apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts
+++ b/apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts
@@ -3,6 +3,7 @@ import { parseFEN } from "../../engine";
 import { LANDS } from "../lands";
 import { LESSONS } from "../lessons";
 import { TACTICS, TACTICS2 } from "../puzzles";
+import { OPENING_IDS } from "../openings";
 
 const GAME_IDS = [
   "squareRace",
@@ -13,16 +14,17 @@ const GAME_IDS = [
   "hangingHunt",
   "tacticTrainer",
   "rookMaze",
+  "openingTrainer",
 ];
 
 describe("curriculum shape", () => {
-  it("48 lessons, numbered 1..48 in order", () => {
-    expect(LESSONS).toHaveLength(48);
+  it("53 lessons, numbered 1..53 in order", () => {
+    expect(LESSONS).toHaveLength(53);
     LESSONS.forEach((l, i) => expect(l.n).toBe(i + 1));
   });
-  it("9 lands tiling lessons 1..48 exactly once", () => {
-    expect(LANDS).toHaveLength(9);
-    const seen = new Array(49).fill(0);
+  it("10 lands tiling lessons 1..53 exactly once", () => {
+    expect(LANDS).toHaveLength(10);
+    const seen = new Array(54).fill(0);
     for (const land of LANDS) {
       for (let i = land.weeks[0]; i <= land.weeks[1]; i++) seen[i]++;
     }
@@ -37,6 +39,13 @@ describe("curriculum shape", () => {
   it("track 2 lands cover lessons 25..48 only", () => {
     for (const land of LANDS.filter((l) => l.track === 2)) {
       expect(land.weeks[0]).toBeGreaterThanOrEqual(25);
+      expect(land.weeks[1]).toBeLessThanOrEqual(48);
+    }
+  });
+  it("track 3 lands cover lessons 49..53 only", () => {
+    for (const land of LANDS.filter((l) => l.track === 3)) {
+      expect(land.weeks[0]).toBeGreaterThanOrEqual(49);
+      expect(land.weeks[1]).toBeLessThanOrEqual(53);
     }
   });
   it("every land has both check registers", () => {
@@ -71,6 +80,12 @@ describe("curriculum shape", () => {
       const pack = l.gameOpts?.pack ?? "";
       const exists = pack in TACTICS || pack in TACTICS2;
       expect(exists, `lesson ${l.n} pack "${pack}"`).toBe(true);
+    }
+  });
+  it("opening-trainer lessons name a real opening", () => {
+    for (const l of LESSONS.filter((x) => x.game === "openingTrainer")) {
+      const op = l.gameOpts?.opening ?? "";
+      expect(OPENING_IDS, `lesson ${l.n}`).toContain(op);
     }
   });
 });

--- a/apps/web/src/games/chess-quest/content/__tests__/openings.test.ts
+++ b/apps/web/src/games/chess-quest/content/__tests__/openings.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isWhitePiece, legalTargets, applyMove, parseFEN, sqIdx } from "../../engine";
+import { OPENINGS, OPENING_IDS } from "../openings";
+
+const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+describe("openings are engine-legal mainlines", () => {
+  it("has the five classic-set openings", () => {
+    expect([...OPENING_IDS].sort()).toEqual(
+      ["italian", "london", "ruyLopez", "scandinavian", "scotch"].sort(),
+    );
+  });
+
+  it.each(OPENING_IDS.map((id) => [id, OPENINGS[id]] as const))("%s replays legally", (_id, op) => {
+    let board = parseFEN(START).board;
+    let whiteToMove = true;
+    for (const mv of op.line) {
+      const from = sqIdx(mv.from);
+      const to = sqIdx(mv.to);
+      expect(board[from]).not.toBe("");
+      expect(isWhitePiece(board[from])).toBe(whiteToMove);
+      expect(legalTargets(board, from), `${op.id} ${mv.san}`).toContain(to);
+      board = applyMove(board, from, to);
+      whiteToMove = !whiteToMove;
+    }
+    // the learner actually moves in this line
+    expect(op.line.some((_, i) => (i % 2 === 0) === (op.learnerSide === "white"))).toBe(true);
+    expect(op.idea.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/games/chess-quest/content/lands.ts
+++ b/apps/web/src/games/chess-quest/content/lands.ts
@@ -9,7 +9,7 @@ export type Land = {
   goal: string;
   check: string; // Story register
   checkClassic: string; // Classic register
-  track?: 2; // present on Track 2 lands only
+  track?: 2 | 3; // present on Track 2 / Track 3 lands only
 };
 
 export const LANDS: Land[] = [
@@ -103,5 +103,16 @@ export const LANDS: Land[] = [
     check: "She picks moves from a candidate list, and her own games become her study book.",
     checkClassic:
       "You choose from candidate moves, exploit outposts and files, and mine every game you play for lessons.",
+  },
+  {
+    id: 10,
+    glyph: "♚",
+    name: "Opening Range",
+    weeks: [49, 53],
+    track: 3,
+    goal: "Turn opening rules into real repertoire — play five sound openings by hand.",
+    check: "She plays the Italian, Ruy Lopez, Scotch, London and Scandinavian from memory.",
+    checkClassic:
+      "You reproduce five standard openings move-for-move and can state each one’s plan.",
   },
 ];

--- a/apps/web/src/games/chess-quest/content/lessons.ts
+++ b/apps/web/src/games/chess-quest/content/lessons.ts
@@ -11,7 +11,8 @@ export type GameId =
   | "mateInTwo"
   | "hangingHunt"
   | "tacticTrainer"
-  | "rookMaze";
+  | "rookMaze"
+  | "openingTrainer";
 
 export type LessonCopy = { learn: string; play: string; spark: string };
 
@@ -20,7 +21,7 @@ export type Lesson = {
   land: number; // owning land id (1..9)
   title: string;
   game: GameId | null; // null = play on a real board
-  gameOpts?: { pieces?: string[]; pack?: string };
+  gameOpts?: { pieces?: string[]; pack?: string; opening?: string };
   learn: string;
   play: string;
   spark: string; // Story register
@@ -362,7 +363,8 @@ export const LESSONS: Lesson[] = [
     n: 19,
     land: 5,
     title: "Her First Opening",
-    game: null,
+    game: "openingTrainer",
+    gameOpts: { opening: "italian" },
     learn:
       "One recipe, both colors. White: e4, knight f3, bishop c4, castle (the Italian Game). Black against e4: mirror it.",
     play: "The same opening in every game. No memorizing — just a familiar, safe start.",
@@ -580,7 +582,8 @@ export const LESSONS: Lesson[] = [
     n: 31,
     land: 7,
     title: "The Italian, With a Plan",
-    game: null,
+    game: "openingTrainer",
+    gameOpts: { opening: "italian" },
     learn:
       "You know the Italian moves — now the WHY: the bishop eyes f7, the knight guards e5, castling connects the rooks. Every move has a job.",
     play: "Play the Italian and say each piece’s job out loud as it develops. Then swap colors and say black’s jobs.",
@@ -910,6 +913,86 @@ export const LESSONS: Lesson[] = [
       play: "A notated best-of-three at slow pace, fully analyzed afterwards. Then the Mate in 2 pack clean — no hints, no misses.",
       spark:
         "From here it’s rated games, a club, and a puzzle habit. The method you built is the same one titled players use — just add miles.",
+    },
+  },
+
+  /* ---- Track 3: Opening Range (lessons 49–53, Days 97–105) ---- */
+  {
+    n: 49,
+    land: 10,
+    title: "The Italian Game",
+    game: "openingTrainer",
+    gameOpts: { opening: "italian" },
+    learn: "e4, Knight f3, Bishop c4 — the friendly Italian. The bishop stares at f7.",
+    play: "Play the Italian in the trainer until the moves feel automatic. No reading — just play!",
+    spark: "Same three moves every game. Soon your hands know them before your head does.",
+    classic: {
+      learn: "1.e4 e5 2.Nf3 Nc6 3.Bc4 Bc5 — the Italian: rapid development, pressure on f7.",
+      play: "Drill the line in the trainer until it’s reflex, both the moves and the reason.",
+      spark: "Repetition, not theory. One opening played fifty times beats five played ten.",
+    },
+  },
+  {
+    n: 50,
+    land: 10,
+    title: "The Ruy Lopez",
+    game: "openingTrainer",
+    gameOpts: { opening: "ruyLopez" },
+    learn: "Like the Italian, but the bishop goes to b5 to bother the knight guarding e5.",
+    play: "Play the Ruy Lopez line in the trainer. Feel how Bb5 pins the defender.",
+    spark: "The “Spanish torture” — slow, sound pressure the pros still play today.",
+    classic: {
+      learn:
+        "1.e4 e5 2.Nf3 Nc6 3.Bb5 a6 — the Ruy Lopez: pressure the e5 defender, keep long-term bind.",
+      play: "Drill it; note how Bb5 targets the knight, not the pawn directly.",
+      spark: "The most respected 1.e4 e5 opening — worth owning even at club level.",
+    },
+  },
+  {
+    n: 51,
+    land: 10,
+    title: "The Scotch Game",
+    game: "openingTrainer",
+    gameOpts: { opening: "scotch" },
+    learn: "Punch the centre open early with d4, then grab the pawn back with the knight.",
+    play: "Play the Scotch in the trainer: e4, Nf3, d4, take, take with the knight.",
+    spark: "Open lines fast — great when you like lively, attacking games.",
+    classic: {
+      learn:
+        "1.e4 e5 2.Nf3 Nc6 3.d4 exd4 4.Nxd4 — the Scotch: early central break, quick development lead.",
+      play: "Drill the capture sequence until the recapture on d4 is automatic.",
+      spark: "A clean way to avoid heavy Ruy Lopez theory while staying principled.",
+    },
+  },
+  {
+    n: 52,
+    land: 10,
+    title: "The London System",
+    game: "openingTrainer",
+    gameOpts: { opening: "london" },
+    learn: "A calm setup with d4, Nf3 and the bishop out to f4 — plays against almost anything.",
+    play: "Play the London in the trainer. Same easy setup, game after game.",
+    spark: "Low-stress, high-reward: a system you can lean on when you’re tired.",
+    classic: {
+      learn: "1.d4 d5 2.Nf3 Nf6 3.Bf4 — the London: a solid, low-theory system with a clear plan.",
+      play: "Drill the setup; the move order is flexible but the pieces always land the same.",
+      spark: "Ideal one-system repertoire for busy players — minimal memorization.",
+    },
+  },
+  {
+    n: 53,
+    land: 10,
+    title: "The Scandinavian Defense",
+    game: "openingTrainer",
+    gameOpts: { opening: "scandinavian" },
+    learn: "Now you’re Black! Answer e4 with d5 right away, take, then bring the queen to a5 safely.",
+    play: "Play the Scandinavian in the trainer as Black. Hit the centre from move one.",
+    spark: "One opening that works against e4 every single time — no surprises.",
+    classic: {
+      learn:
+        "1.e4 d5 2.exd5 Qxd5 3.Nc3 Qa5 — the Scandinavian: immediate central challenge as Black, queen tucked on a5.",
+      play: "Drill it as Black; learn to develop with tempo after the queen settles.",
+      spark: "A dependable, low-theory answer to 1.e4 you can rely on under pressure.",
     },
   },
 ];

--- a/apps/web/src/games/chess-quest/content/openings.ts
+++ b/apps/web/src/games/chess-quest/content/openings.ts
@@ -1,0 +1,89 @@
+// Opening mainlines for the Opening Trainer. Each line is 3–5 development plies
+// (no castling — the engine doesn't model it, and the setup is the beginner
+// takeaway). Every move is verified engine-legal by content/__tests__.
+
+export type OpeningMove = { from: string; to: string; san: string };
+export type Opening = {
+  id: string;
+  name: string;
+  learnerSide: "white" | "black";
+  line: OpeningMove[]; // full sequence, both sides, in play order
+  idea: string;
+};
+
+const m = (from: string, to: string, san: string): OpeningMove => ({ from, to, san });
+
+export const OPENINGS: Record<string, Opening> = {
+  italian: {
+    id: "italian",
+    name: "The Italian Game",
+    learnerSide: "white",
+    line: [
+      m("e2", "e4", "e4"),
+      m("e7", "e5", "e5"),
+      m("g1", "f3", "Nf3"),
+      m("b8", "c6", "Nc6"),
+      m("f1", "c4", "Bc4"),
+      m("f8", "c5", "Bc5"),
+    ],
+    idea: "Take the centre, aim the bishop at f7, and get ready to castle.",
+  },
+  ruyLopez: {
+    id: "ruyLopez",
+    name: "The Ruy Lopez",
+    learnerSide: "white",
+    line: [
+      m("e2", "e4", "e4"),
+      m("e7", "e5", "e5"),
+      m("g1", "f3", "Nf3"),
+      m("b8", "c6", "Nc6"),
+      m("f1", "b5", "Bb5"),
+      m("a7", "a6", "a6"),
+    ],
+    idea: "Pin the knight that guards e5 — long-term pressure on Black's centre.",
+  },
+  scotch: {
+    id: "scotch",
+    name: "The Scotch Game",
+    learnerSide: "white",
+    line: [
+      m("e2", "e4", "e4"),
+      m("e7", "e5", "e5"),
+      m("g1", "f3", "Nf3"),
+      m("b8", "c6", "Nc6"),
+      m("d2", "d4", "d4"),
+      m("e5", "d4", "exd4"),
+      m("f3", "d4", "Nxd4"),
+    ],
+    idea: "Blast the centre open early and get a big lead in development.",
+  },
+  london: {
+    id: "london",
+    name: "The London System",
+    learnerSide: "white",
+    line: [
+      m("d2", "d4", "d4"),
+      m("d7", "d5", "d5"),
+      m("g1", "f3", "Nf3"),
+      m("g8", "f6", "Nf6"),
+      m("c1", "f4", "Bf4"),
+    ],
+    idea: "A calm, solid setup you can play against almost anything.",
+  },
+  scandinavian: {
+    id: "scandinavian",
+    name: "The Scandinavian Defense",
+    learnerSide: "black",
+    line: [
+      m("e2", "e4", "e4"),
+      m("d7", "d5", "d5"),
+      m("e4", "d5", "exd5"),
+      m("d8", "d5", "Qxd5"),
+      m("b1", "c3", "Nc3"),
+      m("d5", "a5", "Qa5"),
+    ],
+    idea: "Hit the centre at once as Black — then tuck the queen safely on a5.",
+  },
+};
+
+export const OPENING_IDS = Object.keys(OPENINGS);

--- a/apps/web/src/games/chess-quest/index.tsx
+++ b/apps/web/src/games/chess-quest/index.tsx
@@ -17,6 +17,7 @@ import { MateInTwo } from "./components/games/MateInTwo";
 import { HangingHunt } from "./components/games/HangingHunt";
 import { TacticTrainer } from "./components/games/TacticTrainer";
 import { RookMaze } from "./components/games/RookMaze";
+import { OpeningTrainer } from "./components/games/OpeningTrainer";
 import { Certificate } from "./components/quest/Certificate";
 import { GrownUpsDrawer } from "./components/quest/GrownUpsDrawer";
 import { LessonCard } from "./components/quest/LessonCard";
@@ -33,6 +34,7 @@ type Opts = Record<string, unknown>;
 function renderGame(game: GameId, opts: Opts) {
   const pieces = (opts.pieces as string[] | undefined) ?? undefined;
   const pack = (opts.pack as string | undefined) ?? undefined;
+  const opening = (opts.opening as string | undefined) ?? undefined;
   switch (game) {
     case "squareRace":
       return <SquareRace />;
@@ -50,6 +52,8 @@ function renderGame(game: GameId, opts: Opts) {
       return <TacticTrainer pack={pack ?? "fork"} />;
     case "rookMaze":
       return <RookMaze pieces={pieces ?? ["R", "B", "Q"]} />;
+    case "openingTrainer":
+      return <OpeningTrainer opening={opening ?? "italian"} />;
   }
 }
 
@@ -62,6 +66,7 @@ const ARCADE: { id: GameId; emoji: string; title: string; blurb: string; opts: O
   { id: "hangingHunt", emoji: "🔍", title: "Piece Detective", blurb: "Spot the piece that's free to take.", opts: {} },
   { id: "tacticTrainer", emoji: "🎯", title: "Trick Shots", blurb: "Forks, pins, skewers, discovered attacks.", opts: { pack: "fork" } },
   { id: "rookMaze", emoji: "🧩", title: "Rook Maze", blurb: "Slide around the walls to catch the prey.", opts: {} },
+  { id: "openingTrainer", emoji: "📖", title: "Opening Trainer", blurb: "Play a real opening, move by move.", opts: { opening: "italian" } },
 ];
 
 function QuestApp() {

--- a/apps/web/src/games/chess-quest/lib/__tests__/cert.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/cert.test.ts
@@ -2,18 +2,24 @@ import { describe, expect, it } from "vitest";
 import { certTitle } from "../cert";
 
 describe("certTitle", () => {
-  it("both tracks complete → Champion", () => {
-    expect(certTitle(24, 24).title).toBe("Chess Quest Champion");
+  it("all three tracks → Grandmaster", () => {
+    expect(certTitle(24, 24, 5).title).toBe("Chess Quest Grandmaster");
+  });
+  it("tracks 1+2 done, track 3 partial → Champion", () => {
+    expect(certTitle(24, 24, 2).title).toBe("Chess Quest Champion");
   });
   it("track 1 only → First Steps Champion", () => {
-    expect(certTitle(24, 5).title).toBe("First Steps Champion");
+    expect(certTitle(24, 5, 0).title).toBe("First Steps Champion");
   });
   it("track 2 only → Rising Player Champion", () => {
-    expect(certTitle(0, 24).title).toBe("Rising Player Champion");
+    expect(certTitle(0, 24, 0).title).toBe("Rising Player Champion");
+  });
+  it("track 3 only → Opening Range Champion", () => {
+    expect(certTitle(3, 2, 5).title).toBe("Opening Range Champion");
   });
   it("partial → Adventurer with the day count", () => {
-    const r = certTitle(3, 2);
+    const r = certTitle(3, 2, 1);
     expect(r.title).toBe("Chess Quest Adventurer");
-    expect(r.line).toContain("5 of 48");
+    expect(r.line).toContain("6 of 53");
   });
 });

--- a/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts
@@ -143,9 +143,13 @@ describe("lessons + tracks", () => {
     expect(p.landDone({ weeks: [1, 4] })).toBe(false);
     expect(p.trackDone(1)).toBe(2);
     expect(p.trackDone(2)).toBe(1);
+    p.setWeekDone(49, true);
+    p.setWeekDone(53, true);
+    expect(p.trackDone(3)).toBe(2);
     p.setWeekDone(2, false);
     expect(p.isWeekDone(2)).toBe(false);
-    expect(p.weeksDone()).toBe(2);
+    // done now: 1, 25, 49, 53
+    expect(p.weeksDone()).toBe(4);
   });
 
   it("totalStars = weeks done + game stars", () => {

--- a/apps/web/src/games/chess-quest/lib/__tests__/stars.test.ts
+++ b/apps/web/src/games/chess-quest/lib/__tests__/stars.test.ts
@@ -53,4 +53,10 @@ describe("star formulas (ported thresholds)", () => {
     expect(STAR_RULES.rookMaze(6, 5)).toBe(2);
     expect(STAR_RULES.rookMaze(7, 5)).toBe(1);
   });
+  it("openingTrainer by mistakes", () => {
+    expect(STAR_RULES.openingTrainer(0)).toBe(3);
+    expect(STAR_RULES.openingTrainer(1)).toBe(2);
+    expect(STAR_RULES.openingTrainer(2)).toBe(2);
+    expect(STAR_RULES.openingTrainer(3)).toBe(1);
+  });
 });

--- a/apps/web/src/games/chess-quest/lib/cert.ts
+++ b/apps/web/src/games/chess-quest/lib/cert.ts
@@ -1,9 +1,16 @@
-// Certificate title/line by tracks completed (port of js/app.js printCertificate).
-export function certTitle(t1: number, t2: number): { title: string; line: string } {
+// Certificate title/line by tracks completed (port of js/app.js printCertificate,
+// extended for Track 3 "Opening Range").
+export function certTitle(t1: number, t2: number, t3: number): { title: string; line: string } {
+  if (t1 === 24 && t2 === 24 && t3 === 5) {
+    return {
+      title: "Chess Quest Grandmaster",
+      line: "has completed the entire Chess Quest — all 53 lessons, from the first square to a real opening repertoire",
+    };
+  }
   if (t1 === 24 && t2 === 24) {
     return {
       title: "Chess Quest Champion",
-      line: "has completed the entire Chess Quest — all 48 lessons, from the first square to Rising Player strength",
+      line: "has completed Tracks 1 and 2 — 48 lessons, from the empty board to confident club play",
     };
   }
   if (t1 === 24) {
@@ -18,8 +25,14 @@ export function certTitle(t1: number, t2: number): { title: string; line: string
       line: "has completed Track 2 “Rising Player” — 24 lessons of combinations, openings, endgames and strategy",
     };
   }
+  if (t3 === 5) {
+    return {
+      title: "Opening Range Champion",
+      line: "has completed Track 3 “Opening Range” — five sound openings played by hand",
+    };
+  }
   return {
     title: "Chess Quest Adventurer",
-    line: `has bravely conquered ${t1 + t2} of 48 quest days — and the journey continues`,
+    line: `has bravely conquered ${t1 + t2 + t3} of 53 quest days — and the journey continues`,
   };
 }

--- a/apps/web/src/games/chess-quest/lib/progress.tsx
+++ b/apps/web/src/games/chess-quest/lib/progress.tsx
@@ -63,7 +63,7 @@ export type Progress = {
   weeksDone(): number;
   currentWeek(total: number): number;
   landDone(land: { weeks: [number, number] }): boolean;
-  trackDone(track: 1 | 2): number;
+  trackDone(track: 1 | 2 | 3): number;
 
   // activity / streak
   markActivity(dateISO?: string): void;
@@ -258,8 +258,8 @@ export function createProgressState(storage?: Storage): Progress {
       return true;
     },
     trackDone: (track) => {
-      const lo = track === 2 ? 25 : 1;
-      const hi = track === 2 ? 48 : 24;
+      const ranges = { 1: [1, 24], 2: [25, 48], 3: [49, 53] } as const;
+      const [lo, hi] = ranges[track];
       let n = 0;
       for (let i = lo; i <= hi; i++) if (P().weeks[i]) n++;
       return n;

--- a/apps/web/src/games/chess-quest/lib/stars.ts
+++ b/apps/web/src/games/chess-quest/lib/stars.ts
@@ -29,4 +29,8 @@ export const STAR_RULES = {
   rookMaze(moves: number, par: number): number {
     return moves <= par ? 3 : moves <= par + 1 ? 2 : 1;
   },
+  // Opening Trainer: clean run 3 stars, a slip or two still 2.
+  openingTrainer(mistakes: number): number {
+    return mistakes === 0 ? 3 : mistakes <= 2 ? 2 : 1;
+  },
 };

--- a/docs/superpowers/plans/2026-07-14-chess-quest-track3-openings.md
+++ b/docs/superpowers/plans/2026-07-14-chess-quest-track3-openings.md
@@ -1,0 +1,820 @@
+# Chess Quest — Track 3 (Opening Range) + Opening Trainer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a playable opening-technique track — a new Opening Trainer mini-game, a Track 3 "Opening Range" land with 5 lessons, and wire the two existing instruction-only Italian lessons (19, 31) to the trainer.
+
+**Architecture:** New pure `content/openings.ts` data (engine-legal mainlines, ≤5 plies, no castling); a new `OpeningTrainer` React game that drills a line move-by-move; content/store/map/progress/certificate extended from 48→53 lessons and 9→10 lands. The two UI extras (footer link, centered header) already landed on this branch.
+
+**Tech Stack:** React 19 client components, TypeScript, engine barrel (`../engine`), Vitest, Playwright. All new code under `apps/web/src/games/chess-quest/`.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-chess-quest-track3-openings-design.md`. Worktree/branch `worktree-games-track3` (forked from main 5844b32).
+
+## Global Constraints
+
+- All new code under `apps/web/src/games/chess-quest/`; every component starts with `"use client"`. Engine from `../engine`, content from `../content/*`.
+- **Engine has no castling/en passant/promotion-choice** — every opening line is 3–5 development plies using only ordinary moves + captures. Do not add engine features.
+- Opening lines are a single mainline; a wrong move just retries (no transpositions).
+- Star/copy/register conventions unchanged from the existing games (keep-max stars; `useCopy().t(story, classic)`; `Rich` for markup; celebrate = fanfare + confetti; `voice.say` on wins).
+- Timers via `useLater()`. Tap-tap move selection like the other games.
+- Run suites with `rtk proxy npx vitest run …` from `apps/web`. Conventional commits, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Content verification is the acceptance gate for the lines — do not weaken a detector/verifier to make a line pass; fix the line data.
+
+---
+
+### Task 1: Openings data + verification
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/content/openings.ts`
+- Test: `apps/web/src/games/chess-quest/content/__tests__/openings.test.ts`
+
+**Interfaces:**
+- Produces (consumed by Tasks 2, 4, 6): `type OpeningMove = { from: string; to: string; san: string }`; `type Opening = { id: string; name: string; learnerSide: "white" | "black"; line: OpeningMove[]; idea: string }`; `const OPENINGS: Record<string, Opening>`; `const OPENING_IDS: string[]`.
+
+- [ ] **Step 1: Write the failing verification test**
+
+```ts
+// apps/web/src/games/chess-quest/content/__tests__/openings.test.ts
+import { describe, expect, it } from "vitest";
+import { isWhitePiece, legalTargets, applyMove, parseFEN, sqIdx } from "../../engine";
+import { OPENINGS, OPENING_IDS } from "../openings";
+
+const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+describe("openings are engine-legal mainlines", () => {
+  it("has the five classic-set openings", () => {
+    expect(OPENING_IDS.sort()).toEqual(
+      ["italian", "london", "ruyLopez", "scandinavian", "scotch"].sort(),
+    );
+  });
+
+  it.each(OPENING_IDS.map((id) => [id, OPENINGS[id]] as const))("%s replays legally", (_id, op) => {
+    let board = parseFEN(START).board;
+    let whiteToMove = true;
+    let firstLearnerSide: "white" | "black" | null = null;
+    for (const mv of op.line) {
+      const from = sqIdx(mv.from);
+      const to = sqIdx(mv.to);
+      // the mover owns the piece on `from`
+      expect(board[from]).not.toBe("");
+      expect(isWhitePiece(board[from])).toBe(whiteToMove);
+      // the move is legal
+      expect(legalTargets(board, from), `${op.id} ${mv.san}`).toContain(to);
+      if (firstLearnerSide === null && (whiteToMove ? "white" : "black") === op.learnerSide) {
+        firstLearnerSide = whiteToMove ? "white" : "black";
+      }
+      board = applyMove(board, from, to);
+      whiteToMove = !whiteToMove;
+    }
+    // the learner actually moves in this line
+    expect(op.line.some((_, i) => (i % 2 === 0) === (op.learnerSide === "white"))).toBe(true);
+    expect(op.idea.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fail**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/content/__tests__/openings.test.ts`
+Expected: FAIL — cannot resolve `../openings`.
+
+- [ ] **Step 3: Implement openings.ts**
+
+```ts
+// apps/web/src/games/chess-quest/content/openings.ts
+// Opening mainlines for the Opening Trainer. Each line is 3–5 development plies
+// (no castling — the engine doesn't model it, and the setup is the beginner
+// takeaway). Every move is verified engine-legal by content/__tests__.
+
+export type OpeningMove = { from: string; to: string; san: string };
+export type Opening = {
+  id: string;
+  name: string;
+  learnerSide: "white" | "black";
+  line: OpeningMove[]; // full sequence, both sides, in play order
+  idea: string;
+};
+
+const m = (from: string, to: string, san: string): OpeningMove => ({ from, to, san });
+
+export const OPENINGS: Record<string, Opening> = {
+  italian: {
+    id: "italian",
+    name: "The Italian Game",
+    learnerSide: "white",
+    line: [
+      m("e2", "e4", "e4"),
+      m("e7", "e5", "e5"),
+      m("g1", "f3", "Nf3"),
+      m("b8", "c6", "Nc6"),
+      m("f1", "c4", "Bc4"),
+      m("f8", "c5", "Bc5"),
+    ],
+    idea: "Take the centre, aim the bishop at f7, and get ready to castle.",
+  },
+  ruyLopez: {
+    id: "ruyLopez",
+    name: "The Ruy Lopez",
+    learnerSide: "white",
+    line: [
+      m("e2", "e4", "e4"),
+      m("e7", "e5", "e5"),
+      m("g1", "f3", "Nf3"),
+      m("b8", "c6", "Nc6"),
+      m("f1", "b5", "Bb5"),
+      m("a7", "a6", "a6"),
+    ],
+    idea: "Pin the knight that guards e5 — long-term pressure on Black's centre.",
+  },
+  scotch: {
+    id: "scotch",
+    name: "The Scotch Game",
+    learnerSide: "white",
+    line: [
+      m("e2", "e4", "e4"),
+      m("e7", "e5", "e5"),
+      m("g1", "f3", "Nf3"),
+      m("b8", "c6", "Nc6"),
+      m("d2", "d4", "d4"),
+      m("e5", "d4", "exd4"),
+      m("f3", "d4", "Nxd4"),
+    ],
+    idea: "Blast the centre open early and get a big lead in development.",
+  },
+  london: {
+    id: "london",
+    name: "The London System",
+    learnerSide: "white",
+    line: [
+      m("d2", "d4", "d4"),
+      m("d7", "d5", "d5"),
+      m("g1", "f3", "Nf3"),
+      m("g8", "f6", "Nf6"),
+      m("c1", "f4", "Bf4"),
+    ],
+    idea: "A calm, solid setup you can play against almost anything.",
+  },
+  scandinavian: {
+    id: "scandinavian",
+    name: "The Scandinavian Defense",
+    learnerSide: "black",
+    line: [
+      m("e2", "e4", "e4"),
+      m("d7", "d5", "d5"),
+      m("e4", "d5", "exd5"),
+      m("d8", "d5", "Qxd5"),
+      m("b1", "c3", "Nc3"),
+      m("d5", "a5", "Qa5"),
+    ],
+    idea: "Hit the centre at once as Black — then tuck the queen safely on a5.",
+  },
+};
+
+export const OPENING_IDS = Object.keys(OPENINGS);
+```
+
+- [ ] **Step 4: Run → pass**
+
+Run: `rtk proxy npx vitest run src/games/chess-quest/content/__tests__/openings.test.ts`
+Expected: PASS (6 tests: the count + 5 lines). If a line fails legality, fix the FEN/move data — not the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/games/chess-quest/content/openings.ts apps/web/src/games/chess-quest/content/__tests__/openings.test.ts
+git commit -m "feat(chess-quest): opening mainlines + engine-legal verification
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Opening Trainer star rule
+
+**Files:**
+- Modify: `apps/web/src/games/chess-quest/lib/stars.ts`
+- Test: `apps/web/src/games/chess-quest/lib/__tests__/stars.test.ts` (extend)
+
+**Interfaces:**
+- Produces: `STAR_RULES.openingTrainer(mistakes: number): number` — 0 → 3, 1–2 → 2, else 1.
+
+- [ ] **Step 1: Extend the failing test** — add to `stars.test.ts`:
+
+```ts
+  it("openingTrainer by mistakes", () => {
+    expect(STAR_RULES.openingTrainer(0)).toBe(3);
+    expect(STAR_RULES.openingTrainer(1)).toBe(2);
+    expect(STAR_RULES.openingTrainer(2)).toBe(2);
+    expect(STAR_RULES.openingTrainer(3)).toBe(1);
+  });
+```
+
+- [ ] **Step 2: Run → fail** (`rtk proxy npx vitest run src/games/chess-quest/lib/__tests__/stars.test.ts`) — `openingTrainer` undefined.
+
+- [ ] **Step 3: Implement** — add to the `STAR_RULES` object in `lib/stars.ts`:
+
+```ts
+  openingTrainer(mistakes: number): number {
+    return mistakes === 0 ? 3 : mistakes <= 2 ? 2 : 1;
+  },
+```
+
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(chess-quest): opening-trainer star rule`.
+
+---
+
+### Task 3: Opening Trainer game component
+
+**Files:**
+- Create: `apps/web/src/games/chess-quest/components/games/OpeningTrainer.tsx`
+
+**Interfaces:**
+- Consumes: `OPENINGS` (Task 1), `STAR_RULES.openingTrainer` (Task 2), engine barrel, `Board`/`GameShell`/`Rich`, `celebrate`, `voice`, `sfx`, `useProgress`, `useLater`, `useCopy`.
+- Produces: `export function OpeningTrainer({ opening }: { opening: string }): JSX.Element` — consumed by Task 6.
+
+**Behavior contract:** start from the standard position; walk `OPENINGS[opening].line` by ply. Opponent plies (side ≠ `learnerSide`) auto-play after ~550ms via `later()` with a highlight. On a learner ply, highlight the from-square as a hint and accept a tap-tap move: if it matches `line[ply]` → `applyMove`, `sfx.move`, advance, schedule the next opponent reply; else `sfx.bad`, shake, coach nudge, `mistakes++`, board unchanged (retry). At line end → `celebrate()`, `voice.say(name + " — you played the whole line!")`, `setGameStars("openingTrainer", STAR_RULES.openingTrainer(mistakes))`, offer "Play again" (resets ply/board/mistakes). HUD: `{name}` + `move {doneLearnerMoves}/{totalLearnerMoves}`; the opening's `idea` renders under the status.
+
+- [ ] **Step 1: Implement the component**
+
+```tsx
+// apps/web/src/games/chess-quest/components/games/OpeningTrainer.tsx
+"use client";
+
+// Opening Trainer — play a named opening move by move. The trainer auto-plays
+// the book replies; you play your side's moves until the line is complete.
+// Repetition builds the opening into muscle memory ("play it fifty times").
+import { useCallback, useEffect, useState } from "react";
+import { applyMove, isWhitePiece, legalTargets, parseFEN, sqIdx } from "../../engine";
+import { OPENINGS } from "../../content/openings";
+import { celebrate } from "../../lib/celebrate";
+import { sfx } from "../../lib/sfx";
+import { STAR_RULES } from "../../lib/stars";
+import { useLater } from "../../lib/use-later";
+import { useProgress } from "../../lib/progress";
+import { voice } from "../../lib/voice";
+import { Board, Highlight } from "../Board";
+import { GameShell } from "../GameShell";
+
+const START = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+export function OpeningTrainer({ opening }: { opening: string }) {
+  const op = OPENINGS[opening] ?? OPENINGS.italian;
+  const progress = useProgress();
+  const { later, clearPending } = useLater();
+
+  const [position, setPosition] = useState<string[]>(() => parseFEN(START).board);
+  const [ply, setPly] = useState(0);
+  const [selIdx, setSelIdx] = useState(-1);
+  const [mistakes, setMistakes] = useState(0);
+  const [done, setDone] = useState(false);
+  const [highlights, setHighlights] = useState<Partial<Record<number, Highlight>>>({});
+  const [pop, setPop] = useState<{ idx: number; n: number } | null>(null);
+  const [popN, setPopN] = useState(0);
+  const [shake, setShake] = useState(0);
+  const [status, setStatus] = useState("");
+
+  const learnerMovesTotal = op.line.filter(
+    (_, i) => (i % 2 === 0) === (op.learnerSide === "white"),
+  ).length;
+
+  const learnerPly = (i: number) => (i % 2 === 0) === (op.learnerSide === "white");
+
+  const promptFor = useCallback(
+    (i: number) => {
+      if (i >= op.line.length) return `<strong>${op.name}</strong> — line complete!`;
+      return learnerPly(i)
+        ? `Your move: play <strong>${op.line[i].san}</strong>. Tap the glowing piece, then its square.`
+        : `<strong>${op.name}</strong> — watch the reply…`;
+    },
+    // op is stable per opening prop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [op],
+  );
+
+  // Reset to the start of the line.
+  const reset = useCallback(() => {
+    clearPending();
+    setPosition(parseFEN(START).board);
+    setPly(0);
+    setSelIdx(-1);
+    setMistakes(0);
+    setDone(false);
+    setHighlights({});
+    setStatus(promptFor(0));
+  }, [clearPending, promptFor]);
+
+  useEffect(() => {
+    reset();
+  }, [reset]);
+
+  useEffect(() => () => clearPending(), [clearPending]);
+
+  // Drive opponent auto-moves and highlight the learner's from-square.
+  useEffect(() => {
+    if (done || ply >= op.line.length) return;
+    if (!learnerPly(ply)) {
+      later(() => {
+        setPosition((pos) => {
+          const mv = op.line[ply];
+          const next = applyMove(pos, sqIdx(mv.from), sqIdx(mv.to));
+          return next;
+        });
+        const to = sqIdx(op.line[ply].to);
+        setPop({ idx: to, n: popN + 1 });
+        setPopN((v) => v + 1);
+        sfx.move();
+        setPly((p) => p + 1);
+      }, 550);
+    } else {
+      // hint: glow the piece that should move
+      setHighlights({ [sqIdx(op.line[ply].from)]: "hint" });
+      setStatus(promptFor(ply));
+    }
+    // ply drives the sequence; other setters are stable
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ply, done]);
+
+  function finish() {
+    setDone(true);
+    setHighlights({});
+    const stars = STAR_RULES.openingTrainer(mistakes);
+    progress.setGameStars("openingTrainer", stars);
+    setStatus(`<strong>${op.name}</strong> — you played the whole line! ${"★".repeat(stars)}`);
+    voice.say(`${op.name}. You played the whole line!`);
+    celebrate();
+  }
+
+  function onLearnerMove(from: number, to: number) {
+    const mv = op.line[ply];
+    if (from === sqIdx(mv.from) && to === sqIdx(mv.to)) {
+      const next = applyMove(position, from, to);
+      setPosition(next);
+      setPop({ idx: to, n: popN + 1 });
+      setPopN((v) => v + 1);
+      sfx.move();
+      setSelIdx(-1);
+      const nextPly = ply + 1;
+      if (nextPly >= op.line.length) {
+        setPly(nextPly);
+        finish();
+      } else {
+        setPly(nextPly);
+      }
+    } else {
+      setSelIdx(-1);
+      setMistakes((x) => x + 1);
+      setShake((s) => s + 1);
+      sfx.bad();
+      setStatus(
+        `Not the book move — the ${op.name} plays <strong>${mv.san}</strong> here. Follow the glowing piece.`,
+      );
+      setHighlights({ [sqIdx(mv.from)]: "hint" });
+    }
+  }
+
+  function onTap(idx: number) {
+    if (done || ply >= op.line.length || !learnerPly(ply)) return;
+    const pos = position;
+    const p = pos[idx];
+    const mine = p !== "" && isWhitePiece(p) === (op.learnerSide === "white");
+    if (mine) {
+      setSelIdx(idx);
+      const hl: Partial<Record<number, Highlight>> = { [idx]: "sel" };
+      for (const t of legalTargets(pos, idx)) hl[t] = pos[t] === "" ? "move" : "cap";
+      // keep the book from-square glowing too
+      hl[sqIdx(op.line[ply].from)] = "hint";
+      setHighlights(hl);
+      return;
+    }
+    if (selIdx >= 0 && legalTargets(pos, selIdx).includes(idx)) {
+      onLearnerMove(selIdx, idx);
+    } else if (selIdx >= 0) {
+      setShake((s) => s + 1);
+    }
+  }
+
+  const doneLearnerMoves = op.line
+    .slice(0, ply)
+    .filter((_, i) => learnerPly(i)).length;
+
+  return (
+    <GameShell
+      title={`Opening Trainer — ${op.name}`}
+      score={`move ${doneLearnerMoves}/${learnerMovesTotal}`}
+      status={status}
+      extra={<p className="text-center text-xs italic text-slate-500">{op.idea}</p>}
+      controls={
+        <button type="button" className="btn btn-ghost" onClick={reset}>
+          {done ? "Play again" : "Restart"}
+        </button>
+      }
+    >
+      <Board
+        position={position}
+        labels
+        highlights={highlights}
+        popToken={pop}
+        shakeToken={shake}
+        onTap={onTap}
+      />
+    </GameShell>
+  );
+}
+```
+
+- [ ] **Step 2: Lint** — `rtk proxy npx eslint src/games/chess-quest/components/games/OpeningTrainer.tsx`; expect exit 0. Fix any real errors (the shake-animation warning class is tolerated elsewhere; avoid new ones).
+- [ ] **Step 3: Commit** `feat(chess-quest): Opening Trainer game`.
+
+---
+
+### Task 4: Track 3 land + lessons + lesson 19/31 improvement
+
+**Files:**
+- Modify: `apps/web/src/games/chess-quest/content/lands.ts`
+- Modify: `apps/web/src/games/chess-quest/content/lessons.ts`
+- Modify: `apps/web/src/games/chess-quest/content/__tests__/curriculum.test.ts`
+
+**Interfaces:**
+- Consumes: `OPENINGS`/`OPENING_IDS` (Task 1) — lesson `gameOpts.opening` values must be in `OPENING_IDS`.
+- Produces: `LANDS` length 10 (land id 10 track 3, weeks [49,53]); `LESSONS` length 53; `GameId` gains `"openingTrainer"`; lessons 19 & 31 `game: "openingTrainer"`.
+
+- [ ] **Step 1: Update the curriculum test** to the new totals + an opening-lessons check:
+
+Replace the "48 lessons" / "9 lands" / tiling expectations and add the openings check. In `curriculum.test.ts`:
+
+```ts
+import { OPENING_IDS } from "../openings";
+
+const GAME_IDS = [
+  "squareRace",
+  "coinHop",
+  "pawnWars",
+  "mateInOne",
+  "mateInTwo",
+  "hangingHunt",
+  "tacticTrainer",
+  "rookMaze",
+  "openingTrainer",
+];
+```
+
+Update these assertions:
+- `expect(LESSONS).toHaveLength(53);`
+- `expect(LANDS).toHaveLength(10);`
+- tiling loop bound `new Array(54)` and `seen.slice(1)` still all `=== 1`.
+- add: track 3 lands cover 49–53:
+```ts
+  it("track 3 lands cover lessons 49..53 only", () => {
+    for (const land of LANDS.filter((l) => l.track === 3)) {
+      expect(land.weeks[0]).toBeGreaterThanOrEqual(49);
+      expect(land.weeks[1]).toBeLessThanOrEqual(53);
+    }
+  });
+```
+- add: opening-trainer lessons point at a real opening:
+```ts
+  it("opening-trainer lessons name a real opening", () => {
+    for (const l of LESSONS.filter((x) => x.game === "openingTrainer")) {
+      const op = (l.gameOpts as { opening?: string } | undefined)?.opening ?? "";
+      expect(OPENING_IDS, `lesson ${l.n}`).toContain(op);
+    }
+  });
+```
+
+- [ ] **Step 2: Run → fail** (`rtk proxy npx vitest run src/games/chess-quest/content/__tests__/curriculum.test.ts`) — length + game-id mismatches.
+
+- [ ] **Step 3a: Add `openingTrainer` to `GameId`** in `lessons.ts`:
+
+```ts
+export type GameId =
+  | "squareRace"
+  | "coinHop"
+  | "pawnWars"
+  | "mateInOne"
+  | "mateInTwo"
+  | "hangingHunt"
+  | "tacticTrainer"
+  | "rookMaze"
+  | "openingTrainer";
+```
+
+- [ ] **Step 3b: Wire lessons 19 and 31** — change their `game: null` to the trainer. In `lessons.ts` lesson 19 (`n: 19`, "Her First Opening"):
+
+```ts
+    game: "openingTrainer",
+    gameOpts: { opening: "italian" },
+```
+
+(insert after the `title` line, replacing `game: null,`). Same for lesson 31 (`n: 31`, "The Italian, With a Plan"): `game: "openingTrainer", gameOpts: { opening: "italian" },`.
+
+- [ ] **Step 3c: Append the Track 3 land** to `LANDS` in `lands.ts` (after land id 9):
+
+```ts
+  {
+    id: 10,
+    glyph: "♚",
+    name: "Opening Range",
+    weeks: [49, 53],
+    track: 3,
+    goal: "Turn opening rules into real repertoire — play five sound openings by hand.",
+    check: "She plays the Italian, Ruy Lopez, Scotch, London and Scandinavian from memory.",
+    checkClassic:
+      "You reproduce five standard openings move-for-move and can state each one’s plan.",
+  },
+```
+
+- [ ] **Step 3d: Append lessons 49–53** to `LESSONS` in `lessons.ts` (after lesson 48). Each lesson has both copy registers; keep it short (the trainer is the lesson):
+
+```ts
+  {
+    n: 49,
+    land: 10,
+    title: "The Italian Game",
+    game: "openingTrainer",
+    gameOpts: { opening: "italian" },
+    learn: "e4, Knight f3, Bishop c4 — the friendly Italian. The bishop stares at f7.",
+    play: "Play the Italian in the trainer until the moves feel automatic. No reading — just play!",
+    spark: "Same three moves every game. Soon your hands know them before your head does.",
+    classic: {
+      learn: "1.e4 e5 2.Nf3 Nc6 3.Bc4 Bc5 — the Italian: rapid development, pressure on f7.",
+      play: "Drill the line in the trainer until it’s reflex, both the moves and the reason.",
+      spark: "Repetition, not theory. One opening played fifty times beats five played ten.",
+    },
+  },
+  {
+    n: 50,
+    land: 10,
+    title: "The Ruy Lopez",
+    game: "openingTrainer",
+    gameOpts: { opening: "ruyLopez" },
+    learn: "Like the Italian, but the bishop goes to b5 to bother the knight guarding e5.",
+    play: "Play the Ruy Lopez line in the trainer. Feel how Bb5 pins the defender.",
+    spark: "The “Spanish torture” — slow, sound pressure the pros still play today.",
+    classic: {
+      learn: "1.e4 e5 2.Nf3 Nc6 3.Bb5 a6 — the Ruy Lopez: pressure the e5 defender, keep long-term bind.",
+      play: "Drill it; note how Bb5 targets the knight, not the pawn directly.",
+      spark: "The most respected 1.e4 e5 opening — worth owning even at club level.",
+    },
+  },
+  {
+    n: 51,
+    land: 10,
+    title: "The Scotch Game",
+    game: "openingTrainer",
+    gameOpts: { opening: "scotch" },
+    learn: "Punch the centre open early with d4, then grab the pawn back with the knight.",
+    play: "Play the Scotch in the trainer: e4, Nf3, d4, take, take with the knight.",
+    spark: "Open lines fast — great when you like lively, attacking games.",
+    classic: {
+      learn: "1.e4 e5 2.Nf3 Nc6 3.d4 exd4 4.Nxd4 — the Scotch: early central break, quick development lead.",
+      play: "Drill the capture sequence until the recapture on d4 is automatic.",
+      spark: "A clean way to avoid heavy Ruy Lopez theory while staying principled.",
+    },
+  },
+  {
+    n: 52,
+    land: 10,
+    title: "The London System",
+    game: "openingTrainer",
+    gameOpts: { opening: "london" },
+    learn: "A calm setup with d4, Nf3 and the bishop out to f4 — plays against almost anything.",
+    play: "Play the London in the trainer. Same easy setup, game after game.",
+    spark: "Low-stress, high-reward: a system you can lean on when you’re tired.",
+    classic: {
+      learn: "1.d4 d5 2.Nf3 Nf6 3.Bf4 — the London: a solid, low-theory system with a clear plan.",
+      play: "Drill the setup; the move order is flexible but the pieces always land the same.",
+      spark: "Ideal one-system repertoire for busy players — minimal memorization.",
+    },
+  },
+  {
+    n: 53,
+    land: 10,
+    title: "The Scandinavian Defense",
+    game: "openingTrainer",
+    gameOpts: { opening: "scandinavian" },
+    learn: "Now you’re Black! Answer e4 with d5 right away, take, then bring the queen to a5 safely.",
+    play: "Play the Scandinavian in the trainer as Black. Hit the centre from move one.",
+    spark: "One opening that works against e4 every single time — no surprises.",
+    classic: {
+      learn: "1.e4 d5 2.exd5 Qxd5 3.Nc3 Qa5 — the Scandinavian: immediate central challenge as Black, queen tucked on a5.",
+      play: "Drill it as Black; learn to develop with tempo after the queen settles.",
+      spark: "A dependable, low-theory answer to 1.e4 you can rely on under pressure.",
+    },
+  },
+```
+
+- [ ] **Step 4: Run → pass** (`rtk proxy npx vitest run src/games/chess-quest/content`) — openings + curriculum green.
+- [ ] **Step 5: Commit** `feat(chess-quest): Track 3 Opening Range land + lessons; lessons 19/31 play the trainer`.
+
+---
+
+### Task 5: Store trackDone(3) + progress panel + certificate
+
+**Files:**
+- Modify: `apps/web/src/games/chess-quest/lib/progress.tsx` (type + `trackDone`)
+- Modify: `apps/web/src/games/chess-quest/lib/cert.ts`
+- Modify: `apps/web/src/games/chess-quest/lib/__tests__/cert.test.ts`
+- Modify: `apps/web/src/games/chess-quest/lib/__tests__/progress.test.ts`
+- Modify: `apps/web/src/games/chess-quest/components/quest/ProgressPanel.tsx`
+- Modify: `apps/web/src/games/chess-quest/components/quest/Certificate.tsx`
+
+**Interfaces:**
+- Produces: `Progress.trackDone(track: 1 | 2 | 3): number`; `certTitle(t1: number, t2: number, t3: number): { title: string; line: string }`.
+
+- [ ] **Step 1: Extend the failing tests.**
+
+progress.test.ts — extend the tracks test:
+```ts
+    p.setWeekDone(49, true);
+    p.setWeekDone(53, true);
+    expect(p.trackDone(3)).toBe(2);
+```
+
+cert.test.ts — replace/extend for the 3-arg signature:
+```ts
+import { describe, expect, it } from "vitest";
+import { certTitle } from "../cert";
+
+describe("certTitle", () => {
+  it("all three tracks → Grandmaster", () => {
+    expect(certTitle(24, 24, 5).title).toBe("Chess Quest Grandmaster");
+  });
+  it("tracks 1+2 done, track 3 partial → Champion", () => {
+    expect(certTitle(24, 24, 2).title).toBe("Chess Quest Champion");
+  });
+  it("track 1 only", () => {
+    expect(certTitle(24, 5, 0).title).toBe("First Steps Champion");
+  });
+  it("track 2 only", () => {
+    expect(certTitle(0, 24, 0).title).toBe("Rising Player Champion");
+  });
+  it("track 3 only → Opening Range Champion", () => {
+    expect(certTitle(3, 2, 5).title).toBe("Opening Range Champion");
+  });
+  it("partial → Adventurer with the day count", () => {
+    const r = certTitle(3, 2, 1);
+    expect(r.title).toBe("Chess Quest Adventurer");
+    expect(r.line).toContain("6 of 53");
+  });
+});
+```
+
+- [ ] **Step 2: Run → fail** (both files).
+
+- [ ] **Step 3a: `progress.tsx`** — widen the type and the impl.
+
+In the `Progress` type: `trackDone(track: 1 | 2 | 3): number;`
+
+In `createProgressState`, replace `trackDone`:
+```ts
+    trackDone: (track) => {
+      const ranges = { 1: [1, 24], 2: [25, 48], 3: [49, 53] } as const;
+      const [lo, hi] = ranges[track];
+      let n = 0;
+      for (let i = lo; i <= hi; i++) if (P().weeks[i]) n++;
+      return n;
+    },
+```
+
+- [ ] **Step 3b: `lib/cert.ts`** — 3-track title:
+```ts
+export function certTitle(t1: number, t2: number, t3: number): { title: string; line: string } {
+  if (t1 === 24 && t2 === 24 && t3 === 5) {
+    return {
+      title: "Chess Quest Grandmaster",
+      line: "has completed the entire Chess Quest — all 53 lessons, from the first square to a real opening repertoire",
+    };
+  }
+  if (t1 === 24 && t2 === 24) {
+    return {
+      title: "Chess Quest Champion",
+      line: "has completed Tracks 1 and 2 — 48 lessons, from the empty board to confident club play",
+    };
+  }
+  if (t1 === 24) {
+    return {
+      title: "First Steps Champion",
+      line: "has completed Track 1 “First Steps” — 24 lessons, from the empty board to full, careful games",
+    };
+  }
+  if (t2 === 24) {
+    return {
+      title: "Rising Player Champion",
+      line: "has completed Track 2 “Rising Player” — 24 lessons of combinations, openings, endgames and strategy",
+    };
+  }
+  if (t3 === 5) {
+    return {
+      title: "Opening Range Champion",
+      line: "has completed Track 3 “Opening Range” — five sound openings played by hand",
+    };
+  }
+  return {
+    title: "Chess Quest Adventurer",
+    line: `has bravely conquered ${t1 + t2 + t3} of 53 quest days — and the journey continues`,
+  };
+}
+```
+
+- [ ] **Step 3c: `Certificate.tsx`** — pass t3 and update the lands total. Change the `certTitle` call to `certTitle(t1, t2, progress.trackDone(3))` (add `const t3 = progress.trackDone(3);`), and the stats line `of {LANDS.length} lands` already reads live (`LANDS` now length 10) — no other change.
+
+- [ ] **Step 3d: `ProgressPanel.tsx`** — add a Track 3 bar under the two existing ones:
+```tsx
+        <TrackBar label="Track 3 · Opening Range" done={progress.trackDone(3)} total={5} />
+```
+(placed right after the Track 2 `TrackBar`).
+
+- [ ] **Step 4: Run → pass** — `rtk proxy npx vitest run src/games/chess-quest/lib`.
+- [ ] **Step 5: Commit** `feat(chess-quest): trackDone(3), Track 3 progress bar + 3-track certificate`.
+
+---
+
+### Task 6: Map track-3 header, launcher, arcade card
+
+**Files:**
+- Modify: `apps/web/src/games/chess-quest/components/quest/QuestMap.tsx`
+- Modify: `apps/web/src/games/chess-quest/components/games/questData.ts` (GAME_LABEL)
+- Modify: `apps/web/src/games/chess-quest/index.tsx` (renderGame + arcade list)
+
+**Interfaces:**
+- Consumes: `OpeningTrainer` (Task 3), `GameId` `"openingTrainer"` (Task 4).
+
+- [ ] **Step 1: QuestMap track header** — the track-head label currently branches `track === 1 ? "First Steps" : "Rising Player"`. Replace with a map so track 3 shows "Opening Range":
+
+```tsx
+                <span className="mk-display text-sm font-bold text-purple-900">
+                  {track === 1 ? "First Steps" : track === 2 ? "Rising Player" : "Opening Range"}
+                </span>
+```
+
+- [ ] **Step 2: GAME_LABEL** — in `components/games/questData.ts` add to `GAME_LABEL`:
+```ts
+  openingTrainer: "▶ Play the opening",
+```
+(The `GAME_LABEL` type is `Record<GameId, string>`, so this is required once `openingTrainer` joins `GameId` — TypeScript will error until it's added.)
+
+- [ ] **Step 3: renderGame + arcade** — in `index.tsx`:
+
+Add the import:
+```ts
+import { OpeningTrainer } from "./components/games/OpeningTrainer";
+```
+Add the case in `renderGame` (before the closing brace of the switch):
+```ts
+    case "openingTrainer":
+      return <OpeningTrainer opening={(opts.opening as string | undefined) ?? "italian"} />;
+```
+Add an arcade card to the `ARCADE` array:
+```ts
+  { id: "openingTrainer", emoji: "📖", title: "Opening Trainer", blurb: "Play a real opening, move by move.", opts: { opening: "italian" } },
+```
+
+- [ ] **Step 4: Typecheck + lint** — `rtk proxy npx eslint src/games/chess-quest` (expect only the pre-existing Board shake warning) and `rtk proxy npx tsc --noEmit` is covered by the build in Task 7; here confirm eslint is clean.
+- [ ] **Step 5: Commit** `feat(chess-quest): wire Opening Trainer into map header, launcher, arcade`.
+
+---
+
+### Task 7: Verification + e2e + browser demo
+
+**Files:**
+- Modify: `apps/web/e2e/games.spec.ts`
+
+- [ ] **Step 1: Add an e2e** — Track 3 lesson launches the trainer and accepts the first move; arcade Opening Trainer opens. Append to `e2e/games.spec.ts`:
+
+```ts
+test("an Opening Trainer lesson launches and takes the first move", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
+  await page.reload();
+  await page.getByRole("button", { name: "Free play" }).click();
+  await page.getByRole("button", { name: /Opening Trainer/ }).click();
+  await expect(page.getByText(/The Italian Game/)).toBeVisible();
+  // First learner move in the Italian: e2–e4.
+  await page.locator('[data-square="e2"]').click();
+  await page.locator('[data-square="e4"]').click();
+  await expect(page.locator('[data-square="e4"]')).toHaveAttribute("aria-label", /white pawn/);
+});
+```
+
+- [ ] **Step 2: Run e2e** — dev server up on :3000, then `rtk proxy npx playwright test e2e/games.spec.ts --project=parallel --no-deps`. Expected: all pass.
+
+- [ ] **Step 3: Full verification** (from `apps/web`):
+```bash
+rtk proxy npx vitest run          # all green (incl. openings, curriculum 53/10, cert, stars)
+rtk proxy npx eslint src/games    # 0 errors (Board shake warning tolerated)
+rtk proxy npm run build           # clean
+```
+
+- [ ] **Step 4: Browser demo** — open `/games/chess-quest`, Quest tab: confirm Track 3 "Opening Range" section with days 97–105; open Day 97 → Play → drill the Italian to completion (confetti). Free play: open Opening Trainer, play the line. Screenshot the Track 3 map + the trainer mid-line.
+
+- [ ] **Step 5: Commit** `test(chess-quest): e2e for Opening Trainer` and push the branch.
+
+---
+
+### Self-review notes (addressed)
+
+- Engine legality of every line is the Task 1 gate; the trainer never needs castling.
+- `GameId` gains `openingTrainer` in Task 4 before Task 6 references it in `GAME_LABEL`/`renderGame`; `curriculum.test` GAME_IDS updated alongside.
+- Lesson counts: 48→53 and lands 9→10 updated in the same task as the data (Task 4) so the shape test never straddles a half-change.
+- `trackDone` signature widened (Task 5) before the map/panel/cert consume track 3.

--- a/docs/superpowers/specs/2026-07-14-chess-quest-track3-openings-design.md
+++ b/docs/superpowers/specs/2026-07-14-chess-quest-track3-openings-design.md
@@ -1,0 +1,130 @@
+# Chess Quest — Track 3 (Opening Range) + Opening Trainer — design
+
+**Date:** 2026-07-14
+**Status:** Approved (design review 2026-07-14)
+**Worktree/branch:** `worktree-games-track3` (forked from main 5844b32)
+
+## Goal
+
+Add a third quest track of **playable** opening-technique lessons — the learner
+*plays* each opening rather than reading about it. Introduces a new
+**Opening Trainer** mini-game (follow-the-line drilling), a Track 3 "Opening
+Range" land with 5 lessons, and — as a Track 1/2 improvement on the same theme —
+converts the two existing instruction-only Italian lessons to launch the trainer.
+
+Also bundled (small, unrelated UI): a "Games" link in the site footer, and the
+game-player header (back / title / powered-by) centered.
+
+## Decisions (design review)
+
+| Decision | Choice |
+|----------|--------|
+| Play mechanic | Follow-the-line trainer: play your side's moves in order; the trainer auto-plays the book replies |
+| Openings | Italian, Ruy Lopez, Scotch (all white 1.e4 e5); London (white 1.d4); Scandinavian (black, vs 1.e4) |
+| Track shape | New Track 3, one land "Opening Range" (id 10, glyph ♚, `track: 3`), lessons 49–53 = Days 97–105 |
+| Engine gap | No castling/en passant in the engine, so every line is 3–5 development plies (the beginner takeaway anyway) — only moves + captures the engine already supports |
+| Track 1/2 improvement | Lessons 19 ("Her First Opening") and 31 ("The Italian, With a Plan"), currently `game: null`, launch the Opening Trainer (Italian). Other null-game days left as-is |
+
+## Architecture
+
+### Openings data — `src/games/chess-quest/content/openings.ts` (new)
+
+```ts
+export type OpeningMove = { from: string; to: string; san: string };
+export type Opening = {
+  id: string;            // "italian" | "ruyLopez" | "scotch" | "london" | "scandinavian"
+  name: string;
+  learnerSide: "white" | "black";
+  line: OpeningMove[];   // full sequence, both sides, in play order
+  idea: string;          // one-line "why" shown under the board
+};
+export const OPENINGS: Record<string, Opening>;
+```
+
+The five lines (squares are engine indices via `sqIdx` at load; `san` is copy):
+
+1. **italian** (white): e2e4, e7e5, g1f3, b8c6, f1c4, f8c5
+2. **ruyLopez** (white): e2e4, e7e5, g1f3, b8c6, f1b5, a7a6
+3. **scotch** (white): e2e4, e7e5, g1f3, b8c6, d2d4, e5d4, f3d4
+4. **london** (white): d2d4, d7d5, g1f3, g8f6, c1f4
+5. **scandinavian** (black): e2e4, d7d5, e4d5, d8d5, b1c3, d5a5
+
+Every `to` for a learner move must be a legal `applyMove` result on the running
+board (verified by tests — see below); replies are auto-applied likewise.
+
+### Opening Trainer game — `src/games/chess-quest/components/games/OpeningTrainer.tsx` (new)
+
+Props: `{ opening: string }`. Uses `Board`, `GameShell`, engine
+(`legalTargets`/`applyMove`/`sqIdx`/`parseFEN` START), `celebrate`, `voice`,
+`useProgress`, `useLater`, `STAR_RULES.openingTrainer`.
+
+Flow (port of the app's tap-move idiom):
+- Start from the standard position. Maintain `ply` (index into `line`).
+- If `line[ply]` is an opponent move (side ≠ learnerSide), auto-play it after a
+  short `later()` delay, highlight it, advance `ply`. For a black-learner
+  opening this plays white's 1.e4 first.
+- On the learner's turn: highlight the from-square (a gentle hint), accept a
+  tap-tap move. If it equals `line[ply]` → apply, `sfx.move`, advance, then
+  trigger the next opponent reply. If wrong → `sfx.bad`, shake, coach nudge
+  ("Not the book move — try the highlighted piece"), reset the attempt (board
+  stays; count a mistake).
+- When `ply` reaches the end → `celebrate()`, `voice.say(name + " — you played the whole line!")`, award `STAR_RULES.openingTrainer(mistakes)`, show "Play again".
+- HUD: `{name}` + `move {learnerMovesDone}/{learnerMovesTotal}`. The opening's
+  `idea` shows under the board.
+
+`STAR_RULES.openingTrainer(mistakes)`: 0 → 3, 1–2 → 2, else 1. (Add to
+`lib/stars.ts` with tests.)
+
+### Content — lands + lessons
+
+- `content/lands.ts`: add land id 10 `{ glyph: "♚", name: "Opening Range", weeks: [49, 53], track: 3, goal, check, checkClassic }`.
+- `content/lessons.ts`: add `GameId` member `"openingTrainer"`; add lessons 49–53
+  (land 10), each `game: "openingTrainer"`, `gameOpts: { opening: <id> }`, with
+  brief Learn/Play/Tip (Story + Classic) that point at *playing* the line.
+  - 49 Italian, 50 Ruy Lopez, 51 Scotch, 52 London, 53 Scandinavian.
+- **Improvement:** lessons 19 and 31 change `game: null` → `game: "openingTrainer"`,
+  `gameOpts: { opening: "italian" }`. Their existing copy stays (already about
+  the Italian); the Play button now drills it.
+
+### Store, map, progress, certificate
+
+- `lib/progress.ts` `trackDone(track: 1 | 2 | 3)`: track 3 → lessons 49–53 (lo 49, hi 53). Type widened.
+- `QuestMap`: Track 3 header renders "Opening Range" eyebrow — the generic
+  track-head logic already keys off `land.track`; extend the label map to
+  include `3 → "Opening Range"`.
+- `QuestHeader` / progress bar: already computes over `LESSONS.length` (now 53) — no change beyond data.
+- `ProgressPanel`: add a Track 3 bar (`trackDone(3)` / 5).
+- `Certificate` / `lib/cert.ts` `certTitle(t1, t2, t3)`: widen signature.
+  - t1===24 && t2===24 && t3===5 → "Chess Quest Grandmaster" (line: entire quest incl. an opening repertoire)
+  - else fall through to the existing t1/t2 tiers; t3-only (t3===5, others partial) → "Opening Range Champion".
+  - `Certificate` passes `progress.trackDone(3)`; stats line adds lands done/10.
+
+### Games registry / launcher
+
+- `index.tsx` `renderGame`: add `case "openingTrainer": return <OpeningTrainer opening={opts.opening as string ?? "italian"} />`.
+- `GAME_LABEL` (questData): add `openingTrainer: "▶ Play the opening"`.
+- Free-play arcade: add an "Opening Trainer" card (defaults to Italian) so it's
+  reachable outside the quest, consistent with the other 8.
+
+## Testing
+
+- **Vitest — openings content verification** (new `content/__tests__/openings.test.ts`):
+  for each opening, replaying `line` from the start position with `applyMove` keeps
+  every move legal (`legalTargets` contains each `to`), sides alternate correctly,
+  and `learnerSide` matches who moves first among the learner's plies. This is the
+  machine guard that the lines are playable — same rigor as the puzzle packs.
+- **Vitest — stars:** `openingTrainer` thresholds (0→3, 1→2, 2→2, 3→1).
+- **Vitest — curriculum shape** (update existing): 53 lessons, 10 lands, track 3
+  lands cover 49–53, `openingTrainer` added to the valid `GameId` set, lands tile
+  1–53 exactly once, lessons 19 & 31 now have a real game id.
+- **Vitest — cert:** `certTitle` 3-track branches.
+- **Playwright:** a lesson in Track 3 launches the trainer and the first move is
+  accepted; arcade Opening Trainer plays the Italian line to completion.
+
+## Out of scope
+
+- Castling / en passant in the engine (lines stop before castling by design).
+- Deeper opening theory, transpositions, or move-order alternatives (single
+  mainline per opening; wrong moves just retry).
+- The footer link + header centering are trivial UI bundled in this branch, not
+  part of the quest feature.


### PR DESCRIPTION
Adds a third quest track of **playable** opening lessons — you *play* each opening move by move rather than reading about it — plus two small UI bundles.

## Opening Trainer (new mini-game)
Follow-the-line: the board prompts your next move (glowing piece), you tap-tap it, the trainer auto-plays the book reply and advances until the line is done — confetti + stars (clean run = 3). Five classic lines, all ≤5 development plies (the engine has no castling, and the setup is the beginner takeaway anyway):
- Italian, Ruy Lopez, Scotch (1.e4 e5), London (1.d4), Scandinavian (as Black vs 1.e4)

Every line is **machine-verified engine-legal** (content test), same rigor as the puzzle packs.

## Track 3 "Opening Range"
New land (id 10, `track: 3`), lessons 49–53 = Days 97–105, each launching the trainer. Quest map gets a Track 3 section; progress panel a Track 3 bar; certificate a 3-track "Chess Quest Grandmaster" tier. Store `trackDone(3)` and the 48→53 / 9→10 shape updated across content, store, and tests.

## Track 1/2 improvement
Lessons **19 "Her First Opening"** and **31 "The Italian, With a Plan"** were instruction-only (`game: null`); both now launch the Opening Trainer (Italian) — turning two Italian *reading* lessons into *playing* lessons, per the same "play not instructions" theme.

## Bundled UI
- **Games** link in the site footer (Product column)
- Game-player header (back / title / powered-by) centered

## Test plan
- [x] Vitest: 826 passing — opening lines engine-legal, curriculum shape (53 lessons / 10 lands / track 3), star rule, 3-track certTitle, trackDone(3)
- [x] `npm run build` clean (all Track 3 wiring type-checks)
- [x] Browser-verified: Opening Trainer prompts e4, accepts e2–e4, auto-plays …e5, advances to move 1/3 and prompts Nf3
- [x] e2e added (`games.spec.ts`) — runs in CI against Postgres
- eslint clean but for 2 tolerated animation warnings (Board shake, trainer auto-play)

Spec + plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)