### PR TITLE
fix(officials): /o layout 404'd non-member officials on the fixture board

### DIFF
--- a/apps/web/src/app/o/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/o/[orgSlug]/layout.tsx
@@ -1,13 +1,15 @@
 // Console shell for the /o/[orgSlug] tree (PROMPT-30): one Nav + breadcrumb
 // bar for every page underneath — pages stop wiring their own chrome. Auth
-// here allows scorers through so fixture deep-links can reach
-// requireFixturePage; every non-fixture page re-checks and bounces them.
+// here allows scorers AND non-members through so fixture deep-links can reach
+// requireFixturePage (design v2 §A2: an accepted official is usually NOT an
+// org member); every non-fixture page re-checks membership and bounces them.
 import { Nav } from "@/components/nav";
 import { ActiveOrgSync } from "@/components/active-org-sync";
 import { Breadcrumbs } from "@/components/breadcrumbs";
-import { getActiveOrgId, getUserOrgs } from "@/lib/auth";
-import { requireOrgPage } from "@/server/page-auth";
-import { breadcrumbNames } from "@/server/slug-resolve";
+import { notFound, permanentRedirect, redirect } from "next/navigation";
+import { getCurrentUser, getActiveOrgId, getUserOrgs } from "@/lib/auth";
+import { orgBySlug, breadcrumbNames } from "@/server/slug-resolve";
+import { routes } from "@/lib/routes";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary } from "@/lib/i18n";
 import { DictProvider } from "@/components/i18n/dict-provider";
@@ -20,30 +22,46 @@ export default async function OrgLayout({
   params: Promise<{ orgSlug: string }>;
 }) {
   const { orgSlug } = await params;
-  const { user, org } = await requireOrgPage(orgSlug, { allowScorer: true });
-  const [activeOrgId, orgs, names, locale] = await Promise.all([
-    getActiveOrgId(),
-    getUserOrgs(user.id),
-    breadcrumbNames(org.id),
-    resolveLocale(),
-  ]);
-  // The `ui` copy catalog for the whole console subtree — client islands read it
-  // via useMsg(); only the active locale crosses the boundary (v5 i18n cycle 47).
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  const resolved = await orgBySlug(orgSlug);
+  if (resolved && "renamedTo" in resolved) permanentRedirect(routes.orgHome(resolved.renamedTo));
+  if (!resolved) notFound();
+
+  const orgs = await getUserOrgs(user.id);
+  const membership = orgs.find((o) => o.id === resolved.id);
+  const locale = await resolveLocale();
   const ui = await getDictionary(locale, "ui");
-  // Scorers keep the stripped courtside view (doc 13 §3): no org nav or
-  // breadcrumbs — their only /o surface is the fixture console.
-  const scorer = org.role === "scorer";
+
+  // Full console chrome only for members with an organiser role. Scorers (doc
+  // 13 §3) AND non-members reaching a fixture deep-link (an accepted official —
+  // design v2 §A2) get the stripped courtside shell: no org nav or breadcrumbs,
+  // no active-org sync into an org they don't belong to. The child page does
+  // the real gate — a non-member hitting anything but the fixture console 404s
+  // there (every /o page runs its own requireOrgPage/…/requireFixturePage).
+  const chromed = !!membership && membership.role !== "scorer";
+  if (!chromed) {
+    return (
+      <DictProvider dict={ui} locale={locale}>
+        {membership && <ActiveOrgSync orgId={resolved.id} stale={false} />}
+        {children}
+      </DictProvider>
+    );
+  }
+
+  const [activeOrgId, names] = await Promise.all([
+    getActiveOrgId(),
+    breadcrumbNames(resolved.id),
+  ]);
   return (
     <DictProvider dict={ui} locale={locale}>
-      {!scorer && <Nav />}
-      <ActiveOrgSync orgId={org.id} stale={activeOrgId !== org.id} />
-      {!scorer && (
-        <Breadcrumbs
-          orgName={org.name}
-          orgs={orgs.map((o) => ({ name: o.name, slug: o.slug }))}
-          names={names}
-        />
-      )}
+      <Nav />
+      <ActiveOrgSync orgId={resolved.id} stale={activeOrgId !== resolved.id} />
+      <Breadcrumbs
+        orgName={resolved.name}
+        orgs={orgs.map((o) => ({ name: o.name, slug: o.slug }))}
+        names={names}
+      />
       {children}
     </DictProvider>
   );

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -614,6 +614,19 @@ async function officialOnboardingSuite(admin: Session, orgId: string, orgSlug: s
   });
   check("off accepted official scores via the fixture console API", offScore.status === 201);
 
+  // Regression (officials-unify): the accepted official must open the fixture
+  // CONSOLE PAGE itself, not just the score API — the /o layout previously
+  // 404'd non-members (an accepted official is usually a non-member), so the
+  // page-level door stayed shut even though the API passed.
+  const offFixNo = v1data<{ fixture_no: number }>(
+    await v1(admin, `/api/v1/fixtures/${fixtures[0]!.id}`),
+  ).fixture_no;
+  const offConsole = await html(ref, `/o/${orgSlug}/c/${compData.slug}/d/${divData.slug}/f/${offFixNo}`);
+  check(
+    "off accepted official opens the fixture console PAGE (non-member layout door)",
+    offConsole.status === 200 && offConsole.body.includes(`Whistle A ${tag}`),
+  );
+
   // Pending-invite accept-by-id (v11.1 /me "Pending invites" card): officials
   // belong to multiple orgs — a SECOND invite for the same ref, accepted
   // without ever touching the emailed token (the claim id from the invite


### PR DESCRIPTION
## The bug
An accepted official (usually a **non-member** of the org) got a **404 opening the fixture console page**, even though the scoring **API** worked. Confirmed on staging + a clean local DB.

## Root cause
`requireFixturePage` correctly authorises the official, but the **`/o/[orgSlug]` layout** that wraps it called `requireOrgPage` — **members-only** (`if (!org) notFound()`). Option 2 (non-member officials) was never wired into the layout. The 200/404 'flakiness' was RSC page-segment fetches (200) vs full document renders that include the layout (404).

Smoke/e2e missed it because they exercise the score **API** and `/my-matches`, never a GET of the fixture **page**.

## Fix
The layout renders the **stripped courtside shell** for scorers **and non-members** (no org nav/breadcrumbs, no active-org sync), and defers the real gate to each page. Every non-fixture `/o` page already runs its own `requireOrgPage`/`requireCompetitionPage`/`requireDivisionPage` (verified — they 404 non-members), so only the fixture console opens for an official.

## Regression test
Adds a smoke assertion: the accepted official **opens the fixture console PAGE** (`/o/.../f/{no}` → 200 with the entrant name), not just the API. Fails without this fix.

Verified locally: the official now sees the full board (Start match · Forfeit · Abandon · scoring), tsc clean, smoke parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)