### PR TITLE
feat(plg): product-led growth loops on existing free-tier surfaces

### DIFF
--- a/apps/web/content/help/sharing/grow-your-club.md
+++ b/apps/web/content/help/sharing/grow-your-club.md
@@ -1,0 +1,25 @@
+---
+title: Growing your club
+description: Every shared link is a small invitation — share bar, attribution and the free "run your own" path.
+order: 7
+---
+
+Sharing your competition doesn't just inform your own players — every link out is a quiet invitation for someone else to run their own.
+
+## Share it, fast
+
+The public competition page carries a **share bar** right under the title: WhatsApp, copy link, and a native share sheet on phones that support one. Grassroots sport runs on WhatsApp — this is the fastest way a schedule reaches a group chat.
+
+## The "Powered by Seazn Club" line
+
+Free (Community) organisations keep a small **Powered by Seazn Club** line in the public dashboard's footer, with a **Run your own free →** link. Anyone who clicks it lands on the same free sign-up you started with — a parent following one competition can be running their own next season without ever being asked. Upgrading to Pro removes the line entirely; your dashboard carries only your own branding.
+
+## Your own "run your own" nudge
+
+If you've claimed a player profile, `/me` carries the same nudge — **Run your own tournament — free.** — so a player who's spent a season watching from the entrant side has a one-tap path to the organiser side.
+
+## Common questions
+
+**Can I turn off the WhatsApp/copy share bar?** No — it's on every public competition page, free and Pro alike; only the footer attribution line is plan-gated.
+
+**Does the Discover directory help here too?** Yes — public, discoverable competitions get listed there, each with its own "run your own" CTA back to [`/start`](/help/sharing/visibility); see [who can see what](/help/sharing/visibility) for the visibility switch that makes a competition eligible.

--- a/apps/web/content/help/sharing/grow-your-club.md
+++ b/apps/web/content/help/sharing/grow-your-club.md
@@ -22,4 +22,4 @@ If you've claimed a player profile, `/me` carries the same nudge — **Run your 
 
 **Can I turn off the WhatsApp/copy share bar?** No — it's on every public competition page, free and Pro alike; only the footer attribution line is plan-gated.
 
-**Does the Discover directory help here too?** Yes — public, discoverable competitions get listed there, each with its own "run your own" CTA back to [`/start`](/help/sharing/visibility); see [who can see what](/help/sharing/visibility) for the visibility switch that makes a competition eligible.
+**Does the Discover directory help here too?** Yes — public, discoverable competitions get listed there, each with its own "run your own" CTA back to `/start`; see [who can see what](/help/sharing/visibility) for the visibility switch that makes a competition eligible.

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
@@ -14,6 +14,7 @@ import { hasFeature } from "@/lib/entitlements";
 import { resolveSponsors, type SponsorTier } from "@/server/usecases/sponsors";
 import { renderProse } from "@/lib/prose";
 import { CompetitionProse } from "@/components/public-site/competition-prose";
+import { ShareBar } from "@/components/share-bar";
 
 export const revalidate = 30;
 
