### PR TITLE
fix(directory): officials cards — single action row, full-width content

### DIFF
--- a/apps/web/src/components/v2/__tests__/officials-directory-panel.test.tsx
+++ b/apps/web/src/components/v2/__tests__/officials-directory-panel.test.tsx
@@ -1,0 +1,60 @@
+// G5 — card structure: status chip alone in the header row, ALL actions in
+// one wrapped row under the content (was a stacked right rail that squeezed
+// the name column, worst on mobile).
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import en from "@/dictionaries/en/ui.json";
+import {
+  OfficialsDirectoryPanel,
+  type DirectoryOfficial,
+} from "@/components/v2/officials-directory-panel";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+vi.mock("@/components/ui/confirm-provider", () => ({
+  useConfirm: () => vi.fn(async () => false),
+}));
+
+const official = (over: Partial<DirectoryOfficial>): DirectoryOfficial => ({
+  id: "o1",
+  display_name: "Ref One",
+  role_keys: ["referee"],
+  entrant_id: null,
+  email: "ref@example.com",
+  max_per_day: null,
+  claimed: false,
+  invite_pending: false,
+  ...over,
+});
+
+function render(officials: DirectoryOfficial[], canEdit = true) {
+  return renderToStaticMarkup(
+    <DictProvider dict={en as never} locale="en">
+      <OfficialsDirectoryPanel officials={officials} canEdit={canEdit} rolesMultiAllowed />
+    </DictProvider>,
+  );
+}
+
+describe("OfficialsDirectoryPanel card layout (G5)", () => {
+  it("renders one action row per card with delete pushed to the end", () => {
+    const html = render([official({})]);
+    // Single action row: bordered top, wraps on narrow screens.
+    const row = html.match(/<div class="mt-2 flex flex-wrap items-center gap-1\.5 border-t[^"]*"/g);
+    expect(row?.length).toBe(1);
+    expect(html).toContain("ml-auto"); // delete right-aligned in the row
+  });
+
+  it("read-only viewers get no action row and no email", () => {
+    const html = render([official({})], false);
+    expect(html).not.toContain("border-t border-slate-100 pt-2");
+    expect(html).not.toContain("ref@example.com");
+  });
+
+  it("claimed officials keep the status chip but lose the invite action", () => {
+    const html = render([official({ claimed: true })]);
+    expect(html).toContain("Linked");
+    expect(html.match(/Invite/g) ?? []).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/v2/officials-directory-panel.tsx
+++ b/apps/web/src/components/v2/officials-directory-panel.tsx
@@ -145,20 +145,22 @@ export function OfficialsDirectoryPanel({
                       )}
                     </div>
                   </div>
-                  {/* Right rail: link status on top, actions under it — kept
-                      out of the name/roles column so nothing overlaps when
-                      the invite form opens below the row. */}
-                  <div className="flex shrink-0 flex-col items-end gap-1.5">
-                    {o.claimed ? (
-                      <span className="rounded bg-lime-100 px-1.5 py-0.5 text-[11px] text-lime-700">
-                        {msg("officials.linked")}
-                      </span>
-                    ) : o.invite_pending ? (
-                      <span className="rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-700">
-                        {msg("officials.invited")}
-                      </span>
-                    ) : null}
-                    {canEdit && !o.claimed && openRow?.id !== o.id && (
+                  {/* Top-right holds ONLY the link-status chip; the actions
+                      moved to a single row under the content (G5) so the
+                      name/roles column keeps the full card width. */}
+                  {o.claimed ? (
+                    <span className="shrink-0 rounded bg-lime-100 px-1.5 py-0.5 text-[11px] text-lime-700">
+                      {msg("officials.linked")}
+                    </span>
+                  ) : o.invite_pending ? (
+                    <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[11px] text-amber-700">
+                      {msg("officials.invited")}
+                    </span>
+                  ) : null}
+                </div>
+                {canEdit && (
+                  <div className="mt-2 flex flex-wrap items-center gap-1.5 border-t border-slate-100 pt-2">
+                    {!o.claimed && openRow?.id !== o.id && (
                       <button
                         type="button"
                         className="btn btn-ghost py-1 text-xs"
@@ -168,7 +170,7 @@ export function OfficialsDirectoryPanel({
                         {msg("officials.invite")}
                       </button>
                     )}
-                    {canEdit && !(openRow?.id === o.id && openRow.mode === "roles") && (
+                    {!(openRow?.id === o.id && openRow.mode === "roles") && (
                       <button
                         type="button"
                         className="btn btn-ghost py-1 text-xs"
@@ -178,29 +180,27 @@ export function OfficialsDirectoryPanel({
                         {msg("officials.editRoles")}
                       </button>
                     )}
-                    {canEdit && (
-                      <button
-                        type="button"
-                        className="btn btn-ghost py-1 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
-                        disabled={busy}
-                        onClick={() =>
-                          void (async () => {
-                            const ok = await confirm({
-                              title: msg("officials.deleteTitle", { name: o.display_name }),
-                              body: msg("officials.deleteBody"),
-                              confirmLabel: msg("officials.deleteLabel"),
-                              tone: "danger",
-                            });
-                            if (!ok) return;
-                            await run(() => apiV1(`/api/v1/officials/${o.id}`, { method: "DELETE" }));
-                          })()
-                        }
-                      >
-                        {msg("officials.delete")}
-                      </button>
-                    )}
+                    <button
+                      type="button"
+                      className="btn btn-ghost ml-auto py-1 text-xs text-red-600 hover:bg-red-50 hover:text-red-700"
+                      disabled={busy}
+                      onClick={() =>
+                        void (async () => {
+                          const ok = await confirm({
+                            title: msg("officials.deleteTitle", { name: o.display_name }),
+                            body: msg("officials.deleteBody"),
+                            confirmLabel: msg("officials.deleteLabel"),
+                            tone: "danger",
+                          });
+                          if (!ok) return;
+                          await run(() => apiV1(`/api/v1/officials/${o.id}`, { method: "DELETE" }));
+                        })()
+                      }
+                    >
+                      {msg("officials.delete")}
+                    </button>
                   </div>
-                </div>
+                )}
                 {openRow?.id === o.id && (
                   <div className="mt-3 border-t border-slate-100 pt-3">
                     {openRow.mode === "invite" ? (


### PR DESCRIPTION
Per request: the per-card button stack moved into one row.

Before: a vertical right rail (status chip + Invite + Edit roles + Delete) squeezed the name column — noticeably cramped on mobile.
After: top-right keeps only the Linked/Invited chip; all actions in a single wrapped row under the content, Delete right-aligned. Verified at 1280px and 390px including the expanded invite form (no overlap).

Gates: tsc 0 · new markup test 3/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)