### PR TITLE
fix(i18n): hero cookie banner + start-funnel form follow the page locale

### DIFF
--- a/apps/web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/page.tsx
@@ -92,7 +92,15 @@ export default async function HomePage({ params }: { params: Promise<{ lang: str
               </h1>
               <p className="mt-4 max-w-md text-base text-[#b7aede]">{t(d, "home.hero.subhead")}</p>
               <div className="mt-8">
-                <StartFunnelForm variant="night" />
+                <StartFunnelForm
+                  variant="night"
+                  labels={{
+                    sport: t(d, "funnel.sport"),
+                    entrants: t(d, "funnel.entrants"),
+                    date: t(d, "funnel.date"),
+                    submit: t(d, "funnel.submit"),
+                  }}
+                />
               </div>
               <p className="mt-4 text-xs text-[#8d7fc0]">
                 {t(d, "home.hero.freeNote")}

--- a/apps/web/src/components/__tests__/start-funnel-form.test.tsx
+++ b/apps/web/src/components/__tests__/start-funnel-form.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { StartFunnelForm } from "../start-funnel-form";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+describe("StartFunnelForm labels", () => {
+  it("renders English defaults with no labels prop", () => {
+    const html = renderToStaticMarkup(<StartFunnelForm />);
+    expect(html).toContain("Players / teams");
+    expect(html).toContain("Start date");
+    expect(html).toContain("Setup →");
+  });
+
+  it("renders the localized labels a caller passes", () => {
+    const html = renderToStaticMarkup(
+      <StartFunnelForm
+        labels={{
+          sport: "SPORT-FR",
+          entrants: "Joueurs / équipes",
+          date: "Date de début",
+          submit: "Configuration →",
+        }}
+      />,
+    );
+    expect(html).toContain("Joueurs / équipes");
+    expect(html).toContain("Date de début");
+    expect(html).toContain("Configuration →");
+    expect(html).not.toContain("Players / teams");
+    // Sport names stay canonical (they double as the query value).
+    expect(html).toContain("Football");
+  });
+});

--- a/apps/web/src/components/cookie-consent.tsx
+++ b/apps/web/src/components/cookie-consent.tsx
@@ -11,7 +11,7 @@ import {
   needsConsentPrompt,
   type ConsentChoice,
 } from "@/lib/consent";
-import { readLocaleCookie, clientCommon } from "@/lib/client-dict";
+import { readActiveLocale, clientCommon } from "@/lib/client-dict";
 import { DEFAULT_LOCALE, type Locale } from "@/lib/i18n-constants";
 
 /**
@@ -28,7 +28,7 @@ export function CookieConsent() {
   const [locale, setLocale] = useState<Locale>(DEFAULT_LOCALE);
 
   useEffect(() => {
-    setLocale(readLocaleCookie());
+    setLocale(readActiveLocale());
     // Show on first visit, or when the policy version moved on since the
     // visitor last chose (policy change / new third party → re-consent).
     if (needsConsentPrompt()) setVisible(true);

--- a/apps/web/src/components/start-funnel-form.tsx
+++ b/apps/web/src/components/start-funnel-form.tsx
@@ -23,14 +23,33 @@ export function funnelFormClasses(compact: boolean, variant: "light" | "night"):
   } ${variant === "night" ? "mk-funnel-night" : compact ? "" : "border-purple-200 bg-white/80"}`;
 }
 
+/** Field labels — English defaults so the form works with no props (tests,
+ *  non-localized callers); the marketing home passes localized copy. Sport names
+ *  stay canonical: they double as the `sport` query value handed to /start. */
+export interface FunnelLabels {
+  sport: string;
+  entrants: string;
+  date: string;
+  submit: string;
+}
+
+const DEFAULT_FUNNEL_LABELS: FunnelLabels = {
+  sport: "Sport",
+  entrants: "Players / teams",
+  date: "Start date",
+  submit: "Setup →",
+};
+
 /** Hero funnel form (v3/07 §6): sport + field size + date, no auth — the
  *  visitor invests first, authenticates later on /start. */
 export function StartFunnelForm({
   compact = false,
   variant = "light",
+  labels = DEFAULT_FUNNEL_LABELS,
 }: {
   compact?: boolean;
   variant?: "light" | "night";
+  labels?: FunnelLabels;
 }) {
   const router = useRouter();
   const [sport, setSport] = useState<string>("Football");
@@ -51,7 +70,7 @@ export function StartFunnelForm({
       className={funnelFormClasses(compact, variant)}
     >
       <label className="min-w-44 flex-1 text-left">
-        <span className="label mb-1 block text-xs">Sport</span>
+        <span className="label mb-1 block text-xs">{labels.sport}</span>
         <select
           value={sport}
           onChange={(e) => setSport(e.target.value)}
@@ -64,7 +83,7 @@ export function StartFunnelForm({
         </select>
       </label>
       <label className="w-full text-left sm:w-32">
-        <span className="label mb-1 block text-xs">Players / teams</span>
+        <span className="label mb-1 block text-xs">{labels.entrants}</span>
         <input
           type="number"
           min={2}
@@ -76,7 +95,7 @@ export function StartFunnelForm({
         />
       </label>
       <label className="w-full text-left sm:w-40">
-        <span className="label mb-1 block text-xs">Start date</span>
+        <span className="label mb-1 block text-xs">{labels.date}</span>
         <input
           type="date"
           value={date}
@@ -86,7 +105,7 @@ export function StartFunnelForm({
         />
       </label>
       <button type="submit" className="btn btn-primary whitespace-nowrap px-4 py-2.5">
-        Setup →
+        {labels.submit}
       </button>
     </form>
   );

--- a/apps/web/src/dictionaries/en/marketing.json
+++ b/apps/web/src/dictionaries/en/marketing.json
@@ -260,5 +260,9 @@
   "sched.board.trayAria": "Fixtures to place",
   "sched.board.replayCaption": "08:55 — FIXTURES ARRIVE · CLASH CAUGHT · RESOLVED · PUBLISHED — TOUCH TO TAKE OVER",
   "sched.board.runMatchday": "Run your matchday →",
-  "sched.board.publishToPlayers": "Publish to players →"
+  "sched.board.publishToPlayers": "Publish to players →",
+  "funnel.sport": "Sport",
+  "funnel.entrants": "Players / teams",
+  "funnel.date": "Start date",
+  "funnel.submit": "Setup →"
 }

--- a/apps/web/src/dictionaries/es/marketing.json
+++ b/apps/web/src/dictionaries/es/marketing.json
@@ -259,5 +259,9 @@
   "sched.board.trayAria": "Encuentros por colocar",
   "sched.board.replayCaption": "08:55 — LLEGAN LOS ENCUENTROS · CONFLICTO DETECTADO · RESUELTO · PUBLICADO — TOCA PARA TOMAR EL CONTROL",
   "sched.board.runMatchday": "Organiza tu jornada →",
-  "sched.board.publishToPlayers": "Publicar para los jugadores →"
+  "sched.board.publishToPlayers": "Publicar para los jugadores →",
+  "funnel.sport": "Deporte",
+  "funnel.entrants": "Jugadores / equipos",
+  "funnel.date": "Fecha de inicio",
+  "funnel.submit": "Configurar →"
 }

--- a/apps/web/src/dictionaries/fr/marketing.json
+++ b/apps/web/src/dictionaries/fr/marketing.json
@@ -259,5 +259,9 @@
   "sched.board.trayAria": "Rencontres à placer",
   "sched.board.replayCaption": "08:55 — ARRIVÉE DES RENCONTRES · CONFLIT DÉTECTÉ · RÉSOLU · PUBLIÉ — TOUCHEZ POUR PRENDRE LE RELAIS",
   "sched.board.runMatchday": "Gérez votre journée de match →",
-  "sched.board.publishToPlayers": "Publier pour les joueurs →"
+  "sched.board.publishToPlayers": "Publier pour les joueurs →",
+  "funnel.sport": "Sport",
+  "funnel.entrants": "Joueurs / équipes",
+  "funnel.date": "Date de début",
+  "funnel.submit": "Configuration →"
 }

--- a/apps/web/src/dictionaries/nl/marketing.json
+++ b/apps/web/src/dictionaries/nl/marketing.json
@@ -259,5 +259,9 @@
   "sched.board.trayAria": "Te plaatsen wedstrijden",
   "sched.board.replayCaption": "08:55 — WEDSTRIJDEN KOMEN BINNEN · CONFLICT GEVANGEN · OPGELOST · GEPUBLICEERD — RAAK AAN OM OVER TE NEMEN",
   "sched.board.runMatchday": "Organiseer je speeldag →",
-  "sched.board.publishToPlayers": "Publiceren voor spelers →"
+  "sched.board.publishToPlayers": "Publiceren voor spelers →",
+  "funnel.sport": "Sport",
+  "funnel.entrants": "Spelers / teams",
+  "funnel.date": "Startdatum",
+  "funnel.submit": "Instellen →"
 }

--- a/apps/web/src/lib/__tests__/client-dict.test.ts
+++ b/apps/web/src/lib/__tests__/client-dict.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { localeFromPath } from "@/lib/client-dict";
+
+describe("localeFromPath", () => {
+  it("reads the locale from a [lang] route's first segment", () => {
+    expect(localeFromPath("/en")).toBe("en");
+    expect(localeFromPath("/fr")).toBe("fr");
+    expect(localeFromPath("/fr/formats")).toBe("fr");
+    expect(localeFromPath("/es/discover/cricket")).toBe("es");
+    expect(localeFromPath("/nl/live")).toBe("nl");
+  });
+
+  it("returns null when the path carries no locale segment", () => {
+    expect(localeFromPath("/")).toBeNull();
+    expect(localeFromPath("/login")).toBeNull();
+    expect(localeFromPath("/o/riverside/settings/billing")).toBeNull();
+    expect(localeFromPath("/reset-password")).toBeNull();
+    // unsupported locale is not a [lang] route
+    expect(localeFromPath("/de/start")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/client-dict.ts
+++ b/apps/web/src/lib/client-dict.ts
@@ -25,6 +25,25 @@ export function readLocaleCookie(): Locale {
   return hasLocale(v) ? v : DEFAULT_LOCALE;
 }
 
+/** The locale of a `[lang]` route from its first path segment, or null when the
+ *  path carries no locale (root `/`, or non-localized routes like `/login`,
+ *  `/o/…`). Pure — the testable core of readActiveLocale. */
+export function localeFromPath(pathname: string): Locale | null {
+  const seg = pathname.split("/")[1] ?? "";
+  return hasLocale(seg) ? seg : null;
+}
+
+/** Locale a root-layout client island should render in: match the visible
+ *  `[lang]` path first (so the banner is English on /en even if the cookie says
+ *  fr), and fall back to the cookie on paths without a locale segment. */
+export function readActiveLocale(): Locale {
+  if (typeof window !== "undefined") {
+    const fromPath = localeFromPath(window.location.pathname);
+    if (fromPath) return fromPath;
+  }
+  return readLocaleCookie();
+}
+
 /** Look up a `common`-namespace key for `locale`, falling back to en then key. */
 export function clientCommon(locale: Locale, key: string): string {
   return COMMON[locale]?.[key] ?? COMMON[DEFAULT_LOCALE][key] ?? key;

--- a/scripts/i18n/manifest.json
+++ b/scripts/i18n/manifest.json
@@ -1148,7 +1148,11 @@
     "format.explainer.tradeoff": "815c71d7d134656a",
     "format.explainer.liveExample": "7b8549c1e612b31f",
     "format.explainer.generating": "d20a4476a0a85978",
-    "format.explainer.fullGuide": "04f6b2b76e041e74"
+    "format.explainer.fullGuide": "04f6b2b76e041e74",
+    "funnel.sport": "9a085dd854f03306",
+    "funnel.entrants": "060216fd3d636e57",
+    "funnel.date": "8169693101a4536c",
+    "funnel.submit": "ada46c3034cae363"
   },
   "fr": {
     "app.name": "fb56d648fbb9ae92",
@@ -2299,7 +2303,11 @@
     "format.explainer.tradeoff": "815c71d7d134656a",
     "format.explainer.liveExample": "7b8549c1e612b31f",
     "format.explainer.generating": "d20a4476a0a85978",
-    "format.explainer.fullGuide": "04f6b2b76e041e74"
+    "format.explainer.fullGuide": "04f6b2b76e041e74",
+    "funnel.sport": "9a085dd854f03306",
+    "funnel.entrants": "060216fd3d636e57",
+    "funnel.date": "8169693101a4536c",
+    "funnel.submit": "ada46c3034cae363"
   },
   "nl": {
     "app.name": "fb56d648fbb9ae92",
@@ -3450,6 +3458,10 @@
     "format.explainer.tradeoff": "815c71d7d134656a",
     "format.explainer.liveExample": "7b8549c1e612b31f",
     "format.explainer.generating": "d20a4476a0a85978",
-    "format.explainer.fullGuide": "04f6b2b76e041e74"
+    "format.explainer.fullGuide": "04f6b2b76e041e74",
+    "funnel.sport": "9a085dd854f03306",
+    "funnel.entrants": "060216fd3d636e57",
+    "funnel.date": "8169693101a4536c",
+    "funnel.submit": "ada46c3034cae363"
   }
 }


### PR DESCRIPTION
Two i18n gaps spotted while reviewing the home hero in Playwright.

## 1. Cookie banner ignored the page locale
The consent banner lives in the **static root layout**, so it localized off the `seazn_locale` cookie only — giving a French banner on `/en` when the cookie said `fr`. Added `readActiveLocale()`, which prefers the visible `[lang]` path segment (`localeFromPath`) and falls back to the cookie on routes without one (`/`, `/login`, `/o/…`). Banner is now English on `/en`, French on `/fr`.

## 2. Hero start-funnel form was hardcoded English
`StartFunnelForm`'s labels (Sport / Players / teams / Start date / Setup →) are a shared marketing island the page-level extraction skipped — so they stayed English on `/fr`. The form now takes an optional `labels` prop (English defaults, backward-compatible) and the home hero passes localized copy from the `marketing` dict. Sport names stay canonical (they double as the `sport` query value handed to `/start`).

## Verification
- tsc **0** · web unit **944 / 0** · i18n parity **1154 keys × es/fr/nl**
- Regression tests: `localeFromPath` + funnel labels
- Live-verified in Playwright: `/en` hero all English (banner incl.), `/fr` hero all French (banner + funnel: "Joueurs / équipes", "Date de début", "Configuration →")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
