### PR TITLE
fix(officials): Date-safe sort in officials schedule list (crash hotfix)

### DIFF
--- a/apps/web/src/components/v2/__tests__/officials-panel-sort.test.tsx
+++ b/apps/web/src/components/v2/__tests__/officials-panel-sort.test.tsx
@@ -15,4 +15,19 @@ describe("sortFixturesForOfficials", () => {
     expect(sortFixturesForOfficials(input).map((x) => x.id))
       .toEqual(["early", "late", "cancel", "live", "done"]);
   });
+
+  it("handles Date scheduled_at (RSC passes Date, not ISO string) without throwing", () => {
+    // Regression: scheduled_at crosses the RSC boundary as a Date; the old
+    // impl called .localeCompare on it and threw at render time.
+    const f = (id: string, status: string, at: Date | null) =>
+      ({ id, label: id, scheduled_at: at, status, officials: [] });
+    const input = [
+      f("done", "finalized", new Date("2026-08-01T09:00:00Z")),
+      f("late", "scheduled", new Date("2026-08-01T12:00:00Z")),
+      f("early", "scheduled", new Date("2026-08-01T10:00:00Z")),
+      f("unsched", "scheduled", null),
+    ];
+    expect(sortFixturesForOfficials(input).map((x) => x.id))
+      .toEqual(["early", "late", "unsched", "done"]);
+  });
 });

--- a/apps/web/src/components/v2/officials-panel.tsx
+++ b/apps/web/src/components/v2/officials-panel.tsx
@@ -30,7 +30,7 @@ interface Official {
 interface FixtureLite {
   id: string;
   label: string;
-  scheduled_at: string | null;
+  scheduled_at: string | Date | null;
   status: string;
   officials: {
     official_id: string;
@@ -64,11 +64,13 @@ interface Sourced {
 const OFFICIALS_TOP = new Set(["scheduled"]);
 /** Assignment view: matches still needing officials first (scheduled, by
  *  kickoff), then in_play + decided (finalized/cancelled) at the bottom. */
-export function sortFixturesForOfficials<T extends { status: string; scheduled_at: string | null }>(
+export function sortFixturesForOfficials<T extends { status: string; scheduled_at: string | Date | null }>(
   fixtures: T[],
 ): T[] {
-  const byTime = (a: T, b: T) =>
-    (a.scheduled_at ?? "9999").localeCompare(b.scheduled_at ?? "9999");
+  // scheduled_at crosses the RSC boundary as a Date (not an ISO string), so
+  // compare on epoch ms — never string methods. Unscheduled sorts last.
+  const key = (f: T) => (f.scheduled_at == null ? Infinity : new Date(f.scheduled_at).getTime());
+  const byTime = (a: T, b: T) => key(a) - key(b);
   const top = fixtures.filter((f) => OFFICIALS_TOP.has(f.status)).sort(byTime);
   const bottom = fixtures.filter((f) => !OFFICIALS_TOP.has(f.status)).sort(byTime);
   return [...top, ...bottom];
@@ -124,15 +126,15 @@ export function OfficialsPanel({
     set.add(b.date);
     blackoutsByOfficial.set(b.official_id, set);
   }
-  const fixtureDate = (iso: string | null): string | null => {
+  const fixtureDate = (iso: string | Date | null): string | null => {
     if (!iso) return null;
     try {
       return new Date(iso).toLocaleDateString("en-CA", { timeZone: venueTz || "UTC" });
     } catch {
-      return iso.slice(0, 10);
+      return (typeof iso === "string" ? iso : iso.toISOString()).slice(0, 10);
     }
   };
-  const unavailableFor = (officialId: string, scheduledAt: string | null): boolean => {
+  const unavailableFor = (officialId: string, scheduledAt: string | Date | null): boolean => {
     const d = fixtureDate(scheduledAt);
     return d !== null && (blackoutsByOfficial.get(officialId)?.has(d) ?? false);
   };
@@ -146,7 +148,7 @@ export function OfficialsPanel({
     list.push(b.scheduled_at);
     busyByOfficial.set(b.official_id, list);
   }
-  const busyTimeFor = (officialId: string, scheduledAt: string | null): string | null => {
+  const busyTimeFor = (officialId: string, scheduledAt: string | Date | null): string | null => {
     const d = fixtureDate(scheduledAt);
     if (d === null) return null;
     const match = busyByOfficial.get(officialId)?.find((at) => fixtureDate(at) === d);


### PR DESCRIPTION
Hotfix: `sortFixturesForOfficials` called `.localeCompare` on `scheduled_at`, but the RSC boundary passes a **Date**, not an ISO string → TypeError at render → the officials schedule tab crashed with 'Application error'. Fix: compare on epoch ms (`getTime()`), widen `scheduled_at` types to `string | Date | null`, and add a Date-typed regression test.

Verified: tsc clean; sort test 2/2 (incl. the Date case that reproduces the crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)