@@ -131,6 +132,12 @@ export default async function CompetitionHomePage({ params }: Props) {
                 {competition.name}
               </h1>
               {dateLine ? <p className="mt-2 text-sm text-court-muted">{dateLine}</p> : null}
+              <div className="mt-4">
+                <ShareBar
+                  path={`/shared/${org.slug}/${competition.slug}`}
+                  title={competition.name}
+                />
+              </div>
             </div>
             {registrationOpen ? (
               <Link

--- a/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { notFound, permanentRedirect } from "next/navigation";
 import Image from "next/image";
 import { Barlow_Condensed } from "next/font/google";
+import { AttributionLink } from "@/components/attribution-link";
 import { isReservedSlug } from "@/lib/public-site";
 import { publicThemeStyle } from "@/lib/public-theme";
 import { getPublicOrg } from "@/server/public-site/data";
@@ -108,10 +109,8 @@ export default async function PublicOrgLayout({
             (branding entitlement, resolved server-side). */}
         {org.branded ? null : (
           <p>
-            Powered by{" "}
-            <a href="https://seazn.club" className="font-medium text-accent-strong underline">
-              seazn.club
-            </a>
+            Powered by <span className="font-medium">Seazn Club</span> ·{" "}
+            <AttributionLink surface="badge" />
           </p>
         )}
       </footer>

--- a/apps/web/src/app/[lang]/(marketing)/discover/__tests__/page.test.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/discover/__tests__/page.test.tsx
@@ -64,9 +64,32 @@ describe("/discover — PLG organiser funnel", () => {
   });
 
   it("non-empty state (fr): uses the localized plural count string", async () => {
-    vi.mocked(getDiscoveryDirectory).mockResolvedValue([ENTRY, { ...ENTRY, id: "comp-2" }]);
+    vi.mocked(getDiscoveryDirectory).mockResolvedValue([
+      ENTRY,
+      { ...ENTRY, id: "comp-2", org_slug: "northside", org_name: "Northside" },
+    ]);
     const html = await renderDiscover("fr");
     expect(html).toContain("/fr/start?utm_source=discover&amp;utm_medium=directory&amp;utm_campaign=plg");
     expect(html).toContain("2 clubs en direct actuellement");
+  });
+
+  it("counts DISTINCT clubs, not competitions: two live competitions from the same org show '1 club'", async () => {
+    vi.mocked(getDiscoveryDirectory).mockResolvedValue([
+      ENTRY,
+      { ...ENTRY, id: "comp-2", slug: "riverside-cup-2", name: "Riverside Cup 2" },
+    ]);
+    const html = await renderDiscover("en");
+    expect(html).toContain("1 club live right now");
+    expect(html).not.toContain("2 clubs live right now");
+  });
+
+  it("only counts clubs with an in-play competition as 'live now', not merely-listed upcoming ones", async () => {
+    vi.mocked(getDiscoveryDirectory).mockResolvedValue([
+      ENTRY,
+      { ...ENTRY, id: "comp-2", org_slug: "northside", org_name: "Northside", in_play_count: 0, status: "upcoming" },
+    ]);
+    const html = await renderDiscover("en");
+    expect(html).toContain("1 club live right now");
+    expect(html).not.toContain("2 clubs live right now");
   });
 });

--- a/apps/web/src/app/[lang]/(marketing)/discover/__tests__/page.test.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/discover/__tests__/page.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DiscoveryEntry } from "@/server/usecases/public";
+
+// PLG task 6: /discover must funnel fans → organisers via /start (not /login)
+// and surface a live "N clubs live now" counter when entries exist. Keep the
+// shell to a no-op passthrough (its nav/footer are their own async server
+// components and would otherwise thenable-leak into renderToStaticMarkup).
+vi.mock("@/components/marketing/marketing-shell", () => ({
+  MarketingShell: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/server/public-site/discovery", () => ({
+  getDiscoveryDirectory: vi.fn(),
+  listDiscoverySports: vi.fn(async () => []),
+}));
+
+import { getDiscoveryDirectory } from "@/server/public-site/discovery";
+import DiscoverPage from "../page";
+
+const ENTRY: DiscoveryEntry = {
+  id: "comp-1",
+  name: "Riverside Cup",
+  slug: "riverside-cup",
+  starts_on: null,
+  ends_on: null,
+  status: "live",
+  city: null,
+  country: null,
+  tagline: null,
+  hero_image_path: null,
+  featured: false,
+  org_name: "Riverside CC",
+  org_slug: "riverside",
+  sports: ["cricket"],
+  entrant_count: 8,
+  in_play_count: 1,
+  next_fixture_at: null,
+};
+
+async function renderDiscover(lang: "en" | "fr") {
+  const el = await DiscoverPage({
+    params: Promise.resolve({ lang }),
+    searchParams: Promise.resolve({}),
+  });
+  return renderToStaticMarkup(el);
+}
+
+describe("/discover — PLG organiser funnel", () => {
+  it("empty state: CTA links to /start (not /login), no counter shown", async () => {
+    vi.mocked(getDiscoveryDirectory).mockResolvedValue([]);
+    const html = await renderDiscover("en");
+    expect(html).not.toContain("/login");
+    expect(html).toContain("/en/start?utm_source=discover&amp;utm_medium=directory&amp;utm_campaign=plg");
+  });
+
+  it("non-empty state: shows the live club count and a /start CTA", async () => {
+    vi.mocked(getDiscoveryDirectory).mockResolvedValue([ENTRY]);
+    const html = await renderDiscover("en");
+    expect(html).not.toContain("/login");
+    expect(html).toContain("/en/start?utm_source=discover&amp;utm_medium=directory&amp;utm_campaign=plg");
+    // 1 entry -> singular form of the count string, real number not hardcoded.
+    expect(html).toContain("1 club live right now");
+  });
+
+  it("non-empty state (fr): uses the localized plural count string", async () => {
+    vi.mocked(getDiscoveryDirectory).mockResolvedValue([ENTRY, { ...ENTRY, id: "comp-2" }]);
+    const html = await renderDiscover("fr");
+    expect(html).toContain("/fr/start?utm_source=discover&amp;utm_medium=directory&amp;utm_campaign=plg");
+    expect(html).toContain("2 clubs en direct actuellement");
+  });
+});

--- a/apps/web/src/app/[lang]/(marketing)/discover/page.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/discover/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/server/public-site/discovery";
 import { DiscoveryCard, sportEmoji } from "@/components/discovery-cards";
 import { getDictionary, t } from "@/lib/i18n";
+import { plural } from "@/lib/i18n-runtime";
 import { hasLocale } from "@/lib/i18n-constants";
 import { sportLabel } from "@/lib/scoring-vocab";
 import { msgFor } from "@/lib/messages-i18n";
@@ -78,6 +79,15 @@ export default async function DiscoverPage({
         <p className="mt-2 max-w-xl text-slate-600">
           {t(d, "discover.subhead")}
         </p>
+        {entries.length > 0 && (
+          <p className="mt-2 flex items-center gap-2 text-sm font-semibold text-purple-700">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
+            </span>
+            {plural(d, "discover.liveCount", entries.length, lang)}
+          </p>
+        )}
 
         {/* Sport chips + status filter (plain links — cacheable). */}
         <div className="mt-6 flex flex-wrap items-center gap-2">
@@ -121,7 +131,10 @@ export default async function DiscoverPage({
         {entries.length === 0 ? (
           <div className="mt-16 text-center">
             <p className="text-slate-500">{t(d, "discover.empty")}</p>
-            <Link href="/login?tab=signup" className="btn btn-primary mt-4 inline-flex">
+            <Link
+              href={`/${lang}/start?utm_source=discover&utm_medium=directory&utm_campaign=plg`}
+              className="btn btn-primary mt-4 inline-flex"
+            >
               {t(d, "discover.runYourOwn")} →
             </Link>
           </div>
@@ -140,7 +153,7 @@ export default async function DiscoverPage({
             {t(d, "discover.cta.body")}
           </p>
           <Link
-            href="/login?tab=signup"
+            href={`/${lang}/start?utm_source=discover&utm_medium=directory&utm_campaign=plg`}
             className="btn mt-4 inline-flex bg-white px-6 font-semibold text-purple-900 hover:bg-purple-50"
           >
             {t(d, "discover.cta.button")} →

--- a/apps/web/src/app/[lang]/(marketing)/discover/page.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/discover/page.tsx
@@ -85,7 +85,14 @@ export default async function DiscoverPage({
               <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75" />
               <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
             </span>
-            {plural(d, "discover.liveCount", entries.length, lang)}
+            {plural(
+              d,
+              "discover.liveCount",
+              new Set(
+                entries.filter((e) => e.in_play_count > 0).map((e) => e.org_slug),
+              ).size,
+              lang,
+            )}
           </p>
         )}
 

--- a/apps/web/src/app/embed/layout.tsx
+++ b/apps/web/src/app/embed/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AttributionLink } from "@/components/attribution-link";
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false }, // widgets live inside other sites
@@ -25,14 +26,7 @@ export default function EmbedLayout({ children }: { children: React.ReactNode })
     <div className="min-h-4 bg-white p-3">
       {children}
       <p className="mt-3 text-right text-[10px] text-zinc-400">
-        <a
-          href="https://seazn.club"
-          target="_blank"
-          rel="noreferrer"
-          className="hover:text-zinc-600"
-        >
-          live on seazn.club
-        </a>
+        <AttributionLink surface="embed" />
       </p>
       <script dangerouslySetInnerHTML={{ __html: AUTO_HEIGHT }} />
     </div>

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -13,6 +13,7 @@ import { RsvpControl } from "@/components/me/rsvp-control";
 import { OfficiatingLane } from "@/components/me/officiating-lane";
 import { ConsentCard } from "@/components/me/consent-card";
 import { LogoutButton } from "@/components/logout-button";
+import { RunYourOwnCta } from "@/components/run-your-own-cta";
 import { Zoned, ViewerTzProvider } from "@/components/client-time";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary, t } from "@/lib/i18n";
@@ -79,6 +80,8 @@ export default async function MePage({
           </p>
         )}
         <h1 className="page-title mb-6">{t(ui, "me.title")}</h1>
+
+        <RunYourOwnCta label={t(ui, "me.runYourOwn.title")} cta={t(ui, "me.runYourOwn.cta")} />
 
         {!officiating.is_official &&
           pendingOfficiatingClaims.length === 0 &&

--- a/apps/web/src/components/__tests__/attribution-link.test.tsx
+++ b/apps/web/src/components/__tests__/attribution-link.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({
+  EVENTS: { ATTRIBUTION_CLICKED: "attribution_clicked" },
+  track,
+}));
+
+import { AttributionLink } from "../attribution-link";
+
+// No jsdom/@testing-library/react in this workspace (vitest.config.ts runs
+// environment: "node" — see console-link.test.tsx for the established
+// pattern): call the component function directly and inspect the returned
+// element's props instead of rendering to a DOM.
+describe("AttributionLink", () => {
+  it("links to /start with surface UTM and fires the event on click", () => {
+    const el = AttributionLink({ surface: "badge" });
+    expect(el.props.children).toMatch(/run your own free/i);
+    expect(el.props.href).toContain("seazn.club/start");
+    expect(el.props.href).toContain("utm_source=badge");
+    el.props.onClick();
+    expect(track).toHaveBeenCalledWith("attribution_clicked", { surface: "badge" });
+  });
+});

--- a/apps/web/src/components/__tests__/run-your-own-cta.test.tsx
+++ b/apps/web/src/components/__tests__/run-your-own-cta.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({
+  EVENTS: { PLAYER_STARTED_OWN_ORG: "player_started_own_org" },
+  track,
+}));
+
+import { RunYourOwnCta } from "../run-your-own-cta";
+
+// No jsdom/@testing-library/react in this workspace (vitest.config.ts runs
+// environment: "node" — see attribution-link.test.tsx for the established
+// pattern): call the component function directly and inspect the returned
+// element's props instead of rendering to a DOM.
+describe("RunYourOwnCta", () => {
+  it("links to /start and fires the loop event on click", () => {
+    const el = RunYourOwnCta({ label: "Run your own tournament — free.", cta: "Start free →" });
+    const link = el.props.children[1];
+    expect(link.props.children).toBe("Start free →");
+    expect(link.props.href).toContain("/start");
+    link.props.onClick();
+    expect(track).toHaveBeenCalledWith("player_started_own_org", { from: "me" });
+  });
+});

--- a/apps/web/src/components/__tests__/share-bar.test.tsx
+++ b/apps/web/src/components/__tests__/share-bar.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ EVENTS: { SHARE_FIRED: "share_fired" }, track }));
+
+import { shareLinks } from "../share-bar";
+
+describe("shareLinks (ShareBar pure helper)", () => {
+  beforeEach(() => {
+    track.mockClear();
+  });
+
+  it("builds an absolute url and a wa.me link with the encoded title + url", () => {
+    const { url, wa } = shareLinks(
+      "https://seazn.club",
+      "/shared/riverside/spring-cup",
+      "Spring Cup",
+    );
+    expect(url).toBe("https://seazn.club/shared/riverside/spring-cup");
+    expect(wa).toBe(
+      `https://wa.me/?text=${encodeURIComponent("Spring Cup — https://seazn.club/shared/riverside/spring-cup")}`,
+    );
+  });
+});

--- a/apps/web/src/components/__tests__/share-bar.test.tsx
+++ b/apps/web/src/components/__tests__/share-bar.test.tsx
@@ -1,9 +1,10 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
 
 const { track } = vi.hoisted(() => ({ track: vi.fn() }));
 vi.mock("@/lib/analytics", () => ({ EVENTS: { SHARE_FIRED: "share_fired" }, track }));
 
-import { shareLinks } from "../share-bar";
+import { shareLinks, ShareBar } from "../share-bar";
 
 describe("shareLinks (ShareBar pure helper)", () => {
   beforeEach(() => {
@@ -20,5 +21,30 @@ describe("shareLinks (ShareBar pure helper)", () => {
     expect(wa).toBe(
       `https://wa.me/?text=${encodeURIComponent("Spring Cup — https://seazn.club/shared/riverside/spring-cup")}`,
     );
+  });
+});
+
+describe("ShareBar hydration safety", () => {
+  const origNav = globalThis.navigator;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: origNav,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("omits the native-share button on first render even when navigator.share is present (avoids hydration mismatch)", () => {
+    Object.defineProperty(globalThis, "navigator", {
+      value: { share: () => {} },
+      configurable: true,
+      writable: true,
+    });
+
+    const html = renderToStaticMarkup(<ShareBar path="/x" title="Y" />);
+
+    expect(html).not.toContain('data-testid="native-share"');
+    expect(html).toContain("WhatsApp");
   });
 });

--- a/apps/web/src/components/attribution-link.tsx
+++ b/apps/web/src/components/attribution-link.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { EVENTS, track } from "@/lib/analytics";
+
+const START = "https://seazn.club/start";
+
+/** Free-tier attribution turned into an acquisition CTA (PLG L1). Renders the
+ *  brand line + a tracked "Run your own free →" link back to /start. */
+export function AttributionLink({ surface }: { surface: "badge" | "embed" }) {
+  const href = `${START}?utm_source=${surface}&utm_medium=attribution&utm_campaign=plg`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() => track(EVENTS.ATTRIBUTION_CLICKED, { surface })}
+      className="font-medium underline hover:opacity-80"
+    >
+      Run your own free →
+    </a>
+  );
+}

--- a/apps/web/src/components/run-your-own-cta.tsx
+++ b/apps/web/src/components/run-your-own-cta.tsx
@@ -1,0 +1,20 @@
+"use client";
+import Link from "next/link";
+import { EVENTS, track } from "@/lib/analytics";
+
+/** Player→organiser loop (PLG L2): nudges an engaged player on /me to start
+ *  their own competition. Copy is passed in so the page localizes it. */
+export function RunYourOwnCta({ label, cta }: { label: string; cta: string }) {
+  return (
+    <div className="card mt-6 flex flex-col gap-2 p-6 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-sm font-medium">{label}</p>
+      <Link
+        href="/start?utm_source=me&utm_medium=player&utm_campaign=plg"
+        onClick={() => track(EVENTS.PLAYER_STARTED_OWN_ORG, { from: "me" })}
+        className="btn btn-primary text-sm"
+      >
+        {cta}
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/components/share-bar.tsx
+++ b/apps/web/src/components/share-bar.tsx
@@ -21,7 +21,11 @@ export function shareLinks(
 export function ShareBar({ path, title }: { path: string; title: string }) {
   const [origin, setOrigin] = useState("");
   const [copied, setCopied] = useState(false);
-  useEffect(() => setOrigin(window.location.origin), []);
+  const [canShare, setCanShare] = useState(false);
+  useEffect(() => {
+    setOrigin(window.location.origin);
+    setCanShare(typeof navigator !== "undefined" && "share" in navigator);
+  }, []);
   const { url, wa } = shareLinks(origin, path, title);
 
   async function native() {
@@ -45,8 +49,13 @@ export function ShareBar({ path, title }: { path: string; title: string }) {
 
   return (
     <div className="flex flex-wrap items-center gap-2 text-xs">
-      {typeof navigator !== "undefined" && "share" in navigator && (
-        <button type="button" onClick={native} className="btn btn-ghost">
+      {canShare && (
+        <button
+          type="button"
+          onClick={native}
+          className="btn btn-ghost"
+          data-testid="native-share"
+        >
           Share
         </button>
       )}

--- a/apps/web/src/components/share-bar.tsx
+++ b/apps/web/src/components/share-bar.tsx
@@ -1,0 +1,68 @@
+"use client";
+import { useEffect, useState } from "react";
+import { EVENTS, track } from "@/lib/analytics";
+
+/**
+ * Pure helper (regression-tested in node env — no window/DOM needed): builds
+ * the absolute share URL and the WhatsApp deep-link from an explicit origin.
+ */
+export function shareLinks(
+  origin: string,
+  path: string,
+  title: string,
+): { url: string; wa: string } {
+  const url = `${origin}${path}`;
+  const wa = `https://wa.me/?text=${encodeURIComponent(`${title} — ${url}`)}`;
+  return { url, wa };
+}
+
+/** Fan-facing share row (PLG L3): native share on mobile, WhatsApp + copy
+ *  everywhere. Grassroots sport runs on WhatsApp. */
+export function ShareBar({ path, title }: { path: string; title: string }) {
+  const [origin, setOrigin] = useState("");
+  const [copied, setCopied] = useState(false);
+  useEffect(() => setOrigin(window.location.origin), []);
+  const { url, wa } = shareLinks(origin, path, title);
+
+  async function native() {
+    track(EVENTS.SHARE_FIRED, { channel: "native" });
+    try {
+      await navigator.share?.({ title, url });
+    } catch {
+      /* dismissed */
+    }
+  }
+  async function copy() {
+    track(EVENTS.SHARE_FIRED, { channel: "copy" });
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* blocked */
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      {typeof navigator !== "undefined" && "share" in navigator && (
+        <button type="button" onClick={native} className="btn btn-ghost">
+          Share
+        </button>
+      )}
+      <a
+        href={wa}
+        target="_blank"
+        rel="noreferrer"
+        onClick={() => track(EVENTS.SHARE_FIRED, { channel: "whatsapp" })}
+        className="btn btn-ghost"
+        aria-label="Share on WhatsApp"
+      >
+        WhatsApp
+      </a>
+      <button type="button" onClick={copy} className="btn btn-ghost">
+        {copied ? "Copied ✓" : "Copy link"}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/dictionaries/en/marketing.json
+++ b/apps/web/src/dictionaries/en/marketing.json
@@ -239,6 +239,8 @@
   "discover.searchButton": "Search",
   "discover.empty": "No tournaments match right now.",
   "discover.runYourOwn": "Run your own",
+  "discover.liveCount.one": "{count} club live right now",
+  "discover.liveCount.other": "{count} clubs live right now",
   "discover.cta.title": "Run your own tournament",
   "discover.cta.body": "Any sport, any format — free for community clubs.",
   "discover.cta.button": "Start free",

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -212,6 +212,8 @@
   "confirm.unlinkPlayer.body": "{name} loses access to this profile on their player home. Matches and results stay. You can invite them to claim again later.",
   "confirm.unlinkPlayer.label": "Unlink",
   "me.title": "My matches & teams",
+  "me.runYourOwn.title": "Run your own tournament — free.",
+  "me.runYourOwn.cta": "Start free →",
   "me.eyebrow": "Player home",
   "me.claimed": "Profile claimed — this is your player home now.",
   "me.empty": "Nothing here yet. When an organiser rosters you into a team or draw, your matches land on this page.",

--- a/apps/web/src/dictionaries/es/marketing.json
+++ b/apps/web/src/dictionaries/es/marketing.json
@@ -238,6 +238,8 @@
   "discover.searchButton": "Buscar",
   "discover.empty": "No hay torneos que coincidan ahora mismo.",
   "discover.runYourOwn": "Organiza el tuyo",
+  "discover.liveCount.one": "{count} club en directo ahora mismo",
+  "discover.liveCount.other": "{count} clubes en directo ahora mismo",
   "discover.cta.title": "Organiza tu propio torneo",
   "discover.cta.body": "Cualquier deporte, cualquier formato: gratis para clubes comunitarios.",
   "discover.cta.button": "Empieza gratis",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -212,6 +212,8 @@
   "confirm.unlinkPlayer.body": "{name} perderá el acceso a este perfil en su página de jugador. Los partidos y resultados se mantienen. Puedes volver a invitarlo a reclamar más tarde.",
   "confirm.unlinkPlayer.label": "Desvincular",
   "me.title": "Mis partidos y equipos",
+  "me.runYourOwn.title": "Organiza tu propio torneo — gratis.",
+  "me.runYourOwn.cta": "Empezar gratis →",
   "me.eyebrow": "Página de jugador",
   "me.claimed": "Perfil reclamado: esta es ahora tu página de jugador.",
   "me.empty": "Aquí no hay nada todavía. Cuando un organizador te incluya en un equipo o cuadro, tus partidos aparecerán en esta página.",

--- a/apps/web/src/dictionaries/fr/marketing.json
+++ b/apps/web/src/dictionaries/fr/marketing.json
@@ -238,6 +238,8 @@
   "discover.searchButton": "Rechercher",
   "discover.empty": "Aucun tournoi ne correspond pour le moment.",
   "discover.runYourOwn": "Organisez le vôtre",
+  "discover.liveCount.one": "{count} club en direct actuellement",
+  "discover.liveCount.other": "{count} clubs en direct actuellement",
   "discover.cta.title": "Organisez votre propre tournoi",
   "discover.cta.body": "Tout sport, tout format — gratuit pour les clubs communautaires.",
   "discover.cta.button": "Commencer gratuitement",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -212,6 +212,8 @@
   "confirm.unlinkPlayer.body": "{name} perd l'accès à ce profil sur son espace joueur. Les matchs et résultats restent. Vous pourrez l'inviter à revendiquer à nouveau plus tard.",
   "confirm.unlinkPlayer.label": "Dissocier",
   "me.title": "Mes matchs et équipes",
+  "me.runYourOwn.title": "Organisez votre propre tournoi — gratuit.",
+  "me.runYourOwn.cta": "Démarrer gratuitement →",
   "me.eyebrow": "Espace joueur",
   "me.claimed": "Profil revendiqué — c'est désormais votre espace joueur.",
   "me.empty": "Rien ici pour l'instant. Lorsqu'un organisateur vous intègre à une équipe ou à un tableau, vos matchs apparaissent sur cette page.",

--- a/apps/web/src/dictionaries/nl/marketing.json
+++ b/apps/web/src/dictionaries/nl/marketing.json
@@ -238,6 +238,8 @@
   "discover.searchButton": "Zoeken",
   "discover.empty": "Geen toernooien komen op dit moment overeen.",
   "discover.runYourOwn": "Organiseer je eigen",
+  "discover.liveCount.one": "{count} club nu live",
+  "discover.liveCount.other": "{count} clubs nu live",
   "discover.cta.title": "Organiseer je eigen toernooi",
   "discover.cta.body": "Elke sport, elk format — gratis voor community-clubs.",
   "discover.cta.button": "Gratis beginnen",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -212,6 +212,8 @@
   "confirm.unlinkPlayer.body": "{name} verliest toegang tot dit profiel op hun spelershome. Wedstrijden en resultaten blijven behouden. Je kunt ze later opnieuw uitnodigen om te claimen.",
   "confirm.unlinkPlayer.label": "Ontkoppelen",
   "me.title": "Mijn wedstrijden & teams",
+  "me.runYourOwn.title": "Organiseer je eigen toernooi — gratis.",
+  "me.runYourOwn.cta": "Gratis starten →",
   "me.eyebrow": "Spelershome",
   "me.claimed": "Profiel geclaimd — dit is nu jouw spelershome.",
   "me.empty": "Hier is nog niets. Wanneer een organisator je aan een team of schema toevoegt, verschijnen je wedstrijden op deze pagina.",

--- a/apps/web/src/lib/__tests__/analytics-events.test.ts
+++ b/apps/web/src/lib/__tests__/analytics-events.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { EVENTS } from "@/lib/analytics-events";
+
+describe("PLG growth events", () => {
+  it("exposes the loop event names", () => {
+    expect(EVENTS.ATTRIBUTION_CLICKED).toBe("attribution_clicked");
+    expect(EVENTS.SHARE_FIRED).toBe("share_fired");
+    expect(EVENTS.PLAYER_STARTED_OWN_ORG).toBe("player_started_own_org");
+    expect(EVENTS.COMPETITION_MADE_PUBLIC).toBe("competition_made_public");
+    expect(EVENTS.EMBED_RENDERED).toBe("embed_rendered");
+  });
+});

--- a/apps/web/src/lib/analytics-events.ts
+++ b/apps/web/src/lib/analytics-events.ts
@@ -32,6 +32,12 @@ export const EVENTS = {
   BILLING_INTERVAL_CHANGED: "billing_interval_changed",
   SUBSCRIPTION_CANCEL_SCHEDULED: "subscription_cancel_scheduled",
   SUBSCRIPTION_RESUMED: "subscription_resumed",
+  // PLG growth loops (2026-07-17 plan) — distribution + referral.
+  ATTRIBUTION_CLICKED: "attribution_clicked",
+  SHARE_FIRED: "share_fired",
+  PLAYER_STARTED_OWN_ORG: "player_started_own_org",
+  COMPETITION_MADE_PUBLIC: "competition_made_public",
+  EMBED_RENDERED: "embed_rendered",
 } as const;
 
 export type AnalyticsEvent = (typeof EVENTS)[keyof typeof EVENTS];

--- a/apps/web/src/lib/email-templates/__tests__/compose.test.ts
+++ b/apps/web/src/lib/email-templates/__tests__/compose.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { renderEmail } from "@/lib/email-templates/compose";
+
+// Growth loop (PLG L2): every outbound platform email carries a persistent,
+// English-only micro-CTA back to /start — consistent with the existing
+// "Powered by seazn.club" style attribution elsewhere in the product.
+describe("email shell footer", () => {
+  it("includes a run-your-own CTA linking to /start", () => {
+    const html = renderEmail({
+      subject: "Subject",
+      preheader: "Preheader",
+      eyebrow: "Eyebrow",
+      title: "Title",
+      contentHtml: "<p>Body</p>",
+    });
+    expect(html).toContain("seazn.club/start");
+    expect(html).toMatch(/run your own/i);
+  });
+});

--- a/apps/web/src/lib/email-templates/html/base.html
+++ b/apps/web/src/lib/email-templates/html/base.html
@@ -101,6 +101,9 @@
               <p style="margin:0 0 8px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 {{FOOTER_NOTE}}
               </p>
+              <p style="margin:0 0 8px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+                <a href="https://seazn.club/start?utm_source=email&amp;utm_medium=footer&amp;utm_campaign=plg" style="color:#6931c9;text-decoration:underline;">Run your own &mdash; free</a>
+              </p>
               <p style="margin:0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 &copy; {{YEAR}} Seazn Club &middot; Any sport &middot; Live in minutes
               </p>

--- a/apps/web/src/lib/help.ts
+++ b/apps/web/src/lib/help.ts
@@ -45,6 +45,7 @@ export const HELP_ARTICLE_SLUGS = [
   "sharing/embeds",
   "sharing/languages",
   "sharing/sponsors",
+  "sharing/grow-your-club",
   "billing/plans",
   "billing/downgrade",
   "billing/event-pass",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -1120,6 +1120,8 @@ export type DictionaryKey =
   | "me.rsvp.notePlaceholder"
   | "me.rsvp.out"
   | "me.rsvp.saved"
+  | "me.runYourOwn.cta"
+  | "me.runYourOwn.title"
   | "me.tbd"
   | "me.teams.title"
   | "me.title"

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -567,6 +567,8 @@ export type DictionaryKey =
   | "discover.filter.live"
   | "discover.filter.upcoming"
   | "discover.h1"
+  | "discover.liveCount.one"
+  | "discover.liveCount.other"
   | "discover.meta.description"
   | "discover.meta.title"
   | "discover.runYourOwn"

--- a/apps/web/src/server/usecases/__tests__/competition-made-public.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-made-public.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { shouldFireMadePublic } from "../competitions";
+
+// Pure decision-helper regression test (Task 5, PLG activation funnel).
+// COMPETITION_MADE_PUBLIC must fire only on the transition INTO "public" —
+// never on create-already-public-from-nothing double counting, and never
+// when an already-public competition is patched without a visibility change.
+describe("shouldFireMadePublic", () => {
+  it("fires private -> public", () => {
+    expect(shouldFireMadePublic("private", "public")).toBe(true);
+  });
+
+  it("fires undefined -> public (create directly public)", () => {
+    expect(shouldFireMadePublic(undefined, "public")).toBe(true);
+  });
+
+  it("fires unlisted -> public", () => {
+    expect(shouldFireMadePublic("unlisted", "public")).toBe(true);
+  });
+
+  it("does not fire public -> public (no re-fire on unrelated patch)", () => {
+    expect(shouldFireMadePublic("public", "public")).toBe(false);
+  });
+
+  it("does not fire private -> unlisted", () => {
+    expect(shouldFireMadePublic("private", "unlisted")).toBe(false);
+  });
+
+  it("does not fire private -> undefined (no visibility change in patch)", () => {
+    expect(shouldFireMadePublic("private", undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -171,7 +171,7 @@ export async function createCompetition(
       event: EVENTS.COMPETITION_MADE_PUBLIC,
       distinctId: auth.userId ?? `org:${auth.orgId}`,
       orgId: auth.orgId,
-      properties: { competitionId: row.id },
+      properties: { competition_id: row.id },
     });
   }
   return row;
@@ -324,7 +324,7 @@ export async function patchCompetition(
       event: EVENTS.COMPETITION_MADE_PUBLIC,
       distinctId: auth.userId ?? `org:${auth.orgId}`,
       orgId: auth.orgId,
-      properties: { competitionId: id },
+      properties: { competition_id: id },
     });
   }
   return row;

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -165,6 +165,15 @@ export async function createCompetition(
     orgId: auth.orgId,
     properties: { visibility: input.visibility },
   });
+  // Activation funnel completion — created directly public (no prior state).
+  if (shouldFireMadePublic(undefined, input.visibility)) {
+    await captureServer({
+      event: EVENTS.COMPETITION_MADE_PUBLIC,
+      distinctId: auth.userId ?? `org:${auth.orgId}`,
+      orgId: auth.orgId,
+      properties: { competitionId: row.id },
+    });
+  }
   return row;
 }
 
@@ -176,6 +185,17 @@ export async function getCompetition(auth: AuthCtx, id: string): Promise<Competi
     const frozen = await frozenCompetitionIds(auth.orgId, tx);
     return { ...row, frozen: frozen.has(row.id) };
   });
+}
+
+// Activation funnel (feature 1): `competition_made_public` fires exactly once
+// per transition INTO "public" — never on create-already-public double count
+// with itself, and never re-fired by an unrelated patch to an already-public
+// competition. Pure so create + patch can share one rule.
+export function shouldFireMadePublic(
+  oldVisibility: string | null | undefined,
+  newVisibility: string | null | undefined,
+): boolean {
+  return newVisibility === "public" && oldVisibility !== "public";
 }
 
 // A frozen competition is read-only — but retiring it (status → completed/
@@ -205,6 +225,7 @@ export async function patchCompetition(
   }
   let statusChangedTo: string | null = null;
   let previousSlug: string | null = null;
+  let oldVisibility: string | null = null;
   const { row, discoveryTouched } = await withTenant(auth.orgId, async (tx) => {
     if (patch.slug) {
       if (RESERVED_ENTITY_SLUGS.has(patch.slug)) {
@@ -220,6 +241,7 @@ export async function patchCompetition(
       select visibility, discoverable, status, name, slug from competitions where id = ${id}`;
     if (!before) throw new HttpError(404, "competition not found");
     if (patch.status && patch.status !== before.status) statusChangedTo = patch.status;
+    oldVisibility = before.visibility;
 
     const effective = { ...patch };
     // Rename regenerates the slug (v3/01 §2); the old slug keeps redirecting
@@ -293,6 +315,16 @@ export async function patchCompetition(
       distinctId: auth.userId ?? `org:${auth.orgId}`,
       orgId: auth.orgId,
       properties: { competition_id: id },
+    });
+  }
+  // Activation funnel completion (feature 1) — fires once, on the
+  // transition INTO "public" only (see shouldFireMadePublic).
+  if (shouldFireMadePublic(oldVisibility, patch.visibility)) {
+    await captureServer({
+      event: EVENTS.COMPETITION_MADE_PUBLIC,
+      distinctId: auth.userId ?? `org:${auth.orgId}`,
+      orgId: auth.orgId,
+      properties: { competitionId: id },
     });
   }
   return row;

--- a/docs/superpowers/runbooks/plg-posthog-dashboards.md
+++ b/docs/superpowers/runbooks/plg-posthog-dashboards.md
@@ -1,0 +1,12 @@
+# PLG PostHog dashboards
+
+## 1. Activation funnel
+Steps (event names): funnel_draft_created → funnel_claimed →
+competition_created → competition_made_public → result_entered (★ north-star).
+Breakdown by organization group. Target: % reaching result_entered.
+
+## 2. K-factor panel
+- attribution_clicked / active org (surface: badge|embed)
+- share_fired / public page view (channel: native|whatsapp|copy)
+- player_started_own_org / player_account_created  (loop #1 rate)
+Watch these, not signup counts.

--- a/docs/superpowers/specs/2026-07-17-product-led-growth-design.md
+++ b/docs/superpowers/specs/2026-07-17-product-led-growth-design.md
@@ -1,0 +1,167 @@
+# Product-Led Growth (PLG) — GTM design
+
+**Date:** 2026-07-17
+**Scope:** Product-led growth engine only, sport/area-agnostic.
+**Status:** Approved design. Next step: implementation plan (writing-plans).
+
+## Context
+
+Seazn Club is pre-launch (app live, demo orgs seeded, no real external
+customers). Founder is solo, near-full-time, small budget (a few hundred
+£/mo), with warm access to a few local clubs/schools and cold beyond.
+
+The agreed GTM frame is **A + C blend**: a hyperlocal beachhead as the spine,
+with product-led viral surfaces switched on from day 1, holding national
+sport-vertical SEO/content for phase 2. **This document covers the
+product-led (C) half only.** The hyperlocal playbook, content calendar, email
+campaigns, sport-tech events, and the local→county→national→international
+ladder are deliberately parked (available on request) and out of scope here.
+
+## Thesis
+
+The free tier is not charity — it is the **ad network**. Every free org's
+public pages, embeds, and emails recruit the next org. The Pro upgrade trigger
+is already the correct one: **removing the "Powered by Seazn" badge**
+(white-label). The flywheel: *more (tasteful) free-tier attribution → more
+inbound orgs AND stronger Pro pull.* Therefore we sharpen free-tier
+attribution, never weaken it.
+
+## Surface audit (grounded in the codebase)
+
+Most distribution surfaces already exist. The work is to **activate the loops
+on top of them** and **instrument** them.
+
+| Surface | State | Location |
+|---|---|---|
+| No-account draw (TOFU hook) | ✓ built | home hero / `/formats` |
+| `/start` 60s onboarding | ✓ built | `app/[lang]/(marketing)/start` |
+| "Powered by Seazn" badge — free-only, Pro removes | ✓ built | `app/(public)/shared/[orgSlug]/layout.tsx:111` |
+| Embed + `seazn.club` backlink | ✓ built (passive) | `app/embed/layout.tsx:29-34` |
+| Discover directory + per-sport SEO, no empty shells | ✓ built | `/discover`, `/discover/[sport]`, `app/sitemap.ts` |
+| OG unfurl cards (WhatsApp/iMessage/X) | ✓ built | `/join`, `(public)/shared/.../opengraph-image.tsx` |
+| Registration copy-link + QR (organiser-side) | ✓ built | `.../registrations/page.tsx` (`CopyLink`) |
+| PostHog analytics pipe | ✓ built | `lib/posthog-server.ts` |
+| Entitlements / white-label engine | ✓ built | `lib/entitlements.ts`, `dashboard.branding` |
+| Player→organiser "Run your own" CTA | △ MISSING | `/me`, `/my-matches`, email footers |
+| One-tap share on fan/live pages | △ MISSING | share is organiser-side only |
+| Attribution as a CTA (not passive brand) | △ passive | badge + embed copy |
+| Growth funnel instrumented in PostHog | △ likely absent | no named taxonomy/north-star |
+| Fan→organiser convert on Discover/public | △ SEO-only | `/discover` has no "start yours" CTA |
+
+## Activation model + north-star
+
+- **TOFU:** no-account draw / `/start`.
+- **★ North-star (activation):** org created → **made public** → **≥1 result
+  scored**. Everything is measured against the % of new orgs reaching this.
+- **Habit:** repeat events, matchday board usage.
+- **Expand:** players onboarded per org.
+- **Refer:** embeds live, shares fired, player→org conversions.
+
+## The three growth loops
+
+1. **Organiser → Player → Organiser.** Club runs comp → players get accounts,
+   live pages, emails → some run their own thing. Fuel: player-facing
+   "Run your own →" (L2).
+2. **Club → Club (local density).** Neighbouring clubs see each other via
+   Discover + shared players + embeds. This is what makes the hyperlocal
+   beachhead compound — density beats reach.
+3. **Embed / public page → web visitor → organiser.** Live scores on a club's
+   own site → attribution click → `/start`. Fuel: CTA-ify attribution (L1) +
+   share (L3).
+
+## Roadmap — six levers (ICE-sequenced)
+
+| # | Lever | What | Effort | Loop | Metric |
+|---|---|---|---|---|---|
+| L4 | Instrument first | PostHog growth-event taxonomy + north-star + k-factor dashboard, shipped before launch | Med | all | the metrics |
+| L1 | CTA-ify attribution | "Powered by Seazn"/"live on seazn.club" → "Run your own free →" + UTM | Tiny | 3 | attrib CTR→`/start` |
+| L2 | Player→organiser nudge | "Run your own tournament →" in `/me`, `/my-matches`, email footers | Low | 1 | player→new-org |
+| L3 | One-tap share on fan pages | native `navigator.share` + WhatsApp + copy on public live/standings/fixture | Low-Med | 3 | shares→views→`/start` |
+| L6 | Activation guardrail | guided create→public→first-result path; measure & kill drop-off | Med | activation | % orgs hit north-star |
+| L5 | Fan→organiser on Discover | "Start your own free" + live social proof ("N clubs live now") on Discover/public | Low-Med | 2/3 | discover→`/start` |
+
+### Per-lever detail
+
+**L4 — Instrument first.** Define the event taxonomy below in PostHog; build
+one activation funnel and one k-factor panel. Ship before telling anyone, so
+launch data lands from day 1. Reuse `lib/posthog-server.ts`; entitlements stay
+the source of truth for plan state.
+
+**L1 — CTA-ify attribution.** The impressions already exist (badge + embed
+backlink). Change passive brand copy to an action + UTM: badge in
+`(public)/shared/[orgSlug]/layout.tsx`, embed link in `embed/layout.tsx`.
+Keep it tasteful; free-only gating via `dashboard.branding` is unchanged (Pro
+still removes). Decide during planning whether the embed backlink stays on for
+Pro (external-site distribution argument) or follows the badge entitlement.
+
+**L2 — Player→organiser nudge.** Add "Run your own tournament →" to `/me`,
+`/my-matches`, and transactional email footers. Verify exact `/me` layout in
+planning. This turns loop #1 on — the single cheapest high-leverage lever.
+
+**L3 — One-tap share on fan pages.** Add native `navigator.share` + WhatsApp
+deep-link + copy on the public live/standings/fixture pages that players and
+parents actually open (organiser-side `CopyLink` already exists; this is the
+fan-facing equivalent). Grassroots sport runs on WhatsApp — highest-ROI share
+surface for the segment.
+
+**L6 — Activation guardrail.** Ensure a guided create→make-public→first-result
+path exists; instrument each step; remove the biggest drop-off. Verify whether
+an onboarding path already exists (`/onboarding`, `/start`) during planning.
+
+**L5 — Fan→organiser on Discover.** The directory earns SEO/fan traffic today
+but does not convert fans into organisers. Add a "Start your own free" CTA and
+live social-proof counters to Discover + public pages.
+
+## Instrumentation (PostHog)
+
+Named events:
+`draw_played`, `start_initiated`, `org_created`, `comp_made_public`,
+`first_result_scored` (★ activation), `embed_rendered`, `attribution_clicked`,
+`share_fired`, `player_account_created`, `player_started_own_org`.
+
+Two dashboards:
+- **Activation funnel:** draw_played → start_initiated → org_created →
+  comp_made_public → first_result_scored.
+- **K-factor panel:** attribution_clicked / share_fired / player→org
+  conversions per active org.
+
+This is the entire GTM dashboard. Watch these, not vanity signups.
+
+## Monetization flywheel
+
+`dashboard.branding` (remove badge) is already the Pro trigger. Every
+attribution surface sharpened by L1/L3 makes "remove it" more valuable AND
+recruits more free orgs. Free tier is simultaneously the ad network and the
+upgrade funnel. Corollary: never weaken free-tier attribution; only make it
+more tasteful and more action-oriented.
+
+## Pre-launch sequencing
+
+`L4 (instrument) → L1 (cheap conversion) → L2 + L3 (loops) → L6 (activation)
+→ L5 (discover)`. L4 lands before a single person is told.
+
+## Open questions (verify during planning, not blocking)
+
+1. Exact `/me` and `/my-matches` layout for the L2 nudge placement.
+2. Whether an activation onboarding path already exists for L6
+   (`/onboarding`, `/start`).
+3. Whether the embed backlink should follow the `dashboard.branding`
+   entitlement or stay always-on (external-site distribution argument).
+4. Which transactional email templates are player-facing (candidates for the
+   L2 footer CTA) vs. account/operator-facing.
+
+## Out of scope (parked)
+
+Hyperlocal beachhead playbook, content calendar, email marketing campaigns,
+sport-tech events/PR, and the local→county→national→international acquisition
+ladder. Each is a separate GTM workstream, available on request.
+
+## Success criteria
+
+- L4 dashboards live and capturing before launch.
+- Every free-tier public/embed/email surface carries an action-oriented,
+  UTM-tagged path back to `/start`.
+- Loops #1 and #3 are instrumented and firing (non-zero player→org and
+  share→start conversions).
+- A named activation north-star (% orgs reaching first_result_scored) is
+  tracked and improving.

--- a/docs/superpowers/specs/2026-07-17-product-led-growth-plan.md
+++ b/docs/superpowers/specs/2026-07-17-product-led-growth-plan.md
@@ -1,0 +1,576 @@
+# Product-Led Growth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Activate Seazn Club's built-in distribution surfaces into instrumented growth loops (attribution CTAs, player→organiser + share loops) so every free-tier org recruits the next.
+
+**Architecture:** Extend the existing PostHog taxonomy (`lib/analytics-events.ts`) with loop events, fire them from small client components (`lib/analytics` `track()`), and convert passive brand surfaces (badge, embed, `/me`, emails, Discover) into UTM-tagged CTAs back to `/start`. No schema changes — analytics is external (PostHog) and the surfaces already exist.
+
+**Tech Stack:** Next.js (this fork — read `node_modules/next/dist/docs/` before route/layout changes), React server + client components, PostHog (`posthog-js` client, `posthog-node` server), Vitest + Testing Library, i18n dictionaries (`dictionaries/<lang>/*.json`, `lib/messages.ts` `ui` namespace).
+
+## Global Constraints
+
+Copied verbatim from project rules (AGENTS.md + team conventions). Every task implicitly includes these:
+
+- **This is NOT stock Next.js** — read the relevant guide in `node_modules/next/dist/docs/` before writing route/layout/metadata code.
+- **Regression test each change** — every code change ships a test that FAILS without the change.
+- **Extend `scripts/smoke.ts`** — each feature adds coverage on both pro and free paths.
+- **Update help** — MANDATORY closing pass: update `content/help/*.md` in the same branch, never skip.
+- **i18n parity** — every new user-facing string added to `dictionaries/en/*.json` (or `lib/messages.ts` `ui`) must be added to `fr`, `es`, `nl` too (parity is gated).
+- **Verify before push** — run `tsc` + unit tests before any push (unit alone has missed tsc breaks).
+- **Analytics event names are canonical in `lib/analytics-events.ts`** — never inline a raw string; add to `EVENTS` and reference `EVENTS.X`.
+- **PostHog is best-effort** — capture must never throw into the request it rides on (existing `captureServer`/`track` already swallow errors; keep that).
+- **No DB migration** in this plan. If you reach for one, stop — you've mis-scoped.
+- Work in a git worktree (`superpowers:using-git-worktrees`), not the main checkout.
+
+## File Structure
+
+**New files:**
+- `apps/web/src/components/attribution-link.tsx` — client CTA link (badge + embed), fires `ATTRIBUTION_CLICKED`.
+- `apps/web/src/components/share-bar.tsx` — client share row (native share + WhatsApp + copy), fires `SHARE_FIRED`.
+- `apps/web/src/components/run-your-own-cta.tsx` — client "Run your own tournament →" card, fires `PLAYER_STARTED_OWN_ORG`.
+- `docs/superpowers/runbooks/plg-posthog-dashboards.md` — the two PostHog dashboards (external config, documented not coded).
+- Test files colocated under `__tests__/` beside each.
+
+**Modified files:**
+- `apps/web/src/lib/analytics-events.ts` — add loop events to `EVENTS`.
+- `apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx:109-116` — badge → `<AttributionLink>`.
+- `apps/web/src/app/embed/layout.tsx:27-36` — backlink → `<AttributionLink>`.
+- `apps/web/src/app/me/page.tsx` — mount `<RunYourOwnCta>`.
+- `apps/web/src/lib/email-templates/compose.ts` — shell footer CTA line.
+- `apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx` — mount `<ShareBar>` in hero.
+- `apps/web/src/app/[lang]/(marketing)/discover/page.tsx:124` — CTA → `/start` + live counter.
+- The competition-publish action (locate in Task 5) — fire `COMPETITION_MADE_PUBLIC`.
+- `dictionaries/{en,fr,es,nl}/*.json` and/or `lib/messages.ts` — new strings.
+- `scripts/smoke.ts`, `content/help/*.md` — per Global Constraints.
+
+**Task order (dependency + ICE sequence):** Task 1 (events) → 2 (L1) → 3 (L2) → 4 (L3) → 5 (L6) → 6 (L5).
+
+---
+
+### Task 1: Growth event taxonomy + dashboard runbook (L4)
+
+**Files:**
+- Modify: `apps/web/src/lib/analytics-events.ts`
+- Create: `docs/superpowers/runbooks/plg-posthog-dashboards.md`
+- Test: `apps/web/src/lib/__tests__/analytics-events.test.ts`
+
+**Interfaces:**
+- Produces: `EVENTS.ATTRIBUTION_CLICKED = "attribution_clicked"`, `EVENTS.SHARE_FIRED = "share_fired"`, `EVENTS.PLAYER_STARTED_OWN_ORG = "player_started_own_org"`, `EVENTS.COMPETITION_MADE_PUBLIC = "competition_made_public"`, `EVENTS.EMBED_RENDERED = "embed_rendered"`. All typed into the existing `AnalyticsEvent` union. Consumed by Tasks 2–6.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// apps/web/src/lib/__tests__/analytics-events.test.ts
+import { describe, expect, it } from "vitest";
+import { EVENTS } from "@/lib/analytics-events";
+
+describe("PLG growth events", () => {
+  it("exposes the loop event names", () => {
+    expect(EVENTS.ATTRIBUTION_CLICKED).toBe("attribution_clicked");
+    expect(EVENTS.SHARE_FIRED).toBe("share_fired");
+    expect(EVENTS.PLAYER_STARTED_OWN_ORG).toBe("player_started_own_org");
+    expect(EVENTS.COMPETITION_MADE_PUBLIC).toBe("competition_made_public");
+    expect(EVENTS.EMBED_RENDERED).toBe("embed_rendered");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- src/lib/__tests__/analytics-events.test.ts`
+Expected: FAIL — `EVENTS.ATTRIBUTION_CLICKED` is `undefined`.
+
+- [ ] **Step 3: Add the events**
+
+In `apps/web/src/lib/analytics-events.ts`, inside the `EVENTS` object (after `SUBSCRIPTION_RESUMED`), add:
+
+```ts
+  // PLG growth loops (2026-07-17 plan) — distribution + referral.
+  ATTRIBUTION_CLICKED: "attribution_clicked",
+  SHARE_FIRED: "share_fired",
+  PLAYER_STARTED_OWN_ORG: "player_started_own_org",
+  COMPETITION_MADE_PUBLIC: "competition_made_public",
+  EMBED_RENDERED: "embed_rendered",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test --workspace apps/web -- src/lib/__tests__/analytics-events.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Write the dashboard runbook**
+
+Create `docs/superpowers/runbooks/plg-posthog-dashboards.md` documenting the two dashboards an operator builds in PostHog (external config — no code):
+
+```markdown
+# PLG PostHog dashboards
+
+## 1. Activation funnel
+Steps (event names): funnel_draft_created → funnel_claimed →
+competition_created → competition_made_public → result_entered (★ north-star).
+Breakdown by organization group. Target: % reaching result_entered.
+
+## 2. K-factor panel
+- attribution_clicked / active org (surface: badge|embed)
+- share_fired / public page view (channel: native|whatsapp|copy)
+- player_started_own_org / player_account_created  (loop #1 rate)
+Watch these, not signup counts.
+```
+
+- [ ] **Step 6: Verify + commit**
+
+Run: `npm run typecheck --workspace apps/web && npm run test --workspace apps/web -- src/lib/__tests__/analytics-events.test.ts`
+Expected: tsc clean, test PASS.
+
+```bash
+git add apps/web/src/lib/analytics-events.ts apps/web/src/lib/__tests__/analytics-events.test.ts docs/superpowers/runbooks/plg-posthog-dashboards.md
+git commit -m "feat(analytics): add PLG growth-loop events + dashboard runbook"
+```
+
+---
+
+### Task 2: CTA-ify attribution (L1)
+
+Convert the passive "Powered by seazn.club" badge and the "live on seazn.club" embed backlink into a UTM-tagged CTA that fires `ATTRIBUTION_CLICKED`. Free-tier gating (`org.branded`) is unchanged — Pro still removes the badge.
+
+**Files:**
+- Create: `apps/web/src/components/attribution-link.tsx`
+- Test: `apps/web/src/components/__tests__/attribution-link.test.tsx`
+- Modify: `apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx` (badge, ~lines 109-116)
+- Modify: `apps/web/src/app/embed/layout.tsx` (backlink, lines 27-36)
+
+**Interfaces:**
+- Consumes: `EVENTS.ATTRIBUTION_CLICKED`, `track` (from `@/lib/analytics`).
+- Produces: `<AttributionLink surface="badge" | "embed" />` (client component).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// apps/web/src/components/__tests__/attribution-link.test.tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const track = vi.fn();
+vi.mock("@/lib/analytics", () => ({
+  EVENTS: { ATTRIBUTION_CLICKED: "attribution_clicked" },
+  track,
+}));
+
+import { AttributionLink } from "../attribution-link";
+
+describe("AttributionLink", () => {
+  it("links to /start with surface UTM and fires the event on click", () => {
+    render(<AttributionLink surface="badge" />);
+    const link = screen.getByRole("link", { name: /run your own free/i });
+    expect(link).toHaveAttribute("href", expect.stringContaining("seazn.club/start"));
+    expect(link).toHaveAttribute("href", expect.stringContaining("utm_source=badge"));
+    fireEvent.click(link);
+    expect(track).toHaveBeenCalledWith("attribution_clicked", { surface: "badge" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test --workspace apps/web -- src/components/__tests__/attribution-link.test.tsx`
+Expected: FAIL — cannot find `../attribution-link`.
+
+- [ ] **Step 3: Create the component**
+
+```tsx
+// apps/web/src/components/attribution-link.tsx
+"use client";
+import { EVENTS, track } from "@/lib/analytics";
+
+const START = "https://seazn.club/start";
+
+/** Free-tier attribution turned into an acquisition CTA (PLG L1). Renders the
+ *  brand line + a tracked "Run your own free →" link back to /start. */
+export function AttributionLink({ surface }: { surface: "badge" | "embed" }) {
+  const href = `${START}?utm_source=${surface}&utm_medium=attribution&utm_campaign=plg`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() => track(EVENTS.ATTRIBUTION_CLICKED, { surface })}
+      className="font-medium underline hover:opacity-80"
+    >
+      Run your own free →
+    </a>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test --workspace apps/web -- src/components/__tests__/attribution-link.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Wire into the shared badge**
+
+In `apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx`, replace the `org.branded ? null : (...)` block (lines ~109-116) with:
+
+```tsx
+        {org.branded ? null : (
+          <p>
+            Powered by <span className="font-medium">Seazn Club</span> ·{" "}
+            <AttributionLink surface="badge" />
+          </p>
+        )}
+```
+
+Add at top: `import { AttributionLink } from "@/components/attribution-link";`
+
+- [ ] **Step 6: Wire into the embed backlink**
+
+In `apps/web/src/app/embed/layout.tsx`, replace the `<a href="https://seazn.club">…live on seazn.club</a>` (lines 28-35) with `<AttributionLink surface="embed" />` and add the import. Keep the wrapping `<p className="mt-3 text-right text-[10px] text-zinc-400">`.
+
+- [ ] **Step 7: Verify + commit**
+
+Run: `npm run typecheck --workspace apps/web && npm run test --workspace apps/web -- src/components/__tests__/attribution-link.test.tsx`
+Expected: tsc clean, test PASS. (Embed stays English-only — a widget footer, not per-org localized; the shared badge line "Powered by Seazn Club" is brand copy, no new dict key.)
+
+```bash
+git add apps/web/src/components/attribution-link.tsx apps/web/src/components/__tests__/attribution-link.test.tsx "apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx" apps/web/src/app/embed/layout.tsx
+git commit -m "feat(plg): CTA-ify free-tier attribution badge + embed backlink"
+```
+
+---
+
+### Task 3: Player→organiser CTA in /me + email footer (L2)
+
+**Files:**
+- Create: `apps/web/src/components/run-your-own-cta.tsx`
+- Test: `apps/web/src/components/__tests__/run-your-own-cta.test.tsx`
+- Modify: `apps/web/src/app/me/page.tsx` (mount CTA in `<main>`)
+- Modify: `apps/web/src/lib/email-templates/compose.ts` (shell footer CTA)
+- Test: `apps/web/src/lib/email-templates/__tests__/compose.test.ts`
+- Modify: `dictionaries/{en,fr,es,nl}` or `lib/messages.ts` `ui` — `me.runYourOwn.title` / `me.runYourOwn.cta`
+
+**Interfaces:**
+- Consumes: `EVENTS.PLAYER_STARTED_OWN_ORG`, `track`.
+- Produces: `<RunYourOwnCta label={string} cta={string} />`.
+
+- [ ] **Step 1: Write the failing component test**
+
+```tsx
+// apps/web/src/components/__tests__/run-your-own-cta.test.tsx
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+const track = vi.fn();
+vi.mock("@/lib/analytics", () => ({ EVENTS: { PLAYER_STARTED_OWN_ORG: "player_started_own_org" }, track }));
+import { RunYourOwnCta } from "../run-your-own-cta";
+
+describe("RunYourOwnCta", () => {
+  it("links to /start and fires the loop event", () => {
+    render(<RunYourOwnCta label="Run your own" cta="Start free →" />);
+    const link = screen.getByRole("link", { name: /start free/i });
+    expect(link).toHaveAttribute("href", expect.stringContaining("/start"));
+    fireEvent.click(link);
+    expect(track).toHaveBeenCalledWith("player_started_own_org", { from: "me" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** — `npm run test --workspace apps/web -- src/components/__tests__/run-your-own-cta.test.tsx` → FAIL (missing module).
+
+- [ ] **Step 3: Create the component**
+
+```tsx
+// apps/web/src/components/run-your-own-cta.tsx
+"use client";
+import Link from "next/link";
+import { EVENTS, track } from "@/lib/analytics";
+
+/** Player→organiser loop (PLG L2): nudges an engaged player to start their own
+ *  competition. Copy is passed in so the page localizes it. */
+export function RunYourOwnCta({ label, cta }: { label: string; cta: string }) {
+  return (
+    <div className="card mt-6 flex flex-col gap-2 p-6 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-sm font-medium">{label}</p>
+      <Link
+        href="/start?utm_source=me&utm_medium=player&utm_campaign=plg"
+        onClick={() => track(EVENTS.PLAYER_STARTED_OWN_ORG, { from: "me" })}
+        className="btn btn-primary text-sm"
+      >
+        {cta}
+      </Link>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify pass** — same command → PASS.
+
+- [ ] **Step 5: Add i18n strings (en + parity)**
+
+Add to the `ui` namespace source (`lib/messages.ts` or `dictionaries/en/*` per how `me.*` keys are defined — grep `"me.title"` to find the file):
+`me.runYourOwn.title` = `"Run your own tournament — free."`, `me.runYourOwn.cta` = `"Start free →"`. Add the same keys with translations to `fr`, `es`, `nl` (parity gate). Use `npm run i18n:translate` if the repo's pipeline exists, else translate the two strings.
+
+- [ ] **Step 6: Mount in /me**
+
+In `apps/web/src/app/me/page.tsx` `<main>`, after the page title block, add:
+
+```tsx
+        <RunYourOwnCta label={t(ui, "me.runYourOwn.title")} cta={t(ui, "me.runYourOwn.cta")} />
+```
+
+Add import: `import { RunYourOwnCta } from "@/components/run-your-own-cta";`
+
+- [ ] **Step 7: Write failing email-footer test**
+
+```ts
+// apps/web/src/lib/email-templates/__tests__/compose.test.ts
+import { describe, expect, it } from "vitest";
+import { composeEmail } from "@/lib/email-templates/compose";
+// Adapt to compose's real export/signature (grep `export` in compose.ts).
+
+describe("email shell footer", () => {
+  it("includes a run-your-own CTA linking to /start", () => {
+    const html = composeEmail({ /* minimal valid shell args */ } as never).html;
+    expect(html).toContain("/start");
+    expect(html).toMatch(/run your own/i);
+  });
+});
+```
+
+- [ ] **Step 8: Run to verify fail**, then add a persistent CTA line to the shell footer HTML in `compose.ts` (near the `FOOTER_NOTE` placeholder, ~line 150): a small `<a href="https://seazn.club/start?utm_source=email&utm_medium=footer&utm_campaign=plg">Run your own — free</a>`. Re-run → PASS.
+
+- [ ] **Step 9: Verify + commit**
+
+Run: `npm run typecheck --workspace apps/web && npm run test --workspace apps/web -- src/components/__tests__/run-your-own-cta.test.tsx src/lib/email-templates/__tests__/compose.test.ts`
+Expected: all PASS.
+
+```bash
+git add apps/web/src/components/run-your-own-cta.tsx apps/web/src/components/__tests__/run-your-own-cta.test.tsx apps/web/src/app/me/page.tsx apps/web/src/lib/email-templates/compose.ts apps/web/src/lib/email-templates/__tests__/compose.test.ts apps/web/src/lib/messages.ts apps/web/src/dictionaries
+git commit -m "feat(plg): player→organiser CTA in /me + email footer"
+```
+
+---
+
+### Task 4: ShareBar on public fan pages (L3)
+
+Native `navigator.share` + WhatsApp deep-link + copy on the public competition page fans/parents open. Fires `SHARE_FIRED`.
+
+**Files:**
+- Create: `apps/web/src/components/share-bar.tsx`
+- Test: `apps/web/src/components/__tests__/share-bar.test.tsx`
+- Modify: `apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx` (hero `<section>` ~line 89)
+
+**Interfaces:**
+- Consumes: `EVENTS.SHARE_FIRED`, `track`.
+- Produces: `<ShareBar path={string} title={string} />` (client).
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// apps/web/src/components/__tests__/share-bar.test.tsx
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+const track = vi.fn();
+vi.mock("@/lib/analytics", () => ({ EVENTS: { SHARE_FIRED: "share_fired" }, track }));
+import { ShareBar } from "../share-bar";
+
+describe("ShareBar", () => {
+  beforeEach(() => { track.mockClear(); Object.defineProperty(window, "location", { value: { origin: "https://seazn.club" }, writable: true }); });
+
+  it("builds a wa.me link to the absolute URL and fires share_fired", () => {
+    render(<ShareBar path="/shared/riverside/spring-cup" title="Spring Cup" />);
+    const wa = screen.getByRole("link", { name: /whatsapp/i });
+    expect(wa).toHaveAttribute("href", expect.stringContaining("wa.me/?text="));
+    expect(decodeURIComponent(wa.getAttribute("href")!)).toContain("https://seazn.club/shared/riverside/spring-cup");
+    fireEvent.click(wa);
+    expect(track).toHaveBeenCalledWith("share_fired", { channel: "whatsapp" });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify fail** → FAIL (missing module).
+
+- [ ] **Step 3: Create the component**
+
+```tsx
+// apps/web/src/components/share-bar.tsx
+"use client";
+import { useEffect, useState } from "react";
+import { EVENTS, track } from "@/lib/analytics";
+
+/** Fan-facing share row (PLG L3): native share on mobile, WhatsApp + copy
+ *  everywhere. Grassroots sport runs on WhatsApp. */
+export function ShareBar({ path, title }: { path: string; title: string }) {
+  const [origin, setOrigin] = useState("");
+  const [copied, setCopied] = useState(false);
+  useEffect(() => setOrigin(window.location.origin), []);
+  const url = origin ? `${origin}${path}` : path;
+  const wa = `https://wa.me/?text=${encodeURIComponent(`${title} — ${url}`)}`;
+
+  async function native() {
+    track(EVENTS.SHARE_FIRED, { channel: "native" });
+    try { await navigator.share?.({ title, url }); } catch { /* dismissed */ }
+  }
+  async function copy() {
+    track(EVENTS.SHARE_FIRED, { channel: "copy" });
+    try { await navigator.clipboard.writeText(url); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch { /* blocked */ }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      {typeof navigator !== "undefined" && "share" in navigator && (
+        <button type="button" onClick={native} className="btn btn-ghost">Share</button>
+      )}
+      <a href={wa} target="_blank" rel="noreferrer" onClick={() => track(EVENTS.SHARE_FIRED, { channel: "whatsapp" })} className="btn btn-ghost" aria-label="Share on WhatsApp">WhatsApp</a>
+      <button type="button" onClick={copy} className="btn btn-ghost">{copied ? "Copied ✓" : "Copy link"}</button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify pass** → PASS.
+
+- [ ] **Step 5: Mount in the public competition hero**
+
+In `apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx`, inside the hero `<section>` (after the `<h1>` at ~line 130), add:
+
+```tsx
+              <div className="mt-4">
+                <ShareBar path={`/shared/${org.slug}/${competition.slug}`} title={competition.name} />
+              </div>
+```
+
+Add import: `import { ShareBar } from "@/components/share-bar";` (confirm the competition display field name — grep the file for `competition.` to match `name`/`title`).
+
+- [ ] **Step 6: Verify + commit**
+
+Run: `npm run typecheck --workspace apps/web && npm run test --workspace apps/web -- src/components/__tests__/share-bar.test.tsx`
+Expected: tsc clean, PASS.
+
+```bash
+git add apps/web/src/components/share-bar.tsx apps/web/src/components/__tests__/share-bar.test.tsx "apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx"
+git commit -m "feat(plg): fan-facing ShareBar (native + WhatsApp + copy) on public comp page"
+```
+
+---
+
+### Task 5: COMPETITION_MADE_PUBLIC event (L6, activation funnel completion)
+
+The activation funnel already has `competition_created` → `result_entered`; add the missing "made public" step so the north-star funnel is complete. No guided-onboarding UI in this plan (deferred) — instrumentation first.
+
+**Files:**
+- Modify: the server action that flips a competition to public/visible (locate below).
+- Test: colocated test for that action, or `apps/web/src/lib/__tests__/`.
+
+**Interfaces:**
+- Consumes: `captureServer` (`@/lib/posthog-server`), `EVENTS.COMPETITION_MADE_PUBLIC`.
+
+- [ ] **Step 1: Locate the publish action**
+
+Run: `grep -rniE "is_public|visibility|publish|make.?public|listed" apps/web/src/server apps/web/src/app --include=*.ts | grep -viE "test|posthog" | head`
+Pick the handler that transitions a competition to public. Note its file + the point after the successful DB write.
+
+- [ ] **Step 2: Write the failing test**
+
+Write a test that calls that handler (or its usecase) with a competition transitioning to public and asserts `captureServer` is invoked with `event: EVENTS.COMPETITION_MADE_PUBLIC` and the `orgId`. Mock `@/lib/posthog-server`:
+
+```ts
+import { vi, expect, it } from "vitest";
+const captureServer = vi.fn();
+vi.mock("@/lib/posthog-server", () => ({ captureServer }));
+// import + call the located publish usecase with a going-public transition
+it("captures competition_made_public on publish", async () => {
+  // await publishCompetition({ ... });
+  expect(captureServer).toHaveBeenCalledWith(expect.objectContaining({ event: "competition_made_public" }));
+});
+```
+
+- [ ] **Step 3: Run to verify fail**, then add after the successful publish write:
+
+```ts
+await captureServer({
+  event: EVENTS.COMPETITION_MADE_PUBLIC,
+  distinctId: userId,
+  orgId,
+  properties: { competitionId },
+});
+```
+
+Import `captureServer` and `EVENTS` if not present. Re-run → PASS.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `npm run typecheck --workspace apps/web && npm run test --workspace apps/web -- <the test file>`
+
+```bash
+git add <handler file> <test file>
+git commit -m "feat(plg): fire competition_made_public to complete the activation funnel"
+```
+
+---
+
+### Task 6: Sharpen Discover CTA + live counter (L5)
+
+Discover already has a signup CTA (`page.tsx:124`, `/login?tab=signup`). Point it at `/start` with "Start your own free", and add a live social-proof counter from the existing discovery data source.
+
+**Files:**
+- Modify: `apps/web/src/app/[lang]/(marketing)/discover/page.tsx` (CTA ~line 124; counter near the `<h1>` ~line 75)
+- Modify: `dictionaries/{en,fr,es,nl}/marketing.json` — `discover.cta.start`, `discover.liveCount`
+- Test: `apps/web/src/app/[lang]/(marketing)/discover/__tests__/page.test.tsx` (or extend existing discover test)
+
+**Interfaces:**
+- Consumes: the discovery listing already loaded in the page (count of live competitions). Grep the file for the variable holding the live list (`listDiscover…` / the mapped array).
+
+- [ ] **Step 1: Write the failing test** — assert the primary CTA links to `/start` (not `/login`) and that a live-count string renders when the list is non-empty. Mirror the existing discover test's render setup (grep `discover` under `__tests__`).
+
+- [ ] **Step 2: Run to verify fail.**
+
+- [ ] **Step 3: Change the CTA** — replace `href="/login?tab=signup"` with `` href={`/${lang}/start?utm_source=discover&utm_medium=directory&utm_campaign=plg`} `` and the label with `t(d, "discover.cta.start")`.
+
+- [ ] **Step 4: Add the counter** — near the `<h1>` (line 75), render `t(d, "discover.liveCount", { count })` where `count` is the live-competition list length already in scope (only when `> 0`, per the "no empty SEO shells" convention).
+
+- [ ] **Step 5: Add i18n strings** — `discover.cta.start` = `"Start your own — free"`, `discover.liveCount` = `"{count} clubs live right now"`, to `en` + `fr`/`es`/`nl` (parity).
+
+- [ ] **Step 6: Run to verify pass.**
+
+- [ ] **Step 7: Verify + commit**
+
+```bash
+git add "apps/web/src/app/[lang]/(marketing)/discover/page.tsx" apps/web/src/dictionaries "apps/web/src/app/[lang]/(marketing)/discover/__tests__"
+git commit -m "feat(plg): Discover fan→organiser CTA to /start + live club counter"
+```
+
+---
+
+### Task 7: Closing pass — smoke + help (Global Constraints)
+
+**Files:**
+- Modify: `scripts/smoke.ts`
+- Modify: `content/help/*.md` (grep for the growth/sharing/getting-started article; add or extend)
+
+- [ ] **Step 1: Extend smoke** — add assertions on both free and pro paths: (a) free-tier public comp page contains the attribution CTA + ShareBar; (b) `/me` renders the run-your-own CTA; (c) Discover renders the `/start` CTA. Follow the existing `scripts/smoke.ts` structure (it's large — copy a nearby public-page check as the template).
+
+- [ ] **Step 2: Run smoke** — `npm run test:smoke` (or the repo's smoke command; grep `"smoke"` in `package.json`). Expected: PASS including new assertions.
+
+- [ ] **Step 3: Update help** — add/extend a help article on sharing + growing your club (attribution, share buttons, "run your own"). Register the slug if the repo uses a help-slug registry (grep `slug` under `content/help` tooling).
+
+- [ ] **Step 4: Final verify + commit**
+
+Run: `npm run typecheck --workspace apps/web && npm run test && npm run test:smoke`
+Expected: all green.
+
+```bash
+git add scripts/smoke.ts content/help
+git commit -m "test(plg): smoke coverage + help for growth loops"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** L1→Task 2, L2→Task 3, L3→Task 4, L4→Task 1, L5→Task 6, L6→Task 5. North-star (`result_entered`) already exists + funnel completed by Task 5. Monetization flywheel: unchanged `org.branded`/`dashboard.branding` gate preserved (Task 2 Step 5). All six levers + instrumentation covered.
+
+**Placeholder scan:** Two intentional locate-steps (Task 5 Step 1 publish handler; Task 6 live-list variable) give exact grep commands, not vague "handle it" — acceptable per plan rules. Email test (Task 3 Step 7) says "adapt to compose's real signature" — mitigated by the grep instruction; implementer must read `compose.ts` exports first.
+
+**Type consistency:** `track(event, properties)` and `captureServer({event, distinctId, orgId, properties})` match the real signatures read from `lib/analytics.ts` and `lib/posthog-server.ts`. Event constants referenced as `EVENTS.X` throughout, all defined in Task 1. Component prop names (`surface`, `path`/`title`, `label`/`cta`) consistent between definition and mount sites.
+
+**No schema/migration** — confirmed; analytics is external.

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -339,6 +339,10 @@ await i18nSuite();
   await playerAccountsSuite(admin, org2.id);
   await officialOnboardingSuite(admin, org2.id, renamed.slug);
 
+  // --- PLG growth loops (design/plg): attribution CTA + fan ShareBar on
+  // free AND pro public pages, /me player→organiser nudge, /discover /start.
+  await plgGrowthSuite(admin, org2.id, renamed.slug);
+
   // --- design/v9 PROMPT-55: dispute-loss recovery surfaces.
   await disputeSurfacesSuite();
 
@@ -727,6 +731,78 @@ async function officialOnboardingSuite(admin: Session, orgId: string, orgSlug: s
   check(
     "off booked-elsewhere never leaks the other org's competition/division",
     !sched.body.includes(`Busy Cup ${tag}`) && !sched.body.includes(`Busy A ${tag}`),
+  );
+}
+
+/** PLG growth loops (design/plg): the free-tier "Powered by Seazn Club"
+ *  footer is an acquisition CTA (attribution-link.tsx) and every public
+ *  competition page carries a fan-facing share bar (share-bar.tsx) — pro
+ *  orgs keep the share bar but drop the attribution footer (unchanged
+ *  org.branded gate). /me carries the player→organiser nudge
+ *  (run-your-own-cta.tsx) and /discover always offers the /start CTA. */
+async function plgGrowthSuite(admin: Session, proOrgId: string, proOrgSlug: string): Promise<void> {
+  admin.cookies["seazn_org"] = proOrgId;
+
+  // --- Pro path: share bar present, "Powered by" attribution footer gone.
+  const proComp = v1data<{ id: string; slug: string }>(
+    await v1(admin, "/api/v1/competitions", "POST", {
+      name: `PLG Pro Cup ${tag}`,
+      visibility: "public",
+    }),
+  );
+  const proShared = await html(newSession(), `/shared/${proOrgSlug}/${proComp.slug}`);
+  check(
+    "plg pro page keeps the fan ShareBar",
+    proShared.status === 200 &&
+      proShared.body.includes("Share on WhatsApp") &&
+      proShared.body.includes("Copy link"),
+  );
+  check(
+    "plg pro page has no 'Powered by' attribution footer",
+    !proShared.body.includes("Powered by"),
+  );
+
+  // --- Free path: a fresh community owner's public page carries both the
+  // attribution CTA and the fan ShareBar.
+  const free = newSession();
+  const freeVer = await signIn(free, `plg_free_${tag}@example.com`);
+  const freeOrgs = (await call(free, "/api/orgs")) as { id: string; slug: string }[];
+  const freeOrg = freeOrgs.find((o) => o.id === freeVer.org_id)!;
+  const freeComp = v1data<{ id: string; slug: string }>(
+    await v1(free, "/api/v1/competitions", "POST", {
+      name: `PLG Free Cup ${tag}`,
+      visibility: "public",
+    }),
+  );
+  const freeShared = await html(newSession(), `/shared/${freeOrg.slug}/${freeComp.slug}`);
+  check(
+    "plg free page carries the 'Powered by' attribution CTA",
+    freeShared.status === 200 &&
+      freeShared.body.includes("Powered by") &&
+      freeShared.body.includes("Run your own free"),
+  );
+  check(
+    "plg free page also renders the fan ShareBar",
+    freeShared.body.includes("Share on WhatsApp") && freeShared.body.includes("Copy link"),
+  );
+
+  // --- /me: the player→organiser "run your own" CTA.
+  const meRun = await html(free, "/me");
+  check(
+    "plg /me renders the run-your-own-tournament CTA",
+    meRun.status === 200 &&
+      meRun.body.includes("Run your own tournament") &&
+      meRun.body.includes("utm_source=me"),
+  );
+
+  // --- /discover: the acquisition CTA back to /start (unconditional —
+  // renders whether or not any club happens to be live right now).
+  const discover = await html(newSession(), "/en/discover");
+  check(
+    "plg /discover offers the /start acquisition CTA",
+    discover.status === 200 &&
+      discover.body.includes("utm_source=discover") &&
+      discover.body.includes("Start free"),
   );
 }
 


### PR DESCRIPTION
## Summary

Turns free-tier distribution surfaces that **already ship** into instrumented growth loops. No new distribution built, **no DB migration**. The free tier stays the ad network; Pro still removes the "Powered by seazn.club" badge (monetization trigger unchanged). Sport-agnostic, pre-launch.

## What changes visually (per surface)

| Surface | Change | Tier |
|---|---|---|
| Public shared page — attribution badge | "Powered by seazn.club" footer gains a **"Run your own free →"** CTA (→ `/start` + UTM) | Free only (Pro removes the whole badge, unchanged) |
| Embed backlink | The `seazn.club` backlink under embeds becomes the same tracked **"Run your own free →"** CTA | Free embeds |
| `/me` page | New **"Run your own tournament →"** card, localized ×4, mounted above the fold | All players |
| Transactional email footer | Static English **"Run your own free →"** line added to the email shell | All emails |
| Public competition page — **ShareBar** | New one-tap share row: **native share + WhatsApp + Copy link** in the hero (native button only where supported) | Public |
| `/discover` directory | Both sign-up CTAs repointed to **`/start`** (+UTM) instead of `/login`; a live **"N clubs live right now"** counter (distinct live clubs) above the grid | Public |
| _(no visual change)_ | `competition_made_public` fires server-side when a competition goes public — the activation north-star step | — |

## Instrumentation (PostHog)

5 new canonical events in `lib/analytics-events.ts` (never inline strings): `attribution_clicked`, `share_fired`, `player_started_own_org`, `competition_made_public`, `embed_rendered` (defined; wiring reserved). Dashboards documented in `docs/superpowers/runbooks/plg-posthog-dashboards.md`.

Activation funnel: `funnel_draft_created → funnel_claimed → competition_created → `**`competition_made_public`**` → result_entered` — this branch adds the previously-missing "made public" step that closes it.

## Tests & docs

- Regression test per change (node-env unit + pure helpers): `attribution-link`, `run-your-own-cta`, `share-bar` (`shareLinks` + SSR-safety), `shouldFireMadePublic` (6 cases), `discover` page (distinct-club + live-vs-upcoming).
- `scripts/smoke.ts`: new `plgGrowthSuite` — free-vs-Pro attribution, `/me` CTA, Discover `/start` CTA.
- Help: `content/help/sharing/grow-your-club.md` added + slug registered.
- i18n parity en/fr/es/nl for `/me` + Discover strings. Growth micro-CTAs on the badge/embed/email footer stay **English** to match the existing unlocalized "Powered by seazn.club" badge.

## Review

7 tasks reviewed task-by-task; final whole-branch review (opus): **ready to merge, 0 Critical / 0 Important**. 3 post-review Minors fixed in a30a667 (distinct-club count, snake_case event key, help link).

## Verification

`npm run typecheck --workspace apps/web` clean · `npm run test --workspace apps/web` **1067 passed / 323 skipped** (DB + smoke suites skip locally — run on CI/staging with a live server+DB).

Strategy + design visual summary (artifact): https://claude.ai/code/artifact/55b283c5-f3b8-41f5-80f9-ac9f22ef423e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
