### PR TITLE
fix(stages): let the only stage be deleted (format-lock escape)

### DIFF
--- a/apps/web/content/help/divisions/settings.md
+++ b/apps/web/content/help/divisions/settings.md
@@ -13,6 +13,6 @@ Every division has a **Settings tab** (visible to editors) beside Entrants, Fixt
 
 ## Common questions
 
-**Why can't I change the format?** Fixtures exist — a schedule (and any results) were built on the old format. Delete the stages from the Fixtures tab first, or archive the division and start a fresh one.
+**Why can't I change the format?** Fixtures exist — a schedule (and any results) were built on the old format. On the **Fixtures tab**, delete the stages first (last stage down; a plain League has just the one), then the Format section unlocks. If a stage already has **played** results — anything in play, decided or finalized — it can't be deleted; archive the division and start a fresh one instead.
 
 **Who sees the Settings tab?** Owners, admins and editors of the competition. Viewers never see it.

--- a/apps/web/src/components/v2/__tests__/stages-panel-delete.test.tsx
+++ b/apps/web/src/components/v2/__tests__/stages-panel-delete.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StagesPanel } from "@/components/v2/stages-panel";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+vi.mock("@/components/ui/confirm-provider", () => ({
+  useConfirm: () => vi.fn(async () => false),
+}));
+
+// Regression (2026-07-14): a pure League division has ONE stage. The Delete
+// affordance was gated on `stages.length > 1`, so the only stage never showed
+// Delete — yet the server's deleteStage happily removes the last/only stage
+// when nothing is played. Result: once fixtures were generated, the format
+// lock ("delete the stages first") had no escape. The button must appear for
+// a single unplayed stage, and must NOT appear once a fixture is played.
+const STAGE = {
+  id: "s1", seq: 0, kind: "league", name: "League",
+  config: {}, qualification: null, status: "active",
+};
+const baseProps = {
+  divisionId: "d1", orgSlug: "org", compSlug: "comp", divSlug: "div",
+  stages: [STAGE],
+  entrantNames: { e1: "Alpha", e2: "Bravo" },
+  canEdit: true,
+  tz: "UTC",
+  canExport: false,
+};
+const fixture = (status: string) => ({
+  id: "f1", stage_id: "s1", pool_id: null, round_no: 1, seq_in_round: 1,
+  fixture_no: 1, home_entrant_id: "e1", away_entrant_id: "e2",
+  scheduled_at: "2026-08-16T13:30:00.000Z", venue: null, court_label: null,
+  status, outcome: null,
+});
+
+const deleteButton = />\s*Delete\s*<\/button>/;
+
+describe("StagesPanel — Delete on the only stage", () => {
+  it("shows Delete for a single league stage with generated-but-unplayed fixtures", () => {
+    const html = renderToStaticMarkup(
+      <StagesPanel {...baseProps} fixtures={[fixture("scheduled")]} />,
+    );
+    expect(html).toMatch(deleteButton);
+  });
+
+  it("hides Delete once a fixture is played (matches the server guard)", () => {
+    const html = renderToStaticMarkup(
+      <StagesPanel {...baseProps} fixtures={[fixture("finalized")]} />,
+    );
+    expect(html).not.toMatch(deleteButton);
+  });
+
+  it("hides Delete from viewers (canEdit=false)", () => {
+    const html = renderToStaticMarkup(
+      <StagesPanel {...baseProps} canEdit={false} fixtures={[fixture("scheduled")]} />,
+    );
+    expect(html).not.toMatch(deleteButton);
+  });
+});

--- a/apps/web/src/components/v2/stages-panel.tsx
+++ b/apps/web/src/components/v2/stages-panel.tsx
@@ -268,7 +268,10 @@ export function StagesPanel({ divisionId, orgSlug, compSlug, divSlug, stages, fi
             .sort();
           return { from: times[0] ?? null, to: times[times.length - 1] ?? null };
         };
-        // Mirrors the server guard: last stage only, nothing played yet.
+        // Mirrors the server guard (deleteStage) EXACTLY: only the last stage
+        // in the graph, and only when it owns no played fixtures. No "keep one
+        // stage" rule — the server deletes the sole stage of a pure League too,
+        // which is the only escape from the format lock once fixtures exist.
         const deletable =
           stage.seq === Math.max(...stages.map((s) => s.seq)) &&
           !stageFixtures.some((f) => ["in_play", "decided", "finalized"].includes(f.status));
@@ -308,7 +311,7 @@ export function StagesPanel({ divisionId, orgSlug, compSlug, divSlug, stages, fi
                   )}
                 </>
               )}
-              {canEdit && deletable && stages.length > 1 && (
+              {canEdit && deletable && (
                 <button
                   type="button"
                   disabled={busy !== null}


### PR DESCRIPTION
## Bug

A pure **League** division has a single stage. Once fixtures are generated, the **Format** section locks (`Format is locked — fixtures exist. Delete the stages first if you must change it`). But the **Delete** button on the Fixtures tab was gated on `stages.length > 1`, so the *only* stage never showed Delete — a dead-end: you couldn't delete the one stage the message told you to delete.

Reported case: League fixtures generated + scheduled, **none played/started** — still couldn't change format or delete the stage.

## Root cause

`stages-panel.tsx` gated the Delete affordance on `stages.length > 1`, stricter than the server. `server/usecases/stages.ts` `deleteStage` only refuses a stage that has a **later** stage or **played** fixtures (`in_play`/`decided`/`finalized`) — it deletes the last/only stage fine when nothing is played. The client `deletable` flag already mirrors that guard; the extra `stages.length > 1` was the bug.

## Fix

Drop `&& stages.length > 1`. Multi-stage behavior is unchanged (`deletable` still requires `seq === max`); single-stage now matches the API, restoring the format-lock escape path.

Still by design: a stage with **played** results can't be deleted — archive the division instead (help updated).

## Tests / docs
- Regression (`renderToStaticMarkup`): Delete shows for a single unplayed league stage, hides once a fixture is played, hides for viewers. **Fails against the `stages.length > 1` code, passes with the fix** (verified both ways).
- `tsc` clean; full web unit suite green (860 pass).
- `content/help/divisions/settings.md` clarifies the escape path + the played-results case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)