### PR TITLE
style(email): bulletproof system font stack — drop web fonts (direction B)

### DIFF
--- a/apps/web/src/lib/__tests__/email-builders.test.ts
+++ b/apps/web/src/lib/__tests__/email-builders.test.ts
@@ -229,7 +229,12 @@ describe("email builders compose from the html templates", () => {
       expect(out.html).toContain('bgcolor="#150b36"');
       expect(out.html).toContain('bgcolor="#a3e635"');
       expect(out.html).toContain("&#9679;");
-      expect(out.html).toContain("Barlow Condensed");
+      // Direction B: one bulletproof system stack, no web fonts (see
+      // email-html-templates.test.ts for the full font pin).
+      expect(out.html).toContain(
+        "-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif",
+      );
+      expect(out.html).not.toContain("fonts.googleapis.com");
       // Preheader div present and filled.
       expect(out.html).toContain("mso-hide:all");
       // No template token survives substitution.

--- a/apps/web/src/lib/__tests__/email-html-templates.test.ts
+++ b/apps/web/src/lib/__tests__/email-html-templates.test.ts
@@ -102,3 +102,28 @@ describe("email html templates", () => {
     expect(preview).toContain(">Bank transfer to Riverside Racquets CC");
   });
 });
+
+// Direction B (2026-07-18): bulletproof system stack, no web fonts. Gmail and
+// Outlook never load webfont <link>s, so the old Barlow Condensed declaration
+// degraded to Arial Narrow there — every mail now uses the one system stack
+// below and renders the same in every client.
+const SYSTEM_STACK = "-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif";
+
+const ALL_HTML = [
+  ...Object.keys(CONTRACT),
+  "previews/registration-standings.html",
+];
+
+describe("email font system (direction B — bulletproof)", () => {
+  for (const file of ALL_HTML) {
+    it(`${file} declares only the system stack`, () => {
+      const s = read(file);
+      expect(s).not.toMatch(/fonts\.googleapis\.com|fonts\.gstatic\.com/);
+      expect(s).not.toMatch(/Barlow|Arial Narrow|Helvetica Neue/);
+      const families = s.match(/font-family:[^;"]*/g) ?? [];
+      for (const f of families) {
+        expect(f).toBe(`font-family:${SYSTEM_STACK}`);
+      }
+    });
+  }
+});

--- a/apps/web/src/lib/email-templates/html/README.md
+++ b/apps/web/src/lib/email-templates/html/README.md
@@ -7,9 +7,10 @@ in with plain string replacement — no JSX/MJML build step, works as-is with
 the Resend send path in `lib/email.ts`.
 
 The design carries the public "courtside" identity into the inbox: the
-`#231738` court slab masthead with the 3px `#7c3aed` court line, Barlow
-Condensed display type (falls back to Arial Narrow where web fonts don't
-load), and the scorebug standings table as the signature block.
+`#231738` court slab masthead with the 3px `#7c3aed` court line, a heavy
+system-grotesque display treatment (uppercase, weight 800 — no web fonts,
+so every client renders it identically), and the scorebug standings table
+as the signature block.
 
 ## Files
 
@@ -91,8 +92,11 @@ plain-text inputs). `email-builders.test.ts` pins each recipe.
 ## Client-compat notes
 
 - Layout is nested tables + inline styles; no flexbox/grid/margin-on-div.
-- Barlow Condensed loads via Google Fonts `<link>` (Apple Mail, some others);
-  everyone else gets Arial Narrow → the layout is metric-tolerant to both.
+- No web fonts. One system stack everywhere
+  (`-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif`): SF Pro on
+  Apple, Segoe UI on Windows, Roboto on Android — identical render in every
+  client, Gmail and Outlook included. Display role = weight 800 uppercase
+  with tight tracking; `email-html-templates.test.ts` pins the stack.
 - CTA uses the td-bgcolor button pattern — clickable/painted in Outlook.
 - `color-scheme: light` is declared so dark-mode clients keep the courtside
   contrast instead of auto-inverting the slab.

--- a/apps/web/src/lib/email-templates/html/base.html
+++ b/apps/web/src/lib/email-templates/html/base.html
@@ -16,9 +16,6 @@
     </xml>
   </noscript>
   <![endif]-->
-  <!--[if !mso]><!-->
-  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&display=swap" rel="stylesheet">
-  <!--<![endif]-->
   <style>
     /* Client resets */
     body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
@@ -31,7 +28,7 @@
       .sz-container { width: 100% !important; }
       .sz-content { padding: 28px 20px !important; }
       .sz-masthead { padding: 16px 20px !important; }
-      .sz-title { font-size: 26px !important; line-height: 30px !important; }
+      .sz-title { font-size: 24px !important; line-height: 28px !important; }
     }
   </style>
 </head>
