### PR TITLE
fix(games): Opening Trainer hangs on opponent-ending lines (Italian, Ruy Lopez)

### DIFF
--- a/apps/web/e2e/games.spec.ts
+++ b/apps/web/e2e/games.spec.ts
@@ -60,6 +60,29 @@ test("an Opening Trainer lesson launches and takes the first move", async ({ pag
   await expect(page.locator('[data-square="e4"]')).toHaveAttribute("aria-label", /white pawn/);
 });
 
+test("an Opening Trainer line finishes (incl. an opponent-ending line)", async ({ page }) => {
+  await page.goto("/games/chess-quest");
+  await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
+  await page.reload();
+  await page.getByRole("button", { name: "Free play" }).click();
+  await page.getByRole("button", { name: /Opening Trainer/ }).click();
+  await expect(page.getByText(/The Italian Game/)).toBeVisible();
+  // Play the three learner moves; the trainer auto-plays Black's replies. The
+  // Italian ends on Black's Bc5, so completion must be driven off the opponent
+  // reply (regression: it used to hang without finishing).
+  const play = async (from: string, to: string) => {
+    await page.locator(`[data-square="${from}"]`).click();
+    await page.locator(`[data-square="${to}"]`).click();
+  };
+  await play("e2", "e4");
+  await expect(page.getByText("Nf3")).toBeVisible(); // after Black's auto …e5, next prompt is Nf3
+  await play("g1", "f3");
+  await expect(page.getByText("Bc4")).toBeVisible(); // after auto …Nc6, next prompt is Bc4
+  await play("f1", "c4");
+  await expect(page.getByText(/you played the whole line/)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Play again" })).toBeVisible();
+});
+
 test("unknown game slug 404s", async ({ page }) => {
   const res = await page.goto("/games/not-a-game");
   expect(res?.status()).toBe(404);

--- a/apps/web/e2e/games.spec.ts
+++ b/apps/web/e2e/games.spec.ts
@@ -60,28 +60,82 @@ test("an Opening Trainer lesson launches and takes the first move", async ({ pag
   await expect(page.locator('[data-square="e4"]')).toHaveAttribute("aria-label", /white pawn/);
 });
 
-test("an Opening Trainer line finishes (incl. an opponent-ending line)", async ({ page }) => {
-  await page.goto("/games/chess-quest");
-  await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
-  await page.reload();
-  await page.getByRole("button", { name: "Free play" }).click();
-  await page.getByRole("button", { name: /Opening Trainer/ }).click();
-  await expect(page.getByText(/The Italian Game/)).toBeVisible();
-  // Play the three learner moves; the trainer auto-plays Black's replies. The
-  // Italian ends on Black's Bc5, so completion must be driven off the opponent
-  // reply (regression: it used to hang without finishing).
-  const play = async (from: string, to: string) => {
-    await page.locator(`[data-square="${from}"]`).click();
-    await page.locator(`[data-square="${to}"]`).click();
-  };
-  await play("e2", "e4");
-  await expect(page.getByText("Nf3")).toBeVisible(); // after Black's auto …e5, next prompt is Nf3
-  await play("g1", "f3");
-  await expect(page.getByText("Bc4")).toBeVisible(); // after auto …Nc6, next prompt is Bc4
-  await play("f1", "c4");
-  await expect(page.getByText(/you played the whole line/)).toBeVisible();
-  await expect(page.getByRole("button", { name: "Play again" })).toBeVisible();
-});
+// Every Track 3 opening must play its whole line to completion. Each step is
+// the learner's move plus the SAN the trainer prompts for it — we wait for that
+// prompt (which also covers the trainer's auto-reply, and the auto-1.e4 the
+// Scandinavian plays before Black's first move) before making the move. Covers
+// opponent-ending lines (Italian, Ruy Lopez — the regression), captures
+// (Scotch), a learner-ending line (London), and a Black-learner line where the
+// trainer moves first (Scandinavian).
+const OPENING_WALKTHROUGHS: { day: number; title: string; steps: [string, string, string][] }[] = [
+  {
+    day: 97,
+    title: "The Italian Game",
+    steps: [
+      ["e2", "e4", "e4"],
+      ["g1", "f3", "Nf3"],
+      ["f1", "c4", "Bc4"],
+    ],
+  },
+  {
+    day: 99,
+    title: "The Ruy Lopez",
+    steps: [
+      ["e2", "e4", "e4"],
+      ["g1", "f3", "Nf3"],
+      ["f1", "b5", "Bb5"],
+    ],
+  },
+  {
+    day: 101,
+    title: "The Scotch Game",
+    steps: [
+      ["e2", "e4", "e4"],
+      ["g1", "f3", "Nf3"],
+      ["d2", "d4", "d4"],
+      ["f3", "d4", "Nxd4"],
+    ],
+  },
+  {
+    day: 103,
+    title: "The London System",
+    steps: [
+      ["d2", "d4", "d4"],
+      ["g1", "f3", "Nf3"],
+      ["c1", "f4", "Bf4"],
+    ],
+  },
+  {
+    day: 105,
+    title: "The Scandinavian Defense",
+    steps: [
+      ["d7", "d5", "d5"],
+      ["d8", "d5", "Qxd5"],
+      ["d5", "a5", "Qa5"],
+    ],
+  },
+];
+
+for (const opening of OPENING_WALKTHROUGHS) {
+  test(`Opening Trainer plays ${opening.title} to completion`, async ({ page }) => {
+    await page.goto("/games/chess-quest");
+    await page.evaluate(() => localStorage.removeItem("seazn-games:chess-quest:v1"));
+    await page.reload();
+    // Launch the opening from its Track 3 lesson.
+    await page.getByRole("button", { name: `Day ${opening.day}: ${opening.title}` }).click();
+    await page.getByRole("button", { name: /Play the opening/ }).click();
+    await expect(page.getByText(new RegExp(opening.title)).first()).toBeVisible();
+
+    for (const [from, to, san] of opening.steps) {
+      // Wait for this move to be prompted (covers the trainer's prior auto-move).
+      await expect(page.getByText(san, { exact: true }).first()).toBeVisible();
+      await page.locator(`[data-square="${from}"]`).click();
+      await page.locator(`[data-square="${to}"]`).click();
+    }
+    await expect(page.getByText(/you played the whole line/)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Play again" })).toBeVisible();
+  });
+}
 
 test("unknown game slug 404s", async ({ page }) => {
   const res = await page.goto("/games/not-a-game");

--- a/apps/web/src/games/chess-quest/components/games/OpeningTrainer.tsx
+++ b/apps/web/src/games/chess-quest/components/games/OpeningTrainer.tsx
@@ -65,9 +65,25 @@ export function OpeningTrainer({ opening }: { opening: string }) {
 
   useEffect(() => () => clearPending(), [clearPending]);
 
-  // Auto-play opponent moves; glow the learner's from-square on their turn.
+  const finish = useCallback(() => {
+    setDone(true);
+    setHighlights({});
+    const stars = STAR_RULES.openingTrainer(mistakes);
+    progress.setGameStars("openingTrainer", stars);
+    setStatus(`<strong>${op.name}</strong> — you played the whole line! ${"★".repeat(stars)}`);
+    voice.say(`${op.name}. You played the whole line!`);
+    celebrate();
+  }, [mistakes, op.name, progress]);
+
+  // Drive the sequence off `ply`: finish the line, auto-play opponent replies,
+  // or glow the learner's from-square. Completion runs here (not in
+  // onLearnerMove) so lines that end on an opponent move also finish.
   useEffect(() => {
-    if (done || ply >= op.line.length) return;
+    if (done) return;
+    if (ply >= op.line.length) {
+      finish();
+      return;
+    }
     if (!learnerPly(ply)) {
       later(() => {
         const mv = op.line[ply];
@@ -85,16 +101,6 @@ export function OpeningTrainer({ opening }: { opening: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ply, done]);
 
-  function finish() {
-    setDone(true);
-    setHighlights({});
-    const stars = STAR_RULES.openingTrainer(mistakes);
-    progress.setGameStars("openingTrainer", stars);
-    setStatus(`<strong>${op.name}</strong> — you played the whole line! ${"★".repeat(stars)}`);
-    voice.say(`${op.name}. You played the whole line!`);
-    celebrate();
-  }
-
   function onLearnerMove(from: number, to: number) {
     const mv = op.line[ply];
     if (from === sqIdx(mv.from) && to === sqIdx(mv.to)) {
@@ -103,9 +109,9 @@ export function OpeningTrainer({ opening }: { opening: string }) {
       setPopN((v) => v + 1);
       sfx.move();
       setSelIdx(-1);
-      const nextPly = ply + 1;
-      setPly(nextPly);
-      if (nextPly >= op.line.length) finish();
+      // Completion is handled by the ply-driven effect (covers opponent-ending
+      // lines too), so just advance.
+      setPly(ply + 1);
     } else {
       setSelIdx(-1);
       setMistakes((x) => x + 1);


### PR DESCRIPTION
## Bug
The Opening Trainer stopped responding after the last move on lines that end with an opponent (Black) move — the **Italian** and **Ruy Lopez**. The board reached the final position but never celebrated: status stuck on the previous "Your move…", button stayed "Restart", and every tap was ignored.

## Root cause
`finish()` was only called from `onLearnerMove` (when the learner plays the last move). Lines ending on an opponent move are completed by the auto-reply path, which advanced `ply` past the end but never called `finish()` — so `done` never became true and the `ply >= length` guard silently swallowed further taps.

## Fix
Completion now runs from the single ply-driven effect (`ply >= line.length → finish()`), removed from `onLearnerMove`. One completion path covers both learner-ending (Scotch, London, Scandinavian) and opponent-ending (Italian, Ruy Lopez) lines.

## Verified
- Browser: played the full Italian → "you played the whole line! ★★★" + "Play again"
- New regression e2e plays the full Italian (opponent-ending) to completion — **9/9 e2e pass**
- 155 chess-quest vitest green, eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)