### PR TITLE
feat(entrants): badge upload UI in the entrants panel + crest chips on the public bracket

### DIFF
--- a/apps/web/content/help/entrants/team-badges-and-bulk-enrolment.md
+++ b/apps/web/content/help/entrants/team-badges-and-bulk-enrolment.md
@@ -4,6 +4,6 @@ description: Give every entrant a crest — upload one or paste a URL — and en
 order: 4
 ---
 
-**Badges.** Every entrant can carry a badge — a club crest, a national flag, a pair's emblem — shown on standings, the bracket, public pages and (with branded exports) your PDFs. Upload an image on the entrant, or paste an image URL when creating it. No club setup required, on every plan; entrants without a badge keep their initials monogram, and a team entrant falls back to its club's logo automatically.
+**Badges.** Every entrant can carry a badge — a club crest, a national flag, a pair's emblem — shown on standings, the bracket, public pages and (with branded exports) your PDFs. In the division's **Entrants** tab, expand an entrant's row to upload, replace or remove its badge; the API also accepts an image URL when creating the entrant. No club setup required, on every plan; entrants without a badge keep their initials monogram, and a team entrant falls back to its club's logo automatically.
 
 **Bulk enrolment.** Enrolling a full squad no longer means creating each player first. When you add an entrant, roster members can be **new people inline** — just a name — created together with the entrant in one step, mixed freely with existing people picked by ID. A 26-player national squad is one request, not 27.

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
@@ -153,6 +153,7 @@ export default async function DivisionHomePage({ params }: Props) {
                 kind={stage.kind as "knockout" | "double_elim" | "stepladder"}
                 fixtures={stageFixtures}
                 entrantNames={entrantNames}
+                entrantLogos={entrantLogos}
                 fixtureHref={(id) => `${basePath}/fixtures/${id}`}
               />
             </section>

--- a/apps/web/src/app/embed/divisions/[id]/[widget]/page.tsx
+++ b/apps/web/src/app/embed/divisions/[id]/[widget]/page.tsx
@@ -71,6 +71,7 @@ export default async function EmbedWidgetPage({ params }: Props) {
         kind={stage.kind as "knockout" | "double_elim" | "stepladder"}
         fixtures={fixtures.filter((f) => f.stage_id === stage.id)}
         entrantNames={entrantNames}
+        entrantLogos={entrantLogos}
         fixtureHref={(fixtureId) => `${publicPath}/fixtures/${fixtureId}`}
       />
     ) : (

--- a/apps/web/src/components/public-site/__tests__/bracket.test.tsx
+++ b/apps/web/src/components/public-site/__tests__/bracket.test.tsx
@@ -57,4 +57,26 @@ describe("public Bracket", () => {
     );
     expect(html).not.toContain('data-bracket="two-sided"');
   });
+
+  it("renders badge chips in nodes when entrantLogos provides them (F4)", () => {
+    const fixtures = [
+      F("f1", 0, 1, "a", "d", null),
+      F("f2", 0, 2, "b", "c", null),
+      F("f3", 1, 1, null, null, null),
+    ];
+    const logos = { a: "https://flags.example/a.png", b: null };
+    const html = renderToStaticMarkup(
+      createElement(Bracket, {
+        kind: "knockout", fixtures: fixtures as never, entrantNames: names,
+        entrantLogos: logos, fixtureHref: href,
+      }),
+    );
+    expect(html).toContain('src="https://flags.example/a.png"');
+    // b has no badge and d has no entry — exactly one img chip.
+    expect(html.match(/<img/g)?.length).toBe(1);
+    const without = renderToStaticMarkup(
+      createElement(Bracket, { kind: "knockout", fixtures: fixtures as never, entrantNames: names, fixtureHref: href }),
+    );
+    expect(without).not.toContain("<img");
+  });
 });

--- a/apps/web/src/components/public-site/bracket.tsx
+++ b/apps/web/src/components/public-site/bracket.tsx
@@ -17,6 +17,9 @@ interface Props {
   kind: "knockout" | "double_elim" | "stepladder";
   fixtures: PublicFixture[];
   entrantNames: Record<string, string>;
+  /** Resolved badge/crest URLs (entrant badge → team logo) — same map the
+   *  standings table takes; nodes render a crest chip before the name. */
+  entrantLogos?: Record<string, string | null>;
   fixtureHref: (fixtureId: string) => string;
 }
 