@@ -55,10 +52,10 @@
             <td class="sz-masthead" bgcolor="#150b36" style="background-color:#150b36;border-radius:14px 14px 0 0;padding:18px 32px 6px;">
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td align="left" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:21px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f5f0e8;">
+                  <td align="left" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:21px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f5f0e8;">
                     Seazn&nbsp;<span style="color:#a3e635;">Club</span>
                   </td>
-                  <td align="right" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(245,240,232,0.64);">
+                  <td align="right" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(245,240,232,0.64);">
                     {{MASTHEAD_TAG}}
                   </td>
                 </tr>
@@ -80,12 +77,12 @@
             <td class="sz-content" bgcolor="#ffffff" style="background-color:#ffffff;border-radius:0 0 14px 14px;padding:36px 32px;">
 
               <!-- Eyebrow -->
-              <p style="margin:0 0 6px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:2.5px;text-transform:uppercase;color:#6931c9;">
+              <p style="margin:0 0 6px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:2.5px;text-transform:uppercase;color:#6931c9;">
                 {{EYEBROW}}
               </p>
 
               <!-- Title -->
-              <h1 class="sz-title" style="margin:0 0 18px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:32px;line-height:36px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;color:#1d1928;">
+              <h1 class="sz-title" style="margin:0 0 18px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:28px;line-height:33px;font-weight:800;text-transform:uppercase;letter-spacing:0.2px;color:#1d1928;">
                 {{TITLE}}
               </h1>
 
@@ -98,13 +95,13 @@
           <!-- ============ Footer ============ -->
           <tr>
             <td style="padding:24px 32px;">
-              <p style="margin:0 0 8px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+              <p style="margin:0 0 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 {{FOOTER_NOTE}}
               </p>
-              <p style="margin:0 0 8px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+              <p style="margin:0 0 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 <a href="https://seazn.club/start?utm_source=email&amp;utm_medium=footer&amp;utm_campaign=plg" style="color:#6931c9;text-decoration:underline;">Run your own &mdash; free</a>
               </p>
-              <p style="margin:0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+              <p style="margin:0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 &copy; {{YEAR}} Seazn Club &middot; Any sport &middot; Live in minutes
               </p>
             </td>

--- a/apps/web/src/lib/email-templates/html/blocks/button.html
+++ b/apps/web/src/lib/email-templates/html/blocks/button.html
@@ -2,7 +2,7 @@
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0;">
   <tr>
     <td align="center" bgcolor="#7c3aed" style="background-color:#7c3aed;border-radius:10px;">
-      <a href="{{CTA_URL}}" target="_blank" style="display:inline-block;padding:13px 32px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:17px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#ffffff;text-decoration:none;border-radius:10px;">
+      <a href="{{CTA_URL}}" target="_blank" style="display:inline-block;padding:13px 32px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:15px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#ffffff;text-decoration:none;border-radius:10px;">
         {{CTA_LABEL}}
       </a>
     </td>

--- a/apps/web/src/lib/email-templates/html/blocks/link-fallback.html
+++ b/apps/web/src/lib/email-templates/html/blocks/link-fallback.html
@@ -1,5 +1,5 @@
 <!-- "Button not working?" plain-link fallback -->
-<p style="margin:20px 0 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+<p style="margin:20px 0 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
   Button not working? Paste this link into your browser:<br>
   <a href="{{FALLBACK_URL}}" target="_blank" style="color:#6931c9;text-decoration:underline;word-break:break-all;">{{FALLBACK_URL}}</a>
 </p>

