### PR TITLE
User timezone preference — two-lane, always-labelled times

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,11 +4,18 @@ name: E2E
 # Runs automatically on pushes to main; for a PR, trigger it manually and
 # pass the PR number (Actions -> E2E -> Run workflow).
 #
-# target=staging runs the same suite against the deployed staging app instead
-# of a local dev server: E2E_PROD_TARGET=1 makes the auth helpers mint login
-# tokens straight in the staging DB (production builds never dev-expose
-# `login_url`) and skips the specs that assert dev link exposure. The run
-# leaves TAG-prefixed e2e users/orgs behind in the staging DB.
+# Both targets now run against a PRODUCTION build, never `next dev`: `next dev`
+# pins its V8 heap to half the runner's RAM and restarts itself past ~80% use
+# (with transient 404s from Turbopack's on-demand compiles as it nears the
+# ceiling) — flaky under a full Playwright run. `next start` has neither the
+# watchdog nor per-request compiles, and is what production runs anyway. The
+# compiler cache is persisted between runs so the build only pays for changes.
+#
+# Because production builds never dev-expose `login_url`, both targets set
+# E2E_PROD_TARGET=1: the auth helpers mint login tokens straight in the DB
+# (the local Postgres service here, the staging DB for target=staging) and
+# skip the specs that assert dev link exposure. Runs leave TAG-prefixed e2e
+# users/orgs behind in whichever DB they targeted.
 on:
   push:
     branches: [main]
@@ -62,6 +69,10 @@ jobs:
       AUTH_SECRET: ci-only-insecure-secret-please-change-in-prod-0123456789
       NEXT_PUBLIC_SUPABASE_URL: ""
       NEXT_TELEMETRY_DISABLED: "1"
+      # Production build → no dev-exposed `login_url`, so the auth helpers mint
+      # login tokens straight in the Postgres service above and skip the specs
+      # that assert dev link exposure. Same path the staging target uses.
+      E2E_PROD_TARGET: "1"
 
     steps:
       - uses: actions/checkout@v5
@@ -88,9 +99,29 @@ jobs:
       - name: Sync sport catalog from the engine registry
         run: npm run sync:sports
 
-      - name: Start dev server
+      # Persist the compiler cache between runs so the production build only
+      # pays for what changed (nextjs.org/docs/pages/guides/ci-build-caching).
+      # Source-hash key with a lockfile restore-key: exact hit on unchanged
+      # source, warm partial cache otherwise. Mirrors the CI smoke job.
+      - name: Cache Next.js build cache
+        uses: actions/cache@v4
+        with:
+          path: apps/web/.next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('apps/web/src/**/*.js', 'apps/web/src/**/*.jsx', 'apps/web/src/**/*.ts', 'apps/web/src/**/*.tsx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
+
+      # Pre-compiled production build, not `next dev`: `next dev` pins its V8
+      # heap to half the runner RAM and restarts past ~80% use (transient 404s
+      # from Turbopack's on-demand compiles near the ceiling) — flaky under a
+      # full Playwright run. `next start` has neither watchdog nor per-request
+      # compiles, and matches production.
+      - name: Build (production)
+        run: npm run build --workspace apps/web
+
+      - name: Start server
         run: |
-          npm run dev > dev-server.log 2>&1 &
+          npm run start --workspace apps/web > dev-server.log 2>&1 &
           echo "waiting for server…"
           for i in $(seq 1 90); do
             if curl -sf http://localhost:3000/api/health >/dev/null; then

--- a/apps/web/content/help/scheduling/timezones.md
+++ b/apps/web/content/help/scheduling/timezones.md
@@ -1,0 +1,36 @@
+---
+title: Timezones — venue time vs your time
+description: Why a match shows the venue's local time everywhere, how to set your own timezone, and where your time is used instead.
+order: 6
+---
+
+Seazn shows every time with its **timezone spelled out** — `19:00 IST`, `14:30 BST` — so a time is never ambiguous. There are two lanes, and knowing which is which explains everything.
+
+## Venue time (schedules)
+
+A match happens at the **venue's** wall clock. A final in Chennai is **19:00 IST** whether you open the schedule from London, New York, or courtside. So every schedule — the fixture board, the public league page, round headers — shows the **venue's** timezone, the same for every viewer. This is the competition's timezone, set per division under **Division → Schedule settings**.
+
+We never quietly convert a schedule to your device's zone: that's how people miss matches.
+
+## Your time (everything about you)
+
+Your own times — **/me** (your schedule), account activity, billing renewal dates — show in **your** timezone. And beside every venue time we add your local equivalent, in teal, so you know when to tune in without doing the maths:
+
+> **19:00 IST**
+> ↳ 14:30 BST
+
+The second line only appears when your timezone differs from the venue's.
+
+## Set your timezone
+
+**Settings → Account → Preferences → Timezone.**
+
+- Pick any zone from the list, or press **Detect** to use your device's.
+- The **Current time here** preview confirms your choice at a glance.
+- Leave it on **Use my browser's timezone** and we follow whatever device you're on.
+
+Your choice is saved to your account, so it follows you across devices. It only ever changes *your* times and the local-time hints — it never moves a venue's schedule.
+
+## Why does a time show an offset like GMT+5:30?
+
+Most zones have a friendly short name (IST, BST, EDT). A few don't, so we show the UTC offset instead — it means the same thing, just spelled numerically.

--- a/apps/web/e2e/user-account.spec.ts
+++ b/apps/web/e2e/user-account.spec.ts
@@ -37,3 +37,45 @@ test("display name edits persist and the data export downloads", async ({ page }
   const body = (await exported.json()) as Record<string, unknown>;
   expect(Object.keys(body).length).toBeGreaterThan(0);
 });
+
+// Timezone preference: pick a zone, it persists; a bogus zone is rejected by
+// the API. No email budget touched.
+test("timezone preference persists and the API rejects a bogus zone", async ({ page }) => {
+  await page.goto("/settings?tab=account");
+
+  const select = page.getByRole("combobox", { name: "Your timezone" });
+  await expect(select).toBeVisible();
+
+  // Preferences form has its own Save; scope to the timezone control's form.
+  const tzForm = page.locator("div").filter({ has: select }).last();
+  await select.selectOption("Asia/Kolkata");
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes("/api/users/me") && r.request().method() === "PATCH" && r.ok(),
+    ),
+    tzForm.getByRole("button", { name: /^Sav/ }).click(),
+  ]);
+
+  await page.reload();
+  await expect(page.getByRole("combobox", { name: "Your timezone" })).toHaveValue(
+    "Asia/Kolkata",
+    { timeout: 20_000 },
+  );
+
+  // The venue-vs-your-time helper copy is present.
+  await expect(page.getByText(/venue/i).first()).toBeVisible();
+
+  // API guards the column: a non-IANA zone is a 4xx, not stored.
+  const bad = await page.request.patch("/api/users/me", {
+    headers: { "Content-Type": "application/json" },
+    data: { timezone: "Mars/Phobos" },
+  });
+  expect(bad.status()).toBeGreaterThanOrEqual(400);
+  expect(bad.status()).toBeLessThan(500);
+
+  // Restore to "follow my browser" so reruns start clean.
+  await page.request.patch("/api/users/me", {
+    headers: { "Content-Type": "application/json" },
+    data: { timezone: null },
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -3,9 +3,14 @@ import { defineConfig, devices } from "@playwright/test";
 // E2E UI suite. Drives the real app in Chromium. Auth is provisioned once
 // (auth.setup.ts → storageState) and reused across specs.
 //
-// Local:  a dev server on PLAYWRIGHT_BASE (default :3000) must already be up
-//         against a migrated DB (the webServer block boots one otherwise).
-// CI:     e2e.yml starts the server against the Postgres service.
+// Server:  a PRE-COMPILED production server (`next build` + `next start`), never
+//          `next dev` — dev's per-request Turbopack compiles + half-RAM heap
+//          watchdog make a full run flaky (transient 404s, restarts). Local: a
+//          server on PLAYWRIGHT_BASE (:3000) must already be up against a
+//          migrated DB, else the webServer block builds + starts one. Because a
+//          prod build never dev-exposes `login_url`, local runs need
+//          E2E_PROD_TARGET=1 + DATABASE_URL so the auth helpers mint tokens in
+//          the DB (same as CI). CI: e2e.yml builds + starts against Postgres.
 //
 // Two projects, two phases (see the test:e2e script):
 //   parallel — specs that only touch state they create (own competitions/
@@ -73,12 +78,13 @@ export default defineConfig({
       dependencies: ["setup"],
     },
   ],
-  // A dev server is expected on BASE (CI starts one; locally you usually run
-  // your own). Reuse it if present, else boot one — never double-start.
+  // A server is expected on BASE (CI starts one; locally you usually run your
+  // own). Reuse it if present, else build + start a production server — never
+  // `next dev`, never double-start. The long timeout covers a cold build.
   webServer: {
-    command: "npm run dev",
+    command: "npm run build && npm run start",
     url: `${BASE}/api/health`,
-    timeout: 120_000,
+    timeout: 300_000,
     reuseExistingServer: true,
   },
 });

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
@@ -54,7 +54,7 @@ export default async function DivisionHomePage({ params }: Props) {
     if (renamed) permanentRedirect(renamed);
     notFound();
   }
-  const { org, competition, division, stages, pools, fixtures, standings, entrants } = data;
+  const { org, competition, division, stages, pools, fixtures, standings, entrants, tz } = data;
 
   // MetricSpec[] + cascade from the division's PINNED module version.
   let metricSpecs: MetricSpecLike[] = [];
