### PR TITLE
fix(ui/ci): dedupe Danger-zone heading + staging deploy cancel-in-progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,9 @@ jobs:
       && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     concurrency:
       group: deploy-staging
-      cancel-in-progress: false
+      # Staging is latest-wins: stacked merges to main supersede the deploy in
+      # flight instead of queuing three identical ones (2026-07-18 merge train).
+      cancel-in-progress: true
     env:
       # Job-level mapping so the sync step's `if:` can see whether the secret
       # exists (the secrets context isn't readable from step conditionals).

--- a/apps/web/src/components/v2/division-danger-zone.tsx
+++ b/apps/web/src/components/v2/division-danger-zone.tsx
@@ -62,9 +62,10 @@ export function DivisionDangerZone({ divisionId, divisionName, orgSlug, compSlug
   }
 
   return (
-    <section className="card mt-8 border-red-100 p-5">
-      <h2 className="text-sm font-semibold text-red-700">{msg("danger.zone")}</h2>
-      <p className="mt-1 text-xs text-slate-500">{msg("danger.desc")}</p>
+    // No own card/heading: the settings "Danger zone" disclosure Group is the
+    // card AND the label — the inner h2 duplicated it ("Danger zone" twice).
+    <section>
+      <p className="text-xs text-slate-500">{msg("danger.desc")}</p>
       {error && (
         <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">{error}</p>
       )}


### PR DESCRIPTION
Two smalls from tonight's review:

- **Danger zone duplication**: the settings disclosure summary AND the inner component both said "Danger zone" (your paste showed it). The Group is the card + label now; inner h2/card chrome removed.
- **Deploy concurrency**: `deploy-staging` flips to `cancel-in-progress: true` — today's triple merge train ran three sequential identical deploys; staging is latest-wins.

Gates: tsc 0 · lib+v2 suites 474/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)