### PR TITLE
feat(brackets): double-elim two-lane geometry + round-robin results grid

### DIFF
--- a/apps/web/content/help/divisions/bracket-view.md
+++ b/apps/web/content/help/divisions/bracket-view.md
@@ -11,4 +11,6 @@ Knockout stages render as the classic **two-sided bracket**: quarter-finals on t
 - **Big screen** — the [slideshow](/help/sharing/slideshow) and [presentation mode](/help/sharing/presentation-mode) get a bracket slide.
 - **Poster** — Documents → *Bracket poster* exports a landscape PDF of the tree, scaled to one sheet, with your branding on Pro.
 
-Double-elimination and stepladder stages keep their own views — the two-sided shape is single-elimination's.
+**Double elimination** gets its own geometry on the public page: the winners bracket on top, the losers bracket beneath it, and the grand final (plus the bracket-reset match, when configured) joining the two lanes on the right. Stepladder stages keep their rung-by-rung view — that ladder *is* their shape.
+
+**Round-robin stages** (leagues and groups) have no tree — their visual is the **results grid**: a team-by-team crosstable under each standings table on the public page, home side down the rows, away side across the columns, every played score linked to its match and a pulsing dot for matches in play.

--- a/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/[competitionSlug]/[divisionSlug]/page.tsx
@@ -18,6 +18,7 @@ import { Tabs } from "@/components/public-site/tabs";
 import { Schedule } from "@/components/public-site/schedule";
 import { StandingsTable } from "@/components/public-site/standings-table";
 import { Bracket } from "@/components/public-site/bracket";
+import { ResultsMatrix } from "@/components/public-site/results-matrix";
 import type { MetricSpecLike } from "@/lib/public-site";
 
 export const revalidate = 30;
@@ -165,22 +166,47 @@ export default async function DivisionHomePage({ params }: Props) {
         if (snapshots.length === 0) return null;
         return (
           <section key={stage.id}>
-            {snapshots.map((snap) => (
-              <div key={snap.pool_id ?? "overall"} className="mb-6">
-                <StandingsTable
-                  rows={snap.rows as StandingsRow[]}
-                  metricSpecs={metricSpecs}
-                  cascade={cascade}
-                  entrantNames={entrantNames}
-                  entrantLogos={entrantLogos}
-                  caption={
-                    snap.pool_id
-                      ? `${stage.name} — ${poolName.get(snap.pool_id) ?? "Pool"}`
-                      : stage.name
-                  }
-                />
-              </div>
-            ))}
+            {snapshots.map((snap) => {
+              // G2 — crosstable under each round-robin table, in rank order.
+              const ranked = [...(snap.rows as StandingsRow[])].sort(
+                (a, b) => (a.rank ?? 99) - (b.rank ?? 99),
+              );
+              const poolFixtures = fixtures.filter(
+                (f) => f.stage_id === stage.id && (f.pool_id ?? null) === (snap.pool_id ?? null),
+              );
+              return (
+                <div key={snap.pool_id ?? "overall"} className="mb-6 space-y-3">
+                  <StandingsTable
+                    rows={snap.rows as StandingsRow[]}
+                    metricSpecs={metricSpecs}
+                    cascade={cascade}
+                    entrantNames={entrantNames}
+                    entrantLogos={entrantLogos}
+                    caption={
+                      snap.pool_id
+                        ? `${stage.name} — ${poolName.get(snap.pool_id) ?? "Pool"}`
+                        : stage.name
+                    }
+                  />
+                  {poolFixtures.length > 0 && (
+                    <details>
+                      <summary className="cursor-pointer text-xs font-medium text-ink-muted hover:text-ink">
+                        Results grid
+                      </summary>
+                      <div className="mt-2">
+                        <ResultsMatrix
+                          entrantIds={ranked.map((r) => r.entrantId)}
+                          entrantNames={entrantNames}
+                          entrantLogos={entrantLogos}
+                          fixtures={poolFixtures}
+                          fixtureHref={(id) => `${basePath}/fixtures/${id}`}
+                        />
+                      </div>
+                    </details>
+                  )}
+                </div>
+              );
+            })}
           </section>
         );
       })}

