### PR TITLE
fix(seo): env-derived site origin — stg OG/SEO URLs pointed at unresolvable prod domain

### DIFF
--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/page.tsx
@@ -13,6 +13,7 @@ import { publicThemeStyle } from "@/lib/public-theme";
 import { hasFeature } from "@/lib/entitlements";
 import { resolveSponsors, type SponsorTier } from "@/server/usecases/sponsors";
 import { renderProse } from "@/lib/prose";
+import { competitionMetaDescription } from "@/lib/public-meta";
 import { CompetitionProse } from "@/components/public-site/competition-prose";
 import { ShareBar } from "@/components/share-bar";
 
@@ -39,7 +40,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!data) return {};
   return {
     title: `${data.competition.name} — ${data.org.name}`,
-    description: data.competition.description?.slice(0, 160) ?? undefined,
+    description: competitionMetaDescription(
+      data.competition.name,
+      data.org.name,
+      data.competition.description,
+    ),
     // Doc 09 §1: unlisted = link-only. Keep crawlers out but the page up.
     ...(data.competition.visibility === "unlisted"
       ? { robots: { index: false, follow: false } }

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/players/[personId]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getPublicPlayer } from "@/server/public-site/data";
+import { playerMetaDescription } from "@/lib/public-meta";
 
 export const revalidate = 300; // doc 09 §3: entrant/player pages revalidate 300
 
@@ -25,6 +26,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!data) return {};
   return {
     title: `${data.player.name} — ${data.competition.name}`,
+    description: playerMetaDescription(data.player.name, data.competition.name),
     ...(data.competition.visibility === "unlisted"
       ? { robots: { index: false, follow: false } }
       : {}),

--- a/apps/web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/page.tsx
@@ -38,7 +38,7 @@ export async function generateMetadata({
     openGraph: {
       title: t(d, "home.og.title"),
       description: t(d, "home.og.description"),
-      url: "https://seazn.club",
+      url: "/",
       siteName: "Seazn Club",
       type: "website",
     },

--- a/apps/web/src/app/games/page.tsx
+++ b/apps/web/src/app/games/page.tsx
@@ -9,7 +9,8 @@ export const metadata: Metadata = {
   title: "Games — free browser games | Seazn Club",
   description:
     "Play free browser games by Seazn Club. Learn-to-play quests and quick challenges — no install, no sign-up.",
-  alternates: { canonical: "https://seazn.club/games" },
+  // Relative — resolved against the root layout's metadataBase.
+  alternates: { canonical: "/games" },
 };
 
 export default function GamesPage() {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { barlowCondensed } from "@/lib/fonts";
+import { siteOrigin } from "@/lib/site-origin";
 import { AnalyticsBootstrap } from "@/components/analytics-bootstrap";
 import { CookieConsent } from "@/components/cookie-consent";
 import { ConfirmProvider } from "@/components/ui/confirm-provider";
@@ -19,7 +20,7 @@ export const metadata: Metadata = {
   },
   description:
     "Run fair, fun, multi-sport tournaments for your club. Chess, carrom, cricket and more.",
-  metadataBase: new URL("https://seazn.club"),
+  metadataBase: new URL(siteOrigin()),
   icons: {
     icon: [
       { url: "/icons/icon-16.png", sizes: "16x16", type: "image/png" },

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { siteOrigin } from "@/lib/site-origin";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -9,6 +10,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/o/", "/dashboard", "/admin", "/api/", "/settings", "/competitions/", "/divisions/", "/fixtures/", "/directory", "/players", "/people", "/clubs", "/orgs/"],
       },
     ],
-    sitemap: "https://seazn.club/sitemap.xml",
+    sitemap: `${siteOrigin()}/sitemap.xml`,
   };
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -2,8 +2,9 @@ import type { MetadataRoute } from "next";
 import { listPublicSitemapEntries } from "@/server/public-site/data";
 import { listDiscoverySports } from "@/server/public-site/discovery";
 import { liveGames } from "@/games/registry";
+import { siteOrigin } from "@/lib/site-origin";
 
-const BASE = "https://seazn.club";
+const BASE = siteOrigin();
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();

--- a/apps/web/src/lib/__tests__/public-meta.test.ts
+++ b/apps/web/src/lib/__tests__/public-meta.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { competitionMetaDescription, playerMetaDescription } from "@/lib/public-meta";
+
+describe("competitionMetaDescription", () => {
+  it("uses the competition's own description, truncated to 160", () => {
+    const long = "x".repeat(200);
+    expect(competitionMetaDescription("WC", "FIFA", long)).toBe("x".repeat(160));
+  });
+
+  it("falls back to generated copy when the description is missing or blank", () => {
+    for (const empty of [undefined, null, "", "   "]) {
+      expect(competitionMetaDescription("FIFA World Cup 2026", "FIFA", empty)).toBe(
+        "Live scores, standings and brackets for FIFA World Cup 2026 — hosted by FIFA on Seazn Club.",
+      );
+    }
+  });
+});
+
+describe("playerMetaDescription", () => {
+  it("always yields supporting text for the player card", () => {
+    expect(playerMetaDescription("A. Kannan", "Riverside Open")).toBe(
+      "A. Kannan's player card at Riverside Open — appearances, results and stats on Seazn Club.",
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/site-origin.test.ts
+++ b/apps/web/src/lib/__tests__/site-origin.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { siteOrigin } from "@/lib/site-origin";
+
+describe("siteOrigin", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers OAUTH_BASE_URL and strips a trailing slash", () => {
+    vi.stubEnv("OAUTH_BASE_URL", "https://seazn-club-stg.fly.dev/");
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://other.example");
+    expect(siteOrigin()).toBe("https://seazn-club-stg.fly.dev");
+  });
+
+  it("falls back to NEXT_PUBLIC_BASE_URL", () => {
+    vi.stubEnv("OAUTH_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "https://seazn-club-stg.fly.dev");
+    expect(siteOrigin()).toBe("https://seazn-club-stg.fly.dev");
+  });
+
+  it("defaults to the production domain when nothing is set", () => {
+    vi.stubEnv("OAUTH_BASE_URL", "");
+    vi.stubEnv("NEXT_PUBLIC_BASE_URL", "");
+    expect(siteOrigin()).toBe("https://seazn.club");
+  });
+});

--- a/apps/web/src/lib/public-meta.ts
+++ b/apps/web/src/lib/public-meta.ts
@@ -1,0 +1,21 @@
+// Meta-description builders for the public /shared tree. A page must always
+// return a non-empty description: this Next build does not fall back to the
+// root layout's description, so `undefined` here means NO meta description,
+// og:description or twitter:description at all (caught by a link-preview
+// inspector on stg).
+export function competitionMetaDescription(
+  competitionName: string,
+  orgName: string,
+  competitionDescription?: string | null,
+): string {
+  const own = competitionDescription?.trim();
+  if (own) return own.slice(0, 160);
+  return `Live scores, standings and brackets for ${competitionName} — hosted by ${orgName} on Seazn Club.`;
+}
+
+export function playerMetaDescription(
+  playerName: string,
+  competitionName: string,
+): string {
+  return `${playerName}'s player card at ${competitionName} — appearances, results and stats on Seazn Club.`;
+}

--- a/apps/web/src/lib/site-origin.ts
+++ b/apps/web/src/lib/site-origin.ts
@@ -1,0 +1,12 @@
+// Canonical site origin for metadata-time absolute URLs (metadataBase,
+// sitemap, robots, canonicals). Env-driven so staging emits its own host
+// instead of the production domain; falls back to the production domain when
+// nothing is set. Deliberately NOT header-derived: a dynamic read in the root
+// layout would opt every page out of static rendering (PERF-A).
+export function siteOrigin(): string {
+  return (
+    process.env.OAUTH_BASE_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    "https://seazn.club"
+  ).replace(/\/$/, "");
+}


### PR DESCRIPTION
The opengraph.xyz preview of the stg FIFA page was blank: `metadataBase` (and robots/sitemap/canonical/og:url) hardcoded `https://seazn.club`, which doesn't resolve. New `siteOrigin()` helper (OAUTH_BASE_URL → NEXT_PUBLIC_BASE_URL → prod default — the email senders' chain); page URLs go relative and resolve via metadataBase. Header-derivation rejected deliberately: dynamic read in root layout kills static rendering (PERF-A).

Ops (stg): `fly secrets set OAUTH_BASE_URL=https://seazn-club-stg.fly.dev -a seazn-club-stg` — I'll set it after merge. Bonus fix: request-less officiating emails on stg currently link to localhost:3000 via the same unset env.

Gates: tsc 0 · site-origin test 3/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)