@@ -27,26 +30,37 @@ function sideLabel(entrantId: string | null, names: Record<string, string>): str
 function FixtureCard({
   fixture,
   entrantNames,
+  entrantLogos,
   href,
 }: {
   fixture: PublicFixture;
   entrantNames: Record<string, string>;
+  entrantLogos?: Record<string, string | null>;
   href: string;
 }) {
   const winner = fixture.outcome?.winner;
-  const side = (id: string | null) => (
-    <span
-      className={
-        id && id === winner
-          ? "truncate font-semibold text-ink"
-          : winner
-            ? "truncate text-ink-muted"
-            : "truncate text-ink"
-      }
-    >
-      {sideLabel(id, entrantNames)}
-    </span>
-  );
+  const side = (id: string | null) => {
+    const badge = id ? entrantLogos?.[id] : null;
+    return (
+      <span className="flex min-w-0 items-center gap-1.5">
+        {badge ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={badge} alt="" className="h-3.5 w-3.5 shrink-0 rounded-[3px] object-cover" />
+        ) : null}
+        <span
+          className={
+            id && id === winner
+              ? "truncate font-semibold text-ink"
+              : winner
+                ? "truncate text-ink-muted"
+                : "truncate text-ink"
+          }
+        >
+          {sideLabel(id, entrantNames)}
+        </span>
+      </span>
+    );
+  };
   const live = fixture.status === "in_play";
   return (
     <Link
@@ -95,11 +109,13 @@ function TwoSided({
   layout,
   fixtures,
   entrantNames,
+  entrantLogos,
   fixtureHref,
 }: {
   layout: BracketLayout;
   fixtures: PublicFixture[];
   entrantNames: Record<string, string>;
+  entrantLogos?: Record<string, string | null>;
   fixtureHref: (fixtureId: string) => string;
 }) {
   const byId = new Map(fixtures.map((f) => [f.id, f]));
@@ -170,7 +186,7 @@ function TwoSided({
               className="absolute"
               style={{ left: colX(node), top: nodeTop(node), width: NODE_W }}
             >
-              <FixtureCard fixture={f} entrantNames={entrantNames} href={fixtureHref(f.id)} />
+              <FixtureCard fixture={f} entrantNames={entrantNames} entrantLogos={entrantLogos} href={fixtureHref(f.id)} />
             </div>
           );
         })}
@@ -179,7 +195,7 @@ function TwoSided({
   );
 }
 
-export function Bracket({ kind, fixtures, entrantNames, fixtureHref }: Props) {
+export function Bracket({ kind, fixtures, entrantNames, entrantLogos, fixtureHref }: Props) {
   // PROMPT-62: the connected two-sided tree, when the shape allows it.
   if (kind === "knockout") {
     const result = twoSidedBracket(fixtures);
@@ -189,6 +205,7 @@ export function Bracket({ kind, fixtures, entrantNames, fixtureHref }: Props) {
           layout={result.layout}
           fixtures={fixtures}
           entrantNames={entrantNames}
+          entrantLogos={entrantLogos}
           fixtureHref={fixtureHref}
         />
       );
@@ -231,6 +248,7 @@ export function Bracket({ kind, fixtures, entrantNames, fixtureHref }: Props) {
                     key={f.id}
                     fixture={f}
                     entrantNames={entrantNames}
+                    entrantLogos={entrantLogos}
                     href={fixtureHref(f.id)}
                   />
                 ))}

--- a/apps/web/src/components/v2/__tests__/entrant-badge-control.test.tsx
+++ b/apps/web/src/components/v2/__tests__/entrant-badge-control.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { EntrantBadgeControl } from "@/components/v2/entrants-panel";
+
+// F4 — static markup like the sibling panel tests; interactions are covered
+// by the API route tests (setEntrantBadge) and the smoke suite.
+
+const base = { id: "e1", display_name: "Mexico" };
+
+describe("EntrantBadgeControl", () => {
+  it("with a badge: preview image + Replace + Remove", () => {
+    const html = renderToStaticMarkup(
+      <EntrantBadgeControl
+        entrant={{ ...base, badge_url: "https://flags.example/mx.png" }}
+        canEdit
+        busy={false}
+        onBadge={() => {}}
+      />,
+    );
+    expect(html).toContain('src="https://flags.example/mx.png"');
+    expect(html).toContain("Replace");
+    expect(html).toContain("Remove");
+    expect(html).toContain('aria-label="Badge for Mexico"');
+  });
+
+  it("without a badge: monogram + Upload, no Remove", () => {
+    const html = renderToStaticMarkup(
+      <EntrantBadgeControl entrant={{ ...base, badge_url: null }} canEdit busy={false} onBadge={() => {}} />,
+    );
+    expect(html).not.toContain("<img");
+    expect(html).toContain(">M<"); // monogram initial
+    expect(html).toContain("Upload");
+    expect(html).not.toContain("Remove");
+  });
+
+  it("read-only: preview only, no controls", () => {
+    const html = renderToStaticMarkup(
+      <EntrantBadgeControl
+        entrant={{ ...base, badge_url: "https://flags.example/mx.png" }}
+        canEdit={false}
+        busy={false}
+        onBadge={() => {}}
+      />,
+    );
+    expect(html).toContain('src="https://flags.example/mx.png"');
+    expect(html).not.toContain("Replace");
+    expect(html).not.toContain("type=\"file\"");
+  });
+});

--- a/apps/web/src/components/v2/entrants-panel.tsx
+++ b/apps/web/src/components/v2/entrants-panel.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiV1, ApiV1Error } from "@/lib/client-v1";
+import { resolveEntrantBadge } from "@/lib/entrant-badge";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { useConfirm } from "@/components/ui/confirm-provider";
 import { useMsg } from "@/components/i18n/dict-provider";
