### PR TITLE
docs(v10-v12): design corpus — sponsor CRM, official onboarding, matchday docs

### DIFF
--- a/design/v10/README.md
+++ b/design/v10/README.md
@@ -1,0 +1,61 @@
+# v10 — Sponsor CRM & Monetization
+
+> **Status (2026-07-14):** design only. PROMPT-56 not yet implemented.
+> Target branch (build time): `feat/v10-sponsor-crm` (own worktree off `main`).
+> **Heaviest of the v10→v12 wave** — flagged during brainstorming as
+> plausibly its own multi-prompt wave; kept as one prompt with clearly
+> separable commits (model → manager UI → monetization → placement).
+> **Migrations:** one new delta, **use the next free `V###`** (V280 is the last
+> on `main`; v5-i18n carries V281 unmerged — check contention before numbering,
+> per the V-number-contention gotcha).
+
+## Theme
+
+Sponsors exist today as a **shallow branding array**, not a feature. The whole
+implementation is `apps/web/src/lib/org-branding.ts`: a `Sponsor` is
+`{ name, url?, logo? }`, stored inside the `branding` jsonb on both
+`organizations` and `competitions` (`mergeSponsors` / `brandingSponsors`, blob
+merge so a colour write never clobbers the sponsor list). It renders in exactly
+three places — the org settings editor (`components/org-sponsors.tsx`), the
+public competition page (`(public)/shared/[orgSlug]/[competitionSlug]/page.tsx`,
+competition-level then org-level, deduped by name), and the register-page
+masthead line — and is Pro-gated by the public org read (v3/10 #5). No tiers, no
+per-competition management surface, no placement on the poster/embed/slideshow,
+no money, no analytics.
+
+**v10 turns sponsorship into a product an organiser can sell.** Three layers:
+
+1. **Real model.** Promote sponsors out of the branding blob into first-class
+   `sponsors` rows (org- or competition-scoped) carrying a **tier**
+   (`title | gold | silver | partner`), display order, logo, and status.
+   `brandingSponsors()` becomes a back-compat read shim while existing blobs are
+   migrated; the public renderers switch to the table.
+2. **Placement everywhere.** Tier-grouped sponsor strips on the public
+   competition and division pages, the poster PDF, the embed widgets, the
+   slideshow, and (via v12) the admit-one ticket. Click-through goes through a
+   tracked redirect so organisers can prove value to a sponsor.
+3. **Monetization.** An organiser publishes **sponsor packages** (price /
+   currency / what's included) and takes payment through the **same Stripe
+   Connect destination-charge rail as entry fees** (`usecases/registrations.ts`
+   is the precedent: `transfer_data` to the club's connected account, platform
+   `application_fee_amount`). A paid order activates the sponsor automatically.
+
+## Prompts
+
+- `prompts/PROMPT-56-sponsor-crm.md` — `sponsors` / `sponsor_packages` /
+  `sponsor_orders` tables + RLS + entitlement seed; org & per-competition
+  sponsor manager; tiered public placement + tracked click redirect; Connect
+  checkout for packages reusing the entry-fee rail and `billing-events`
+  webhook dispatch; invoice/receipt emails; help, smoke, tests.
+
+## Non-goals (explicit)
+
+- **Sponsor self-serve signup portal** (a sponsor logging in to buy a slot
+  unprompted) — organiser-initiated only for v10; a public "become a sponsor"
+  funnel is a later wave.
+- **Programmatic ad serving / rotation / CPM billing** — placement is
+  deterministic by tier + order, billed per package, not per impression.
+- **Recovering Stripe fees or handling sponsor-side disputes** beyond what the
+  entry-fee rail already does (v9 dispute recovery applies unchanged).
+- **Removing the branding-blob path outright** — it stays as a read shim for
+  one release so no existing public page loses its sponsor strip mid-migration.

--- a/design/v10/prompts/PROMPT-56-sponsor-crm.md
+++ b/design/v10/prompts/PROMPT-56-sponsor-crm.md
@@ -1,0 +1,203 @@
+# PROMPT-56 — Sponsor CRM & monetization: real model, tiers, placement, paid packages
+
+**Read first:**
+- `apps/web/src/lib/org-branding.ts` — the entire current sponsor
+  implementation: `Sponsor { name, url?, logo? }`, `OrgBranding`,
+  `mergeSponsors` / `brandingSponsors` (blob-merge so a colour write never
+  clobbers sponsors). This becomes a **read shim**, not the source of truth.
+- `apps/web/src/components/org-sponsors.tsx` — the existing org-settings editor
+  you replace with the tiered manager.
+- `apps/web/src/app/o/[orgSlug]/settings/page.tsx` (~L282) — the `OrgSponsors`
+  mount point + `msg("sponsors.title")` + the "Sponsor slots require Pro" copy.
+- `apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx`
+  (~L58–L263) — public render: competition-level then org-level, deduped by
+  name. Switch to the table + tier grouping.
+- `apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/register/page.tsx`
+  (~L28–L56) — the register-page masthead sponsor line (same switch).
+- `apps/web/src/app/api/orgs/[id]/route.ts` — `mergeSponsors` / `mergeBrandColor`
+  write path; the entitlement-gated public org read that nulls sponsors today.
+- `apps/web/src/server/usecases/registrations.ts` — **the Connect precedent**:
+  destination charge with `transfer_data` → connected account,
+  `application_fee_amount` → platform, PaymentIntent creation, and the
+  idempotency conventions. Sponsor-package checkout mirrors this exactly.
+- `apps/web/src/server/usecases/billing-events.ts` — webhook dispatch;
+  `payment_intent.succeeded` handling + **`/admin/billing-events` can REPLAY**,
+  so every handler is idempotent.
+- `apps/web/src/lib/entitlements.ts` — `requireFeature(orgId, key)` resolves
+  `plan_entitlements`; new keys are **seeded by migration**, not code.
+- `design/v10/README.md` (scope + non-goals).
+
+**Depends:** none (parallel-safe with v11). **Migration:** one delta, next free
+`V###` after V280 (verify contention vs the unmerged v5-i18n V281).
+
+## Context
+
+Sponsorship today is a `Sponsor[]` living inside two `branding` jsonb columns
+(`organizations.branding`, `competitions.branding`). That was fine for "put five
+logos on the public page" (v3/10 #5) and is wrong for a sellable product: no
+tier, no ordering guarantees beyond array position, no per-competition editing
+surface, no revenue, no proof-of-delivery for the sponsor. This prompt makes
+sponsorship first-class **without a flag-day**: existing blobs keep rendering
+via a shim until migrated, and the public pages read the new table.
+
+Money reuses the **entry-fee rail unchanged**. An org sells a *sponsor package*
+(a priced offer) and the buyer pays by card; funds settle to the org's
+**connected account** via a destination charge, platform takes an application
+fee, exactly like a registration entry fee. No new Stripe primitives — same
+`getStripe()`, same connected-account resolution, same `billing-events`
+dispatch, same v9 dispute economics.
+
+## Task
+
+Commit the work in the four separable slices below (each independently
+reviewable / revertable).
+
+### 1. Model + migration (`V###`)
+
+Add three tables (schema `seazn_club`, tenant `org_id`, RLS mirroring
+`officials` / registration tables — copy the grant pattern from the newest
+`db/migration/deltas` file, and add public-read grants where the public renderer
+needs them, mirroring how public competition reads already reach branding):
+
+- `sponsors` — `id, org_id, competition_id (nullable ⇒ org-wide), name, url,
+  logo_path, tier ('title'|'gold'|'silver'|'partner'), display_order int,
+  status ('active'|'pending'|'inactive') default 'active', click_count int
+  default 0, created_at`.
+- `sponsor_packages` — `id, org_id, competition_id (nullable), name,
+  description, price_cents, currency, tier, active bool, created_at`.
+- `sponsor_orders` — `id, org_id, package_id, sponsor_name, sponsor_email,
+  payment_intent_id, amount_cents, currency, status
+  ('pending'|'paid'|'failed'|'refunded'), sponsor_id (nullable, set on
+  activation), created_at, paid_at`.
+
+Seed **entitlement keys** into `plan_entitlements` in the same migration
+(mirror how `officials.auto` / `exports.branded` are seeded — find them in the
+existing seed migration): `sponsors.tiers` (Pro — tiers + per-competition
+manager) and `sponsors.monetize` (Pro — packages + Connect checkout). The
+un-tiered single-logo strip stays free (community) so no existing free org
+loses its current sponsor line.
+
+**Backfill:** copy every `branding.sponsors[]` entry (org and competition) into
+`sponsors` rows (`tier='partner'`, `display_order` = array index,
+`competition_id` set for competition blobs, else null). Leave the blob in place
+(the shim reads it if the table is empty for that scope — belt-and-braces during
+rollout).
+
+### 2. Sponsor manager (`usecases/sponsors.ts` + API + UI)
+
+- New `apps/web/src/server/usecases/sponsors.ts`: `listSponsors`,
+  `createSponsor`, `patchSponsor`, `deleteSponsor`, `reorderSponsors`, all
+  `withTenant`; `assertTierAllowed` calls `requireFeature(orgId,
+  "sponsors.tiers")` when `tier !== 'partner'` **or** when
+  `competition_id !== null` (per-competition management is the Pro line). Zod
+  inputs like `officials.ts`.
+- API under `api/v1/orgs/[id]/sponsors` (+ `[sponsorId]` for patch/delete/
+  reorder), following the `officials` route shape (`v1`, `requireResourceAuth`,
+  `parseBody`).
+- Replace `components/org-sponsors.tsx` with a tiered manager: rows grouped by
+  tier, drag-or-arrow reorder, logo upload via the existing content-upload path
+  (the current editor already uploads to storage — reuse it; **logo_path is a
+  storage path, resolved to a URL at render**, as the current public code notes),
+  a competition selector (Pro) to scope a sponsor to one competition, and the
+  Pro upsell where `sponsors.tiers` is denied.
+
+### 3. Public placement (tier-grouped + tracked clicks)
+
+- `brandingSponsors()` stays but gains a DB-backed sibling
+  `resolveSponsors(orgId, competitionId?)` that returns table rows
+  (competition-scoped first, then org-wide, deduped by name, ordered by
+  `tier` rank then `display_order`), falling back to the blob shim only when the
+  table has no rows for that org. Public pages call the resolver.
+- Update the public competition page + register masthead to render **tier
+  groups** (title row large, then gold/silver/partner in descending prominence)
+  — keep it inside the existing Pro-gated public read.
+- Add a tracked redirect route `apps/web/src/app/s/[sponsorId]/route.ts`:
+  `GET` → increment `sponsors.click_count` (fire-and-forget, never block the
+  redirect) → `302` to the sponsor `url`. Public sponsor links point here.
+- Placement reaches the **poster PDF, embeds, and slideshow** by feeding
+  `resolveSponsors` into their existing branding inputs — **but the PDF/embed
+  *rendering* of sponsors is v12's job**; here, just make the data available
+  (the poster route + embed loaders already read branding — point them at the
+  resolver so v12 has real rows to draw).
+
+### 4. Monetization (Connect checkout for packages)
+
+- `usecases/sponsors.ts`: `createSponsorPackage` / `listPackages` /
+  `deactivatePackage` (Pro `sponsors.monetize`), and `startSponsorCheckout`:
+  - Resolve the org's connected account exactly as `registrations.ts` does;
+    refuse (`PaymentRequiredError` / 409) if the org isn't Connect-onboarded,
+    reusing the same guard/ToS-gate v9 added before Connect actions.
+  - Create the PaymentIntent as a **destination charge**: `amount` =
+    package `price_cents`, `currency`, `transfer_data.destination` = connected
+    account, `application_fee_amount` = the platform fee (reuse the entry-fee
+    fee helper — do **not** re-derive the fee formula), `metadata` =
+    `{ kind: 'sponsor', order_id, package_id, org_id }`, idempotency key
+    `sponsor-order-${order_id}`. Insert the `sponsor_orders` row `pending`
+    first, then create the intent (same order as registrations).
+- Webhook: extend `billing-events.ts` dispatch — on
+  `payment_intent.succeeded` with `metadata.kind === 'sponsor'`, mark the order
+  `paid`/`paid_at`, **create the activated `sponsor` row** (tier from the
+  package, `status='active'`) and link `sponsor_orders.sponsor_id`, all
+  idempotent (short-circuit if the order is already `paid` OR a sponsor already
+  carries this `order_id` — mirror the v9 metadata/list belt-and-braces so an
+  `/admin/billing-events` replay can't double-activate). On
+  `payment_intent.payment_failed` mark `failed`. Dispute/refund flow through the
+  **existing** v9 handlers unchanged (sponsor orders are just another charge).
+- **Emails** (`email-templates/`, register in `email.ts` + `index.ts`, pin
+  chrome in `email-builders.test.ts`: `bgcolor="#150b36"`, `#a3e635`,
+  `&#9679;`): `sponsor-invoice` (pay-now CTA, mirrors `payment-reminder.ts`) to
+  the sponsor email at checkout start, `sponsor-receipt` on `paid`.
+
+### 5. Cross-cutting (mandatory — do not skip)
+
+- **Help** (`content/help/**`): a "Sponsors" page under the org/branding
+  section — tiers, per-competition scoping, selling packages, where logos
+  appear, click stats. (House rule: every branch updates help in the same PR.)
+- **Smoke** (`scripts/smoke.ts`): extend both pro + free paths — free org adds a
+  `partner` logo and sees it publicly; pro org creates a tiered sponsor + a
+  package, runs a test-mode Connect checkout to `paid`, asserts the sponsor
+  activated and the click redirect increments.
+- **Tests** (every change ships a failing-without-it test):
+  - `org-branding` shim: table rows win over blob; blob fallback when table
+    empty; backfill idempotent.
+  - `sponsors` usecase: tier/competition gating denies without `sponsors.tiers`;
+    reorder + dedup + tier-rank ordering in `resolveSponsors`.
+  - checkout: destination charge shape (fee, transfer destination, metadata,
+    idempotency key) with a stubbed `getStripe()` (follow
+    `registrations.test.ts` / `dispute-evidence.test.ts` stub seam).
+  - webhook: `paid` activates exactly once under replay; `failed` path; a
+    stray non-sponsor intent is ignored.
+  - click redirect: increments once, 302s to the url, never blocks on the
+    increment.
+
+## Acceptance
+
+- `npm run typecheck`, unit suites (incl. new sponsor + email tests), smoke
+  green; help-content registry test green.
+- Test-mode simulation documented in the PR: create package → checkout with
+  `4242 4242 4242 4242` → webhook `paid` → sponsor appears tier-grouped on the
+  public competition page → click logo → redirect + `click_count` +1 → replay
+  the succeeded event from `/admin/billing-events` → no duplicate sponsor.
+- An existing org with blob sponsors still renders its strip before AND after
+  backfill (no public regression).
+- Connect-not-onboarded org is refused package checkout with the same gate as
+  entry fees.
+
+## Gotchas (do not relearn)
+
+- **Never replace the branding blob** — `mergeSponsors`/`mergeBrandColor` exist
+  because colour and sponsors share one column. During migration you read the
+  blob; you don't rewrite it.
+- **`logo` is a storage path, not a URL** — resolve at render (the current
+  public code comments this on every use).
+- Keep Stripe calls **outside** `sql` transactions (established withdraw/refund
+  rule).
+- `/admin/billing-events` replays at will → the `paid`→activate handler needs
+  the same idempotency story v9 uses (order-status check *and* sponsor-exists
+  check; Stripe idempotency keys expire ~24h so the DB guard is mandatory, not
+  optional).
+- Resolve the org owner via `org_members.role='owner'`, **not**
+  `organizations.created_by`, for any owner-addressed email (the created-by trap
+  PR #89 fixed).
+- V-number contention: v5-i18n holds V281 unmerged — number the delta against
+  what's actually on `main` at build time and re-check before pushing.

--- a/design/v11/README.md
+++ b/design/v11/README.md
@@ -1,0 +1,57 @@
+# v11 — Referee / Umpire Onboarding
+
+> **Status (2026-07-14):** design only. PROMPT-57 not yet implemented.
+> Target branch (build time): `feat/v11-official-onboarding` (own worktree off
+> `main`). **Depends on nothing in v10** — can build in parallel — but its
+> printable rota is consumed by v12, so land v11 before v12.
+> **Migrations:** one new delta, **use the next free `V###`** after v10's
+> (check V-number contention).
+
+## Theme
+
+The **officials engine is already built** — it just has no human on the other
+end. `apps/web/src/server/usecases/officials.ts` + `@seazn/engine/officials`
+give an `officials` table (`org_id, person_id, entrant_id, display_name,
+role_keys[], home_pool_id, max_per_day`), CRUD, spreadsheet import, seeded
+auto-assign, and per-fixture manual set/lock; `fixture_officials` is the write
+source and `fixtures.officials` the denormalised read cache. An organiser can
+already conjure a referee named "Priya" and drop her onto Court 3 at 09:15.
+
+What's missing is **Priya**. There is no way to invite a real person to an
+official record, no way for that person to claim it, and nowhere for them to see
+their own assignments, say "can't do Sunday", or reach the score pad for a match
+they're reffing. Players already have this whole path (PROMPT-53: invite →
+claim → `/me`); officials have none of it.
+
+**v11 gives officials the player-account treatment, reusing that infra
+end-to-end:**
+
+- **Invite** an official by email from the officials manager
+  (`usecases/invites.ts`, `email-templates/claim-invite.ts` are the pattern).
+- **Claim** links the invite to the signed-in user and stamps
+  `officials.person_id` (`usecases/person-claims.ts`, `claim/[token]/page.tsx`).
+- **Portal** lives inside **`/me`** (decision taken in brainstorming — one
+  identity, a person can be both a player and a referee): an *Officiating* lane
+  showing assigned fixtures (`me/assigned-fixtures` already returns them),
+  **accept / decline** per assignment, **availability / blackout dates**, the
+  **device link** to score each assigned match, and a **printable rota** (the
+  v12 doc).
+
+## Prompts
+
+- `prompts/PROMPT-57-official-onboarding.md` — `officials.email` + claim
+  linkage; `official_availability` (blackout dates) + `fixture_officials.response`
+  (pending/accepted/declined); invite/claim flow reusing the person-claim rail;
+  `/me` officiating lane (assignments, accept-decline, availability, device
+  link); assignment + change notification emails; `/me/rota.pdf` hook for v12;
+  help, smoke, tests.
+
+## Non-goals (explicit)
+
+- **Pay / match fees / expense tracking** — deferred (overlaps v10's Connect
+  money work; officiating payouts are a wave of their own).
+- **Qualifications / certifications on file** — the badge/grade of a referee is
+  out; `role_keys` stays the only capability signal for v11.
+- **Auto-reassign on decline** — a declined assignment flags on the organiser's
+  console for a manual re-pick; the engine is not re-run automatically.
+- **A separate `/officials` app or portal** — explicitly folded into `/me`.

--- a/design/v11/prompts/PROMPT-57-official-onboarding.md
+++ b/design/v11/prompts/PROMPT-57-official-onboarding.md
@@ -1,0 +1,163 @@
+# PROMPT-57 — Official onboarding: invite → claim → officiating lane in /me
+
+**Read first:**
+- `apps/web/src/server/usecases/officials.ts` — the officials model in full
+  (`OfficialRow`: `person_id, entrant_id, display_name, role_keys[],
+  home_pool_id, max_per_day`), CRUD, import, `engineInput` (note it already
+  joins `person_id` → `entrant_members` for the plays-while-reffing rule),
+  auto-assign. You add `email` + claim linkage here.
+- `apps/web/src/server/usecases/invites.ts` and
+  `apps/web/src/server/usecases/person-claims.ts` — **the exact rail to reuse.**
+  Player onboarding (PROMPT-53) already does invite-by-email → tokenised claim →
+  stamp `person_id`. Officials get the same, not a new mechanism.
+- `apps/web/src/app/claim/[token]/page.tsx`, `apps/web/src/app/api/invites/**`,
+  `apps/web/src/app/api/claims/**`, `apps/web/src/app/api/v1/persons/[id]/claim-invites/**`
+  — claim/accept surfaces.
+- `apps/web/src/app/me/page.tsx` — the player portal you extend with an
+  *Officiating* lane (decision: officials live in `/me`, one identity).
+- `apps/web/src/app/api/v1/me/assigned-fixtures/route.ts` and
+  `me/fixtures/[id]/availability` — assigned fixtures already return for a
+  person; availability RSVP already exists for players (reuse its shape).
+- `apps/web/src/app/api/v1/fixtures/[id]/officials/route.ts` +
+  `fixtures/[id]/device-links/**` — assignment write source + the score-pad
+  device links you surface to the assigned official.
+- `apps/web/src/lib/email-templates/claim-invite.ts` + `invite.ts` +
+  `index.ts` — email pattern.
+- `design/v11/README.md` (scope + non-goals).
+
+**Depends:** none (parallel-safe with v10). **Consumed by:** v12 rota.
+**Migration:** one delta, next free `V###` after v10's (verify contention).
+
+## Context
+
+An `officials` row is a capability the organiser conjures; there is no person
+attached unless `person_id` is set, and nothing ever sets it from the official's
+side. Players solved the identical problem in PROMPT-53: an organiser creates a
+`person`, invites an email, the recipient claims a token, and `person_id` binds
+to their user — after which `/me` shows their matches and availability. **v11 is
+that same rail pointed at `officials`, plus the assignment-response and
+availability state a referee actually needs.** No new claim mechanism, no new
+portal app.
+
+The engine already reads `fixture_officials` (assignments) and respects
+`locked`. v11 adds a **response** dimension (an official can accept or decline a
+specific assignment) and a **blackout** dimension (dates they're unavailable),
+both of which the organiser sees on the console and — as a later nicety, not
+this prompt — the auto-assigner could consume. For v11, a decline **flags**;
+it does not auto-reassign (non-goal).
+
+## Task
+
+### 1. Model + migration (`V###`)
+
+- `officials.email` (nullable text) — the invite target; and confirm the claim
+  binds `officials.person_id` (already exists) via the person-claim rail.
+- `fixture_officials.response` (`'pending'|'accepted'|'declined'` default
+  `'pending'`) + `responded_at`, `decline_reason` (nullable). Backfill existing
+  rows to `'accepted'` (they were manually placed — treat as agreed, so no
+  console lights up red on deploy).
+- `official_availability` — `id, org_id, official_id, date, status
+  ('unavailable' default), note, created_at`, unique `(official_id, date)`.
+  RLS + grants mirroring `officials` (copy the newest `db/migration/deltas`
+  grant block). Entitlement: the officiating **portal is free** (community) —
+  onboarding a volunteer ref must not require Pro; only the pre-existing
+  `officials.auto` / `officials.roles_multi` gates stay Pro.
+
+### 2. Invite + claim (reuse the person-claim rail)
+
+- In `usecases/officials.ts`, add `inviteOfficial(auth, officialId, email)`:
+  set `officials.email`, ensure a linked `person` (create if
+  `person_id` null, mirroring how player invites create the person), and mint a
+  claim invite through **`usecases/invites.ts` / `person-claims.ts`** — do not
+  fork a parallel token system. Role of the invite = official (so the claim
+  landing copy says "claim your officiating profile", not "your player
+  profile").
+- Send the invite email via a `claim-invite`-style template, addressed to the
+  official's email, deep-linking the existing `claim/[token]` flow. The claim
+  handler already stamps `person_id`; assert it also works when the person is an
+  official (add the officiating variant of the claim landing copy in
+  `claim/[token]/page.tsx`).
+- API: `POST api/v1/officials/[id]/invite` (v1 envelope, `requireResourceAuth`
+  "official"/"org" "write"). Surface an **Invite** action per official in the
+  officials manager UI (wherever `officials` are listed in the console).
+
+### 3. Officiating lane in `/me`
+
+- Extend `me/page.tsx` (and the data loader behind it): when the signed-in
+  person is linked to any `officials` row, show an **Officiating** section:
+  - **My assignments** from `me/assigned-fixtures` filtered to official
+    assignments (join `fixture_officials` where `official_id` ∈ the person's
+    officials), each with competition/division, court, time (respect the user's
+    timezone — the two-lane always-labelled display from the timezone wave),
+    role, and `response` state.
+  - **Accept / Decline** per assignment → `PATCH
+    api/v1/me/assigned-fixtures/[id]/response` writing `fixture_officials
+    .response`/`responded_at`/`decline_reason` (guard: only the assigned
+    official's own person may write; only `pending`→ transitions allowed, plus
+    re-accept of a prior decline before matchday).
+  - **Availability** — a compact date picker writing `official_availability`
+    via `POST/DELETE api/v1/me/availability/officiating` (reuse the player
+    availability RSVP component shape).
+  - **Score this match** — for an assigned, not-yet-final fixture, surface the
+    existing **device link** (`fixtures/[id]/device-links`) so the official
+    reaches the score pad with no separate login (reuse the link mint; don't
+    invent a new one).
+  - **Download my rota** — link to `/me/rota.pdf` (the route is added in v12;
+    here just render the link, disabled/"coming soon" if v12 hasn't landed, so
+    v11 is shippable alone).
+
+### 4. Organiser-side visibility + notifications
+
+- On the fixture/officials console, show each assignment's `response`
+  (pending/accepted/declined + reason) — a declined assignment is a **flag** for
+  a manual re-pick (no auto-reassign).
+- **Emails** (`email-templates/`, register + chrome-pin as usual): on assign,
+  `official-assigned` (fixtures/times/role, accept-decline CTA to `/me`); on a
+  schedule change to an assigned fixture, `official-assignment-changed`. Address
+  the official's email; owner-addressed copies (if any) resolve via
+  `org_members.role='owner'`.
+
+### 5. Cross-cutting (mandatory)
+
+- **Help** (`content/help/**`): "Officials / referees" page — inviting an
+  official, what the official sees in `/me`, accept/decline, availability,
+  scoring from a device link.
+- **Smoke** (`scripts/smoke.ts`): pro + free paths — create official, invite,
+  claim as a second user, see the assignment in `/me`, accept it, mark a
+  blackout date, open the device link; free org proves the portal isn't
+  Pro-gated.
+- **Tests** (fail-without-it):
+  - invite creates/links a person and mints a claim through the shared rail
+    (not a new token table); claim stamps `person_id` on the official.
+  - response transitions: pending→accepted, pending→declined(+reason),
+    illegal transitions rejected, only the assigned official's person may write.
+  - backfill: pre-existing `fixture_officials` become `accepted` (no console
+    regression).
+  - availability unique per (official,date); delete clears it.
+  - `/me` shows officiating only when linked; a pure player sees no lane.
+
+## Acceptance
+
+- `npm run typecheck`, unit suites, smoke green; help registry green.
+- Documented run: organiser invites `ref@example.com` → claim as that user →
+  `/me` shows the assigned fixture with Accept/Decline → decline with a reason →
+  organiser console shows the flag → no auto-reassign fired.
+- A person who is both a player and an official sees both lanes under one login.
+- Deploying against existing data lights up **zero** false decline flags
+  (backfill = accepted).
+
+## Gotchas (do not relearn)
+
+- **Reuse `person-claims`/`invites` — do not fork a token system.** The 1h-vs-24h
+  link-TTL bug and the email-address-bound accept fix already live there; a
+  parallel path would re-introduce both.
+- Owner-addressed email → `org_members.role='owner'`, never `created_by`.
+- `engineInput` in `officials.ts` already resolves `person_id`→entrants for the
+  plays-while-reffing rule; your `email`/response columns must not disturb that
+  join or the `COLS` tuple used across CRUD (add columns deliberately, update
+  `COLS` + inserts together — the SQL uses an explicit column tuple).
+- Times in `/me` use the user-timezone two-lane always-labelled format (don't
+  emit a raw host-zone time; Node-ICU emits offsets not `IST` — the timezone
+  wave documents the helper to use).
+- The officials vitest suites run against real Postgres (`DATABASE_URL` on
+  :54329, fresh `createdb`); use random unique names/refs in seeds.

--- a/design/v12/README.md
+++ b/design/v12/README.md
@@ -1,0 +1,70 @@
+# v12 — Matchday Documents (improve the PDFs, add the missing ones)
+
+> **Status (2026-07-14):** design only. PROMPT-58 not yet implemented.
+> Target branch (build time): `feat/v12-scheduling-docs` (own worktree off
+> `main`). **Soft-depends on v10 + v11:** the branded-render half is fully
+> independent and can land first; the sponsor footer needs v10's model and the
+> officials rota needs v11's assignments/response data. Build v12 last.
+> **Migrations:** likely **none** (documents read existing data). The one hard
+> change is the shared `DocKind` enum in `@seazn/engine`.
+
+## Theme
+
+The document pipeline is mature but **the PDF renderer throws the design away.**
+`packages/engine/src/exports/types.ts` defines a `DocModel` that already carries
+`branding: { colors, logos, sponsors }` and a `DocKind` enum
+(`timetable | scoresheet | roster | standings | match_report | participants`).
+`build.ts` assembles those models (`buildTimetable`, `buildStandings`,
+`buildRoster`, `buildParticipants`); `usecases/exports.ts::buildDivisionDocModel`
+wires them to routes (`exports/[kind]`, `competitions/[id]/exports/timetable`,
+`schedule/report`, `poster.pdf`). Then `apps/web/src/server/doc-render.ts`
+renders it as **bare black Helvetica tables and ignores `model.branding`
+entirely** — no masthead, no org name, no logo, no brand colour, no sponsor
+line. Every export the product produces looks like a 2004 mail-merge, while the
+email templates and the admit-one ticket (see `ticket-new.png`) show the actual
+SEAZN "courtside" look the org expects.
+
+**v12 is two halves:**
+
+1. **Improve every existing PDF at once** by making `doc-render.ts` honour
+   `DocBranding`: a branded masthead bar (SEAZN wordmark + org name, brand
+   colour rule, optional org logo), a footer that already exists but restyled,
+   and a **tier-grouped sponsor line** fed from v10. Because all exports share
+   one renderer, this single change upgrades the timetable, scoresheet, roster,
+   standings, participants, poster, schedule report, and v9 dispute-evidence
+   PDFs simultaneously. Gate the branded chrome on the existing
+   `exports.branded` Pro entitlement (the `types.ts` comment already anticipates
+   it: *"Pro `exports.branded` — nulled server-side otherwise"*).
+
+2. **Add the documents that don't exist yet**, surfaced from a **Documents**
+   control on the organiser schedule board (`components/v2/board/board-tray.tsx`
+   / the schedule page shell, plus the `o/[orgSlug]/.../schedule` slug route):
+   - **Order of play** — the timetable, already built, now branded.
+   - **Match sheets** — per-fixture score-entry sheets (the `scoresheet` kind +
+     `DocSection.signatures`/`formLines`/`swatches`, which already exist but
+     aren't surfaced from the board).
+   - **Officials rota** — new `officials_rota` kind, per-official schedule from
+     v11's `fixture_officials` + response state.
+   - **Admit-one tickets** — new `admit_ticket` kind, per-entrant pass with QR
+     in the `ticket-new.png` style, generated from confirmed registrations.
+
+## Prompts
+
+- `prompts/PROMPT-58-scheduling-docs.md` — teach `doc-render.ts` the branded
+  masthead/logo/sponsor chrome (colour + logo + tier-grouped sponsor line),
+  gated on `exports.branded`; add `officials_rota` + `admit_ticket` `DocKind`s
+  and their builders in `@seazn/engine/exports`; a Documents panel on the
+  schedule board wiring PDF+XLSX per doc; QR for tickets reusing existing infra;
+  golden `DocModel` tests, help, smoke.
+
+## Non-goals (explicit)
+
+- **A WYSIWYG document designer** — chrome is derived from org branding + tier
+  rules, not hand-laid.
+- **Per-fixture custom scoresheet templates per sport** — the existing
+  sport-neutral `scoresheet` section shape is reused as-is.
+- **Emailing tickets/sheets** — v12 produces downloadable/printable files;
+  delivery stays the organiser's job (registration emails already carry the
+  reference + lookup link).
+- **Re-theming the public web schedule** — this wave is print/PDF only; the
+  public HTML schedule is untouched.

--- a/design/v12/prompts/PROMPT-58-scheduling-docs.md
+++ b/design/v12/prompts/PROMPT-58-scheduling-docs.md
@@ -1,0 +1,169 @@
+# PROMPT-58 — Matchday documents: brand the PDFs, add rota + admit tickets
+
+**Read first:**
+- `apps/web/src/server/doc-render.ts` — the renderer that **ignores
+  `model.branding`**. `docModelToPdf` opens with a plain
+  `Helvetica-Bold 16` title and never touches `branding`; `drawSection` /
+  `drawTable` are bare B/W. This file is the whole "improve existing PDF" lever.
+- `packages/engine/src/exports/types.ts` — `DocModel` already carries
+  `branding: DocBranding { colors, logos[], sponsors[] }` and the `DocKind`
+  enum (`timetable | scoresheet | roster | standings | match_report |
+  participants`). You add `officials_rota` + `admit_ticket` here.
+- `packages/engine/src/exports/build.ts` — `buildTimetable`, `buildStandings`,
+  `buildRoster`, `buildParticipants`. You add `buildOfficialsRota` +
+  `buildAdmitTickets`. Pure + deterministic (`printedAt` is an input — goldens
+  assert the model; keep it that way).
+- `apps/web/src/server/usecases/exports.ts` — `buildDivisionDocModel` (wires
+  builders to routes; sets `branding` — currently probably passing it through or
+  nulling it). This is where branded chrome gets its data.
+- `apps/web/src/app/api/v1/divisions/[id]/exports/[kind]/route.ts` — the export
+  route (kind enum, `format=pdf|xlsx`, `blank`, `landscape`, `pageBreaks`). Add
+  the new kinds + a rota/ticket route.
+- `apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/poster.pdf/route.ts`
+  — existing branded-ish PDF; the sponsor data now comes from v10's
+  `resolveSponsors`.
+- `apps/web/src/components/v2/board/board-tray.tsx` + the schedule page shell +
+  `apps/web/src/app/o/[orgSlug]/c/[compSlug]/**/schedule` — where the
+  **Documents** control mounts.
+- v10 `resolveSponsors` (sponsor rows + tiers) and v11 `fixture_officials
+  .response` + `official_availability` — the data the new docs draw.
+- `ticket-new.png` (repo root) — the admit-one visual target.
+- `design/v12/README.md` (scope + non-goals).
+
+**Depends (soft):** v10 (sponsor line data), v11 (rota data). The **branded
+chrome half is fully independent** — land it first if v10/v11 aren't merged;
+guard the sponsor line + rota builder behind "data present" so partial landing
+degrades cleanly. **Migration:** none (docs read existing data). The one hard
+change is the shared `DocKind` enum (engine package + any exhaustive switch).
+
+## Context
+
+Every export the product makes runs through one renderer, and that renderer
+throws the brand away. `DocModel.branding` was designed in (Jul3/06) — colours,
+logo storage paths, sponsor names — and `doc-render.ts` simply never reads it,
+so the timetable, scoresheet, roster, standings, participants list, schedule
+report, and v9 dispute-evidence PDF all come out as identical black tables.
+Fixing the renderer once upgrades all of them. The `types.ts` comment already
+anticipates the gate: *branding is Pro `exports.branded`, nulled server-side
+otherwise* — so free orgs keep the plain doc, Pro orgs get the courtside look.
+
+The two documents an organiser actually asks for on matchday don't exist yet: a
+**per-official rota** (now that v11 gives officials real assignments + accept
+state) and a **printable admit ticket** (the QR pass in `ticket-new.png`,
+generated from confirmed registrations). Both are new `DocKind`s built the same
+pure way as the existing ones.
+
+## Task
+
+### 1. Brand the renderer (the "improve existing" half)
+
+In `doc-render.ts`, when `model.branding` is present:
+
+- **Masthead band** at the top of page 1 (and repeated as a slim header on
+  later pages): a coloured bar using `branding.colors.primary` (fallback to the
+  SEAZN night `#150b36` / lime `#a3e635` from the email chrome), the **SEAZN
+  wordmark**, the **org name** (from `model.title` or a new
+  `branding.orgName`), and the **org logo** if `branding.logos[0]` resolves
+  (storage path → bytes; embed with `doc.image`, fixed height, keep aspect). A
+  1px brand-colour rule under the title replaces the current bare title.
+- **Sponsor line** in the footer band (above the existing "printed …" line):
+  tier-grouped sponsor **names** from `branding.sponsors` (title first, then
+  gold/silver/partner), small caps, wrapped — logos on the ticket only, names
+  in table docs to keep them readable. Skip silently if empty.
+- Keep `docModelToXlsx` mostly as-is but add the org name + sponsor row to the
+  header block so the spreadsheet isn't anonymous.
+- **Gate:** `buildDivisionDocModel` (and the poster/report callers) set
+  `branding` only when `requireFeature(orgId, "exports.branded")` passes; else
+  `branding` stays undefined and the renderer draws the plain doc (existing
+  behaviour byte-for-byte — pin it with a golden so free-tier output doesn't
+  drift).
+- Feed `branding.sponsors` from v10's `resolveSponsors(orgId, competitionId)`
+  and `branding.logos`/`colors` from the org branding blob.
+
+### 2. New `DocKind`s + builders (`@seazn/engine/exports`)
+
+- Extend the `DocKind` enum: `officials_rota`, `admit_ticket`. Update every
+  exhaustive switch/registry that consumes it (TypeScript will flag them —
+  chase them all; the `types.ts` change plus `build.ts` index).
+- `buildOfficialsRota(input, opts)` — one `DocSection` **per official**
+  (`pageBreakBefore` when `pageBreaks='per_team'`-style scoping), a table of
+  their assigned fixtures (date/time, court, competition·division, role,
+  opponent labels, `response` state), driven by v11 `fixture_officials` joined
+  to `officials`. Include a `signatures`/`formLines` block ("Official:
+  ______  ·  Signed: ______") for a sign-on sheet. Pure — take rows in, no DB.
+- `buildAdmitTickets(input, opts)` — one ticket per confirmed registration in
+  the `ticket-new.png` layout: entrant name, competition + dates, reference
+  code, **QR** (the check-in URL), "ADMIT ONE / SCAN AT THE DESK", org masthead.
+  Two per A4 (`columnsHint: 2` already supported). The **QR is a data payload
+  on the model** (the check-in URL string), rendered to an image in
+  `doc-render.ts` using the existing QR lib (find the one PROMPT-53 used for
+  player check-in / the current ticket surface — reuse, don't add a dep);
+  keep the builder pure by putting the URL, not pixels, in the model.
+- Add server assembly in `usecases/exports.ts`:
+  `buildOfficialsRotaDoc(auth, divisionId|competitionId)` and
+  `buildAdmitTicketsDoc(auth, competitionId, filter)`, pulling the rows and
+  attaching branding as in §1.
+
+### 3. Routes + the Documents panel on the board
+
+- Routes: extend `exports/[kind]` kind enum with `officials_rota`; add
+  `api/v1/competitions/[id]/exports/tickets` (admit tickets, `format=pdf`) and
+  `api/v1/me/rota.pdf` (the v11-promised personal rota — the signed-in
+  official's own assignments only, `requireResourceAuth` on self). Raw-file
+  responses with `Content-Disposition`, matching the existing export route.
+- **Documents panel**: a control on the schedule board (`board-tray.tsx` or the
+  schedule page shell) and on the `o/[orgSlug]/.../schedule` slug route — a menu
+  listing **Order of play** (timetable), **Match sheets** (scoresheet),
+  **Officials rota**, **Admit tickets**, each offering PDF (and XLSX where the
+  doc is tabular). Wire to the routes above. Match sheets + timetable already
+  build — this surfaces them where the organiser is actually standing on
+  matchday, not buried in a division export menu.
+
+### 4. Cross-cutting (mandatory)
+
+- **Help** (`content/help/**`): a "Matchday documents" page — what each document
+  is, PDF vs XLSX, branded vs plain (Pro), tickets + QR check-in, rota.
+- **Smoke** (`scripts/smoke.ts`): pro path generates a branded timetable +
+  officials rota + admit tickets and asserts non-empty PDFs with the masthead;
+  free path generates the plain timetable and asserts branding is absent.
+- **Tests** (fail-without-it):
+  - **Golden `DocModel`s** for `buildOfficialsRota` + `buildAdmitTickets`
+    (deterministic with a fixed `printedAt`) — extend
+    `packages/engine/src/exports/build.test.ts`.
+  - Renderer: with branding → masthead/logo/sponsor draw calls happen; without
+    branding → byte-identical to today's plain output (pin the free-tier
+    golden so the brand work can't regress free exports).
+  - `exports.branded` gate: Pro org gets branded chrome, community org gets
+    plain, driven by a stubbed entitlement.
+  - `/me/rota.pdf` returns only the caller's own assignments (authz test).
+
+## Acceptance
+
+- `npm run typecheck`, engine + web unit suites (incl. new goldens), smoke
+  green; help registry green.
+- Documented run: open a division's schedule board → Documents → **Order of
+  play** downloads a **branded** PDF (masthead, org logo, tier-grouped sponsor
+  line) for a Pro org and a **plain** PDF for a free org; **Officials rota**
+  lists each official's assignments + response; **Admit tickets** produce
+  scannable QR passes matching `ticket-new.png`; an official opens `/me` →
+  **Download my rota** → their own schedule only.
+- Every pre-existing export (timetable/scoresheet/roster/standings/
+  participants/schedule-report/dispute-evidence) still generates — the branded
+  chrome is additive, and the free-tier golden is unchanged.
+
+## Gotchas (do not relearn)
+
+- **Builders stay pure** — `printedAt` and the QR **URL** are inputs; no
+  `Date.now()`, no image bytes in the model (goldens assert the model). Pixels
+  live only in `doc-render.ts`.
+- Logos/QR: storage paths and URLs resolve to bytes **in the renderer**; a
+  missing/broken logo must degrade to no-logo, never throw (a broken export is
+  worse than an unbranded one).
+- Extending `DocKind` breaks exhaustive switches at compile time — that's the
+  point; fix them all rather than defaulting, or a new kind silently renders
+  blank.
+- The free-tier plain output is a **contract** (some orgs print it today) — pin
+  it with a golden before touching the renderer so "improve" never means
+  "change what free users already rely on".
+- Don't add a QR/PDF dependency — reuse whatever the current ticket/check-in
+  surface (`ticket-new.png` flow, PROMPT-53 check-in) already imports.


### PR DESCRIPTION
Three sequential design waves from the 2026-07-14 brainstorm. **Design only — no implementation.** Each wave builds later in its own worktree off `main`.

| Wave | Prompt | Scope |
|---|---|---|
| **v10** | PROMPT-56 | Sponsor CRM + monetization: promote sponsors from the `branding` blob to real tiered tables (`sponsors`/`sponsor_packages`/`sponsor_orders`), per-competition scoping, tracked `/s/[id]` click redirect, and Connect-paid packages on the existing entry-fee destination-charge rail. |
| **v11** | PROMPT-57 | Referee/umpire onboarding: reuse the player claim rail (invite → claim → stamp `officials.person_id`); officiating lane in `/me` (accept/decline, availability, device links, rota). Portal is free. |
| **v12** | PROMPT-58 | Matchday documents: teach `doc-render.ts` to honour `DocModel.branding` (it's ignored today → one fix brands all 8 existing exports), add `officials_rota` + `admit_ticket` doc kinds, surface a Documents panel on the schedule board. |

**Build order:** v10 → v11 → v12 (v10 ∥ v11 parallel-safe; v12 soft-depends on both).

**Notes for build time:** next migration is **V281** (V280 last on `main`; v5-i18n holds V281 unmerged — re-check contention). Entitlement keys are DB-seeded `plan_entitlements`. Root `ticket-new.png` / `email-*.png` are the SEAZN courtside visual reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)