### PR TITLE
feat(me): My stats section — PROMPT-65 stat blocks, self-view

### DIFF
--- a/apps/web/content/help/players/player-stats-and-photo.md
+++ b/apps/web/content/help/players/player-stats-and-photo.md
@@ -6,4 +6,6 @@ order: 3
 
 **Stats on your profile.** A public player profile now shows per-division totals — goals, assists, cards, awards, whatever the sport tracks — pulled straight from the scored matches. There's nothing to enter: play, get scored, the numbers appear. The stat labels come from the sport itself, so a cricketer sees runs and wickets where a footballer sees goals. Profiles (and their stats) only exist for players who've consented to a public name; the leaderboard table in the organiser console remains a Pro feature.
 
+**Stats on Me.** The same numbers live under **My stats** on your own **Me** page — every competition you play in, private ones included, because they're yours. Where the competition is public and your name consent is on, each block links to your public profile.
+
 **Your photo, yours.** From **Me**, next to your privacy toggles, upload or remove your own photo — no need to ask an organiser. It shows publicly only while your *show my photo* consent is on. Profiles of under-16 players stay organiser-managed.

--- a/apps/web/src/app/me/page.tsx
+++ b/apps/web/src/app/me/page.tsx
@@ -7,7 +7,13 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { getActiveOrgId, getCurrentUser, getUserOrgs } from "@/lib/auth";
 import { routes } from "@/lib/routes";
-import { listMyFixtures, listMyPersons, type MyFixture, type MyResult } from "@/server/usecases/me";
+import {
+  listMyFixtures,
+  listMyPersons,
+  listMyPlayerStats,
+  type MyFixture,
+  type MyResult,
+} from "@/server/usecases/me";
 import { getMyOfficiating, listPendingOfficiatingClaims } from "@/server/usecases/me-officiating";
 import { RsvpControl } from "@/components/me/rsvp-control";
 import { OfficiatingLane } from "@/components/me/officiating-lane";
@@ -31,7 +37,7 @@ export default async function MePage({
     getDictionary(locale, "console"),
     getDictionary(locale, "ui"),
   ]);
