### PR TITLE
feat(tour): Stripe Connect + billing tour steps; brand mark on night surfaces

### DIFF
--- a/apps/web/content/help/getting-started/create-your-organisation.md
+++ b/apps/web/content/help/getting-started/create-your-organisation.md
@@ -13,6 +13,13 @@ Everything you run on seazn.club lives inside an **organisation** — your club,
 3. Add a **logo** and **brand colour** (Pro) so dashboards and share images carry your identity.
 4. Invite teammates under **Settings → Team** — owners and admins can edit everything, scorers only score their assigned matches, viewers can look but not touch. Invites never change an existing member's role: a viewer who accepts an umpire invite keeps viewer access and just gains those matches to score ([how scorer invites work](/help/scoring/scorer-role)).
 
+## Get set up to get paid
+
+The welcome tour walks you through this next, right after naming your organisation:
+
+1. **Connect Stripe** under **Settings → Payments** so you can take **card entry fees** — registrants pay at sign-up and the money settles straight into your own Stripe account. It's a one-time, secure onboarding; [here's the whole money journey](/help/registration/card-payments).
+2. Check **Settings → Plan & billing** — you start on the free **Community** plan. Card entry fees and other paid extras unlock on **Pro**; you can [compare plans and upgrade](/help/billing/plans) whenever you're ready. Running a free event? Community is plenty.
+
 ## Common questions
 
 **Can I run more than one organisation?** Yes — switch between them from the organisation menu. Each has its own competitions, team and plan.

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -587,9 +587,11 @@ body {
 .mk-nav-night .mk-nav-link:hover { opacity: 1; background: rgb(245 240 232 / 0.08); }
 .mk-nav-night .mk-nav-link.btn-ghost { background: transparent; border-color: #3b2a6e; color: var(--mk-cream); }
 .mk-nav-night .mk-nav-cta { background: var(--mk-lime); color: var(--mk-night); }
+/* Logo swap: light navs show the night-ink mark, the night hero shows the
+   cream mark (lime pitch line + red ball). Exactly one renders at a time. */
+.mk-nav-logo-img-night { display: none; }
 .mk-nav-night .mk-nav-logo-img { display: none; }
-.mk-nav-night .mk-nav-logo-text { color: var(--mk-cream); }
-.mk-nav-solid .mk-nav-logo-text { display: none; }
+.mk-nav-night .mk-nav-logo-img-night { display: block; }
 /* Dark funnel form variant */
 .mk-funnel-night { border-color: #3b2a6e; background: rgb(26 15 62 / 0.75); }
 .mk-funnel-night .label { color: #b7aede; }

--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -130,7 +130,7 @@ export default async function BillingPage({
         )}
 
         {/* Current plan */}
-        <section className="card mb-6 p-5">
+        <section data-tour="billing-plan" className="card mb-6 p-5">
           <h2 className="mb-4 text-xs font-semibold uppercase tracking-wide text-purple-600">
             Current plan
           </h2>

--- a/apps/web/src/components/__tests__/console-theme.test.tsx
+++ b/apps/web/src/components/__tests__/console-theme.test.tsx
@@ -46,14 +46,17 @@ describe("floodlit console theme", () => {
     expect(html).toContain("Riverside");
   });
 
-  it("night stage mounts the wordmark over its children", () => {
+  it("night stage mounts the brand mark (not a text lockup) over its children", () => {
     const html = renderToStaticMarkup(
       <NightStage>
         <p>ticket window</p>
       </NightStage>,
     );
     expect(html).toContain("app-night-stage");
-    expect(html).toContain("Seazn");
+    // The cream wordmark carrying the lime pitch line + red ball — the mark, not
+    // plain "Seazn Club" text. The alt keeps the accessible name.
+    expect(html).toContain("/logo-wide-night.png");
+    expect(html).toContain('alt="Seazn Club"');
     expect(html).toContain("ticket window");
   });
 });

--- a/apps/web/src/components/__tests__/product-tour.test.ts
+++ b/apps/web/src/components/__tests__/product-tour.test.ts
@@ -1,0 +1,77 @@
+// Product-tour flow contract: the onboarding walk must run
+// org → rename → get paid (Stripe Connect) → plan & billing → create a
+// competition. The Connect and Billing stops were added between renaming the
+// org and creating the first competition; this pins that order and the anchors
+// each step highlights so a reorder or a renamed data-tour target trips here.
+import { describe, expect, it, vi } from "vitest";
+
+// product-tour.tsx is a client component; stub the navigation hooks so importing
+// the module (for its STEPS table) never touches a real router.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: () => {} }),
+}));
+
+import { STEPS, placeTooltip } from "@/components/product-tour";
+import { routes } from "@/lib/routes";
+
+describe("product tour flow", () => {
+  it("walks org → get paid → billing → create competition, in order", () => {
+    expect(STEPS.map((s) => s.id)).toEqual([
+      "welcome",
+      "org-chip",
+      "org-rename",
+      "connect",
+      "billing",
+      "new-competition",
+      "wizard",
+    ]);
+  });
+
+  it("the Connect step lives on the payments page and highlights the Stripe card", () => {
+    const connect = STEPS.find((s) => s.id === "connect")!;
+    expect(connect.target).toBe("connect-stripe");
+    expect(connect.path("acme")).toBe(routes.payments("acme"));
+  });
+
+  it("the Billing step lives on the billing page and highlights the plan card", () => {
+    const billing = STEPS.find((s) => s.id === "billing")!;
+    expect(billing.target).toBe("billing-plan");
+    expect(billing.path("acme")).toBe(routes.billing("acme"));
+  });
+
+  it("get paid then billing sit between renaming the org and creating a competition", () => {
+    const idx = (id: string) => STEPS.findIndex((s) => s.id === id);
+    expect(idx("org-rename")).toBeLessThan(idx("connect"));
+    expect(idx("connect")).toBeLessThan(idx("billing"));
+    expect(idx("billing")).toBeLessThan(idx("new-competition"));
+  });
+});
+
+describe("tour tooltip placement", () => {
+  // The Connect step highlights the whole Stripe card (~484px). On a phone
+  // (667px tall) that fits neither below nor above the target, so the tooltip
+  // must centre instead of rendering off-screen — the bug the mobile pass found.
+  it("centres for a target taller than the viewport", () => {
+    const style = placeTooltip({ top: 12, left: 24, width: 320, height: 484 }, 375, 667);
+    expect(style.transform).toBe("translate(-50%, -50%)");
+    expect(style.top).toBe("50%");
+    expect(style.bottom).toBeUndefined();
+  });
+
+  it("places below when the target leaves room beneath it", () => {
+    const style = placeTooltip({ top: 100, left: 40, width: 200, height: 40 }, 1280, 800);
+    expect(style.top).toBe(100 + 40 + 16);
+    expect(style.transform).toBeUndefined();
+  });
+
+  it("places above when there is room over the target but not under it", () => {
+    const style = placeTooltip({ top: 600, left: 40, width: 200, height: 40 }, 1280, 667);
+    expect(style.bottom).toBe(667 - 600 + 16);
+    expect(style.top).toBeUndefined();
+  });
+
+  it("centres when there is no target (hidden on mobile)", () => {
+    expect(placeTooltip(null, 375, 667).transform).toBe("translate(-50%, -50%)");
+  });
+});

--- a/apps/web/src/components/marketing-nav.tsx
+++ b/apps/web/src/components/marketing-nav.tsx
@@ -27,13 +27,14 @@ export async function MarketingNav({
       {night ? <NavScrollFlip /> : null}
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         <Link href="/" aria-label="Seazn Club — home" className="flex items-center gap-2">
-          {/* logo-wide.png is the night-ink wordmark on transparent — right
-              for light navs; the night state swaps to the cream text lockup. */}
+          {/* logo-wide.png is the night-ink wordmark for light navs; the night
+              state swaps to logo-wide-night.png — the cream wordmark carrying
+              the lime pitch line + red ball, legible over the floodlit hero.
+              Exactly one shows at a time via CSS (globals.css §mk-nav). */}
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src="/logo-wide.png" alt="Seazn Club" className="mk-nav-logo-img h-9 w-auto" />
-          <span aria-hidden className="mk-nav-logo-text mk-display text-xl font-bold tracking-[0.08em]">
-            SEAZN <span className="text-lime-400">CLUB</span>
-          </span>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/logo-wide-night.png" alt="Seazn Club" className="mk-nav-logo-img-night h-9 w-auto" />
         </Link>
         <nav className="flex items-center gap-1 sm:gap-2">
           {LINKS.map((l) => (

--- a/apps/web/src/components/night-stage.tsx
+++ b/apps/web/src/components/night-stage.tsx
@@ -16,11 +16,11 @@ export function NightStage({
     <main className="app-night-stage grid min-h-screen place-items-center px-4 py-10">
       <div className={`w-full ${maxW}`}>
         <div className="mb-6 text-center">
-          <Link
-            href="/"
-            className="app-display inline-block text-2xl font-bold leading-none text-cream"
-          >
-            Seazn <span className="text-lime-400">Club</span>
+          <Link href="/" aria-label="Seazn Club — home" className="inline-block">
+            {/* The brand mark, not a text lockup: cream wordmark with the lime
+                pitch line + red ball, legible on the night stage. */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/logo-wide-night.png" alt="Seazn Club" className="mx-auto h-9 w-auto" />
           </Link>
         </div>
         {children}

--- a/apps/web/src/components/org-payment-instructions.tsx
+++ b/apps/web/src/components/org-payment-instructions.tsx
@@ -107,7 +107,7 @@ export function OrgPaymentInstructions({
     <div className="space-y-5">
       {/* Stripe Connect (owners only — the API enforces it too). */}
       {isOwner && (
-        <div className="rounded-lg border border-slate-200 p-4">
+        <div data-tour="connect-stripe" className="rounded-lg border border-slate-200 p-4">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
               <p className="text-sm font-medium text-slate-800">Card payments (Stripe)</p>

--- a/apps/web/src/components/product-tour.tsx
+++ b/apps/web/src/components/product-tour.tsx
@@ -17,7 +17,7 @@ interface TourStep {
   body: string;
 }
 
-const STEPS: TourStep[] = [
+export const STEPS: TourStep[] = [
   {
     id: "welcome",
     path: (org: string) => routes.orgHome(org),
@@ -37,7 +37,21 @@ const STEPS: TourStep[] = [
     path: (org: string) => routes.orgSettings(org),
     target: "org-rename",
     title: "Rename your organisation",
-    body: "Type a new name here and save. The tabs on the left also cover your team, plan and API keys.",
+    body: "Type a new name here and save. The tabs on the left cover your team, plan and API keys — next, let's set up getting paid.",
+  },
+  {
+    id: "connect",
+    path: (org: string) => routes.payments(org),
+    target: "connect-stripe",
+    title: "Get paid",
+    body: "Connect Stripe to take card entry fees — payouts land straight in your bank. You're sent to Stripe's secure onboarding; Seazn Club never sees your details.",
+  },
+  {
+    id: "billing",
+    path: (org: string) => routes.billing(org),
+    target: "billing-plan",
+    title: "Your plan & billing",
+    body: "You're on the free Community plan. Track usage, view invoices and upgrade to Pro here whenever you're ready.",
   },
   {
     id: "new-competition",
@@ -58,8 +72,28 @@ const STEPS: TourStep[] = [
 export const TOUR_STORAGE_KEY = "seazn.tour.step";
 const PADDING = 8;
 const TOOLTIP_WIDTH = 320;
+const TOOLTIP_HEIGHT = 220; // placement estimate; the card itself is auto-height
 
 type Rect = { top: number; left: number; width: number; height: number };
+
+/** Where the tooltip sits relative to the highlighted target: below when it
+ *  fits, else above when it fits, else centered. A target taller than the
+ *  viewport (a whole settings card on a phone) fits neither side, so it centers
+ *  rather than render off-screen. A null rect (no/hidden target) also centers. */
+export function placeTooltip(rect: Rect | null, vw: number, vh: number): React.CSSProperties {
+  const centered: React.CSSProperties = {
+    top: "50%",
+    left: "50%",
+    transform: "translate(-50%, -50%)",
+  };
+  if (!rect) return centered;
+  const left = Math.min(Math.max(rect.left, 16), Math.max(vw - TOOLTIP_WIDTH - 16, 16));
+  const gap = PADDING + 8;
+  const belowTop = rect.top + rect.height + gap;
+  if (belowTop + TOOLTIP_HEIGHT <= vh) return { top: belowTop, left };
+  if (rect.top - gap - TOOLTIP_HEIGHT >= 0) return { bottom: vh - rect.top + gap, left };
+  return centered;
+}
 
 function measure(target: string): Rect | null {
   const el = document.querySelector(`[data-tour="${target}"]`);
@@ -183,20 +217,9 @@ export function ProductTour({ autoStart, orgSlug }: { autoStart: boolean; orgSlu
   const s = STEPS[step];
   const isLast = step === STEPS.length - 1;
 
-  // Tooltip placement: below the target when there's room, otherwise above;
-  // centered card when there's no target.
-  let tooltipStyle: React.CSSProperties;
-  if (rect) {
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
-    const left = Math.min(Math.max(rect.left, 16), Math.max(vw - TOOLTIP_WIDTH - 16, 16));
-    const below = rect.top + rect.height + PADDING + 220 < vh;
-    tooltipStyle = below
-      ? { top: rect.top + rect.height + PADDING + 8, left }
-      : { bottom: vh - rect.top + PADDING + 8, left };
-  } else {
-    tooltipStyle = { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
-  }
+  // Tooltip placement: below the target when it fits, else above, else centered
+  // (a target taller than the viewport would push the tooltip off-screen).
+  const tooltipStyle = placeTooltip(rect, window.innerWidth, window.innerHeight);
 
   return createPortal(
     <div className="fixed inset-0 z-[100]" role="dialog" aria-modal="true" aria-label="Product tour">

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1140,6 +1140,17 @@ async function uiSystemSuite(admin: Session, proOrgSlug: string): Promise<void> 
     "v3/11 manage sections stay hidden without a Stripe customer (pro)",
     !proBilling.body.includes("Payment methods"),
   );
+  // Product tour: the Billing and Connect steps highlight real anchors — the
+  // plan card on billing, the Stripe card on payments (owner-only).
+  check(
+    "product tour: billing step anchor present (pro)",
+    proBilling.body.includes('data-tour="billing-plan"'),
+  );
+  const proPayments = await html(admin, `/o/${proOrgSlug}/settings/payments`);
+  check(
+    "product tour: Connect step anchor present on payments (owner)",
+    proPayments.status === 200 && proPayments.body.includes('data-tour="connect-stripe"'),
+  );
   const freeCancel = await raw(free, "/api/billing/cancel", "POST", {});
   check("v3/11 cancel wants a Stripe customer first (free)", freeCancel.status === 400);
   const proAddress = await raw(admin, "/api/billing/address", "POST", {
@@ -1154,6 +1165,10 @@ async function uiSystemSuite(admin: Session, proOrgSlug: string): Promise<void> 
     freeBilling.status === 200 &&
       freeBilling.body.includes("Upgrade to Pro") &&
       !freeBilling.body.includes("Manage billing →"),
+  );
+  check(
+    "product tour: billing step anchor present (free)",
+    freeBilling.body.includes('data-tour="billing-plan"'),
   );
 }
 


### PR DESCRIPTION
## What

**Product tour** now walks: `welcome → org-chip → org-rename →` **`Get paid (Stripe Connect)`** `→` **`Plan & billing`** `→ new-competition → wizard`.

- Connect step → payments page, spotlights the Stripe card (`data-tour="connect-stripe"`).
- Billing step → billing page, spotlights the plan card (`data-tour="billing-plan"`).
- Tooltip placement now **centres** when a target is taller than the viewport (a whole settings card on a phone) instead of rendering off-screen — caught in the mobile pass (Connect card is 484px on a 667px screen; tooltip was landing at top:-235).

**Brand logo on night surfaces.** Home hero nav and login rendered a text-only "SEAZN CLUB" lockup (`.mk-nav-night` hid the logo image; `NightStage` hardcoded text). They now show `logo-wide-night.png` — the cream wordmark carrying the **lime pitch line (`#a3e635`) + red ball (`#ef4444`)**. Solid/light navs unchanged (already carried the mark).

## Tests / help
- `product-tour.test.ts` — step order + anchors + `placeTooltip()` placement cases (incl. tall-target → centred).
- `console-theme.test.tsx` — NightStage now asserts the logo image, not text.
- `smoke.ts` — asserts both tour anchors on live billing/payments (pro + free).
- `create-your-organisation.md` — documents the new get-paid/billing onboarding stop.

## Verify
- `tsc --noEmit` clean · **868 unit pass / 0 fail** · eslint 0 errors.
- Browser desktop **and** mobile (375×667): all 7 tour steps incl. both new ones, and the mark on home night hero, home solid nav, and login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)