### PR TITLE
feat(observability): wire Sentry on staging + app error boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,8 @@ jobs:
         run: echo "::warning::STAGING_STRIPE_SECRET_KEY not set — Stripe prices not synced; checkout will 503 until 'npm run stripe:sync' runs against staging."
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy -c fly.stg.toml --remote-only
+      - run: flyctl deploy -c fly.stg.toml --remote-only --build-arg SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN"
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}
+          # Source-map upload only (next.config.js). Secret — never in fly.stg.toml.
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,17 @@ ENV NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=$NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN
 ENV NEXT_PUBLIC_BASE_URL=$NEXT_PUBLIC_BASE_URL
 
+# Sentry source-map upload during `next build` (next.config.js). ORG/PROJECT
+# come from fly.toml [build.args]; AUTH_TOKEN is passed via `fly deploy
+# --build-arg` from CI — it is a SECRET, never committed. Upload self-disables
+# when SENTRY_AUTH_TOKEN is absent (local builds).
+ARG SENTRY_ORG
+ARG SENTRY_PROJECT
+ARG SENTRY_AUTH_TOKEN
+ENV SENTRY_ORG=$SENTRY_ORG
+ENV SENTRY_PROJECT=$SENTRY_PROJECT
+ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
+
 RUN npm run build --workspace apps/web
 
 # ── Stage 2: minimal production image ────────────────────────────────────────

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+// App-wide route error boundary (observability): any render error under the
+// root layout degrades to this instead of Next's bare "Application error"
+// message (which is all prod shows once React redacts the real error). We
+// report to Sentry here and offer a retry — `reset()` re-renders the failed
+// segment. Copy is hardcoded English on purpose: this must render even when
+// the thing that failed is the i18n/dictionary provider itself.
+import { useEffect } from "react";
+import * as Sentry from "@sentry/nextjs";
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="mx-auto flex min-h-[60vh] max-w-md flex-col items-center justify-center gap-4 px-4 text-center">
+      <h1 className="text-lg font-semibold text-slate-800">Something went wrong</h1>
+      <p className="text-sm text-slate-500">
+        This page hit an unexpected error. Try again — if it keeps happening,
+        the team has been notified.
+      </p>
+      {error.digest && (
+        <p className="text-xs text-slate-400">Reference: {error.digest}</p>
+      )}
+      <button type="button" onClick={reset} className="btn btn-primary">
+        Try again
+      </button>
+    </main>
+  );
+}

--- a/fly.stg.toml
+++ b/fly.stg.toml
@@ -7,6 +7,9 @@ primary_region = "lhr"
 [env]
   OAUTH_BASE_URL   = "https://seazn-club-stg.fly.dev"
   NEXT_PUBLIC_BASE_URL = "https://seazn-club-stg.fly.dev"
+  # Server-side Sentry reads the DSN at RUNTIME (NEXT_PUBLIC_* build args are
+  # not in server process.env — see note above). A DSN is public, safe to commit.
+  NEXT_PUBLIC_SENTRY_DSN = "https://3c300139a524e663ef1d8bef297ad486@o4511704992382976.ingest.de.sentry.io/4511704994676816"
 
 [build]
   [build.args]
@@ -16,7 +19,9 @@ primary_region = "lhr"
     NEXT_PUBLIC_BASE_URL               = "https://seazn-club-stg.fly.dev"
     NEXT_PUBLIC_POSTHOG_KEY            = "phc_rjdhs5RCqJEg5jTH3UG4Dt9DxsLemdiejW3Upkbe4ERM"
     NEXT_PUBLIC_POSTHOG_HOST           = "https://eu.posthog.com"
-    # NEXT_PUBLIC_SENTRY_DSN           = "https://..."
+    NEXT_PUBLIC_SENTRY_DSN             = "https://3c300139a524e663ef1d8bef297ad486@o4511704992382976.ingest.de.sentry.io/4511704994676816"
+    SENTRY_ORG                         = "seazn-club"
+    SENTRY_PROJECT                     = "javascript-nextjs"
 
 [http_service]
   internal_port        = 3000


### PR DESCRIPTION
Enables Sentry on staging and adds a graceful error boundary — so render errors report + degrade nicely instead of the bare 'Application error' (which is all prod-mode shows).

## Changes
- **fly.stg.toml** — set `NEXT_PUBLIC_SENTRY_DSN` as a client build arg AND a server runtime `[env]` var (server config reads it at runtime; NEXT_PUBLIC build args aren't in server process.env). Add `SENTRY_ORG`/`SENTRY_PROJECT` build args. DSN is public → safe to commit.
- **Dockerfile** — forward `SENTRY_ORG/PROJECT/AUTH_TOKEN` into `next build` so the Sentry plugin uploads source maps (deploy is `--remote-only`, so they must reach the remote builder).
- **ci.yml** — pass `SENTRY_AUTH_TOKEN` as a `--build-arg` from the new GH Actions secret. **Secret — never committed.**
- **app/error.tsx** — app-wide route error boundary → `Sentry.captureException` + a retry button. Hardcoded English (must render even if i18n is what failed).

## Notes
- GH Actions secret `SENTRY_AUTH_TOKEN` already set.
- Deploy config only exercises on the post-merge staging deploy; I'll watch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)