--- a/apps/web/src/lib/email-templates/html/blocks/panel.html
+++ b/apps/web/src/lib/email-templates/html/blocks/panel.html
@@ -2,11 +2,11 @@
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 20px;">
   <tr>
     <td bgcolor="#f5effe" style="background-color:#f5effe;border:1px solid #decefb;border-radius:12px;padding:16px 20px;">
-      <p style="margin:0 0 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#6931c9;">
+      <p style="margin:0 0 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#6931c9;">
         {{PANEL_TITLE}}
       </p>
       <!-- Token kept flush against the tags: pre-line would render template newlines -->
-      <p style="margin:0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;color:#3d3849;white-space:pre-line;">{{PANEL_BODY}}</p>
+      <p style="margin:0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;color:#3d3849;white-space:pre-line;">{{PANEL_BODY}}</p>
     </td>
   </tr>
 </table>

--- a/apps/web/src/lib/email-templates/html/blocks/paragraph.html
+++ b/apps/web/src/lib/email-templates/html/blocks/paragraph.html
@@ -1,3 +1,3 @@
-<p style="margin:0 0 16px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:15px;line-height:24px;color:#3d3849;">
+<p style="margin:0 0 16px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:24px;color:#3d3849;">
   {{TEXT}}
 </p>

--- a/apps/web/src/lib/email-templates/html/blocks/standings-row-leader.html
+++ b/apps/web/src/lib/email-templates/html/blocks/standings-row-leader.html
@@ -1,9 +1,9 @@
 <!-- Leader row: accent bar + soft violet fill. Use for rank 1 (or the recipient's row). -->
 <tr>
-  <td width="40" align="center" bgcolor="#f5effe" style="background-color:#f5effe;border-left:3px solid #7c3aed;padding:10px 0 10px 5px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">{{RANK}}</td>
-  <td align="left" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 4px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;color:#1d1928;">{{NAME}}</td>
-  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">{{PLAYED}}</td>
-  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">{{WON}}</td>
-  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">{{LOST}}</td>
-  <td width="48" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 8px 10px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">{{POINTS}}</td>
+  <td width="40" align="center" bgcolor="#f5effe" style="background-color:#f5effe;border-left:3px solid #7c3aed;padding:10px 0 10px 5px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">{{RANK}}</td>
+  <td align="left" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;color:#1d1928;">{{NAME}}</td>
+  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">{{PLAYED}}</td>
+  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">{{WON}}</td>
+  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">{{LOST}}</td>
+  <td width="48" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 8px 10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">{{POINTS}}</td>
 </tr>

--- a/apps/web/src/lib/email-templates/html/blocks/standings-row.html
+++ b/apps/web/src/lib/email-templates/html/blocks/standings-row.html
@@ -1,9 +1,9 @@
 <!-- Standard standings row. Alternate ROW_BG between #ffffff and #faf9fc. -->
 <tr>
-  <td width="40" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0 10px 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">{{RANK}}</td>
-  <td align="left" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 4px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">{{NAME}}</td>
-  <td width="36" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">{{PLAYED}}</td>
-  <td width="36" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">{{WON}}</td>
-  <td width="36" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">{{LOST}}</td>
-  <td width="48" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 8px 10px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">{{POINTS}}</td>
+  <td width="40" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0 10px 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">{{RANK}}</td>
+  <td align="left" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">{{NAME}}</td>
+  <td width="36" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">{{PLAYED}}</td>
+  <td width="36" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">{{WON}}</td>
+  <td width="36" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">{{LOST}}</td>
+  <td width="48" align="center" bgcolor="{{ROW_BG}}" style="background-color:{{ROW_BG}};padding:10px 8px 10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">{{POINTS}}</td>
 </tr>

--- a/apps/web/src/lib/email-templates/html/blocks/standings.html
+++ b/apps/web/src/lib/email-templates/html/blocks/standings.html
@@ -8,10 +8,10 @@
     <td colspan="6" bgcolor="#150b36" style="background-color:#150b36;padding:12px 16px;">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>
-          <td align="left" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f7f5fb;">
+          <td align="left" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f7f5fb;">
             {{STANDINGS_TITLE}}
           </td>
-          <td align="right" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(247,245,251,0.64);">
+          <td align="right" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(247,245,251,0.64);">
             {{STANDINGS_META}}
           </td>
         </tr>
@@ -21,12 +21,12 @@
 
   <!-- Column labels -->
   <tr>
-    <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0 8px 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">#</td>
-    <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 4px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">{{NAME_HEADER}}</td>
-    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">P</td>
-    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">W</td>
-    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">L</td>
-    <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 8px 8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#1d1928;border-bottom:1px solid #e5e2ec;">Pts</td>
+    <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0 8px 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">#</td>
+    <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">{{NAME_HEADER}}</td>
+    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">P</td>
+    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">W</td>
+    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">L</td>
+    <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 8px 8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#1d1928;border-bottom:1px solid #e5e2ec;">Pts</td>
   </tr>
 
   {{STANDINGS_ROWS}}

--- a/apps/web/src/lib/email-templates/html/previews/registration-standings.html
+++ b/apps/web/src/lib/email-templates/html/previews/registration-standings.html
@@ -16,9 +16,6 @@
     </xml>
   </noscript>
   <![endif]-->
-  <!--[if !mso]><!-->
-  <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&display=swap" rel="stylesheet">
-  <!--<![endif]-->
   <style>
     /* Client resets */
     body, table, td, a { -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }
@@ -31,7 +28,7 @@
       .sz-container { width: 100% !important; }
       .sz-content { padding: 28px 20px !important; }
       .sz-masthead { padding: 16px 20px !important; }
-      .sz-title { font-size: 26px !important; line-height: 30px !important; }
+      .sz-title { font-size: 24px !important; line-height: 28px !important; }
     }
   </style>
 </head>