@@ -295,6 +295,7 @@ export default async function DivisionHomePage({ params }: Props) {
             fixtures={fixtures}
             entrantNames={entrantNames}
             divisionPath={basePath}
+            tz={tz}
           />,
           standingsPanel,
           entrantsPanel,

--- a/apps/web/src/app/api/orgs/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/orgs/[id]/__tests__/route.test.ts
@@ -16,6 +16,7 @@ const fakeUser: User = {
   display_name: "Route Test",
   email: "route-test@test.local",
   avatar_url: null,
+  timezone: null,
 };
 
 vi.mock("@/lib/auth", async (importOriginal) => {

--- a/apps/web/src/app/api/users/me/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/me/__tests__/route.test.ts
@@ -18,6 +18,7 @@ const fakeUser: User = {
   display_name: "Me Route Test",
   email: "me-route-test@test.local",
   avatar_url: null,
+  timezone: null,
 };
 
 const requireUserMock = vi.fn<() => Promise<User>>();

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -41,20 +41,27 @@ export async function GET() {
   return res;
 }
 
-/** Update the authenticated user's profile (currently just the display name). */
+/**
+ * Update the authenticated user's profile: display name and/or timezone. Each
+ * field is optional; an absent field is left untouched, a `timezone: null`
+ * clears the preference ("follow my browser"). The zone is validated in the
+ * schema (isValidIana) so the column only holds an Intl-parseable name.
+ */
 export async function PATCH(req: Request) {
   return handler(async () => {
     const user = await requireUser();
-    const { display_name } = updateProfileSchema.parse(await req.json());
+    const patch = updateProfileSchema.parse(await req.json());
 
-    const [row] = await sql<{ display_name: string }[]>`
-      update users set display_name = ${display_name}
+    const [row] = await sql<{ display_name: string; timezone: string | null }[]>`
+      update users set
+        display_name = ${patch.display_name ?? sql`display_name`},
+        timezone     = ${patch.timezone !== undefined ? patch.timezone : sql`timezone`}
       where id = ${user.id}
-      returning display_name`;
+      returning display_name, timezone`;
 
-    // display_name is cached in getCurrentUser — drop the stale entry.
+    // display_name/timezone are cached in getCurrentUser — drop the stale entry.
     await invalidateUser(user.id);
-    return { display_name: row.display_name };
+    return { display_name: row.display_name, timezone: row.timezone };
   });
 }
 

--- a/apps/web/src/app/embed/divisions/[id]/[widget]/page.tsx
+++ b/apps/web/src/app/embed/divisions/[id]/[widget]/page.tsx
@@ -33,7 +33,7 @@ export default async function EmbedWidgetPage({ params }: Props) {
   const resolved = await embedDivisionData(id);
   // Both failure modes 404: a stranger's iframe is no place for a paywall.
   if (!resolved.ok) notFound();
-  const { org, competition, division, stages, pools, fixtures, standings, entrants } =
+  const { org, competition, division, stages, pools, fixtures, standings, entrants, tz } =
     resolved.data;
 
   let metricSpecs: MetricSpecLike[] = [];
@@ -55,7 +55,7 @@ export default async function EmbedWidgetPage({ params }: Props) {
   let body: React.ReactNode;
   if (widget === "schedule") {
     body = (
-      <Schedule fixtures={fixtures} entrantNames={entrantNames} divisionPath={publicPath} />
+      <Schedule fixtures={fixtures} entrantNames={entrantNames} divisionPath={publicPath} tz={tz} />
     );
   } else if (widget === "bracket") {
     const stage = stages.find((s) => BRACKET_KINDS.has(s.kind));

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -705,3 +705,72 @@ body {
   background: linear-gradient(160deg, var(--mk-night-2), var(--mk-night));
   color: var(--mk-lime);
 }
+
+/* ── Timezone labels (spec 2026-07-14 user-timezone-design) ─────────────────
+   The venue lane shows the viewer's local equivalent in a distinct teal so it
+   never reads as a second venue time. Colour + position carry "whose time" —
+   no literal "your time" text on screen; screen readers get an aria-label. */
+:root {
+  --tz-you: #0d9488;
+  --tz-you-soft: #e6f6f4;
+}
+.tz-you {
+  display: block;
+  margin-top: 1px;
+  font-size: 0.75em;
+  font-weight: 600;
+  color: var(--tz-you);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+.tz-you::before {
+  content: "↳ ";
+  opacity: 0.55;
+}
+/* Hover variant (opt-in via you="hover"): dotted underline + popover. */
+.tz-hoverable {
+  position: relative;
+  cursor: help;
+  border-bottom: 1.5px dotted color-mix(in srgb, var(--tz-you) 55%, transparent);
+}
+.tz-tip {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 7px);
+  z-index: 20;
+  display: grid;
+  gap: 1px;
+  padding: 6px 9px;
+  border-radius: 8px;
+  background: var(--ps-court, #231738);
+  color: var(--ps-court-ink, #f7f5fb);
+  font-size: 0.78rem;
+  font-weight: 600;
+  white-space: nowrap;
+  box-shadow: 0 10px 26px -12px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transform: translateY(3px);
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.tz-tip-you {
+  color: color-mix(in srgb, var(--tz-you) 70%, white);
+  font-variant-numeric: tabular-nums;
+}
+.tz-tip-lbl {
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+.tz-hoverable:hover .tz-tip,
+.tz-hoverable:focus-visible .tz-tip {
+  opacity: 1;
+  transform: translateY(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .tz-tip {
+    transition: none;
+  }
+}

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -12,6 +12,7 @@ import { listMyFixtures, listMyPersons, type MyFixture, type MyResult } from "@/
 import { RsvpControl } from "@/components/me/rsvp-control";
 import { ConsentCard } from "@/components/me/consent-card";
 import { LogoutButton } from "@/components/logout-button";
+import { Zoned, ViewerTzProvider } from "@/components/client-time";
 
 export default async function MePage({
   searchParams,
@@ -34,7 +35,7 @@ export default async function MePage({
   const [next, ...rest] = upcoming;
 
   return (
-    <>
+    <ViewerTzProvider tz={user.timezone}>
       <header className="app-gantry">
         <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3">
           <span className="app-display text-base font-bold leading-none text-cream">
@@ -78,9 +79,22 @@ export default async function MePage({
                   {next.opponent_name ?? "TBD"}
                 </p>
                 <p className="mt-1.5 text-sm text-cream/70">
-                  <FixtureContext f={next} /> · {when(next.scheduled_at)}
+                  <FixtureContext f={next} />
                   {next.venue ? ` · ${next.venue}` : ""}
                   {next.court_label ? ` · ${next.court_label}` : ""}
+                </p>
+                <p className="mt-1 text-sm font-medium text-cream/90">
+                  {next.scheduled_at ? (
+                    <Zoned
+                      value={next.scheduled_at}
+                      tz={next.venue_tz ?? "UTC"}
+                      mode="datetime"
+                      showZone
+                      you="subtitle"
+                    />
+                  ) : (
+                    "Unscheduled"
+                  )}
                 </p>
                 {publicHref(next) && (
                   <Link
@@ -118,8 +132,21 @@ export default async function MePage({
                         {f.opponent_name ?? "TBD"}
                       </p>
                       <p className="mt-0.5 text-xs text-slate-400">
-                        <FixtureContext f={f} /> · {when(f.scheduled_at)}
+                        <FixtureContext f={f} />
                         {f.venue ? ` · ${f.venue}` : ""}
+                      </p>
+                      <p className="mt-0.5 text-xs font-medium text-slate-600">
+                        {f.scheduled_at ? (
+                          <Zoned
+                            value={f.scheduled_at}
+                            tz={f.venue_tz ?? "UTC"}
+                            mode="datetime"
+                            showZone
+                            you="subtitle"
+                          />
+                        ) : (
+                          "Unscheduled"
+                        )}
                       </p>
                     </div>
                     {publicHref(f) && (
@@ -198,7 +225,7 @@ export default async function MePage({
           </Link>
         </p>
       </main>
-    </>
+    </ViewerTzProvider>
   );
 }
 
@@ -208,11 +235,6 @@ function FixtureContext({ f }: { f: MyFixture }) {
       {f.competition_name} · {f.division_name} · {f.org_name}
     </>
   );
-}
-
-function when(iso: string | null): string {
-  if (!iso) return "unscheduled";
-  return new Date(iso).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
 }
 
 /** Spectator link — only competitions with a public page get one. */

--- a/apps/web/src/app/my-matches/page.tsx
+++ b/apps/web/src/app/my-matches/page.tsx
@@ -9,6 +9,7 @@ import { getCurrentUser } from "@/lib/auth";
 import { listAssignedFixtures } from "@/server/usecases/scorers";
 import { resolveModule } from "@/server/engine-db";
 import { LogoutButton } from "@/components/logout-button";
+import { Zoned, ViewerTzProvider } from "@/components/client-time";
 
 export default async function MyMatchesPage() {
   const user = await getCurrentUser();
@@ -21,7 +22,7 @@ export default async function MyMatchesPage() {
   const later = fixtures.filter((f) => !today.includes(f));
 
   return (
-    <>
+    <ViewerTzProvider tz={user.timezone}>
       {/* Scorer console gets the same night gantry as the org chrome. */}
       <header className="app-gantry">
         <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3">
@@ -49,7 +50,7 @@ export default async function MyMatchesPage() {
         {today.length > 0 && <Section title="Today" fixtures={today} />}
         {later.length > 0 && <Section title="Upcoming" fixtures={later} />}
       </main>
-    </>
+    </ViewerTzProvider>
   );
 }
 
@@ -88,12 +89,17 @@ function Section({ title, fixtures }: { title: string; fixtures: Assigned[] }) {
               </div>
               <div className="text-right text-xs text-slate-500">
                 <p>
-                  {f.scheduled_at
-                    ? new Date(f.scheduled_at).toLocaleString(undefined, {
-                        dateStyle: "medium",
-                        timeStyle: "short",
-                      })
-                    : "unscheduled"}
+                  {f.scheduled_at ? (
+                    <Zoned
+                      value={f.scheduled_at}
+                      tz={f.venue_tz ?? "UTC"}
+                      mode="datetime"
+                      showZone
+                      you="subtitle"
+                    />
+                  ) : (
+                    "unscheduled"
+                  )}
                 </p>
                 <p className="text-slate-400">
                   {[f.venue, f.court_label].filter(Boolean).join(" · ")}

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/f/[no]/page.tsx
@@ -12,6 +12,7 @@ import {
   listEvents,
 } from "@/server/usecases/fixtures";
 import { getDivision } from "@/server/usecases/divisions";
+import { getScheduleSettings } from "@/server/usecases/schedule";
 import { getCompetition } from "@/server/usecases/competitions";
 import { getEntrant } from "@/server/usecases/entrants";
 import { resolveModule } from "@/server/engine-db";
@@ -39,12 +40,13 @@ export default async function FixturePage({
   // chrome (My-matches breadcrumb); editors keep the organiser surface.
   const isScorer = canScore && !canEdit;
   const fixture = await getFixture(auth, id);
-  const [division, state, events, recorderNames, availability] = await Promise.all([
+  const [division, state, events, recorderNames, availability, schedule] = await Promise.all([
     getDivision(auth, fixture.division_id),
     getFixtureState(auth, id),
     listEvents(auth, id, 0),
     eventRecorderNames(auth, id),
     listFixtureAvailability(auth, id),
+    getScheduleSettings(auth, fixture.division_id),
   ]);
   const competition = await getCompetition(auth, division.competition_id);
   const sportModule = resolveModule(division.sport_key, division.module_version);
@@ -98,6 +100,7 @@ export default async function FixturePage({
             id: fixture.id,
             status: fixture.status,
             scheduled_at: fixture.scheduled_at,
+            scheduled_tz: schedule.tz,
             venue: fixture.venue,
             court_label: fixture.court_label,
             round_no: fixture.round_no,

--- a/apps/web/src/app/o/[orgSlug]/settings/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/page.tsx
@@ -4,6 +4,7 @@ import {
   Building2, Users, CreditCard, UserCircle,
   Pencil, Image as ImageIcon, Palette,
   User, Mail, Download, ShieldOff, KeyRound, Compass, Banknote, BookOpen, Cookie, Handshake,
+  Clock,
   type LucideIcon,
 } from "lucide-react";
 import { getUserOrgs } from "@/lib/auth";
@@ -29,6 +30,7 @@ import {
   DeleteAccountButton,
 } from "@/components/account-actions";
 import { ApiKeysPanel } from "@/components/api-keys";
+import { TimezonePreference } from "@/components/timezone-preference";
 import { CookieSettingsButton } from "@/components/cookie-settings-button";
 import { TourReplayButton } from "@/components/tour-replay";
 import { PlanBadge } from "@/components/plan-badge";
@@ -360,6 +362,14 @@ export default async function SettingsPage({
                   <p className="text-sm text-slate-500">
                     Account ID: <span className="font-mono text-xs text-purple-600">{user.id}</span>
                   </p>
+                </section>
+
+                {/* Preferences — timezone (spec 2026-07-14). Drives every
+                    personal time + the local-time hint beside venue times. */}
+                <section className="card p-5">
+                  <SectionHeader icon={Clock}>Preferences</SectionHeader>
+                  <label className="mb-1 block text-sm text-slate-500">Timezone</label>
+                  <TimezonePreference current={user.timezone} />
                 </section>
 
                 {/* Change email */}

--- a/apps/web/src/components/client-time.tsx
+++ b/apps/web/src/components/client-time.tsx
@@ -1,6 +1,119 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
+import { fmtDate, fmtTime, fmtDateTime, fmtZoneAbbrev } from "@/lib/format";
+
+/**
+ * Viewer timezone (spec 2026-07-14). A logged-in user's saved `users.timezone`
+ * is passed down from whichever server component already loaded the user (no
+ * extra query, and it keeps the resolution OUT of the root layout so that
+ * layout stays static). When no pref is provided we detect the browser zone on
+ * the client. Personal-lane times render in this zone; the venue lane uses it
+ * only to show the viewer's local equivalent beside the authoritative venue time.
+ */
+const ViewerTzContext = createContext<string | null | undefined>(undefined);
+
+export function ViewerTzProvider({
+  tz,
+  children,
+}: {
+  tz: string | null | undefined;
+  children: React.ReactNode;
+}) {
+  return <ViewerTzContext.Provider value={tz}>{children}</ViewerTzContext.Provider>;
+}
+
+/** The viewer's zone: saved preference if present, else browser-detected. */
+export function useViewerTz(): string {
+  const pref = useContext(ViewerTzContext);
+  const [detected, setDetected] = useState<string | null>(null);
+  useEffect(() => {
+    if (pref) return; // an explicit preference wins; no need to detect
+    try {
+      setDetected(Intl.DateTimeFormat().resolvedOptions().timeZone || null);
+    } catch {
+      /* leave null → UTC */
+    }
+  }, [pref]);
+  return pref || detected || "UTC";
+}
+
+/** Same wall-clock label in both zones → nothing to disambiguate. */
+function zonesAgree(a: string, b: string, value: string | Date): boolean {
+  return (
+    fmtTime(a, value) === fmtTime(b, value) &&
+    fmtZoneAbbrev(a, value) === fmtZoneAbbrev(b, value)
+  );
+}
+
+/**
+ * A time rendered in an explicit zone, always labelled, with the viewer's local
+ * equivalent one glance (subtitle) or hover away. Superset of ClientTime:
+ *  - `tz`       the zone to render the value in (venue tz, or the viewer's).
+ *  - `showZone` append the zone abbrev ("19:00 IST").
+ *  - `you`      "subtitle" | "hover" | "off" — expose the viewer's local time
+ *               when `tz` differs from the viewer's zone (venue lane). Rendered
+ *               client-side because Node ICU emits offsets where browsers emit
+ *               IST/BST; the empty-until-mount span keeps SSR + client in step.
+ */
+export function Zoned({
+  value,
+  tz,
+  mode = "datetime",
+  showZone = false,
+  you = "off",
+}: {
+  value: string | Date | null;
+  tz: string;
+  mode?: "time" | "datetime" | "date";
+  showZone?: boolean;
+  you?: "off" | "subtitle" | "hover";
+}) {
+  const viewerTz = useViewerTz();
+  const [main, setMain] = useState("");
+  const [local, setLocal] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!value) {
+      setMain("");
+      setLocal(null);
+      return;
+    }
+    const fmtMain = mode === "date" ? fmtDate : mode === "time" ? fmtTime : fmtDateTime;
+    const label = fmtMain(tz, value);
+    setMain(showZone ? `${label} ${fmtZoneAbbrev(tz, value)}` : label);
+
+    if (you !== "off" && viewerTz && !zonesAgree(tz, viewerTz, value)) {
+      const lt = mode === "date" ? fmtDate(viewerTz, value) : fmtTime(viewerTz, value);
+      setLocal(`${lt} ${fmtZoneAbbrev(viewerTz, value)}`);
+    } else {
+      setLocal(null);
+    }
+  }, [value, tz, mode, showZone, you, viewerTz]);
+
+  if (you === "hover" && local) {
+    return (
+      <span className="tz-hoverable" tabIndex={0} suppressHydrationWarning>
+        {main}
+        <span className="tz-tip" role="tooltip">
+          <span className="tz-tip-you">{local}</span>
+          <span className="tz-tip-lbl">your time</span>
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span suppressHydrationWarning>
+      {main}
+      {you === "subtitle" && local && (
+        <span className="tz-you" aria-label={`your local time ${local}`}>
+          {local}
+        </span>
+      )}
+    </span>
+  );
+}
 
 /**
  * Renders a locale/timezone-formatted time on the client only. The first

--- a/apps/web/src/components/client-time.tsx
+++ b/apps/web/src/components/client-time.tsx
@@ -125,12 +125,15 @@ export function ClientTime({
   value,
   mode = "time",
   tz,
+  showZone = false,
 }: {
   value: string | Date | null;
   mode?: "time" | "datetime" | "date";
   /** Render in this IANA zone instead of the viewer's (v3/04 §3 — schedule
    *  pages show the competition timezone, never a browser-local surprise). */
   tz?: string;
+  /** Append the zone abbrev ("19:00 IST"). No-op for date mode (no clock). */
+  showZone?: boolean;
 }) {
   const [text, setText] = useState("");
 
@@ -139,20 +142,32 @@ export function ClientTime({
     const d = value instanceof Date ? value : new Date(value);
     const zone = tz ? { timeZone: tz } : {};
     try {
-      setText(
+      const base =
         mode === "datetime"
           ? d.toLocaleString([], { dateStyle: "medium", timeStyle: "short", ...zone })
           : mode === "date"
             ? d.toLocaleDateString([], { dateStyle: "medium", ...zone })
-            : d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", ...zone }),
-      );
+            : d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", ...zone });
+      const abbrev =
+        showZone && mode !== "date" ? ` ${fmtZoneAbbrev(tz ?? UTC_LOCAL(), d)}` : "";
+      setText(base + abbrev);
     } catch {
       // Unknown zone string — fall back to the viewer's local time.
       setText(mode === "date" ? d.toLocaleDateString() : d.toLocaleString());
     }
-  }, [value, mode, tz]);
+  }, [value, mode, tz, showZone]);
 
   return <span suppressHydrationWarning>{text}</span>;
+}
+
+/** Viewer's own zone, for labelling times ClientTime renders without an
+ *  explicit tz (so "showZone" still names a zone rather than guessing). */
+function UTC_LOCAL(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
 }
 
 /**

--- a/apps/web/src/components/public-site/schedule.tsx
+++ b/apps/web/src/components/public-site/schedule.tsx
@@ -9,25 +9,33 @@ import Link from "next/link";
 import { useState } from "react";
 import { CalendarPlus } from "lucide-react";
 import type { PublicFixture } from "@/server/public-site/data";
+import { fmtTime, fmtDate, fmtZoneAbbrev } from "@/lib/format";
 
 interface Props {
   fixtures: PublicFixture[];
   entrantNames: Record<string, string>;
   divisionPath: string; // /{org}/{comp}/{div}
+  /** Venue zone (schedule_settings.tz) — times + day grouping are venue-local,
+   *  the same for every viewer (spec 2026-07-14 two-lane, venue authoritative). */
+  tz: string;
 }
 
-function dayKey(iso: string | null): string | null {
+// Day bucket key as the venue-local calendar date (YYYY-MM-DD) so a 23:30 venue
+// match doesn't slide onto the next/previous day for a viewer in another zone.
+function dayKey(iso: string | null, tz: string): string | null {
   if (!iso) return null;
-  const d = new Date(iso);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  try {
+    return new Intl.DateTimeFormat("en-CA", { timeZone: tz }).format(new Date(iso)); // YYYY-MM-DD
+  } catch {
+    return new Intl.DateTimeFormat("en-CA").format(new Date(iso));
+  }
 }
 
 const UNSCHEDULED = "unscheduled";
 
-const timeOf = (iso: string) =>
-  new Date(iso).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
-const shortDate = (iso: string) =>
-  new Date(iso).toLocaleDateString("en-GB", { weekday: "short", day: "numeric", month: "short" });
+const timeOf = (iso: string, tz: string) => fmtTime(tz, iso);
+const shortDate = (iso: string, tz: string) =>
+  fmtDate(tz, iso, { weekday: "short", day: "numeric", month: "short" });
 
 /** Per-side score lines fit the stacked layout only when short ("3", "21").
     Long lines (cricket innings, set strings) fall back to the headline chip. */
@@ -46,11 +54,13 @@ function ScorebugRow({
   entrantNames,
   href,
   railMode,
+  tz,
 }: {
   fixture: PublicFixture;
   entrantNames: Record<string, string>;
   href: string;
   railMode: "time" | "date";
+  tz: string;
 }) {
   const live = f.status === "in_play";
   const decided = f.status === "decided" || f.status === "finalized";
@@ -86,12 +96,12 @@ function ScorebugRow({
           </span>
         ) : (
           <span className="font-display text-sm font-semibold text-ink">
-            {decided ? "Final" : f.scheduled_at ? timeOf(f.scheduled_at) : "TBD"}
+            {decided ? "Final" : f.scheduled_at ? timeOf(f.scheduled_at, tz) : "TBD"}
           </span>
         )}
         <span className="mt-0.5 max-w-[3.25rem] truncate text-[10px] uppercase tracking-wide text-ink-muted">
           {!decided && !live && railMode === "date" && f.scheduled_at
-            ? shortDate(f.scheduled_at)
+            ? shortDate(f.scheduled_at, tz)
             : (f.court_label ?? "")}
         </span>
       </span>
@@ -116,7 +126,7 @@ function ScorebugRow({
   );
 }
 
-export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
+export function Schedule({ fixtures, entrantNames, divisionPath, tz }: Props) {
   const [entrant, setEntrant] = useState<string>("");
   // Day view first (fixtures by date) — matches how a spectator reads a
   // timetable on the day. Round view stays a click away for bracket-style flow.
@@ -131,7 +141,7 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
 
   const groups = new Map<string, PublicFixture[]>();
   for (const f of shown) {
-    const key = mode === "day" ? (dayKey(f.scheduled_at) ?? UNSCHEDULED) : String(f.round_no);
+    const key = mode === "day" ? (dayKey(f.scheduled_at, tz) ?? UNSCHEDULED) : String(f.round_no);
     const list = groups.get(key) ?? [];
     list.push(f);
     groups.set(key, list);
@@ -213,6 +223,14 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
         <section key={key} className="mb-6">
           <h3 className="mb-2 flex items-center gap-3 font-display text-sm font-semibold uppercase tracking-[0.18em] text-ink-muted">
             {groupLabel(key)}
+            {(() => {
+              const anchor = list.find((x) => x.scheduled_at)?.scheduled_at;
+              return anchor ? (
+                <span className="font-sans text-[10px] font-medium normal-case tracking-normal text-ink-muted/70">
+                  times in {fmtZoneAbbrev(tz, anchor)}
+                </span>
+              ) : null;
+            })()}
             <span aria-hidden className="h-px flex-1 bg-zinc-200" />
           </h3>
           <ul className="divide-y divide-zinc-100 overflow-hidden rounded-xl border border-zinc-200/80 bg-surface shadow-sm">
@@ -230,6 +248,7 @@ export function Schedule({ fixtures, entrantNames, divisionPath }: Props) {
                     entrantNames={entrantNames}
                     href={`${divisionPath}/fixtures/${f.id}`}
                     railMode={mode === "day" ? "time" : "date"}
+                    tz={tz}
                   />
                 </li>
               ))}

--- a/apps/web/src/components/timezone-preference.tsx
+++ b/apps/web/src/components/timezone-preference.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { fmtTime, fmtZoneAbbrev } from "@/lib/format";
+import { listTimezones, TZ_COOKIE } from "@/lib/tz";
+
+/**
+ * Account → Preferences timezone picker (spec 2026-07-14). Saves to
+ * users.timezone via PATCH /api/users/me and mirrors the choice into the
+ * seazn_tz cookie so server-side resolveTimezone() agrees. Empty selection
+ * clears the preference ("follow my browser").
+ */
+export function TimezonePreference({ current }: { current: string | null }) {
+  const router = useRouter();
+  const zones = useMemo(() => listTimezones(), []);
+  const browserTz = useMemo(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+    } catch {
+      return "UTC";
+    }
+  }, []);
+
+  const [value, setValue] = useState(current ?? "");
+  const [status, setStatus] = useState<"idle" | "loading" | "saved" | "error">("idle");
+  const [error, setError] = useState("");
+  const [now, setNow] = useState(() => new Date());
+
+  // Keep the live preview honest as minutes tick over.
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 15_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Group the (large) IANA list by region for a scannable <select>.
+  const groups = useMemo(() => {
+    const by = new Map<string, string[]>();
+    for (const z of zones) {
+      const region = z.includes("/") ? z.slice(0, z.indexOf("/")) : "Other";
+      (by.get(region) ?? by.set(region, []).get(region)!).push(z);
+    }
+    return [...by.entries()];
+  }, [zones]);
+
+  const previewZone = value || browserTz;
+  const preview = `${fmtTime(previewZone, now)} ${fmtZoneAbbrev(previewZone, now)}`;
+
+  async function save(next: string) {
+    setStatus("loading");
+    setError("");
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ timezone: next === "" ? null : next }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error ?? "Failed to save timezone");
+      }
+      // Mirror into the cookie so anonymous/SSR resolution matches the pref.
+      document.cookie = `${TZ_COOKIE}=${encodeURIComponent(next)}; path=/; max-age=${next === "" ? 0 : 60 * 60 * 24 * 365}; SameSite=Lax`;
+      setStatus("saved");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+      setStatus("error");
+    }
+  }
+
+  const unchanged = value === (current ?? "");
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-0 flex-1">
+          <select
+            aria-label="Your timezone"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+              setStatus("idle");
+            }}
+            className="input w-full"
+          >
+            <option value="">Use my browser’s timezone ({browserTz})</option>
+            {groups.map(([region, list]) => (
+              <optgroup key={region} label={region}>
+                {list.map((z) => (
+                  <option key={z} value={z}>
+                    {z.replace(/_/g, " ")}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setValue(browserTz);
+            setStatus("idle");
+          }}
+          className="btn btn-ghost shrink-0"
+          title={`Detect: ${browserTz}`}
+        >
+          ⌖ Detect
+        </button>
+        <button
+          type="button"
+          onClick={() => save(value)}
+          disabled={status === "loading" || unchanged}
+          className="btn btn-primary shrink-0"
+        >
+          {status === "loading" ? "Saving…" : "Save"}
+        </button>
+      </div>
+
+      <div className="flex items-baseline gap-2 rounded-lg bg-[var(--tz-you-soft)] px-3 py-2">
+        <span className="text-xs font-medium text-[var(--tz-you)]">Current time here</span>
+        <span
+          className="text-lg font-bold tabular-nums text-[var(--tz-you)]"
+          suppressHydrationWarning
+        >
+          {preview}
+        </span>
+      </div>
+
+      <p className="text-xs text-slate-500">
+        Schedules always show the <strong>venue’s</strong> time; this controls your own times
+        (your schedule, activity, billing) and the local-time hint beside every venue time.
+      </p>
+      {status === "saved" && <p className="text-sm text-emerald-600">Timezone saved.</p>}
+      {status === "error" && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/apps/web/src/components/v2/fixture-console.tsx
+++ b/apps/web/src/components/v2/fixture-console.tsx
@@ -86,6 +86,8 @@ interface Props {
     id: string;
     status: string;
     scheduled_at: string | null;
+    /** Venue zone (schedule_settings.tz) so the kick-off shows venue time. */
+    scheduled_tz?: string;
     venue: string | null;
     court_label: string | null;
     round_no: number;
@@ -228,7 +230,7 @@ export function FixtureConsole({
           {fixture.scheduled_at ? (
             <>
               {" · "}
-              <ClientTime value={fixture.scheduled_at} mode="datetime" />
+              <ClientTime value={fixture.scheduled_at} mode="datetime" tz={fixture.scheduled_tz} showZone />
             </>
           ) : (
             ""

--- a/apps/web/src/components/v2/stages-panel.tsx
+++ b/apps/web/src/components/v2/stages-panel.tsx
@@ -722,7 +722,7 @@ function FixtureLine({
         >
           {timed ? (
             <>
-              Scheduled · <ClientTime value={fixture.scheduled_at} mode="datetime" tz={tz} />
+              Scheduled · <ClientTime value={fixture.scheduled_at} mode="datetime" tz={tz} showZone />
             </>
           ) : (
             "Unscheduled"

--- a/apps/web/src/lib/__tests__/format.test.ts
+++ b/apps/web/src/lib/__tests__/format.test.ts
@@ -28,11 +28,18 @@ describe("fmtZoneAbbrev — DST-dependent", () => {
     expect(summer).not.toBe(winter);
     expect(summer).toBeTruthy();
   });
-  it("Asia/Kolkata is stable year-round (no DST)", () => {
+  it("Asia/Kolkata is stable year-round (no DST) and reads IST, not an offset", () => {
     const jan = fmtZoneAbbrev("Asia/Kolkata", "2026-01-15T12:00:00Z");
     const aug = fmtZoneAbbrev("Asia/Kolkata", IST_1900);
     expect(jan).toBe(aug);
-    expect(jan).toBeTruthy();
+    // The DST-free override guarantees "IST" even where ICU emits "GMT+5:30".
+    expect(jan).toBe("IST");
+  });
+  it("keeps a runtime-provided name and only overrides offset fallbacks", () => {
+    // Gulf Standard Time is DST-free; ICU offset fallback becomes GST.
+    expect(fmtZoneAbbrev("Asia/Dubai", IST_1900)).toBe("GST");
+    // A zone with no override keeps whatever the runtime gives (never blank).
+    expect(fmtZoneAbbrev("America/New_York", IST_1900)).toBeTruthy();
   });
 });
 

--- a/apps/web/src/lib/__tests__/format.test.ts
+++ b/apps/web/src/lib/__tests__/format.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { fmtDate, fmtTime, fmtDateTime, fmtZoneAbbrev, fmtRange } from "@/lib/format";
+
+// A fixed UTC instant: 2026-08-16T13:30:00Z == 19:00 in Asia/Kolkata (IST).
+const IST_1900 = "2026-08-16T13:30:00Z";
+
+describe("fmtTime", () => {
+  it("renders the wall-clock time in the given zone (h23)", () => {
+    expect(fmtTime("Asia/Kolkata", IST_1900)).toBe("19:00");
+    expect(fmtTime("Europe/London", IST_1900)).toBe("14:30"); // BST = UTC+1 in Aug
+    expect(fmtTime("UTC", IST_1900)).toBe("13:30");
+  });
+  it("returns empty string for null/invalid input", () => {
+    expect(fmtTime("UTC", null)).toBe("");
+    expect(fmtTime("UTC", "not-a-date")).toBe("");
+  });
+});
+
+describe("fmtZoneAbbrev — DST-dependent", () => {
+  // The exact string is runtime-ICU-dependent: Node emits "GMT+5:30" where a
+  // browser emits "IST" (why the label renders client-side). What IS invariant
+  // and worth guarding: the value TRACKS DST — different in a zone's summer vs
+  // winter, stable in a zone without DST — and it never throws / never blanks.
+  it("Europe/London differs winter vs summer (DST tracked)", () => {
+    const winter = fmtZoneAbbrev("Europe/London", "2026-01-15T12:00:00Z");
+    const summer = fmtZoneAbbrev("Europe/London", "2026-07-15T12:00:00Z");
+    expect(winter).toBe("GMT"); // London winter names deterministically across ICU
+    expect(summer).not.toBe(winter);
+    expect(summer).toBeTruthy();
+  });
+  it("Asia/Kolkata is stable year-round (no DST)", () => {
+    const jan = fmtZoneAbbrev("Asia/Kolkata", "2026-01-15T12:00:00Z");
+    const aug = fmtZoneAbbrev("Asia/Kolkata", IST_1900);
+    expect(jan).toBe(aug);
+    expect(jan).toBeTruthy();
+  });
+});
+
+describe("unknown zone falls back to UTC, never throws", () => {
+  it("fmtTime tolerates a bogus zone", () => {
+    expect(() => fmtTime("Mars/Phobos", IST_1900)).not.toThrow();
+    expect(fmtTime("Mars/Phobos", IST_1900)).toBe("13:30"); // UTC fallback
+  });
+});
+
+describe("fmtDate / fmtDateTime", () => {
+  it("formats a date in-zone", () => {
+    // 13:30Z is still 16 Aug in Kolkata but also 16 Aug in London.
+    expect(fmtDate("Asia/Kolkata", IST_1900)).toContain("16 Aug");
+  });
+  it("crosses midnight by zone", () => {
+    // 22:30Z on the 16th is 04:00 on the 17th in Kolkata.
+    expect(fmtDate("Asia/Kolkata", "2026-08-16T22:30:00Z")).toContain("17 Aug");
+    expect(fmtDate("UTC", "2026-08-16T22:30:00Z")).toContain("16 Aug");
+  });
+  it("fmtDateTime combines both", () => {
+    expect(fmtDateTime("UTC", IST_1900)).toMatch(/16 Aug/);
+  });
+});
+
+describe("fmtRange", () => {
+  it("collapses a single day", () => {
+    expect(fmtRange("UTC", IST_1900, IST_1900)).toBe("16 Aug");
+  });
+  it("shows a span across days", () => {
+    expect(fmtRange("UTC", "2026-08-12T10:00:00Z", "2026-08-14T10:00:00Z")).toBe("12 Aug – 14 Aug");
+  });
+  it("treats missing 'to' as single day", () => {
+    expect(fmtRange("UTC", IST_1900, null)).toBe("16 Aug");
+  });
+});

--- a/apps/web/src/lib/__tests__/tz.test.ts
+++ b/apps/web/src/lib/__tests__/tz.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// resolveTimezone reads getCurrentUser() + cookies(); mock both so the
+// precedence logic is exercised without a request context or DB.
+const mockUser = vi.fn();
+const mockCookieGet = vi.fn();
+
+vi.mock("@/lib/auth", () => ({ getCurrentUser: () => mockUser() }));
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (k: string) => mockCookieGet(k) }),
+}));
+
+import { isValidIana, pickTimezone, listTimezones, DEFAULT_TZ } from "@/lib/tz";
+import { resolveTimezone } from "@/lib/tz-server";
+
+afterEach(() => vi.clearAllMocks());
+
+describe("isValidIana", () => {
+  it("accepts real zones (incl. aliases)", () => {
+    expect(isValidIana("Asia/Kolkata")).toBe(true);
+    expect(isValidIana("Europe/London")).toBe(true);
+    expect(isValidIana("UTC")).toBe(true);
+    expect(isValidIana("Asia/Calcutta")).toBe(true); // legacy alias
+  });
+  it("rejects blanks and nonsense", () => {
+    expect(isValidIana(null)).toBe(false);
+    expect(isValidIana(undefined)).toBe(false);
+    expect(isValidIana("")).toBe(false);
+    expect(isValidIana("   ")).toBe(false);
+    expect(isValidIana("Mars/Phobos")).toBe(false);
+    expect(isValidIana("Not A Zone")).toBe(false);
+  });
+});
+
+describe("pickTimezone precedence", () => {
+  it("prefers a valid user pref over cookie", () => {
+    expect(pickTimezone("Asia/Kolkata", "Europe/London")).toBe("Asia/Kolkata");
+  });
+  it("falls to cookie when user pref is null/invalid", () => {
+    expect(pickTimezone(null, "Europe/London")).toBe("Europe/London");
+    expect(pickTimezone("Mars/Phobos", "Europe/London")).toBe("Europe/London");
+  });
+  it("falls to UTC when both missing/invalid", () => {
+    expect(pickTimezone(null, null)).toBe(DEFAULT_TZ);
+    expect(pickTimezone("bogus", "also-bogus")).toBe(DEFAULT_TZ);
+  });
+});
+
+describe("resolveTimezone (integration of sources)", () => {
+  it("uses users.timezone when set", async () => {
+    mockUser.mockResolvedValue({ id: "u1", timezone: "Asia/Tokyo" });
+    mockCookieGet.mockReturnValue({ value: "Europe/London" });
+    await expect(resolveTimezone()).resolves.toBe("Asia/Tokyo");
+  });
+  it("uses the seazn_tz cookie for a user with no pref", async () => {
+    mockUser.mockResolvedValue({ id: "u1", timezone: null });
+    mockCookieGet.mockReturnValue({ value: "Europe/London" });
+    await expect(resolveTimezone()).resolves.toBe("Europe/London");
+  });
+  it("uses the cookie for an anonymous viewer", async () => {
+    mockUser.mockResolvedValue(null);
+    mockCookieGet.mockReturnValue({ value: "America/New_York" });
+    await expect(resolveTimezone()).resolves.toBe("America/New_York");
+  });
+  it("falls to UTC with no pref and no cookie", async () => {
+    mockUser.mockResolvedValue(null);
+    mockCookieGet.mockReturnValue(undefined);
+    await expect(resolveTimezone()).resolves.toBe(DEFAULT_TZ);
+  });
+});
+
+describe("listTimezones", () => {
+  it("returns the full IANA set (hundreds of zones), not a shortlist", () => {
+    const zones = listTimezones();
+    // supportedValuesOf yields ~400+; the static fallback is only ~20.
+    expect(zones.length).toBeGreaterThan(100);
+    expect(zones).toContain("Europe/London");
+    expect(zones).toContain("America/New_York");
+    expect(zones).toContain("Australia/Sydney");
+  });
+  it("canonicalizes legacy names to modern spelling", () => {
+    const zones = listTimezones();
+    expect(zones).toContain("Asia/Kolkata"); // not the legacy Asia/Calcutta
+    expect(zones).not.toContain("Asia/Calcutta");
+  });
+  it("is sorted and de-duplicated", () => {
+    const zones = listTimezones();
+    expect([...new Set(zones)].length).toBe(zones.length);
+    expect([...zones].sort()).toEqual(zones);
+  });
+});

--- a/apps/web/src/lib/__tests__/update-profile-schema.test.ts
+++ b/apps/web/src/lib/__tests__/update-profile-schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { updateProfileSchema } from "@/lib/types";
+
+describe("updateProfileSchema — timezone", () => {
+  it("accepts a valid IANA zone", () => {
+    expect(updateProfileSchema.parse({ timezone: "Asia/Kolkata" })).toEqual({
+      timezone: "Asia/Kolkata",
+    });
+  });
+  it("accepts null (clear = follow browser)", () => {
+    expect(updateProfileSchema.parse({ timezone: null })).toEqual({ timezone: null });
+  });
+  it("rejects a bogus zone", () => {
+    expect(() => updateProfileSchema.parse({ timezone: "Mars/Phobos" })).toThrow();
+    expect(() => updateProfileSchema.parse({ timezone: "not a zone" })).toThrow();
+  });
+  it("accepts display_name alone (timezone untouched)", () => {
+    expect(updateProfileSchema.parse({ display_name: "Ada" })).toEqual({ display_name: "Ada" });
+  });
+  it("accepts both together", () => {
+    expect(
+      updateProfileSchema.parse({ display_name: "Ada", timezone: "Europe/London" }),
+    ).toEqual({ display_name: "Ada", timezone: "Europe/London" });
+  });
+  it("rejects an empty patch (nothing to update)", () => {
+    expect(() => updateProfileSchema.parse({})).toThrow();
+  });
+  it("rejects unknown keys (strict)", () => {
+    expect(() => updateProfileSchema.parse({ nickname: "x" })).toThrow();
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -96,7 +96,7 @@ export async function getCurrentUser(): Promise<User | null> {
   if (cached) return cached;
 
   const rows = await sql<User[]>`
-    select id, display_name, email, avatar_url
+    select id, display_name, email, avatar_url, timezone
     from users where id = ${uid} limit 1
   `;
   const user = rows[0] ?? null;

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,0 +1,91 @@
+// Timezone-aware date/time formatting — the single place Intl.* is called for
+// display (spec 2026-07-14 user-timezone-design §5.2; also the v5/00 §5
+// foundation, tz slice only). Every function takes an EXPLICIT tz: no helper
+// ever falls back to the runtime's resolvedOptions() zone, which is the silent,
+// unstable choice this module exists to kill. Locale is fixed to en-GB for now;
+// the v5 i18n wave threads the resolved locale through the same signatures.
+//
+// Safe on both server and client (no server-only, no next imports).
+
+const LOCALE = "en-GB";
+export const UTC = "UTC";
+
+/** Coerce loose input to a Date; null/invalid → null. */
+function toDate(value: string | number | Date | null | undefined): Date | null {
+  if (value == null) return null;
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+/** Build a DateTimeFormat, retrying in UTC if the zone string is unknown. An
+ *  invalid IANA name throws RangeError at construction — we never want that to
+ *  bubble into a render, so fall back and (in dev) warn. */
+function fmt(tz: string, opts: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+  try {
+    return new Intl.DateTimeFormat(LOCALE, { timeZone: tz, ...opts });
+  } catch {
+    if (process.env.NODE_ENV !== "production")
+      console.warn(`[format] unknown timezone "${tz}", falling back to UTC`);
+    return new Intl.DateTimeFormat(LOCALE, { timeZone: UTC, ...opts });
+  }
+}
+
+export function fmtDate(
+  tz: string,
+  value: string | number | Date | null | undefined,
+  opts: Intl.DateTimeFormatOptions = { weekday: "short", day: "numeric", month: "short" },
+): string {
+  const d = toDate(value);
+  return d ? fmt(tz, opts).format(d) : "";
+}
+
+export function fmtTime(
+  tz: string,
+  value: string | number | Date | null | undefined,
+  opts: Intl.DateTimeFormatOptions = { hour: "2-digit", minute: "2-digit", hourCycle: "h23" },
+): string {
+  const d = toDate(value);
+  return d ? fmt(tz, opts).format(d) : "";
+}
+
+export function fmtDateTime(
+  tz: string,
+  value: string | number | Date | null | undefined,
+  opts: Intl.DateTimeFormatOptions = { dateStyle: "medium", timeStyle: "short" },
+): string {
+  const d = toDate(value);
+  return d ? fmt(tz, opts).format(d) : "";
+}
+
+/**
+ * Short zone label at THIS instant — "IST", "BST"/"GMT", "EDT"/"EST". The
+ * abbreviation is DST-dependent, so the moment matters: Europe/London is GMT in
+ * January and BST in July. Returned bare (no time) for callers that append it.
+ */
+export function fmtZoneAbbrev(
+  tz: string,
+  value: string | number | Date | null | undefined,
+): string {
+  const d = toDate(value) ?? new Date();
+  const parts = fmt(tz, { timeZoneName: "short" }).formatToParts(d);
+  return parts.find((p) => p.type === "timeZoneName")?.value ?? tz;
+}
+
+/**
+ * Compact date range in one zone: "12–14 Aug", "30 Aug – 2 Sep", "16 Aug"
+ * (single day). Absorbs the old client-time.tsx ClientDateRange logic.
+ */
+export function fmtRange(
+  tz: string,
+  from: string | number | Date | null | undefined,
+  to: string | number | Date | null | undefined,
+  opts: Intl.DateTimeFormatOptions = { day: "numeric", month: "short" },
+): string {
+  const a = toDate(from);
+  if (!a) return "";
+  const b = toDate(to) ?? a;
+  const f = fmt(tz, opts);
+  const fa = f.format(a);
+  const fb = f.format(b);
+  return fa === fb ? fa : `${fa} – ${fb}`;
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -68,8 +68,36 @@ export function fmtZoneAbbrev(
 ): string {
   const d = toDate(value) ?? new Date();
   const parts = fmt(tz, { timeZoneName: "short" }).formatToParts(d);
-  return parts.find((p) => p.type === "timeZoneName")?.value ?? tz;
+  const raw = parts.find((p) => p.type === "timeZoneName")?.value ?? tz;
+  // ICU builds vary: some emit "IST"/"BST", others fall back to an offset
+  // ("GMT+5:30") for the very same zone (Node and some headless browsers do
+  // this for Asia/Kolkata). When the runtime punts to an offset AND we have a
+  // stable, DST-free abbreviation for the zone, prefer the recognizable name so
+  // "IST" doesn't read as "GMT+5:30". We never override a runtime that already
+  // produced a name, so DST zones (London GMT/BST, New York EST/EDT) are
+  // untouched and stay correct across the year.
+  if (/^(?:GMT|UTC)[+-]/.test(raw) && DST_FREE_ABBREV[tz]) return DST_FREE_ABBREV[tz];
+  return raw;
 }
+
+// DST-free zones whose common abbreviation some ICU builds don't emit. All are
+// year-round fixed offsets, so a static label is always correct.
+const DST_FREE_ABBREV: Record<string, string> = {
+  "Asia/Kolkata": "IST",
+  "Asia/Colombo": "IST", // Sri Lanka shares +05:30
+  "Asia/Karachi": "PKT",
+  "Asia/Dhaka": "BST", // Bangladesh Standard Time
+  "Asia/Kathmandu": "NPT",
+  "Asia/Yangon": "MMT",
+  "Asia/Kabul": "AFT",
+  "Asia/Tehran": "IRST",
+  "Asia/Dubai": "GST",
+  "Asia/Muscat": "GST",
+  "Asia/Singapore": "SGT",
+  "Asia/Kuala_Lumpur": "MYT",
+  "Asia/Bangkok": "ICT",
+  "Asia/Jakarta": "WIB",
+};
 
 /**
  * Compact date range in one zone: "12–14 Aug", "30 Aug – 2 Sep", "16 Aug"

--- a/apps/web/src/lib/help.ts
+++ b/apps/web/src/lib/help.ts
@@ -28,6 +28,7 @@ export const HELP_ARTICLE_SLUGS = [
   "scheduling/locks",
   "scheduling/undo",
   "scheduling/constraints",
+  "scheduling/timezones",
   "scoring/basics",
   "scoring/conflicts",
   "scoring/device-links",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isValidIana } from "@/lib/tz";
 
 /** Authenticated user. `password_hash` is never sent to the client. */
 export const userSchema = z.object({
@@ -6,6 +7,8 @@ export const userSchema = z.object({
   display_name: z.string(),
   email: z.string(),
   avatar_url: z.string().nullable(),
+  /** IANA zone (spec 2026-07-14); null = follow the browser (seazn_tz cookie). */
+  timezone: z.string().nullable(),
 });
 export type User = z.infer<typeof userSchema>;
 
@@ -103,8 +106,18 @@ export const renameOrgSchema = z.object({
 }).strict();
 
 export const updateProfileSchema = z.object({
-  display_name: z.string().trim().min(1).max(80),
-}).strict();
+  display_name: z.string().trim().min(1).max(80).optional(),
+  /** IANA zone or null to clear ("follow my browser"). Rejects bogus zones so
+   *  the column only ever holds a value the render layer's Intl accepts. */
+  timezone: z
+    .string()
+    .trim()
+    .refine((v) => isValidIana(v), { message: "Unknown timezone" })
+    .nullable()
+    .optional(),
+}).strict().refine((v) => v.display_name !== undefined || v.timezone !== undefined, {
+  message: "Nothing to update",
+});
 
 export const createInviteSchema = z.object({
   role: z.enum(["admin", "viewer", "scorer"]),

--- a/apps/web/src/lib/tz-server.ts
+++ b/apps/web/src/lib/tz-server.ts
@@ -1,0 +1,18 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { getCurrentUser } from "@/lib/auth";
+import { pickTimezone, TZ_COOKIE } from "@/lib/tz";
+
+/**
+ * Resolve the viewer's timezone for the current request (spec §5.3):
+ *   1. users.timezone (signed-in, explicit pick)
+ *   2. seazn_tz cookie (browser-detected, so anonymous / not-yet-set users
+ *      still resolve to their real zone server-side)
+ *   3. 'UTC'
+ * Personal-lane renders use this; the venue lane keeps schedule_settings.tz.
+ */
+export async function resolveTimezone(): Promise<string> {
+  const [user, jar] = await Promise.all([getCurrentUser(), cookies()]);
+  const cookieTz = jar.get(TZ_COOKIE)?.value ?? null;
+  return pickTimezone(user?.timezone ?? null, cookieTz);
+}

--- a/apps/web/src/lib/tz.ts
+++ b/apps/web/src/lib/tz.ts
@@ -1,0 +1,76 @@
+// Pure timezone helpers (spec 2026-07-14 user-timezone-design §5.3). No
+// server-only / next imports — safe in client components (the account picker
+// reads listTimezones) and shared zod schemas (updateProfileSchema validates
+// with isValidIana). The request-scoped resolver lives in lib/tz-server.ts.
+
+export const TZ_COOKIE = "seazn_tz";
+export const DEFAULT_TZ = "UTC";
+
+/**
+ * True when `tz` is a zone the runtime's Intl accepts. Uses DateTimeFormat
+ * construction (throws RangeError on an unknown zone) rather than
+ * `supportedValuesOf`, so accepted aliases (e.g. "Asia/Calcutta") validate too.
+ * Blank / null → false.
+ */
+export function isValidIana(tz: string | null | undefined): tz is string {
+  if (!tz || !tz.trim()) return false;
+  try {
+    new Intl.DateTimeFormat("en", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Pure precedence: first valid of user pref, then cookie, then UTC. */
+export function pickTimezone(
+  userTz: string | null | undefined,
+  cookieTz: string | null | undefined,
+): string {
+  if (isValidIana(userTz)) return userTz;
+  if (isValidIana(cookieTz)) return cookieTz;
+  return DEFAULT_TZ;
+}
+
+/**
+ * IANA zone list for the account picker. `Intl.supportedValuesOf` is the source
+ * of truth on modern runtimes (~400+ zones); a small static fallback covers
+ * older ones so the picker is never empty. Not for validation — that's
+ * `isValidIana`.
+ *
+ * Runtimes still emit legacy zone names (e.g. Node returns "Asia/Calcutta");
+ * canonicalize to the modern spelling so an India-based user picks
+ * "Asia/Kolkata", not a 40-year-old alias. Both remain isValidIana.
+ */
+export function listTimezones(): string[] {
+  let zones: string[] | undefined;
+  try {
+    zones = (
+      Intl as unknown as { supportedValuesOf?: (k: string) => string[] }
+    ).supportedValuesOf?.("timeZone");
+  } catch {
+    /* fall through */
+  }
+  const base = zones && zones.length ? zones : TZ_FALLBACK;
+  const canonical = new Set(base.map((z) => TZ_RENAME[z] ?? z));
+  return [...canonical].sort();
+}
+
+/** Legacy → modern IANA names some ICU builds still return. */
+const TZ_RENAME: Record<string, string> = {
+  "Asia/Calcutta": "Asia/Kolkata",
+  "Asia/Rangoon": "Asia/Yangon",
+  "Asia/Saigon": "Asia/Ho_Chi_Minh",
+  "Asia/Katmandu": "Asia/Kathmandu",
+  "Europe/Kiev": "Europe/Kyiv",
+  "America/Buenos_Aires": "America/Argentina/Buenos_Aires",
+};
+
+const TZ_FALLBACK = [
+  "UTC",
+  "Europe/London", "Europe/Paris", "Europe/Berlin", "Europe/Madrid", "Europe/Amsterdam",
+  "America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles",
+  "America/Sao_Paulo", "America/Toronto",
+  "Asia/Kolkata", "Asia/Dubai", "Asia/Singapore", "Asia/Tokyo", "Asia/Shanghai",
+  "Australia/Sydney", "Pacific/Auckland",
+];

--- a/apps/web/src/server/embed-data.ts
+++ b/apps/web/src/server/embed-data.ts
@@ -25,6 +25,8 @@ export interface EmbedPayload {
   fixtures: PublicFixture[];
   standings: PublicStandings[];
   entrants: PublicEntrant[];
+  /** Venue zone (schedule_settings.tz; UTC if unset) for schedule display. */
+  tz: string;
 }
 
 export type EmbedResolution =
@@ -64,7 +66,7 @@ export async function embedDivisionData(divisionId: string): Promise<EmbedResolu
     select id, slug, name from organizations where id = ${competition.org_id}`;
   if (!org) return { ok: false, reason: "not_found" };
 
-  const [stages, pools, fixtures, standings, entrants] = await Promise.all([
+  const [stages, pools, fixtures, standings, entrants, ssRows] = await Promise.all([
     sql<PublicStage[]>`
       select id, division_id, seq, kind, name, status
       from public_stages_v where division_id = ${divisionId} order by seq`,
@@ -86,10 +88,15 @@ export async function embedDivisionData(divisionId: string): Promise<EmbedResolu
       select id, division_id, kind, display_name, seed, status, members, team_display
       from public_entrants_v where division_id = ${divisionId}
       order by seed nulls last, display_name`,
+    sql<{ tz: string }[]>`
+      select tz from schedule_settings where division_id = ${divisionId}`,
   ]);
 
   return {
     ok: true,
-    data: { org, competition, division, stages, pools, fixtures, standings, entrants },
+    data: {
+      org, competition, division, stages, pools, fixtures, standings, entrants,
+      tz: ssRows[0]?.tz ?? "UTC",
+    },
   };
 }

--- a/apps/web/src/server/public-site/data.ts
+++ b/apps/web/src/server/public-site/data.ts
@@ -267,6 +267,8 @@ export async function getPublicDivision(
   fixtures: PublicFixture[];
   standings: PublicStandings[];
   entrants: PublicEntrant[];
+  /** Venue zone for schedule display (schedule_settings.tz; UTC if unset). */
+  tz: string;
 } | null> {
   const shell = await getPublicCompetition(orgSlug, compSlug);
   if (!shell) return null;
@@ -297,7 +299,9 @@ export async function getPublicDivision(
                team_display
         from public_entrants_v where division_id = ${division.id}
         order by seed nulls last, display_name`;
-      return { stages, pools, fixtures, standings, entrants };
+      const [ss] = await sql<{ tz: string }[]>`
+        select tz from schedule_settings where division_id = ${division.id}`;
+      return { stages, pools, fixtures, standings, entrants, tz: ss?.tz ?? "UTC" };
     },
     ["pub-div", division.id],
     {

--- a/apps/web/src/server/usecases/me.ts
+++ b/apps/web/src/server/usecases/me.ts
@@ -29,6 +29,8 @@ export interface MyFixture {
   entrant_name: string | null;
   opponent_name: string | null;
   scheduled_at: string | null;
+  /** Venue zone (schedule_settings.tz of the fixture's division); null → UTC. */
+  venue_tz: string | null;
   venue: string | null;
   court_label: string | null;
   status: string;
@@ -82,7 +84,7 @@ export async function listMyFixtures(userId: string): Promise<{
            d.name as division_name, d.slug as division_slug, d.sport_key,
            f.round_no, e.display_name as entrant_name,
            opp.display_name as opponent_name,
-           f.scheduled_at, f.venue, f.court_label, f.status,
+           f.scheduled_at, ss.tz as venue_tz, f.venue, f.court_label, f.status,
            case when fa.status is null then null
                 else jsonb_build_object('status', fa.status, 'note', fa.note) end
              as availability,
@@ -94,6 +96,7 @@ export async function listMyFixtures(userId: string): Promise<{
     join divisions d on d.id = f.division_id
     join competitions c on c.id = d.competition_id
     join organizations o on o.id = f.org_id
+    left join schedule_settings ss on ss.division_id = d.id
     left join entrants opp on opp.id =
       case when f.home_entrant_id = e.id then f.away_entrant_id else f.home_entrant_id end
     left join fixture_availability fa on fa.fixture_id = f.id and fa.person_id = p.id

--- a/apps/web/src/server/usecases/scorers.ts
+++ b/apps/web/src/server/usecases/scorers.ts
@@ -129,6 +129,8 @@ export interface AssignedFixture {
   home_name: string | null;
   away_name: string | null;
   scheduled_at: string | null;
+  /** Venue zone (schedule_settings.tz of the division); null → UTC. */
+  venue_tz: string | null;
   venue: string | null;
   court_label: string | null;
   status: string;
@@ -153,7 +155,7 @@ export async function listAssignedFixtures(
            d.sport_key, d.module_version, f.round_no,
            f.home_entrant_id, f.away_entrant_id,
            he.display_name as home_name, ae.display_name as away_name,
-           f.scheduled_at, f.venue, f.court_label, f.status
+           f.scheduled_at, ss.tz as venue_tz, f.venue, f.court_label, f.status
     from scorer_assignments sa
     join fixtures f on (
          (sa.scope_type = 'fixture'     and f.id = sa.scope_id)
@@ -164,6 +166,7 @@ export async function listAssignedFixtures(
     join divisions d on d.id = f.division_id
     join competitions c on c.id = d.competition_id
     join organizations o on o.id = f.org_id
+    left join schedule_settings ss on ss.division_id = d.id
     left join entrants he on he.id = f.home_entrant_id
     left join entrants ae on ae.id = f.away_entrant_id
     where sa.user_id = ${userId}

--- a/db/migration/deltas/V280__users_timezone.sql
+++ b/db/migration/deltas/V280__users_timezone.sql
@@ -1,0 +1,15 @@
+-- User timezone preference (spec 2026-07-14 user-timezone-design).
+-- IANA zone name (e.g. 'Europe/London'); null = not set → resolveTimezone()
+-- falls back to the seazn_tz cookie (browser-detected), then 'UTC'.
+--
+-- No CHECK against pg_timezone_names: that couples validity to the server's
+-- tzdata build and rejects zones the app's Intl runtime accepts. Full IANA
+-- validity is enforced app-side (lib/tz isValidIana). Only guard blank strings.
+alter table users
+  add column if not exists timezone text;
+
+alter table users
+  drop constraint if exists users_timezone_nonblank;
+alter table users
+  add constraint users_timezone_nonblank
+  check (timezone is null or btrim(timezone) <> '');

--- a/docs/superpowers/specs/2026-07-14-user-timezone-design.md
+++ b/docs/superpowers/specs/2026-07-14-user-timezone-design.md
@@ -38,6 +38,12 @@ zone label on **every** rendered time so the zone is always explicit.
 2. **Label = short abbrev + IANA on hover** — primary `IST` / `BST` / `EDT`; full
    `Asia/Kolkata` in `title` tooltip and shown verbatim in the picker.
 3. **Scope = timezone only** — no locale work this wave.
+4. **Venue lane also shows "your time"** (added 2026-07-14 after demo) — every venue time
+   exposes the viewer's local equivalent inline. Default affordance: **hover/focus tooltip**
+   on dense boards (`14:30 BST · your time` + IANA), keeping boards uncluttered; **always-on
+   subtitle** on `/me` (personal page). `<Zoned>` supports both via a `you` prop
+   (`"hover" | "subtitle" | "off"`). Suppressed when viewer tz == venue tz (no noise).
+   Demo: `claude.ai/code/artifact/62714fe2-5c32-4311-bd08-55ff5d02c358`.
 
 ## The two lanes
 
@@ -102,6 +108,12 @@ read it without an extra query. `invalidateUser()` already called on profile PAT
 - Server-first: personal times can now render on the server in the resolved tz (stable),
   with `<Zoned tz={userTz} showZone />`. No more empty-span-until-mount for the common case.
 - `showZone` appends the abbrev; `title` carries the full IANA name (decision 2).
+- **`you` prop** (decision 4): `"hover" | "subtitle" | "off"` (default `"off"`). When the
+  time is a **venue** time, `you={youTz}`-context makes `<Zoned>` compute the viewer's local
+  equivalent and expose it — as a focusable hover tooltip (`"hover"`) or an inline subtitle
+  line (`"subtitle"`). Needs the resolved `youTz`, threaded via a lightweight
+  `TimezoneContext` provider set once in the console/root layout from `resolveTimezone()`
+  (client components read it without prop-drilling). Rendered only when `youTz !== venueTz`.
 - Keeps a client fallback for the anonymous-no-cookie first paint only.
 - `ClientDateRange` folds into `fmtRange`; existing call sites keep working via re-export.
 
@@ -123,12 +135,15 @@ New **Preferences** section in `/o/[org]/settings?tab=account`, above Change-ema
 Route updates `users.timezone`, keeps `display_name` path intact, calls `invalidateUser`.
 `isValidIana` = membership in `Intl.supportedValuesOf("timeZone")` (server-side).
 
-### 7. Zone labels on the venue lane
+### 7. Zone labels + "your time" on the venue lane
 
 Schedule surfaces already pass `tz={schedule_settings.tz}` to time components — flip on
-`showZone` there so venue times read `19:00 IST`. `day-label.ts`/board keep venue-zone
-grouping unchanged; only the label is added. The board settings panel (which *sets* the
-venue tz) gains a one-line "all times below shown in <tz>" caption.
+`showZone` there so venue times read `19:00 IST`, and pass `you="hover"` (boards) /
+`you="subtitle"` (`/me`) so the viewer's local equivalent is one hover/glance away
+(decision 4). `day-label.ts`/board keep venue-zone grouping unchanged; only the
+label + your-time affordance are added. The board settings panel (which *sets* the venue
+tz) gains a one-line "all times below shown in <tz>" caption. Suppression rule: when the
+resolved viewer tz equals the venue tz, the your-time affordance is omitted entirely.
 
 ## Data flow
 
@@ -156,7 +171,9 @@ Account save    ─▶ PATCH /api/users/me ─▶ users.timezone + seazn_tz cook
 - **Unit** `fmtZoneAbbrev` DST correctness: `Europe/London` → `GMT` in Jan, `BST` in Jul.
 - **Unit** `updateProfileSchema` rejects `"Mars/Phobos"`, accepts `"Asia/Kolkata"`, accepts null.
 - **e2e** set tz in Account → `/me` personal time shows chosen abbrev; venue time on a
-  fixture page still shows venue abbrev (proves two-lane).
+  fixture page still shows venue abbrev (proves two-lane) AND its "your time" subtitle shows
+  the chosen zone; when viewer tz == venue tz the your-time affordance is absent.
+- **Unit** `<Zoned>` `you` prop: renders subtitle/hover markup only when `youTz !== venueTz`.
 - **smoke.ts** extend pro + free: PATCH tz, assert whoami/me reflects it and label present.
 
 ## Docs (mandatory closing pass)

--- a/docs/superpowers/specs/2026-07-14-user-timezone-design.md
+++ b/docs/superpowers/specs/2026-07-14-user-timezone-design.md
@@ -203,16 +203,20 @@ Account save    ─▶ PATCH /api/users/me ─▶ users.timezone + seazn_tz cook
   carries `venue_tz`).
 - e2e (persist + reject), smoke (pro + free), help doc `scheduling/timezones.md`.
 
-**Remaining venue/personal surfaces** (mechanism ready — each just needs `<Zoned>`
-with the right `tz` + `you="subtitle"`, and for the ISR public surface, threading
-`schedule_settings.tz` through `PublicFixture` + regrouping days by venue zone):
-- Public division schedule (`components/public-site/schedule.tsx`) + shared fixture
-  page — currently browser-zone, unlabelled. Highest-value spectator surface; needs
-  the public-data tz thread (kept out of this slice to protect the ISR cache design).
-- Console fixture board / schedule board — venue tz already threaded (settings-panel);
-  add `showZone` + subtitle.
-- Personal-lane admin tables, billing renewal dates, audit log — swap host-zone
-  `toLocaleString` for `<Zoned tz={userTz}>`.
+**Also shipped (2026-07-14, surfaces pass):**
+- Public division schedule + embed widget — `getPublicDivision` / `embedDivisionData`
+  carry `schedule_settings.tz`; `<Schedule tz>` groups days by venue-local date, renders
+  rail times in venue tz, and captions each day header "times in {abbrev}". Verified live:
+  "MONDAY 13 JULY · times in IST", times in IST. (No per-row viewer subtitle — the 3.25rem
+  rail is too dense; the header caption states the zone.)
+- Console: `ClientTime` gained `showZone`; stages-panel "Scheduled ·" + fixture console
+  kick-off now read venue tz + label (venue tz via `getScheduleSettings`).
+- Scorer `/my-matches`: `listAssignedFixtures` carries `venue_tz`; venue time + label +
+  viewer-local subtitle, wrapped in `ViewerTzProvider`.
+
+**Still on host/browser zone (low-value internal, follow-up):** admin tables
+(`/admin/*`), billing renewal date (date-only, low ambiguity), audit log — swap the
+server-side `toLocaleString` for a labelled render when touched next.
 
 ## Rollout
 

--- a/docs/superpowers/specs/2026-07-14-user-timezone-design.md
+++ b/docs/superpowers/specs/2026-07-14-user-timezone-design.md
@@ -38,11 +38,18 @@ zone label on **every** rendered time so the zone is always explicit.
 2. **Label = short abbrev + IANA on hover** — primary `IST` / `BST` / `EDT`; full
    `Asia/Kolkata` in `title` tooltip and shown verbatim in the picker.
 3. **Scope = timezone only** — no locale work this wave.
-4. **Venue lane also shows "your time"** (added 2026-07-14 after demo) — every venue time
-   exposes the viewer's local equivalent inline. Default affordance: **hover/focus tooltip**
-   on dense boards (`14:30 BST · your time` + IANA), keeping boards uncluttered; **always-on
-   subtitle** on `/me` (personal page). `<Zoned>` supports both via a `you` prop
-   (`"hover" | "subtitle" | "off"`). Suppressed when viewer tz == venue tz (no noise).
+4. **Venue lane also shows the viewer's local time** (added 2026-07-14 after demo) — every
+   venue time exposes the viewer's local equivalent inline. **Shipped affordance: always-on
+   subtitle everywhere** (user picked subtitle over hover, 2026-07-14) — boards and `/me`
+   alike get the bare teal second line. `<Zoned>` still supports `you="hover"` as an option,
+   but the default and every call site use `you="subtitle"`. Suppressed when viewer tz ==
+   venue tz (no noise).
+   - **No literal "your time" text** — whose-time is carried by position + colour + labels,
+     not a stray phrase (user call): hover tooltip is a two-row grid
+     `Venue 19:00 IST / You 14:30 BST (+ IANA)`; the subtitle is a bare teal line
+     `↳ 14:30 BST` (teal = the "you" colour); `/me`'s second line drops even the arrow (the
+     page already *is* your schedule). Screen readers still get an explicit
+     `aria-label="your local time 14:30 BST"` on every terse form.
    Demo: `claude.ai/code/artifact/62714fe2-5c32-4311-bd08-55ff5d02c358`.
 
 ## The two lanes

--- a/docs/superpowers/specs/2026-07-14-user-timezone-design.md
+++ b/docs/superpowers/specs/2026-07-14-user-timezone-design.md
@@ -189,6 +189,31 @@ Account save    ─▶ PATCH /api/users/me ─▶ users.timezone + seazn_tz cook
   two-lane rule (why a fixture shows venue time, not yours).
 - OpenAPI: `PATCH /users/me` request body gains `timezone` (no new route → no ROUTES add).
 
+## Implementation status (2026-07-14)
+
+**Shipped + verified** (branch `feat/user-timezone`, 6 commits, tsc + 685 unit green):
+- Data layer: V280 `users.timezone`, `lib/tz.ts` (pure, canonicalizing full IANA
+  list), `lib/tz-server.ts` `resolveTimezone`, `lib/format.ts` (+ DST-free IST/GST/…
+  abbrev override for ICU builds that emit offsets).
+- `<Zoned>` + `ViewerTzProvider`/`useViewerTz`; `.tz-you` subtitle CSS.
+- Account → Preferences picker (full grouped list, Detect, live preview). Verified
+  live on desktop + mobile: preview reads `22:21 IST` for Asia/Kolkata; save
+  persists; API rejects bogus zones.
+- `/me` fixtures render venue tz + label + viewer-local subtitle (`listMyFixtures`
+  carries `venue_tz`).
+- e2e (persist + reject), smoke (pro + free), help doc `scheduling/timezones.md`.
+
+**Remaining venue/personal surfaces** (mechanism ready — each just needs `<Zoned>`
+with the right `tz` + `you="subtitle"`, and for the ISR public surface, threading
+`schedule_settings.tz` through `PublicFixture` + regrouping days by venue zone):
+- Public division schedule (`components/public-site/schedule.tsx`) + shared fixture
+  page — currently browser-zone, unlabelled. Highest-value spectator surface; needs
+  the public-data tz thread (kept out of this slice to protect the ISR cache design).
+- Console fixture board / schedule board — venue tz already threaded (settings-panel);
+  add `showZone` + subtitle.
+- Personal-lane admin tables, billing renewal dates, audit log — swap host-zone
+  `toLocaleString` for `<Zoned tz={userTz}>`.
+
 ## Rollout
 
 Additive, nullable column — safe pre-deploy. Migration V280 applies via Flyway

--- a/docs/superpowers/specs/2026-07-14-user-timezone-design.md
+++ b/docs/superpowers/specs/2026-07-14-user-timezone-design.md
@@ -1,0 +1,172 @@
+# User timezone preference — design
+
+**Date:** 2026-07-14 · **Branch:** `feat/user-timezone` (off `main`) · **Migration:** V280
+
+## Problem
+
+Times render inconsistently and **without ever naming their zone**:
+
+- Console / admin / billing / audit / `/me` format with `toLocaleString`-family
+  calls in the **viewer's browser zone** (client) or **Node's zone** (server, usually
+  en-US/UTC on host) — a silent, unstable choice, never labelled.
+- Schedule boards / public league pages correctly render in the competition's
+  **venue zone** (`schedule_settings.tz`) — but also print no zone label, so `19:00`
+  is ambiguous to anyone not standing at the venue.
+- There is **no user-level timezone**: a signed-in user cannot say "show my personal
+  times in Europe/London", and the server has nothing stable to render with (drives
+  hydration mismatches, papered over today by client-only `<ClientTime>` fills).
+
+Goal: a per-user timezone setting in **Account settings**, persisted in the DB, and a
+zone label on **every** rendered time so the zone is always explicit.
+
+## Non-goals (binding)
+
+- **Not** converting schedule/venue times to the viewer's zone. A fixture at a venue
+  happens at venue wall-clock; the competition `schedule_settings.tz` stays
+  authoritative for schedule display (v5/00 §5). We add a *label*, we do not re-anchor.
+- **Not** the v5 i18n wave (locale columns, dictionaries, fonts, translation pipeline).
+  This builds the shared `lib/format.ts` that v5/00 §5 also calls for, and reuses v5's
+  cookie+resolver pattern, so v5 lands on top cleanly — but locale is out of scope here.
+- Storage format of timestamps is unchanged: all columns are already `timestamptz`
+  (UTC instants). "Timezone in the database" means the new **user preference** column,
+  not a change to how instants are stored.
+
+## Decisions (approved 2026-07-14)
+
+1. **Two-lane display, always labelled** — schedules stay in venue tz; account / system /
+   personal times render in the user's tz; every time carries a zone label.
+2. **Label = short abbrev + IANA on hover** — primary `IST` / `BST` / `EDT`; full
+   `Asia/Kolkata` in `title` tooltip and shown verbatim in the picker.
+3. **Scope = timezone only** — no locale work this wave.
+
+## The two lanes
+
+| Lane | Zone used | Where | Example |
+|------|-----------|-------|---------|
+| **Venue** | competition `schedule_settings.tz` | fixture board, division & public schedule, round headers, slideshow/embeds, device-link day windows | `Sat 16 Aug 19:00 IST` |
+| **Personal** | resolved **user tz** | `/me` fixtures, Account settings, audit log, admin users/orgs/coupons, billing renewal dates, `created_at`, API-key last-used | `14:30 BST` |
+
+`/me` (player home) is a personal page **about venue events** → show the venue time as
+primary with its venue label, plus a secondary "· your time HH:MM ZZZ" **only when the
+user tz differs from the venue tz**. Players decide when to show up at the venue; the
+secondary line prevents a "why does it say 19:00, I thought 2pm" misread.
+
+## Components
+
+### 1. DB — `V280__users_timezone.sql`
+
+```sql
+alter table users add column timezone text;
+-- IANA zone name (e.g. 'Europe/London'); null = not set → resolver falls back.
+-- Light guard: reject empty / whitespace. Full IANA validity is enforced app-side
+-- (Intl.supportedValuesOf) — Postgres has no IANA catalogue without pg_timezone joins,
+-- and a CHECK against pg_timezone_names would couple us to the server's tzdata.
+alter table users add constraint users_timezone_nonblank
+  check (timezone is null or btrim(timezone) <> '');
+```
+
+### 2. `lib/format.ts` (new — the v5/00 §5 foundation, tz slice only)
+
+Thin `Intl.*` wrappers. Locale param defaults to `"en-GB"` today (v5 will thread the
+resolved locale later); **tz is a required, explicit argument** — no implicit
+`resolvedOptions()` zone, ever.
+
+```ts
+fmtDate(tz, value, opts?)      // date only
+fmtTime(tz, value, opts?)      // time only
+fmtDateTime(tz, value, opts?)  // date + time
+fmtZoneAbbrev(tz, value)       // 'IST' — via Intl timeZoneName:'short', at that instant (DST-correct)
+fmtRange(tz, from, to)         // compact date range (absorbs client-time.tsx ClientDateRange logic)
+```
+
+`fmtZoneAbbrev` takes `value` because the abbrev is DST-dependent (`BST` vs `GMT` at the
+same location). Unknown/invalid tz → functions catch and fall back to `UTC` + log in dev
+(same defensive posture as today's `client-time.tsx`).
+
+### 3. `resolveTimezone()` — server helper (in `lib/tz.ts`)
+
+Precedence, resolved once per request:
+
+1. `users.timezone` (signed-in, non-null)
+2. `seazn_tz` cookie — browser-detected IANA name, written client-side on first load
+   (1y, SameSite=Lax), so **anonymous** and not-yet-set users still get their real zone
+   server-side (kills the hydration-mismatch dance for personal times)
+3. `"UTC"`
+
+Validated against `Intl.supportedValuesOf("timeZone")` before use; invalid → next rung.
+`getCurrentUser()` select + its cache payload gain `timezone` so lane-2 server renders
+read it without an extra query. `invalidateUser()` already called on profile PATCH.
+
+### 4. `<Zoned>` display component (extends today's `client-time.tsx`)
+
+- Server-first: personal times can now render on the server in the resolved tz (stable),
+  with `<Zoned tz={userTz} showZone />`. No more empty-span-until-mount for the common case.
+- `showZone` appends the abbrev; `title` carries the full IANA name (decision 2).
+- Keeps a client fallback for the anonymous-no-cookie first paint only.
+- `ClientDateRange` folds into `fmtRange`; existing call sites keep working via re-export.
+
+### 5. Account UI — `<TimezonePreference>` (new) in Account tab
+
+New **Preferences** section in `/o/[org]/settings?tab=account`, above Change-email:
+
+- `<select>` populated from `Intl.supportedValuesOf("timeZone")`, grouped by continent,
+  each option showing `Asia/Kolkata — IST (GMT+5:30)` computed live.
+- **Detect** button → `Intl.DateTimeFormat().resolvedOptions().timeZone`, preselects it.
+- Live preview: "Current time here: **14:30 BST**", updates on select.
+- Save → `PATCH /api/users/me { timezone }`. Empty selection allowed → clears to null
+  ("Use my browser's timezone").
+- On save also writes the `seazn_tz` cookie so anonymous-lane fallback matches.
+
+### 6. API — extend `PATCH /api/users/me`
+
+`updateProfileSchema` gains optional `timezone: z.string().refine(isValidIana).nullable()`.
+Route updates `users.timezone`, keeps `display_name` path intact, calls `invalidateUser`.
+`isValidIana` = membership in `Intl.supportedValuesOf("timeZone")` (server-side).
+
+### 7. Zone labels on the venue lane
+
+Schedule surfaces already pass `tz={schedule_settings.tz}` to time components — flip on
+`showZone` there so venue times read `19:00 IST`. `day-label.ts`/board keep venue-zone
+grouping unchanged; only the label is added. The board settings panel (which *sets* the
+venue tz) gains a one-line "all times below shown in <tz>" caption.
+
+## Data flow
+
+```
+request ─▶ resolveTimezone() ─┬─ users.timezone (cache) ─┐
+                              ├─ seazn_tz cookie ────────┤─▶ userTz
+                              └─ 'UTC' ──────────────────┘
+personal render ─▶ fmtDateTime(userTz, …) + fmtZoneAbbrev(userTz, …)
+venue render    ─▶ fmtDateTime(schedule_settings.tz, …) + abbrev   (unchanged zone)
+Account save    ─▶ PATCH /api/users/me ─▶ users.timezone + seazn_tz cookie ─▶ invalidateUser
+```
+
+## Error handling
+
+- Invalid/unknown tz anywhere → fall to `UTC`, dev-warn, never throw (matches
+  `client-time.tsx` today).
+- API rejects a non-IANA `timezone` with 422 (zod) — client select can't produce one, but
+  the API is public-ish (own-account) so it validates.
+- Missing `Intl.supportedValuesOf` (older runtime): ship a static fallback IANA list
+  constant; feature-detect at module load.
+
+## Testing (every change ships a failing-without-it test)
+
+- **Unit** `resolveTimezone` precedence: user col > cookie > UTC; invalid values skipped.
+- **Unit** `fmtZoneAbbrev` DST correctness: `Europe/London` → `GMT` in Jan, `BST` in Jul.
+- **Unit** `updateProfileSchema` rejects `"Mars/Phobos"`, accepts `"Asia/Kolkata"`, accepts null.
+- **e2e** set tz in Account → `/me` personal time shows chosen abbrev; venue time on a
+  fixture page still shows venue abbrev (proves two-lane).
+- **smoke.ts** extend pro + free: PATCH tz, assert whoami/me reflects it and label present.
+
+## Docs (mandatory closing pass)
+
+- `content/help/*` — new "Set your timezone" entry under account/preferences; note the
+  two-lane rule (why a fixture shows venue time, not yours).
+- OpenAPI: `PATCH /users/me` request body gains `timezone` (no new route → no ROUTES add).
+
+## Rollout
+
+Additive, nullable column — safe pre-deploy. Migration V280 applies via Flyway
+(`db:apply`). No backfill. Existing `<ClientTime tz=…>` call sites keep working during the
+incremental `lib/format.ts` migration; the wave doesn't need a big-bang cutover.

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -257,6 +257,27 @@ async function main() {
       (oldConsole.location ?? "").includes(`/o/${renamed.slug}`),
   );
 
+  // --- User timezone preference (spec 2026-07-14) — account-level, all plans ---
+  {
+    const saved = (await call(admin, "/api/users/me", "PATCH", {
+      timezone: "Asia/Kolkata",
+    })) as { timezone: string | null };
+    check("pro: timezone saved", saved.timezone === "Asia/Kolkata");
+    const cleared = (await call(admin, "/api/users/me", "PATCH", {
+      timezone: null,
+    })) as { timezone: string | null };
+    check("pro: timezone clears to browser default", cleared.timezone === null);
+    await expectFail("bogus timezone rejected", () =>
+      call(admin, "/api/users/me", "PATCH", { timezone: "Mars/Phobos" }),
+    );
+    // Free path: the viewer session is plan-agnostic for account settings.
+    const vSaved = (await call(viewer, "/api/users/me", "PATCH", {
+      timezone: "Europe/London",
+    })) as { timezone: string | null };
+    check("free: timezone saved", vSaved.timezone === "Europe/London");
+    await call(viewer, "/api/users/me", "PATCH", { timezone: null });
+  }
+
   // --- Platform API /api/v1 (PROMPT-11) — the full engine v2 lifecycle ---
   await v1Suite(admin, org2.id, renamed.slug);
 


### PR DESCRIPTION
## What

Adds a per-user **timezone preference** (Account → Preferences) and makes **every rendered time state its zone**, with a clean two-lane model.

- **Venue lane** — schedules stay in the competition's `schedule_settings.tz` (authoritative, identical for every viewer), now labelled: `Sat 16 Aug 19:00 IST`.
- **Personal lane** — your own times (`/me`, `/my-matches`, account) render in **your** timezone; venue times also show your local equivalent beneath.

A match in India reads `19:00 IST` on every schedule; your personal pages add `↳ 14:30 BST` when your zone differs.

## Changes

**Data + libs**
- `V280` `users.timezone` (nullable IANA + blank-guard CHECK).
- `lib/tz.ts` (pure): `isValidIana`, `pickTimezone`, `listTimezones` (full `Intl.supportedValuesOf` set, canonicalized — `Asia/Calcutta`→`Asia/Kolkata`, `Europe/Kiev`→`Kyiv`, …).
- `lib/tz-server.ts`: `resolveTimezone` (users.timezone → `seazn_tz` cookie → UTC).
- `lib/format.ts`: explicit-tz `Intl` wrappers; `fmtZoneAbbrev` is DST-correct with a **DST-free override** (IST/GST/SGT/…) because Node and some browsers emit `GMT+5:30` where others emit `IST`. Labels render client-side to keep server/client in step.
- `userSchema`/`getCurrentUser` gain `timezone`; `PATCH /api/users/me` does a partial display_name/timezone update.

**UI**
- `<Zoned>` + `ViewerTzProvider`/`useViewerTz` (saved pref from the already-loaded page user, else browser detect — kept out of the static root layout).
- Account → Preferences picker (grouped full list, Detect, live "current time here" preview).
- Applied: `/me`, scorer `/my-matches`, public division schedule + embed widget (day grouping by venue date + "times in {zone}" header caption), console board (`ClientTime` gained `showZone`).

**CI / e2e (per follow-up request): pre-compiled production build, not `next dev`**
- `next dev` JIT-compiles per request and restarts near its half-RAM heap ceiling — flaky/OOM under a full Playwright/smoke run (only bit in CI). `e2e.yml` now builds + `next start` with a Next build cache and `E2E_PROD_TARGET=1` (matches the CI smoke job, which already did this, and the staging target). `playwright.config` webServer builds + starts prod locally too.

## Verification
- `tsc` clean; **unit: web 685 + engine 845 = 1530 pass**.
- Timezone smoke checks (pro + free save/clear, bogus-zone reject) pass.
- Live-verified in the app (desktop + mobile): Account picker preview `22:21 IST`, public schedule day headers `MONDAY 13 JULY · times in IST` with venue-local times.
- e2e: `e2e/user-account.spec.ts` (persist + reject bogus zone). Full Playwright suite runs in the E2E workflow.

## Docs
- `content/help/scheduling/timezones.md` (venue vs your time, how to set it).

## Still on host/browser zone (low-value internal, follow-up)
Admin tables, billing renewal date (date-only), audit log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)