@@ -24,6 +25,7 @@ interface EntrantRow {
   display_name: string;
   seed: number | null;
   status: string;
+  badge_url: string | null;
 }
 interface TeamOption {
   id: string;
@@ -360,6 +362,7 @@ export function EntrantsPanel({
                     apiV1(`/api/v1/entrants/${e.id}/withdraw`, { method: "POST", json: {} }),
                   );
                 }}
+                onBadge={(file) => void run(() => badgeRequest(e.id, file))}
               />
             ))}
           </tbody>
@@ -820,6 +823,86 @@ function CsvImport({
 // Entrant row (+ expandable roster editor)
 // ---------------------------------------------------------------------------
 
+/** F4 — the badge route is multipart, so it can't ride apiV1 (which forces a
+ *  JSON content-type); same raw-fetch pattern as the /me photo upload. */
+async function badgeRequest(entrantId: string, file: File | null): Promise<void> {
+  let res: Response;
+  if (file) {
+    const form = new FormData();
+    form.append("file", file);
+    res = await fetch(`/api/v1/entrants/${entrantId}/badge`, { method: "POST", body: form });
+  } else {
+    res = await fetch(`/api/v1/entrants/${entrantId}/badge`, { method: "DELETE" });
+  }
+  if (!res.ok) {
+    const body = (await res.json().catch(() => null)) as
+      | { error?: { message?: string } }
+      | null;
+    throw new Error(body?.error?.message ?? `badge update failed (${res.status})`);
+  }
+}
+
+/** Exported for the markup test. Renders the crest preview plus, when
+ *  editable, upload/replace + remove controls. */
+export function EntrantBadgeControl({
+  entrant,
+  canEdit,
+  busy,
+  onBadge,
+}: {
+  entrant: Pick<EntrantRow, "id" | "display_name" | "badge_url">;
+  canEdit: boolean;
+  busy: boolean;
+  onBadge: (file: File | null) => void;
+}) {
+  const src = resolveEntrantBadge({ badge_url: entrant.badge_url });
+  return (
+    <div className="flex items-center gap-3">
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={src} alt="" className="h-8 w-8 shrink-0 rounded-md border border-slate-200 object-cover" />
+      ) : (
+        <span
+          aria-hidden
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-slate-100 text-xs font-semibold text-slate-500"
+        >
+          {entrant.display_name.slice(0, 1).toUpperCase()}
+        </span>
+      )}
+      <span className="text-xs text-slate-500">Badge</span>
+      {canEdit && (
+        <>
+          <label className="btn btn-ghost cursor-pointer px-2 py-1 text-xs">
+            {entrant.badge_url ? "Replace" : "Upload"}
+            <input
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/svg+xml"
+              className="hidden"
+              disabled={busy}
+              aria-label={`Badge for ${entrant.display_name}`}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                e.target.value = "";
+                if (file) onBadge(file);
+              }}
+            />
+          </label>
+          {entrant.badge_url && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onBadge(null)}
+              className="btn btn-ghost px-2 py-1 text-xs text-red-600"
+            >
+              Remove
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 function EntrantTableRow({
   entrant,
   canEdit,
@@ -830,6 +913,7 @@ function EntrantTableRow({
   otherTeamsFor,
   onPatch,
   onWithdraw,
+  onBadge,
 }: {
   entrant: EntrantRow;
   canEdit: boolean;
@@ -841,6 +925,7 @@ function EntrantTableRow({
   onPatch: (patch: Record<string, unknown>) => void;
   /** Withdraw with fixture surgery (spec 05 §5) — confirm handled upstream. */
   onWithdraw: () => void;
+  onBadge: (file: File | null) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [members, setMembers] = useState<Member[] | null>(null);
@@ -867,8 +952,15 @@ function EntrantTableRow({
           <button
             type="button"
             onClick={toggle}
-            className="text-left text-sm font-medium text-slate-800 hover:text-purple-700"
+            className="flex items-center gap-2 text-left text-sm font-medium text-slate-800 hover:text-purple-700"
           >
+            {(() => {
+              const src = resolveEntrantBadge({ badge_url: entrant.badge_url });
+              return src ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={src} alt="" className="h-5 w-5 shrink-0 rounded object-cover" />
+              ) : null;
+            })()}
             {entrant.display_name}
             <span className="ml-1.5 text-xs text-slate-400">{open ? "▾" : "▸"}</span>
           </button>
@@ -921,6 +1013,14 @@ function EntrantTableRow({
       {open && (
         <tr>
           <td colSpan={canEdit ? 5 : 4} className="bg-slate-50 px-4 py-3">
+            <div className="mb-3">
+              <EntrantBadgeControl
+                entrant={entrant}
+                canEdit={canEdit}
+                busy={busy}
+                onBadge={onBadge}
+              />
+            </div>
             {members === null ? (
               <p className="text-xs text-slate-400">Loading roster…</p>
             ) : (

--- a/apps/web/src/lib/entrant-badge.ts
+++ b/apps/web/src/lib/entrant-badge.ts
@@ -1,4 +1,4 @@
-import { publicStorageUrl } from "@/lib/supabase-storage";
+import { publicStorageUrl } from "@/lib/storage-url";
 
 // PROMPT-60 — ONE badge resolver reused by every surface (console standings,
 // public pages, embeds, bracket nodes, PDF builders): the entrant's own

--- a/apps/web/src/lib/storage-url.ts
+++ b/apps/web/src/lib/storage-url.ts
@@ -1,0 +1,11 @@
+// Client-safe public-URL builder for the assets bucket. Deliberately free of
+// "server-only": resolveEntrantBadge runs in client components (entrants
+// panel badge control), and NEXT_PUBLIC_* is inlined into the client bundle.
+// Everything that needs the admin client stays in supabase-storage.ts.
+export const ASSETS_BUCKET = "assets";
+
+export function publicStorageUrl(storagePath: string): string {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (!url) return "";
+  return `${url}/storage/v1/object/public/${ASSETS_BUCKET}/${storagePath}`;
+}

--- a/apps/web/src/lib/supabase-storage.ts
+++ b/apps/web/src/lib/supabase-storage.ts
@@ -1,7 +1,10 @@
 import "server-only";
 import { supabaseAdmin } from "@/lib/supabase-admin";
+import { ASSETS_BUCKET, publicStorageUrl } from "@/lib/storage-url";
 
-const ASSETS_BUCKET = "assets";
+// Re-export for the many server-side callers; the implementation lives in the
+// client-safe storage-url.ts (the badge resolver runs in client components).
+export { publicStorageUrl };
 
 /**
  * Generate a signed upload URL for direct browser → Supabase Storage upload.
@@ -23,12 +26,6 @@ export async function getSignedUploadUrl(
  * Public CDN URL for a stored asset.
  * Use this to render images — served from Supabase CDN, not Vercel.
  */
-export function publicStorageUrl(storagePath: string): string {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  if (!url) return "";
-  return `${url}/storage/v1/object/public/${ASSETS_BUCKET}/${storagePath}`;
-}
-
 /**
  * Delete an object from storage. Fire-and-forget — used when replacing or
  * removing an avatar/logo.


### PR DESCRIPTION
F4 from the v13 follow-up list (the last deferred one), plus the public-bracket half of "can we have entrant badges in public pages":

- **Entrants tab**: expand a row → badge preview + Upload/Replace + Remove (multipart POST / DELETE on the existing `/api/v1/entrants/{id}/badge` route); crest thumbnail on the collapsed row.
- **Public bracket nodes** now render crest chips via the same `entrantLogos` map the standings table takes (shared division page + embed widget). Public standings already supported badges — no change needed there.
- Help article updated.

Gates: tsc 0 · web suite 1175/0 (incl. new markup tests: badge control 3, bracket chips 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)