@@ -55,10 +52,10 @@
             <td class="sz-masthead" bgcolor="#150b36" style="background-color:#150b36;border-radius:14px 14px 0 0;padding:18px 32px 6px;">
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
-                  <td align="left" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:21px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f5f0e8;">
+                  <td align="left" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:21px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f5f0e8;">
                     Seazn&nbsp;<span style="color:#a3e635;">Club</span>
                   </td>
-                  <td align="right" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(245,240,232,0.64);">
+                  <td align="right" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(245,240,232,0.64);">
                     Riverside Racquets CC
                   </td>
                 </tr>
@@ -80,28 +77,28 @@
             <td class="sz-content" bgcolor="#ffffff" style="background-color:#ffffff;border-radius:0 0 14px 14px;padding:36px 32px;">
 
               <!-- Eyebrow -->
-              <p style="margin:0 0 6px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:2.5px;text-transform:uppercase;color:#6931c9;">
+              <p style="margin:0 0 6px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:2.5px;text-transform:uppercase;color:#6931c9;">
                 Riverside Racquets CC · Division 1
               </p>
 
               <!-- Title -->
-              <h1 class="sz-title" style="margin:0 0 18px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:32px;line-height:36px;font-weight:700;text-transform:uppercase;letter-spacing:0.5px;color:#1d1928;">
+              <h1 class="sz-title" style="margin:0 0 18px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:28px;line-height:33px;font-weight:800;text-transform:uppercase;letter-spacing:0.2px;color:#1d1928;">
                 Registration received
               </h1>
 
               <!-- Composable content: concatenate blocks/*.html and drop in -->
-              <p style="margin:0 0 16px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:15px;line-height:24px;color:#3d3849;">
+              <p style="margin:0 0 16px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:15px;line-height:24px;color:#3d3849;">
   Thanks Alex — your registration for <strong>Spring Open 2026</strong> has been received. You've joined Division 1; here's how the table looks going into your first week.
 </p>
 <!-- Info panel: payment instructions, notices, secondary detail -->
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:8px 0 20px;">
   <tr>
     <td bgcolor="#f5effe" style="background-color:#f5effe;border:1px solid #decefb;border-radius:12px;padding:16px 20px;">
-      <p style="margin:0 0 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#6931c9;">
+      <p style="margin:0 0 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#6931c9;">
         Entry fee — £25.00
       </p>
       <!-- Token kept flush against the tags: pre-line would render template newlines -->
-      <p style="margin:0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;color:#3d3849;white-space:pre-line;">Bank transfer to Riverside Racquets CC
+      <p style="margin:0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;line-height:22px;color:#3d3849;white-space:pre-line;">Bank transfer to Riverside Racquets CC
 Sort 20-00-00 · Account 1234 5678
 Quote your reference: SZ-4F7K-2Q9D</p>
     </td>
@@ -111,7 +108,7 @@ Quote your reference: SZ-4F7K-2Q9D</p>
 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:24px 0;">
   <tr>
     <td align="center" bgcolor="#7c3aed" style="background-color:#7c3aed;border-radius:10px;">
-      <a href="https://seazn.club/r/SZ-4F7K-2Q9D" target="_blank" style="display:inline-block;padding:13px 32px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:17px;font-weight:600;letter-spacing:1.5px;text-transform:uppercase;color:#ffffff;text-decoration:none;border-radius:10px;">
+      <a href="https://seazn.club/r/SZ-4F7K-2Q9D" target="_blank" style="display:inline-block;padding:13px 32px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:15px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#ffffff;text-decoration:none;border-radius:10px;">
         View your registration
       </a>
     </td>
@@ -127,10 +124,10 @@ Quote your reference: SZ-4F7K-2Q9D</p>
     <td colspan="6" bgcolor="#150b36" style="background-color:#150b36;padding:12px 16px;">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>
-          <td align="left" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f7f5fb;">
+          <td align="left" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;letter-spacing:1.5px;text-transform:uppercase;color:#f7f5fb;">
             Division 1
           </td>
-          <td align="right" style="font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(247,245,251,0.64);">
+          <td align="right" style="font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:rgba(247,245,251,0.64);">
             After week 6
           </td>
         </tr>
@@ -140,55 +137,55 @@ Quote your reference: SZ-4F7K-2Q9D</p>
 
   <!-- Column labels -->
   <tr>
-    <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0 8px 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">#</td>
-    <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 4px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">Team</td>
-    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">P</td>
-    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">W</td>
-    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">L</td>
-    <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 8px 8px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#1d1928;border-bottom:1px solid #e5e2ec;">Pts</td>
+    <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0 8px 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">#</td>
+    <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">Team</td>
+    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">P</td>
+    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">W</td>
+    <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;color:#6f6a7c;border-bottom:1px solid #e5e2ec;">L</td>
+    <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:8px 8px 8px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;font-weight:700;letter-spacing:1px;text-transform:uppercase;color:#1d1928;border-bottom:1px solid #e5e2ec;">Pts</td>
   </tr>
 
   <!-- Leader row: accent bar + soft violet fill. Use for rank 1 (or the recipient's row). -->
 <tr>
-  <td width="40" align="center" bgcolor="#f5effe" style="background-color:#f5effe;border-left:3px solid #7c3aed;padding:10px 0 10px 5px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">1</td>
-  <td align="left" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 4px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;color:#1d1928;">Riverside Aces</td>
-  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">6</td>
-  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">6</td>
-  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">0</td>
-  <td width="48" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 8px 10px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">18</td>
+  <td width="40" align="center" bgcolor="#f5effe" style="background-color:#f5effe;border-left:3px solid #7c3aed;padding:10px 0 10px 5px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">1</td>
+  <td align="left" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;color:#1d1928;">Riverside Aces</td>
+  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">6</td>
+  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">6</td>
+  <td width="36" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#3d3849;">0</td>
+  <td width="48" align="center" bgcolor="#f5effe" style="background-color:#f5effe;padding:10px 8px 10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6931c9;">18</td>
 </tr>
 <!-- Standard standings row. Alternate ROW_BG between #ffffff and #faf9fc. -->
 <tr>
-  <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0 10px 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">2</td>
-  <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 4px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">Oakwood Foxes</td>
-  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">6</td>
-  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">4</td>
-  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">2</td>
-  <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 8px 10px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">12</td>
+  <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0 10px 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">2</td>
+  <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">Oakwood Foxes</td>
+  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">6</td>
+  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">4</td>
+  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">2</td>
+  <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 8px 10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">12</td>
 </tr>
 <!-- Standard standings row. Alternate ROW_BG between #ffffff and #faf9fc. -->
 <tr>
-  <td width="40" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0 10px 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">3</td>
-  <td align="left" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 4px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">Brookvale Tigers</td>
-  <td width="36" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">6</td>
-  <td width="36" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">3</td>
-  <td width="36" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">3</td>
-  <td width="48" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 8px 10px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">9</td>
+  <td width="40" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0 10px 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">3</td>
+  <td align="left" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">Brookvale Tigers</td>
+  <td width="36" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">6</td>
+  <td width="36" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">3</td>
+  <td width="36" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">3</td>
+  <td width="48" align="center" bgcolor="#ffffff" style="background-color:#ffffff;padding:10px 8px 10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">9</td>
 </tr>
 <!-- Standard standings row. Alternate ROW_BG between #ffffff and #faf9fc. -->
 <tr>
-  <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0 10px 8px;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">4</td>
-  <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 4px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">Kingsway Falcons</td>
-  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">6</td>
-  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">1</td>
-  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">5</td>
-  <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 8px 10px 0;font-family:'Barlow Condensed','Arial Narrow',Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">3</td>
+  <td width="40" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0 10px 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#6f6a7c;">4</td>
+  <td align="left" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 4px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:14px;font-weight:600;color:#1d1928;">Kingsway Falcons</td>
+  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">6</td>
+  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">1</td>
+  <td width="36" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#6f6a7c;">5</td>
+  <td width="48" align="center" bgcolor="#faf9fc" style="background-color:#faf9fc;padding:10px 8px 10px 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:16px;font-weight:700;color:#1d1928;">3</td>
 </tr>
 
 
 </table>
 <!-- "Button not working?" plain-link fallback -->
-<p style="margin:20px 0 0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+<p style="margin:20px 0 0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
   Button not working? Paste this link into your browser:<br>
   <a href="https://seazn.club/r/SZ-4F7K-2Q9D" target="_blank" style="color:#6931c9;text-decoration:underline;word-break:break-all;">https://seazn.club/r/SZ-4F7K-2Q9D</a>
 </p>
@@ -200,10 +197,10 @@ Quote your reference: SZ-4F7K-2Q9D</p>
           <!-- ============ Footer ============ -->
           <tr>
             <td style="padding:24px 32px;">
-              <p style="margin:0 0 8px;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+              <p style="margin:0 0 8px;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 You received this because this address registered for Spring Open 2026 at Riverside Racquets CC.
               </p>
-              <p style="margin:0;font-family:'Helvetica Neue',Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
+              <p style="margin:0;font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;line-height:18px;color:#6f6a7c;">
                 &copy; 2026 Seazn Club &middot; Any sport &middot; Live in minutes
               </p>
             </td>


### PR DESCRIPTION
## What

Every outbound email now uses one bulletproof system font stack — `-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif` — instead of the Barlow Condensed web font. Direction **B** from the font-directions review (user-picked from 4 rendered samples).

## Why

Gmail and Outlook strip webfont `<link>`s, so most recipients never saw Barlow Condensed — they got **Arial Narrow** headlines + Helvetica Neue body. The new stack renders SF Pro on Apple, Segoe UI on Windows, Roboto on Android: modern and identical in every client. Theme (night slab, pitch line, ball, scorebug) untouched.

## Changes

- `base.html`: Google Fonts `<link>` removed; title 32px/700 → 28px/800 with 0.2px tracking (mobile 24px); footer on the same stack
- `blocks/button.html`: 17px/600/1.5px → 15px/700/1px
- all 7 blocks + committed preview restyled — token contract and TS builders untouched, so all 20+ emails change at once
- **Tests**: `email-html-templates.test.ts` new suite pins the exact stack per file and bans `fonts.googleapis.com`/`gstatic` (red before the change); `email-builders.test.ts` shell assertion updated

## Verify

- `tsc --noEmit`: 0 errors
- `vitest run` (apps/web): **1167 pass / 0 fail**
- Help pages: no page references email typography — nothing to update

🤖 Generated with [Claude Code](https://claude.com/claude-code)