-  const [{ upcoming, results, teams }, officiating, pendingOfficiatingClaims, persons, orgs, activeOrgId] =
+  const [{ upcoming, results, teams }, officiating, pendingOfficiatingClaims, persons, stats, orgs, activeOrgId] =
     await Promise.all([
       listMyFixtures(user.id),
       getMyOfficiating(user.id),
@@ -40,6 +46,7 @@ export default async function MePage({
       // accept) their very first invite.
       listPendingOfficiatingClaims(user.email),
       listMyPersons(user.id),
+      listMyPlayerStats(user.id),
       // Dual-role seam: organisers who are also players get a door back.
       // Read-only resolve — resolveActiveOrg repairs the cookie, which a
       // Server Component render is not allowed to do.
@@ -252,6 +259,54 @@ export default async function MePage({
                   · {t.division_name} · {t.org_name}
                 </li>
               ))}
+            </ul>
+          </section>
+        )}
+
+        {/* G6 — my stat blocks (PROMPT-65 self-view): every snapshot for my
+            claimed persons, private competitions included; the public-profile
+            link shows only where the public card would actually render
+            (public competition + name consent). */}
+        {stats.length > 0 && (
+          <section className="mb-8" data-testid="me-stats">
+            <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+              {t(ui, "me.stats.title")}
+            </h2>
+            <ul className="space-y-3">
+              {stats.map((s) => {
+                const consented =
+                  persons.find((p) => p.id === s.person_id)?.consent.public_name === true;
+                return (
+                  <li key={`${s.person_id}:${s.division_slug}`} className="card space-y-2 p-4">
+                    <div className="flex flex-wrap items-baseline justify-between gap-2">
+                      <p className="text-sm font-medium text-slate-800">
+                        {s.division_name} · {s.competition_name}
+                        <span className="ml-1.5 text-xs text-slate-400">{s.org_name}</span>
+                      </p>
+                      {s.competition_public && consented && (
+                        <Link
+                          href={`/shared/${s.org_slug}/${s.competition_slug}/players/${s.person_id}`}
+                          className="text-xs font-medium text-purple-700 hover:underline"
+                        >
+                          {t(ui, "me.stats.publicProfile")}
+                        </Link>
+                      )}
+                    </div>
+                    <dl className="flex flex-wrap gap-x-6 gap-y-2">
+                      {s.metrics.map((m) => (
+                        <div key={m.key} className="min-w-16">
+                          <dt className="text-[11px] uppercase tracking-wide text-slate-400">
+                            {m.label}
+                          </dt>
+                          <dd className="font-display text-2xl font-bold tabular-nums text-slate-900">
+                            {m.value}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+                  </li>
+                );
+              })}
             </ul>
           </section>
         )}

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -222,6 +222,8 @@
   "me.upcoming.title": "Coming up",
   "me.results.title": "Recent results",
   "me.teams.title": "My teams",
+  "me.stats.title": "My stats",
+  "me.stats.publicProfile": "Public profile",
   "me.rsvp.in": "In",
   "me.rsvp.maybe": "Maybe",
   "me.rsvp.out": "Out",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -222,6 +222,8 @@
   "me.upcoming.title": "Próximamente",
   "me.results.title": "Resultados recientes",
   "me.teams.title": "Mis equipos",
+  "me.stats.title": "Mis estadísticas",
+  "me.stats.publicProfile": "Perfil público",
   "me.rsvp.in": "Voy",
   "me.rsvp.maybe": "Quizás",
   "me.rsvp.out": "No voy",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -222,6 +222,8 @@
   "me.upcoming.title": "À venir",
   "me.results.title": "Résultats récents",
   "me.teams.title": "Mes équipes",
+  "me.stats.title": "Mes statistiques",
+  "me.stats.publicProfile": "Profil public",
   "me.rsvp.in": "Présent",
   "me.rsvp.maybe": "Peut-être",
   "me.rsvp.out": "Absent",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -222,6 +222,8 @@
   "me.upcoming.title": "Binnenkort",
   "me.results.title": "Recente resultaten",
   "me.teams.title": "Mijn teams",
+  "me.stats.title": "Mijn statistieken",
+  "me.stats.publicProfile": "Openbaar profiel",
   "me.rsvp.in": "Erbij",
   "me.rsvp.maybe": "Misschien",
   "me.rsvp.out": "Niet erbij",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -1155,6 +1155,8 @@ export type DictionaryKey =
   | "me.rsvp.saved"
   | "me.runYourOwn.cta"
   | "me.runYourOwn.title"
+  | "me.stats.publicProfile"
+  | "me.stats.title"
   | "me.tbd"
   | "me.teams.title"
   | "me.title"

--- a/apps/web/src/server/__tests__/player-stats-label.test.ts
+++ b/apps/web/src/server/__tests__/player-stats-label.test.ts
@@ -1,0 +1,19 @@
+// G6 — shared stat labelling against the REAL football module registry:
+// labels come from the declared playerStats model, zero rows drop, retired
+// builds yield [] instead of throwing.
+import { describe, expect, it } from "vitest";
+import { labelPlayerStats } from "@/server/player-stats";
+
+describe("labelPlayerStats", () => {
+  it("labels football counters from the module model and drops zeros", () => {
+    const rows = labelPlayerStats("football", "1.0.0", { goals: 3, assists: 0 });
+    const goals = rows.find((r) => r.key === "goals");
+    expect(goals?.value).toBe(3);
+    expect(goals?.label.toLowerCase()).toContain("goal");
+    expect(rows.find((r) => r.key === "assists")).toBeUndefined();
+  });
+
+  it("returns [] for a retired module build", () => {
+    expect(labelPlayerStats("football", "0.0.1-gone", { goals: 3 })).toEqual([]);
+  });
+});

--- a/apps/web/src/server/player-stats.ts
+++ b/apps/web/src/server/player-stats.ts
@@ -1,0 +1,31 @@
+// Shared player-stat labelling (PROMPT-65 → /me reuse): a snapshot's raw
+// counters become display rows via the sport module's DECLARED playerStats
+// model — metrics, derived, then awards (suffixed _awards in snapshots) —
+// never hardcoded labels. Zero-valued rows are dropped; a retired module
+// build yields [] so callers skip the block instead of breaking the page.
+import { resolveModule } from "@/server/engine-db";
+
+export interface LabelledPlayerStat {
+  key: string;
+  label: string;
+  value: number;
+}
+
+export function labelPlayerStats(
+  sportKey: string,
+  moduleVersion: string,
+  stats: Record<string, number>,
+): LabelledPlayerStat[] {
+  try {
+    const model = resolveModule(sportKey, moduleVersion).playerStats;
+    return [
+      ...(model?.metrics ?? []).map((m) => ({ key: m.key, label: m.label })),
+      ...(model?.derived ?? []).map((d) => ({ key: d.key, label: d.label })),
+      ...(model?.awards ?? []).map((a) => ({ key: `${a.key}_awards`, label: a.label })),
+    ]
+      .map((m) => ({ ...m, value: stats[m.key] ?? 0 }))
+      .filter((m) => m.value !== 0);
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/server/public-site/data.ts
+++ b/apps/web/src/server/public-site/data.ts
@@ -11,6 +11,7 @@ import { unstable_cache } from "next/cache";
 import { sql } from "@/lib/db";
 import { isoDateTime } from "@/lib/public-site";
 import { resolveModule } from "@/server/engine-db";
+import { labelPlayerStats } from "@/server/player-stats";
 
 /** timestamptz → ISO string before rows cross into client components. */
 const normalizeFixture = <T extends { scheduled_at: unknown }>(f: T): T => ({
@@ -440,19 +441,8 @@ export async function getPublicPlayer(
         order by d.name`;
       const stats: PublicPlayerStats[] = [];
       for (const snap of snapshots) {
-        let labelled: { key: string; label: string; value: number }[] = [];
-        try {
-          const model = resolveModule(snap.sport_key, snap.module_version).playerStats;
-          labelled = [
-            ...(model?.metrics ?? []).map((m) => ({ key: m.key, label: m.label })),
-            ...(model?.derived ?? []).map((d) => ({ key: d.key, label: d.label })),
-            ...(model?.awards ?? []).map((a) => ({ key: `${a.key}_awards`, label: a.label })),
-          ]
-            .map((m) => ({ ...m, value: snap.stats[m.key] ?? 0 }))
-            .filter((m) => m.value !== 0);
-        } catch {
-          // retired module build — skip the block rather than break the card
-        }
+        // Shared labelling (G6): same module-declared model as the /me view.
+        const labelled = labelPlayerStats(snap.sport_key, snap.module_version, snap.stats);
         if (labelled.length > 0) {
           stats.push({
             division_name: snap.division_name,

--- a/apps/web/src/server/usecases/__tests__/me.test.ts
+++ b/apps/web/src/server/usecases/__tests__/me.test.ts
@@ -16,6 +16,7 @@ import {
   setMyAvailability,
   checkInToFixture,
   listMyPersons,
+  listMyPlayerStats,
   setMyConsent,
 } from "../me";
 
@@ -217,6 +218,30 @@ describe.skipIf(!HAS_DB)("player home /me (PROMPT-53)", () => {
     // No claimed person on the fixture → null (claim-first interstitial).
     const stranger = await makeUser("stranger");
     expect(await checkInToFixture(stranger, f1.id)).toBeNull();
+  });
+
+  it("listMyPlayerStats: my snapshots labelled via the module model, isolated per user (G6)", async () => {
+    const a = await seedOrg("stats");
+    const rigA = await rig(a.owner);
+    const player = await makeUser("statsplayer");
+    const stranger = await makeUser("statsstranger");
+    await sql`update persons set user_id = ${player} where id = ${rigA.persons[0].id}`;
+    // Snapshot written by the stats folder in production — sport_key rides the
+    // snapshot row; the module version comes from the division.
+    await sql`
+      insert into player_stat_snapshots (division_id, person_id, sport_key, stats, computed_through_seq)
+      values (${rigA.division.id}, ${rigA.persons[0].id}, 'football', ${sql.json({ goals: 2, assists: 0 })}, 1)`;
+
+    const mine = await listMyPlayerStats(player);
+    expect(mine).toHaveLength(1);
+    expect(mine[0]!.competition_public).toBe(true);
+    expect(mine[0]!.division_slug).toBeTruthy();
+    expect(mine[0]!.org_slug).toBeTruthy();
+    const goals = mine[0]!.metrics.find((m) => m.key === "goals");
+    expect(goals?.value).toBe(2);
+    expect(mine[0]!.metrics.find((m) => m.key === "assists")).toBeUndefined();
+
+    expect(await listMyPlayerStats(stranger)).toHaveLength(0);
   });
 
   it("isPlayerOnly: claimed person + no org = true; members and strangers = false", async () => {

--- a/apps/web/src/server/usecases/me.ts
+++ b/apps/web/src/server/usecases/me.ts
@@ -11,6 +11,7 @@ import type { AuthCtx } from "@/server/api-v1/auth";
 import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
 import { publicStorageUrl } from "@/lib/supabase-storage";
 import { uploadPersonPhotoBytes } from "./persons";
+import { labelPlayerStats, type LabelledPlayerStat } from "@/server/player-stats";
 
 export type AvailabilityStatus = "in" | "out" | "maybe";
 
@@ -250,6 +251,51 @@ export async function hasClaimedProfile(userId: string): Promise<boolean> {
   const [row] = await sql<{ has: boolean }[]>`
     select exists(select 1 from persons where user_id = ${userId}) as has`;
   return row?.has === true;
+}
+
+export interface MyStatBlock {
+  person_id: string;
+  person_name: string;
+  org_name: string;
+  org_slug: string;
+  competition_name: string;
+  competition_slug: string;
+  /** Only public competitions get a "public profile" link from /me. */
+  competition_public: boolean;
+  division_name: string;
+  division_slug: string;
+  sport_key: string;
+  metrics: LabelledPlayerStat[];
+}
+
+/** G6 — the PROMPT-65 stat blocks, self-view: every snapshot belonging to a
+ *  person the user has claimed, across ALL orgs/competitions (private ones
+ *  included — these are the player's own numbers; consent gates only the
+ *  PUBLIC card). Labels via the shared module-declared model. */
+export async function listMyPlayerStats(userId: string): Promise<MyStatBlock[]> {
+  const rows = await sql<
+    (Omit<MyStatBlock, "metrics" | "competition_public"> & {
+      module_version: string;
+      visibility: string;
+      stats: Record<string, number>;
+    })[]
+  >`
+    select ps.person_id, p.full_name as person_name,
+           o.name as org_name, o.slug as org_slug,
+           c.name as competition_name, c.slug as competition_slug, c.visibility,
+           d.name as division_name, d.slug as division_slug,
+           ps.sport_key, d.module_version, ps.stats
+    from player_stat_snapshots ps
+    join persons p on p.id = ps.person_id and p.user_id = ${userId}
+    join divisions d on d.id = ps.division_id and d.archived_at is null
+    join competitions c on c.id = d.competition_id
+    join organizations o on o.id = c.org_id
+    order by o.name, c.name, d.name`;
+  return rows.flatMap(({ module_version, visibility, stats, ...row }) => {
+    const metrics = labelPlayerStats(row.sport_key, module_version, stats);
+    if (metrics.length === 0) return [];
+    return [{ ...row, competition_public: visibility === "public", metrics }];
+  });
 }
 
 /** True when the user's ONLY relationship to the platform is a claimed


### PR DESCRIPTION
Per request: the player-profile stats now also render under /me for the logged-in player.

- New `listMyPlayerStats`: snapshots for every claimed person, all orgs/comps, private included (own numbers; consent only gates the public card).
- Labelling extracted to a shared `labelPlayerStats` (module-declared models) and reused by `getPublicPlayer` — one source of truth.
- Public-profile link per block, only when the competition is public AND name consent is on.
- i18n ×4, help updated.

Gates: tsc 0 · me.test 10/0 (new DB test: labelled + isolated per user) · label unit test vs the real football registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)