### PR TITLE
fix(me): officiating lane shows outstanding duties (any date) + completed panel

### DIFF
--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -202,6 +202,7 @@ export default async function MePage({
           <OfficiatingLane
             isOfficial={officiating.is_official}
             assignments={officiating.assignments}
+            completed={officiating.completed}
             blackouts={officiating.blackouts}
             pendingClaims={pendingOfficiatingClaims}
           />

--- a/apps/web/src/components/me/__tests__/officiating-lane.test.tsx
+++ b/apps/web/src/components/me/__tests__/officiating-lane.test.tsx
@@ -46,7 +46,7 @@ describe("OfficiatingLane — pending invites (v11.1)", () => {
 
   it("renders the pending-invites card in pending-only mode (isOfficial=false)", () => {
     const html = renderToStaticMarkup(
-      <OfficiatingLane isOfficial={false} assignments={[]} blackouts={[]} pendingClaims={[claim]} />,
+      <OfficiatingLane isOfficial={false} assignments={[]} completed={[]} blackouts={[]} pendingClaims={[claim]} />,
     );
     expect(html).toContain("Riverside Cup");
     expect(html).toContain("Priya Ref");
@@ -58,7 +58,7 @@ describe("OfficiatingLane — pending invites (v11.1)", () => {
 
   it("renders nothing when there is neither a link nor a pending invite (caller wouldn't mount it)", () => {
     const html = renderToStaticMarkup(
-      <OfficiatingLane isOfficial={false} assignments={[]} blackouts={[]} pendingClaims={[]} />,
+      <OfficiatingLane isOfficial={false} assignments={[]} completed={[]} blackouts={[]} pendingClaims={[]} />,
     );
     // still a valid empty section — the /me page itself decides whether to
     // mount OfficiatingLane at all (is_official || pendingClaims.length>0).
@@ -68,7 +68,7 @@ describe("OfficiatingLane — pending invites (v11.1)", () => {
 
   it("shows both the pending card AND the assignments/blackouts sections once linked", () => {
     const html = renderToStaticMarkup(
-      <OfficiatingLane isOfficial assignments={[]} blackouts={[]} pendingClaims={[claim]} />,
+      <OfficiatingLane isOfficial assignments={[]} completed={[]} blackouts={[]} pendingClaims={[claim]} />,
     );
     expect(html).toContain("Riverside Cup");
     expect(html).toContain("No matches assigned to you yet.");
@@ -90,7 +90,7 @@ describe("OfficiatingLane — score action repoints at the full board", () => {
       fixture_no: 7,
     });
     const html = renderToStaticMarkup(
-      <OfficiatingLane isOfficial assignments={[a]} blackouts={[]} pendingClaims={[]} />,
+      <OfficiatingLane isOfficial assignments={[a]} completed={[]} blackouts={[]} pendingClaims={[]} />,
     );
     const expectedHref = routes.fixture("riverside", "summer", "u11", 7);
     expect(expectedHref).toBe("/o/riverside/c/summer/d/u11/f/7");
@@ -102,8 +102,30 @@ describe("OfficiatingLane — score action repoints at the full board", () => {
   it("does not render a score control for a declined assignment", () => {
     const a = makeAssignment({ response: "declined", fixture_status: "scheduled" });
     const html = renderToStaticMarkup(
-      <OfficiatingLane isOfficial assignments={[a]} blackouts={[]} pendingClaims={[]} />,
+      <OfficiatingLane isOfficial assignments={[a]} completed={[]} blackouts={[]} pendingClaims={[]} />,
     );
     expect(html).not.toContain("Score this match");
+  });
+});
+
+// Finished matches are collapsed behind a "Completed matches" disclosure so the
+// lane leads with outstanding duties; the link expands the list.
+describe("OfficiatingLane — completed matches panel", () => {
+  it("collapses finished matches behind a 'Completed matches' disclosure", () => {
+    const done = makeAssignment({ fixture_status: "decided", home_name: "Falcons", away_name: "Hawks" });
+    const html = renderToStaticMarkup(
+      <OfficiatingLane isOfficial assignments={[]} completed={[done]} blackouts={[]} pendingClaims={[]} />,
+    );
+    expect(html).toContain("Completed matches (1)");
+    expect(html).toContain("<details");
+    expect(html).toContain("Falcons");
+    expect(html).toContain("Hawks");
+  });
+
+  it("renders no completed disclosure when there are none", () => {
+    const html = renderToStaticMarkup(
+      <OfficiatingLane isOfficial assignments={[]} completed={[]} blackouts={[]} pendingClaims={[]} />,
+    );
+    expect(html).not.toContain("Completed matches");
   });
 });

--- a/apps/web/src/components/me/officiating-lane.tsx
+++ b/apps/web/src/components/me/officiating-lane.tsx
@@ -34,11 +34,13 @@ const RAIL: Record<OfficiatingResponse, string> = {
 export function OfficiatingLane({
   isOfficial,
   assignments,
+  completed,
   blackouts,
   pendingClaims,
 }: {
   isOfficial: boolean;
   assignments: MyOfficiatingAssignment[];
+  completed: MyOfficiatingAssignment[];
   blackouts: MyBlackout[];
   pendingClaims: PendingOfficiatingClaim[];
 }) {
@@ -72,9 +74,51 @@ export function OfficiatingLane({
               {msg("me.off.rota")}
             </a>
           </p>
+
+          {completed.length > 0 && (
+            <details className="mt-4">
+              <summary className="cursor-pointer list-none text-xs font-medium uppercase tracking-wide text-slate-400 hover:text-slate-600">
+                {msg("me.off.completed", { count: completed.length })}
+              </summary>
+              <ul className="mt-2 space-y-2">
+                {completed.map((a) => (
+                  <CompletedCard key={`${a.fixture_id}:${a.official_id}:${a.role_key}`} a={a} />
+                ))}
+              </ul>
+            </details>
+          )}
         </>
       )}
     </section>
+  );
+}
+
+/** Read-only row for a finished match (no accept/decline/score) — shown inside
+ *  the collapsed "completed" disclosure. */
+function CompletedCard({ a }: { a: MyOfficiatingAssignment }) {
+  const msg = useMsg();
+  return (
+    <li className="card space-y-1 border-l-4 border-l-slate-200 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-sm text-slate-700">
+          {a.home_name ?? msg("me.tbd")} <span className="text-slate-400">vs</span>{" "}
+          {a.away_name ?? msg("me.tbd")}{" "}
+          <span className="ml-1 rounded bg-slate-100 px-1.5 py-0.5 text-[11px] capitalize text-slate-500">
+            {msg("me.off.role", { role: a.role_key })}
+          </span>
+        </p>
+        <span className="badge bg-slate-100 capitalize text-slate-600">{a.fixture_status}</span>
+      </div>
+      <p className="text-xs text-slate-400">
+        {a.competition_name} · {a.division_name} · {a.org_name}
+        {a.court_label ? ` · ${a.court_label}` : ""}
+      </p>
+      {a.scheduled_at && (
+        <p className="text-xs text-slate-400">
+          <Zoned value={a.scheduled_at} tz={a.venue_tz ?? "UTC"} mode="datetime" showZone you="subtitle" />
+        </p>
+      )}
+    </li>
   );
 }
 

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -1744,6 +1744,7 @@
   "me.off.blackoutEmpty": "No blackout dates yet.",
   "me.off.remove": "Remove",
   "me.off.rota": "Download my rota",
+  "me.off.completed": "Completed matches ({count})",
   "me.off.comingSoon": "Coming soon",
   "me.off.failed": "Something went wrong — try again",
   "me.off.role": "as {role}",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -1744,6 +1744,7 @@
   "me.off.blackoutEmpty": "Aún no hay fechas bloqueadas.",
   "me.off.remove": "Quitar",
   "me.off.rota": "Descargar mi calendario",
+  "me.off.completed": "Partidos finalizados ({count})",
   "me.off.comingSoon": "Próximamente",
   "me.off.failed": "Algo salió mal — inténtalo de nuevo",
   "me.off.role": "como {role}",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -1744,6 +1744,7 @@
   "me.off.blackoutEmpty": "Aucune date d'indisponibilité pour l'instant.",
   "me.off.remove": "Retirer",
   "me.off.rota": "Télécharger mon planning",
+  "me.off.completed": "Matchs terminés ({count})",
   "me.off.comingSoon": "Bientôt disponible",
   "me.off.failed": "Une erreur est survenue — réessayez",
   "me.off.role": "en tant que {role}",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -1744,6 +1744,7 @@
   "me.off.blackoutEmpty": "Nog geen geblokkeerde data.",
   "me.off.remove": "Verwijderen",
   "me.off.rota": "Mijn rooster downloaden",
+  "me.off.completed": "Voltooide wedstrijden ({count})",
   "me.off.comingSoon": "Binnenkort beschikbaar",
   "me.off.failed": "Er ging iets mis — probeer opnieuw",
   "me.off.role": "als {role}",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -1107,6 +1107,7 @@ export type DictionaryKey =
   | "me.off.blackouts"
   | "me.off.cancel"
   | "me.off.comingSoon"
+  | "me.off.completed"
   | "me.off.confirmDecline"
   | "me.off.decline"
   | "me.off.declined"

--- a/apps/web/src/server/usecases/__tests__/me-officiating.test.ts
+++ b/apps/web/src/server/usecases/__tests__/me-officiating.test.ts
@@ -145,6 +145,37 @@ describe.skipIf(!HAS_DB)("official onboarding (PROMPT-57)", () => {
     });
   });
 
+  it("shows outstanding duties even when the scheduled time has passed; finished matches drop off", async () => {
+    const { auth } = await seedOrg();
+    const ref = await makeUser("ref");
+    const { fixtures } = await seedFutureDivision(auth);
+    const official = await createOfficial(auth, { display_name: "Ref R", role_keys: ["referee"] });
+    const invited = await inviteOfficial(auth, official.id, ref.email);
+    await claimPerson(invited.secret, ref.id, ref.email);
+
+    const pastScheduled = fixtures[0]!.id;
+    const pastInPlay = fixtures[1]!.id;
+    const done = fixtures[2]!.id;
+    for (const id of [pastScheduled, pastInPlay, done]) {
+      await patchFixtureOfficials(auth, id, {
+        set: [{ official_id: official.id, role_key: "referee", locked: false }],
+      });
+    }
+    // scheduled time already passed but still not played (outstanding duty);
+    // an in-play match (must always show); a finished/decided match.
+    await sql`update fixtures set scheduled_at = ${new Date(Date.now() - 2 * 86_400_000).toISOString()}, status = 'scheduled' where id = ${pastScheduled}`;
+    await sql`update fixtures set scheduled_at = ${new Date(Date.now() - 3 * 3_600_000).toISOString()}, status = 'in_play' where id = ${pastInPlay}`;
+    await sql`update fixtures set scheduled_at = ${new Date(Date.now() - 5 * 86_400_000).toISOString()}, status = 'decided' where id = ${done}`;
+
+    const mine = await getMyOfficiating(ref.id);
+    const ids = mine.assignments.map((a) => a.fixture_id);
+    const completedIds = mine.completed.map((a) => a.fixture_id);
+    expect(ids).toContain(pastScheduled); // outstanding, past-dated → shows
+    expect(ids).toContain(pastInPlay); // in_play → always shows
+    expect(ids).not.toContain(done); // finished → out of outstanding
+    expect(completedIds).toContain(done); // finished → in the completed panel
+  });
+
   it("guards response transitions and scopes writes to the assigned official", async () => {
     const { auth } = await seedOrg();
     const ref = await makeUser("ref");

--- a/apps/web/src/server/usecases/me-officiating.ts
+++ b/apps/web/src/server/usecases/me-officiating.ts
@@ -50,9 +50,15 @@ export interface MyBlackout {
 export interface MyOfficiating {
   /** The signed-in person is linked to at least one officials row. */
   is_official: boolean;
+  /** Outstanding duties: still scheduled or in_play (any date). */
   assignments: MyOfficiatingAssignment[];
+  /** Finished matches (decided/finalized/abandoned/forfeited/cancelled), most
+   *  recent first — surfaced behind a "completed" disclosure in the lane. */
+  completed: MyOfficiatingAssignment[];
   blackouts: MyBlackout[];
 }
+
+const FINISHED_STATUSES = ["decided", "finalized", "abandoned", "forfeited", "cancelled"] as const;
 
 /** Everything the /me officiating lane renders. Lane shows only when the
  *  person is linked to an officials row — a pure player gets is_official
@@ -62,7 +68,7 @@ export async function getMyOfficiating(userId: string): Promise<MyOfficiating> {
     select exists(
       select 1 from officials o join persons p on p.id = o.person_id
       where p.user_id = ${userId}) as has`;
-  if (!linked?.has) return { is_official: false, assignments: [], blackouts: [] };
+  if (!linked?.has) return { is_official: false, assignments: [], completed: [], blackouts: [] };
 
   const assignments = await sql<MyOfficiatingAssignment[]>`
     select fo.fixture_id, f.fixture_no, o.id as official_id,
@@ -85,10 +91,40 @@ export async function getMyOfficiating(userId: string): Promise<MyOfficiating> {
     left join entrants h on h.id = f.home_entrant_id
     left join entrants a on a.id = f.away_entrant_id
     where p.user_id = ${userId}
+      -- Outstanding duties only. The status gate already drops finished
+      -- matches (decided/finalized/abandoned/forfeited/cancelled), so NO date
+      -- floor: a match still 'scheduled' or 'in_play' is a pending duty even if
+      -- its scheduled time has already passed (an in_play match must always
+      -- show). A previous scheduled_at-in-the-future filter wrongly hid these.
       and f.status in ('scheduled', 'in_play')
-      and (f.scheduled_at is null or f.scheduled_at >= date_trunc('day', now()))
     order by f.scheduled_at nulls last, f.id, fo.role_key
     limit 100`;
+
+  // Finished matches — most recent first — for the collapsed "completed" panel.
+  const completed = await sql<MyOfficiatingAssignment[]>`
+    select fo.fixture_id, f.fixture_no, o.id as official_id,
+           org.name as org_name, org.slug as org_slug,
+           c.name as competition_name, c.slug as competition_slug,
+           c.visibility as competition_visibility,
+           d.name as division_name, d.slug as division_slug, d.sport_key,
+           h.display_name as home_name, a.display_name as away_name,
+           f.scheduled_at, ss.tz as venue_tz, f.venue, f.court_label,
+           f.status as fixture_status,
+           fo.role_key, fo.response, fo.decline_reason, fo.responded_at
+    from persons p
+    join officials o on o.person_id = p.id
+    join fixture_officials fo on fo.official_id = o.id
+    join fixtures f on f.id = fo.fixture_id
+    join divisions d on d.id = f.division_id
+    join competitions c on c.id = d.competition_id
+    join organizations org on org.id = f.org_id
+    left join schedule_settings ss on ss.division_id = d.id
+    left join entrants h on h.id = f.home_entrant_id
+    left join entrants a on a.id = f.away_entrant_id
+    where p.user_id = ${userId}
+      and f.status = any(${[...FINISHED_STATUSES]})
+    order by f.scheduled_at desc nulls last, f.id, fo.role_key
+    limit 50`;
 
   const blackouts = await sql<MyBlackout[]>`
     select oa.date::text as date, min(oa.note) as note
@@ -99,7 +135,7 @@ export async function getMyOfficiating(userId: string): Promise<MyOfficiating> {
     group by oa.date
     order by oa.date`;
 
-  return { is_official: true, assignments, blackouts };
+  return { is_official: true, assignments, completed, blackouts };
 }
 
 export interface PendingOfficiatingClaim {


### PR DESCRIPTION
## Problem
Matches assigned to an official didn't show in their `/me` officiating lane.

**Root cause (verified on stg, not guessed):** `getMyOfficiating` filtered `f.status in ('scheduled','in_play') AND f.scheduled_at >= today`. The date floor hid outstanding duties whose scheduled time had already passed — including **in_play** matches. For `ashokhein+004@gmail.com` on stg: 11 assignments, correctly linked (person↔user↔official), but only **1** dated ≥ today (rest 07-16/07-17), so `/me` showed 1.

## Fix
- **Drop the `scheduled_at >= today` floor.** The `status in ('scheduled','in_play')` gate already excludes finished matches, so a still-scheduled/in_play match is a pending duty regardless of its date.
- **Completed matches panel:** finished matches (`decided/finalized/abandoned/forfeited/cancelled`) are now returned as `completed` (most-recent-first) and surfaced behind a collapsible **"Completed matches (N)"** disclosure in the lane — outstanding duties lead; the link expands the history. Read-only rows (no accept/decline/score).

When a match finishes it leaves `scheduled/in_play` → drops out of the outstanding list and appears in the completed panel.

## Tests / i18n
- `me-officiating.test.ts`: an official assigned to a past-dated **scheduled** + past **in_play** + a **decided** fixture → the first two show as outstanding, the decided one lands in `completed`.
- `officiating-lane.test.tsx`: the completed disclosure renders with its count and collapses the finished matches.
- New `me.off.completed` string in en/fr/es/nl (`i18n:check` green). tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)