### PR TITLE
fix(seo): home og:image restored + e2e social-card regression suite

### DIFF
--- a/apps/web/e2e/seo-meta.spec.ts
+++ b/apps/web/e2e/seo-meta.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import type { APIRequestContext } from "@playwright/test";
+import { activeOrg, createCompetitionViaUi, TAG } from "./helpers";
+
+// Social-card regression net (PR #128 + home og:image fix). Two bugs it
+// pins down: (1) the shared competition page emitted NO meta description /
+// og:description / twitter:description when the competition had no
+// description text — this Next build does not cascade the root layout's
+// description; (2) the home page's page-level `openGraph` object replaced
+// the inherited one wholesale, silently dropping the root file-convention
+// og:image. Meta tags live in the server-rendered HTML, so assertions run
+// on the fetched document, not the hydrated DOM.
+
+function metaContent(html: string, attr: "name" | "property", key: string): string | null {
+  // Next emits attribute orders both ways depending on the tag source.
+  const a = html.match(new RegExp(`<meta[^>]*${attr}="${key}"[^>]*content="([^"]*)"`));
+  const b = html.match(new RegExp(`<meta[^>]*content="([^"]*)"[^>]*${attr}="${key}"`));
+  return a?.[1] ?? b?.[1] ?? null;
+}
+
+async function expectFullSocialCard(
+  request: APIRequestContext,
+  path: string,
+): Promise<void> {
+  const res = await request.get(path);
+  expect(res.status(), `${path} should render`).toBe(200);
+  const html = await res.text();
+
+  for (const [attr, key] of [
+    ["name", "description"],
+    ["property", "og:description"],
+    ["name", "twitter:description"],
+  ] as const) {
+    expect(metaContent(html, attr, key), `${path} must emit ${key}`).toBeTruthy();
+  }
+
+  const image = metaContent(html, "property", "og:image");
+  expect(image, `${path} must emit og:image`).toBeTruthy();
+  // The host comes from siteOrigin() (env-dependent: prod fallback locally,
+  // the real host on stg) — fetch the path against the server under test so
+  // the assertion is host-agnostic and only proves the image route exists.
+  const { pathname, search } = new URL(image!, res.url());
+  const img = await request.get(pathname + search);
+  expect(img.status(), `og:image of ${path} must be fetchable`).toBe(200);
+  expect(img.headers()["content-type"], `og:image of ${path} must be an image`).toContain("image/");
+}
+
+test.describe("social cards (SEO meta)", () => {
+  test("home emits a complete card including the root og:image", async ({ request }) => {
+    await expectFullSocialCard(request, "/en");
+  });
+
+  test("marketing pages inherit the root card", async ({ request }) => {
+    await expectFullSocialCard(request, "/pricing");
+  });
+
+  test("shared competition page emits a complete card even without a description", async ({
+    page,
+    request,
+  }) => {
+    // The wizard has no description field — exactly the state that used to
+    // produce description: undefined and an empty card.
+    await createCompetitionViaUi(page, `SEO Card ${TAG}`);
+    const org = await activeOrg(page);
+    const slug = page.url().match(/\/c\/([^/?]+)$/)![1]!;
+    await expectFullSocialCard(request, `/shared/${org.slug}/${slug}`);
+  });
+});

--- a/apps/web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/page.tsx
@@ -41,6 +41,10 @@ export async function generateMetadata({
       url: "/",
       siteName: "Seazn Club",
       type: "website",
+      // Explicit: in this Next build a page-level openGraph object replaces
+      // the inherited one wholesale, dropping the root file-convention
+      // opengraph-image (home shipped with no og:image at all).
+      images: [{ url: "/opengraph-image", width: 1200, height: 630 }],
     },
   };
 }

--- a/apps/web/src/app/join/[token]/page.tsx
+++ b/apps/web/src/app/join/[token]/page.tsx
@@ -35,7 +35,9 @@ export async function generateMetadata({
     description: invite
       ? `You've been invited as ${invite.role}. Accept your invite and get involved.`
       : "Accept your invite and get involved.",
-    openGraph: { title },
+    // Explicit image: a page-level openGraph object replaces the inherited
+    // one wholesale in this Next build, dropping file-convention images.
+    openGraph: { title, images: [{ url: "/join/opengraph-image", width: 1200, height: 630 }] },
     // Personal links in chat apps: no reason for this to be indexable.
     robots: { index: false },
   };


### PR DESCRIPTION
Follow-on from #128, answering "does the card image work for all URLs?" — audit result:

| URL type | og:image |
|---|---|
| home | **was MISSING** — page-level `openGraph` object replaces the inherited one wholesale in this Next build, dropping the root file-convention image → now explicit |
| /join/[token] | same replace hazard → explicit image added |
| org page, marketing pages | root fallback card ✓ |
| shared comp / division / fixture | own generated cards ✓ |

Plus `e2e/seo-meta.spec.ts` (requested e2e coverage for today's SEO work): home, /pricing and a freshly created shared competition must each emit description / og:description / twitter:description / fetchable og:image. Local run: 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)