--- a/apps/web/src/components/public-site/__tests__/bracket.test.tsx
+++ b/apps/web/src/components/public-site/__tests__/bracket.test.tsx
@@ -58,6 +58,38 @@ describe("public Bracket", () => {
     expect(html).not.toContain('data-bracket="two-sided"');
   });
 
+  it("renders the two-lane double-elim geometry (G1)", () => {
+    // 4-entrant DE with the persisted round numbering (k=2):
+    // WB rounds 1–2, LB rounds 5–6, grand final round 9.
+    const fixtures = [
+      F("w1", 1, 1, "a", "b", null),
+      F("w2", 1, 2, "c", "d", null),
+      F("wf", 2, 1, null, null, null),
+      F("l1", 5, 1, null, null, null),
+      F("lf", 6, 1, null, null, null),
+      F("gf", 9, 1, null, null, null),
+    ];
+    const html = renderToStaticMarkup(
+      createElement(Bracket, { kind: "double_elim", fixtures: fixtures as never, entrantNames: names, fixtureHref: href }),
+    );
+    expect(html).toContain('data-bracket="double-elim"');
+    expect(html).toContain("Winners bracket");
+    expect(html).toContain("Losers bracket");
+    expect(html).toContain("Grand final");
+    expect(html.match(/data-lane="WB"/g)?.length).toBe(3);
+    expect(html.match(/data-lane="LB"/g)?.length).toBe(2);
+    expect(html.match(/data-lane="GF"/g)?.length).toBe(1);
+    expect(html).toContain("<svg");
+  });
+
+  it("keeps the column fallback for irregular double-elim shapes", () => {
+    const fixtures = [F("f1", 1, 1, "a", "b", null), F("f2", 2, 1, "c", "d", null), F("f3", 2, 2, "a", "c", null)];
+    const html = renderToStaticMarkup(
+      createElement(Bracket, { kind: "double_elim", fixtures: fixtures as never, entrantNames: names, fixtureHref: href }),
+    );
+    expect(html).not.toContain('data-bracket="double-elim"');
+  });
+
   it("renders badge chips in nodes when entrantLogos provides them (F4)", () => {
     const fixtures = [
       F("f1", 0, 1, "a", "d", null),

--- a/apps/web/src/components/public-site/__tests__/results-matrix.test.tsx
+++ b/apps/web/src/components/public-site/__tests__/results-matrix.test.tsx
@@ -1,0 +1,51 @@
+// ResultsMatrix (G2) — crosstable markup: rank-ordered axes, home-perspective
+// scoreline cells linked to the fixture, shaded diagonal, dot placeholders.
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { ResultsMatrix } from "../results-matrix";
+
+const FX = (id: string, home: string, away: string, status: string, headline?: string) => ({
+  id, division_id: "d", stage_id: "s", pool_id: null, round_no: 1, seq_in_round: 1,
+  home_entrant_id: home, away_entrant_id: away, scheduled_at: null, venue: null,
+  court_label: null, status, outcome: null,
+  summary: headline ? { headline } : null,
+});
+
+const names = { a: "Ants United", b: "Bees", c: "Cats" };
+const href = (id: string) => `/f/${id}`;
+
+describe("ResultsMatrix", () => {
+  it("puts the home-vs-away scoreline in the right cell, linked", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResultsMatrix, {
+        entrantIds: ["a", "b", "c"],
+        entrantNames: names,
+        fixtures: [FX("f1", "a", "b", "decided", "3–1"), FX("f2", "c", "a", "in_play")] as never,
+        fixtureHref: href,
+      }),
+    );
+    expect(html).toContain("data-results-matrix");
+    expect(html).toContain(">3–1</a>");
+    expect(html).toContain('href="/f/f1"');
+    // Live pairing renders the pulse dot, not a score.
+    expect(html).toContain("animate-live-pulse");
+    // Column headers fall back to initials with the full name as title.
+    expect(html).toContain('title="Ants United"');
+    expect(html).toContain(">AU<");
+    // 3 diagonal cells.
+    expect(html.match(/—/g)?.length).toBe(3);
+  });
+
+  it("returns nothing for fewer than two entrants", () => {
+    const html = renderToStaticMarkup(
+      createElement(ResultsMatrix, {
+        entrantIds: ["a"],
+        entrantNames: names,
+        fixtures: [] as never,
+        fixtureHref: href,
+      }),
+    );
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/components/public-site/bracket.tsx
+++ b/apps/web/src/components/public-site/bracket.tsx
@@ -7,10 +7,13 @@
 import Link from "next/link";
 import type { PublicFixture } from "@/server/public-site/data";
 import {
+  doubleElimBracket,
+  lbRowUnit,
   rowCenter,
   twoSidedBracket,
   type BracketLayout,
   type BracketNode,
+  type DoubleElimLayout,
 } from "@seazn/engine/scheduling";
 
 interface Props {
@@ -195,6 +198,99 @@ function TwoSided({
   );
 }
 
+// G1 — double-elimination two-lane geometry: winners lane on top, losers lane
+// below, grand final (+ optional reset) joining the two lane finals on the
+// right. In-lane connectors come from the layout; the two GF joins are drawn
+// here from the known lane-final positions.
+function DoubleElim({
+  layout,
+  fixtures,
+  entrantNames,
+  entrantLogos,
+  fixtureHref,
+}: {
+  layout: DoubleElimLayout;
+  fixtures: PublicFixture[];
+  entrantNames: Record<string, string>;
+  entrantLogos?: Record<string, string | null>;
+  fixtureHref: (fixtureId: string) => string;
+}) {
+  const byId = new Map(fixtures.map((f) => [f.id, f]));
+  const LANE_GAP = 48;
+  const LABEL_H = 24;
+  const wbH = Math.max(layout.wbRows, 1) * SLOT_H;
+  const lbH = Math.max(layout.lbRows, 0) * SLOT_H;
+  const wbTop = LABEL_H;
+  const lbTop = wbTop + wbH + LANE_GAP + (lbH > 0 ? LABEL_H : 0);
+  const gfX = Math.max(layout.k, layout.lbCols) * COL_W;
+  const totalW = gfX + COL_W * (layout.resetId !== undefined ? 2 : 1);
+  const totalH = lbTop + lbH;
+  const wbY = (col: number, row: number) => wbTop + rowCenter(col, row) * SLOT_H;
+  const lbY = (col: number, row: number) => lbTop + rowCenter(lbRowUnit(col), row) * SLOT_H;
+  const gfY = (wbTop + (lbH > 0 ? lbTop + lbH : wbTop + wbH)) / 2;
+  const wbFinalY = wbY(layout.k - 1, 0);
+  const lbFinalY = layout.lbCols > 0 ? lbY(layout.lbCols - 1, 0) : wbFinalY;
+  const laneLabel = "font-display text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-muted";
+
+  return (
+    <div className="overflow-x-auto" data-bracket="double-elim">
+      <div className="relative" style={{ width: totalW, height: totalH }}>
+        <span className={`absolute ${laneLabel}`} style={{ left: 0, top: 0 }}>
+          Winners bracket
+        </span>
+        {lbH > 0 && (
+          <span className={`absolute ${laneLabel}`} style={{ left: 0, top: wbTop + wbH + LANE_GAP }}>
+            Losers bracket
+          </span>
+        )}
+        <svg aria-hidden className="absolute inset-0" width={totalW} height={totalH} viewBox={`0 0 ${totalW} ${totalH}`}>
+          {layout.connectors.map((c, i) => {
+            const y = c.lane === "WB" ? wbY : lbY;
+            const fx = (c.col - 1) * COL_W + NODE_W;
+            const tx = c.col * COL_W;
+            const fy = y(c.col - 1, c.fromRow);
+            const ty = y(c.col, c.toRow);
+            const midX = (fx + tx) / 2;
+            return (
+              <path key={i} d={`M ${fx} ${fy} H ${midX} V ${ty} H ${tx}`} fill="none" className="stroke-zinc-300" strokeWidth="1.5" />
+            );
+          })}
+          {/* Grand-final joins from both lane finals. */}
+          <path
+            d={`M ${(layout.k - 1) * COL_W + NODE_W} ${wbFinalY} H ${gfX - 12} V ${gfY} H ${gfX}`}
+            fill="none" className="stroke-zinc-300" strokeWidth="1.5"
+          />
+          {layout.lbCols > 0 && (
+            <path
+              d={`M ${(layout.lbCols - 1) * COL_W + NODE_W} ${lbFinalY} H ${gfX - 12} V ${gfY} H ${gfX}`}
+              fill="none" className="stroke-zinc-300" strokeWidth="1.5"
+            />
+          )}
+        </svg>
+        {layout.nodes.map((node) => {
+          const f = byId.get(node.fixtureId);
+          if (!f) return null;
+          const top =
+            node.lane === "WB"
+              ? wbY(node.col, node.row) - NODE_H / 2
+              : node.lane === "LB"
+                ? lbY(node.col, node.row) - NODE_H / 2
+                : gfY - NODE_H / 2;
+          const left = node.lane === "GF" ? gfX + node.col * COL_W : node.col * COL_W;
+          return (
+            <div key={node.fixtureId} data-lane={node.lane} className="absolute" style={{ left, top, width: NODE_W }}>
+              {node.lane === "GF" && (
+                <p className={`mb-1 ${laneLabel}`}>{node.col === 0 ? "Grand final" : "Reset"}</p>
+              )}
+              <FixtureCard fixture={f} entrantNames={entrantNames} entrantLogos={entrantLogos} href={fixtureHref(f.id)} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function Bracket({ kind, fixtures, entrantNames, entrantLogos, fixtureHref }: Props) {
   // PROMPT-62: the connected two-sided tree, when the shape allows it.
   if (kind === "knockout") {
@@ -202,6 +298,21 @@ export function Bracket({ kind, fixtures, entrantNames, entrantLogos, fixtureHre
     if (result.ok) {
       return (
         <TwoSided
+          layout={result.layout}
+          fixtures={fixtures}
+          entrantNames={entrantNames}
+          entrantLogos={entrantLogos}
+          fixtureHref={fixtureHref}
+        />
+      );
+    }
+  }
+  // G1: the two-lane double-elim geometry, when the shape allows it.
+  if (kind === "double_elim") {
+    const result = doubleElimBracket(fixtures);
+    if (result.ok) {
+      return (
+        <DoubleElim
           layout={result.layout}
           fixtures={fixtures}
           entrantNames={entrantNames}

--- a/apps/web/src/components/public-site/results-matrix.tsx
+++ b/apps/web/src/components/public-site/results-matrix.tsx
@@ -1,0 +1,142 @@
+// Server component: round-robin results matrix (G2) — the classic crosstable
+// for league/group stages. Rows = home side, columns = away side; a cell
+// holds the scoreline of home-vs-away (linked), a live dot while in play, or
+// a dot placeholder for an unplayed pairing. Zero per-sport code: scorelines
+// come from ScoreSummary.headline, order comes from the standings.
+import Link from "next/link";
+import type { PublicFixture } from "@/server/public-site/data";
+import { EntityLogo } from "@/components/ui/entity-logo";
+
+interface Props {
+  /** Row/column order — pass the standings rank order. */
+  entrantIds: string[];
+  entrantNames: Record<string, string>;
+  entrantLogos?: Record<string, string | null>;
+  /** Fixtures of ONE pool/stage scope; pairings outside entrantIds are ignored. */
+  fixtures: PublicFixture[];
+  fixtureHref: (fixtureId: string) => string;
+  caption?: string;
+}
+
+const DONE = new Set(["decided", "finalized", "forfeited", "abandoned"]);
+
+export function ResultsMatrix({
+  entrantIds,
+  entrantNames,
+  entrantLogos,
+  fixtures,
+  fixtureHref,
+  caption,
+}: Props) {
+  if (entrantIds.length < 2) return null;
+  // home → away → fixtures (double round-robins stack two lines in a cell).
+  const byPair = new Map<string, PublicFixture[]>();
+  for (const f of fixtures) {
+    if (!f.home_entrant_id || !f.away_entrant_id) continue;
+    const key = `${f.home_entrant_id}:${f.away_entrant_id}`;
+    const list = byPair.get(key) ?? [];
+    list.push(f);
+    byPair.set(key, list);
+  }
+  const initials = (id: string) =>
+    (entrantNames[id] ?? "?")
+      .split(/\s+/)
+      .map((w) => w[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+
+  return (
+    <div
+      className="overflow-x-auto rounded-xl border border-zinc-200/80 bg-surface shadow-sm"
+      data-results-matrix
+    >
+      <table className="w-full text-sm">
+        {caption ? (
+          <caption className="px-4 py-2.5 text-left font-display text-sm font-semibold text-ink">
+            {caption}
+          </caption>
+        ) : null}
+        <thead>
+          <tr className="border-b border-zinc-200/80 text-xs text-ink-muted">
+            <th scope="col" className="px-3 py-2 text-left font-medium">
+              Home \ Away
+            </th>
+            {entrantIds.map((id) => (
+              <th
+                key={id}
+                scope="col"
+                title={entrantNames[id] ?? "?"}
+                className="px-2 py-2 text-center font-medium"
+              >
+                {entrantLogos ? (
+                  <span className="inline-flex items-center justify-center">
+                    <EntityLogo src={entrantLogos[id] ?? null} name={entrantNames[id] ?? "?"} size={20} />
+                  </span>
+                ) : (
+                  initials(id)
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {entrantIds.map((rowId) => (
+            <tr key={rowId} className="border-b border-zinc-100 last:border-0">
+              <th
+                scope="row"
+                className="max-w-44 truncate px-3 py-2 text-left font-medium text-ink"
+              >
+                <span className="flex items-center gap-2">
+                  {entrantLogos ? (
+                    <EntityLogo src={entrantLogos[rowId] ?? null} name={entrantNames[rowId] ?? "?"} size={20} />
+                  ) : null}
+                  <span className="truncate">{entrantNames[rowId] ?? "?"}</span>
+                </span>
+              </th>
+              {entrantIds.map((colId) => {
+                if (rowId === colId) {
+                  return (
+                    <td key={colId} aria-hidden className="bg-zinc-100/70 px-2 py-2 text-center">
+                      <span className="text-zinc-300">—</span>
+                    </td>
+                  );
+                }
+                const cell = byPair.get(`${rowId}:${colId}`) ?? [];
+                return (
+                  <td key={colId} className="px-2 py-2 text-center tabular-nums">
+                    {cell.length === 0 ? (
+                      <span className="text-zinc-300">·</span>
+                    ) : (
+                      <span className="flex flex-col items-center gap-0.5">
+                        {cell.map((f) =>
+                          f.status === "in_play" ? (
+                            <Link key={f.id} href={fixtureHref(f.id)} aria-label="Live">
+                              <span className="animate-live-pulse inline-block h-2 w-2 rounded-full bg-emerald-500" />
+                            </Link>
+                          ) : DONE.has(f.status) && f.summary?.headline ? (
+                            <Link
+                              key={f.id}
+                              href={fixtureHref(f.id)}
+                              className="font-display text-[13px] font-semibold text-accent-strong hover:underline"
+                            >
+                              {f.summary.headline}
+                            </Link>
+                          ) : (
+                            <span key={f.id} className="text-zinc-300">
+                              ·
+                            </span>
+                          ),
+                        )}
+                      </span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -11,8 +11,11 @@ export default defineConfig({
     // (CONNECTION_ENDED). Isolate per file so each owns — and ends — its own
     // connection; the teardown races vanish.
     isolate: true,
-    // Playwright specs (e2e/) run under `playwright test`, not vitest.
-    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**"],
+    // Playwright specs (e2e/) run under `playwright test`, not vitest. The
+    // .next exclude matters: `next build` copies the whole tree (e2e specs
+    // included) into .next/standalone, and vitest globbing those copies after
+    // a local build segfaulted the run.
+    exclude: ["**/node_modules/**", "**/dist/**", "e2e/**", "**/.next/**"],
     // @seazn/engine ships TS source (workspace symlink) — inline it so vitest
     // transforms it instead of treating it as an opaque external dep.
     server: { deps: { inline: [/@seazn\/engine/] } },

--- a/packages/engine/src/scheduling/bracket-layout.test.ts
+++ b/packages/engine/src/scheduling/bracket-layout.test.ts
@@ -111,3 +111,77 @@ describe("twoSidedBracket", () => {
     expect(layoutOf(refsFor(16))).toEqual(layoutOf(refsFor(16)));
   });
 });
+
+// doubleElimBracket (G1) — two-lane geometry recovered from the persisted
+// round_no blocks (WB 1..k, LB 2k+1..4k−2, GF 5k−1, reset 5k).
+import { generateDoubleElim } from "./bracket.ts";
+import { doubleElimBracket, lbRowUnit } from "./bracket-layout.ts";
+
+/** Replicates usecases/stages.ts bracketToGen round numbering. */
+function deRefs(n: number, bracketReset = false): BracketFixtureRef[] {
+  const entrants = Array.from({ length: n }, (_, i) => `e${i + 1}`);
+  const gen = generateDoubleElim({ entrants, bracketReset });
+  const k = gen.rounds;
+  const counters = new Map<string, number>();
+  return gen.fixtures.map((f) => {
+    const lane = f.bracket ?? "WB";
+    const offset = lane === "LB" ? k : lane === "GF" ? 2 * k : 0;
+    const roundNo = offset + f.round + 1;
+    const seq = (counters.get(`${lane}:${roundNo}`) ?? 0) + 1;
+    counters.set(`${lane}:${roundNo}`, seq);
+    return { id: f.id, round_no: roundNo, seq_in_round: seq };
+  });
+}
+
+describe("doubleElimBracket", () => {
+  it("lays out an 8-entrant double elim: WB 3 cols, LB 4 cols, one GF", () => {
+    const res = doubleElimBracket(deRefs(8));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const { layout } = res;
+    expect(layout.k).toBe(3);
+    expect(layout.wbRows).toBe(4);
+    expect(layout.lbRows).toBe(2);
+    expect(layout.lbCols).toBe(4);
+    expect(layout.resetId).toBeUndefined();
+    const lanes = (lane: string) => layout.nodes.filter((nd) => nd.lane === lane);
+    expect(lanes("WB")).toHaveLength(7);
+    expect(lanes("LB")).toHaveLength(6);
+    expect(lanes("GF")).toHaveLength(1);
+    // LB column counts follow the halving pairs 2,2,1,1.
+    const lbCount = (col: number) => lanes("LB").filter((nd) => nd.col === col).length;
+    expect([lbCount(0), lbCount(1), lbCount(2), lbCount(3)]).toEqual([2, 2, 1, 1]);
+    // Major columns get straight in-lane feeds, minor columns get pairs.
+    const major = layout.connectors.filter((c) => c.lane === "LB" && c.col === 1);
+    expect(major).toEqual([
+      { lane: "LB", col: 1, fromRow: 0, toRow: 0 },
+      { lane: "LB", col: 1, fromRow: 1, toRow: 1 },
+    ]);
+  });
+
+  it("keeps the bracket-reset fixture as GF col 1", () => {
+    const res = doubleElimBracket(deRefs(4, true));
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.layout.resetId).toBeDefined();
+    expect(res.layout.nodes.filter((nd) => nd.lane === "GF")).toHaveLength(2);
+  });
+
+  it("rejects single-elim shapes and tampered counts", () => {
+    const se = generateSingleElim({ entrants: ["a", "b", "c", "d"] });
+    const counters = new Map<string, number>();
+    const refs = se.fixtures.map((f) => {
+      const seq = (counters.get(`${f.round}`) ?? 0) + 1;
+      counters.set(`${f.round}`, seq);
+      return { id: f.id, round_no: f.round + 1, seq_in_round: seq };
+    });
+    expect(doubleElimBracket(refs).ok).toBe(false);
+    const de = deRefs(8);
+    expect(doubleElimBracket(de.slice(1)).ok).toBe(false);
+    expect(doubleElimBracket([]).ok).toBe(false);
+  });
+
+  it("lbRowUnit doubles spacing every two columns", () => {
+    expect([0, 1, 2, 3].map(lbRowUnit)).toEqual([0, 0, 1, 1]);
+  });
+});

--- a/packages/engine/src/scheduling/bracket-layout.ts
+++ b/packages/engine/src/scheduling/bracket-layout.ts
@@ -45,6 +45,143 @@ export function rowCenter(col: number, row: number): number {
   return (row + 0.5) * 2 ** col;
 }
 
+// ---------------------------------------------------------------------------
+// Double-elimination two-lane geometry (G1). Structural-only like
+// twoSidedBracket: lanes are recovered from the round_no blocks the
+// persistence mapping emits (bracketToGen): with WB depth k and N = 2^k
+// entrants — WB rounds 1..k, LB rounds 2k+1..4k−2 (2k−2 rounds, counts
+// halving in equal pairs), grand final 5k−1, optional reset 5k. Anything
+// else returns { ok: false } and keeps the existing column view.
+
+export interface DoubleElimNode {
+  fixtureId: string;
+  lane: "WB" | "LB" | "GF";
+  col: number; // 0-based within the lane; GF col 0 = grand final, 1 = reset
+  row: number;
+}
+
+export interface DoubleElimConnector {
+  lane: "WB" | "LB";
+  /** Column of the TARGET node; feeders sit in col − 1 of the same lane. */
+  col: number;
+  fromRow: number;
+  toRow: number;
+}
+
+export interface DoubleElimLayout {
+  nodes: DoubleElimNode[];
+  /** In-lane feeds only — WB drops into LB and the two GF joins are drawn by
+   *  the renderer from the known lane-final positions. */
+  connectors: DoubleElimConnector[];
+  k: number; // WB depth (rounds in the winners lane)
+  wbRows: number; // 2^(k−1) row slots in WB col 0
+  lbRows: number; // 2^(k−2) row slots in LB col 0 (0 when k === 1)
+  lbCols: number; // 2k − 2
+  resetId?: string;
+}
+
+export type DoubleElimLayoutResult =
+  | { ok: true; layout: DoubleElimLayout }
+  | { ok: false; reason: string };
+
+/** LB columns advance in equal-count pairs — vertical spacing doubles every
+ *  TWO columns, so renderers use rowCenter(lbRowUnit(col), row). */
+export function lbRowUnit(col: number): number {
+  return Math.floor(col / 2);
+}
+
+export function doubleElimBracket(
+  fixtures: readonly BracketFixtureRef[],
+): DoubleElimLayoutResult {
+  if (fixtures.length === 0) return { ok: false, reason: "no fixtures" };
+
+  const minRound = Math.min(...fixtures.map((f) => f.round_no));
+  const byRound = new Map<number, BracketFixtureRef[]>();
+  for (const f of fixtures) {
+    const r = f.round_no - minRound;
+    const list = byRound.get(r) ?? [];
+    list.push(f);
+    byRound.set(r, list);
+  }
+  for (const list of byRound.values()) list.sort((a, b) => a.seq_in_round - b.seq_in_round);
+  const count = (r: number) => (byRound.get(r) ?? []).length;
+
+  const c0 = count(0);
+  if (c0 < 1 || (c0 & (c0 - 1)) !== 0) {
+    return { ok: false, reason: `round 0 has ${c0} matches — not a power-of-two field` };
+  }
+  const k = Math.log2(c0) + 1;
+  const lbCols = 2 * k - 2;
+
+  // Expected occupancy, normalised: WB 0..k−1, LB 2k..2k+lbCols−1,
+  // GF 5k−2 (+ reset 5k−1). Everything else must be empty.
+  const expected = new Map<number, number>();
+  for (let r = 0; r < k; r++) expected.set(r, 2 ** (k - 1 - r));
+  for (let L = 0; L < lbCols; L++) expected.set(2 * k + L, 2 ** (k - 2 - Math.floor(L / 2)));
+  expected.set(5 * k - 2, 1);
+  const resetRound = 5 * k - 1;
+
+  for (const [r, want] of expected) {
+    if (count(r) !== want) {
+      return { ok: false, reason: `round ${r + minRound} has ${count(r)} matches, expected ${want}` };
+    }
+  }
+  for (const r of byRound.keys()) {
+    if (!expected.has(r) && r !== resetRound) {
+      return { ok: false, reason: `unexpected round ${r + minRound}` };
+    }
+  }
+  const resetList = byRound.get(resetRound) ?? [];
+  if (resetList.length > 1) {
+    return { ok: false, reason: `reset round has ${resetList.length} matches` };
+  }
+
+  const nodes: DoubleElimNode[] = [];
+  const connectors: DoubleElimConnector[] = [];
+
+  for (let r = 0; r < k; r++) {
+    byRound.get(r)!.forEach((f, i) => {
+      nodes.push({ fixtureId: f.id, lane: "WB", col: r, row: i });
+      if (r > 0) {
+        connectors.push({ lane: "WB", col: r, fromRow: 2 * i, toRow: i });
+        connectors.push({ lane: "WB", col: r, fromRow: 2 * i + 1, toRow: i });
+      }
+    });
+  }
+  for (let L = 0; L < lbCols; L++) {
+    byRound.get(2 * k + L)!.forEach((f, i) => {
+      nodes.push({ fixtureId: f.id, lane: "LB", col: L, row: i });
+      if (L === 0) return; // fed by WB drops only
+      if (L % 2 === 1) {
+        // Major: LB winner comes straight across (the other side is a WB drop).
+        connectors.push({ lane: "LB", col: L, fromRow: i, toRow: i });
+      } else {
+        connectors.push({ lane: "LB", col: L, fromRow: 2 * i, toRow: i });
+        connectors.push({ lane: "LB", col: L, fromRow: 2 * i + 1, toRow: i });
+      }
+    });
+  }
+  nodes.push({ fixtureId: byRound.get(5 * k - 2)![0]!.id, lane: "GF", col: 0, row: 0 });
+  let resetId: string | undefined;
+  if (resetList.length === 1) {
+    resetId = resetList[0]!.id;
+    nodes.push({ fixtureId: resetId, lane: "GF", col: 1, row: 0 });
+  }
+
+  return {
+    ok: true,
+    layout: {
+      nodes,
+      connectors,
+      k,
+      wbRows: 2 ** (k - 1),
+      lbRows: k >= 2 ? 2 ** (k - 2) : 0,
+      lbCols,
+      ...(resetId !== undefined ? { resetId } : {}),
+    },
+  };
+}
+
 export function twoSidedBracket(fixtures: readonly BracketFixtureRef[]): BracketLayoutResult {
   if (fixtures.length === 0) return { ok: false, reason: "no fixtures" };
 


### PR DESCRIPTION
The two real gaps from the format-geometry audit:

- **G1 double_elim**: proper two-lane bracket on the public page — winners bracket on top, losers bracket below, grand final (+ bracket-reset) joining the lane finals. Pure engine layout (`doubleElimBracket`) recovered structurally from the persisted round-number blocks; irregular shapes keep the column fallback. Console panel + PDF poster still use their existing views — follow-up if wanted.
- **G2 results grid**: classic crosstable under every league/group standings table (behind a 'Results grid' disclosure) — home rows × away columns in rank order, scores linked, live matches pulse, badges on both axes.
- Test-infra: vitest excludes `.next/` (build output copies of e2e specs segfaulted local full runs).

Gates: engine 884/0 (4 new layout tests) · web 1175/0 (3 new renderer tests) · tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)