### PR TITLE
test(e2e): pro-plus admin matrix expects DENY-aware cell glyphs

### DIFF
--- a/apps/web/e2e/pro-plus-tier.spec.ts
+++ b/apps/web/e2e/pro-plus-tier.spec.ts
@@ -428,7 +428,8 @@ test.describe("Pro Plus · disclosure + admin matrix", () => {
     const apiWriteRow = page
       .locator("tbody tr")
       .filter({ has: page.getByRole("cell", { name: "api.write", exact: true }) });
-    await expect(apiWriteRow.locator("td").nth(4)).toHaveText("false"); // Pro
-    await expect(apiWriteRow.locator("td").nth(5)).toHaveText("true"); // Pro Plus
+    // DENY-aware admin cells (clubs W1): absent row renders "—", present-true "✓".
+    await expect(apiWriteRow.locator("td").nth(4)).toHaveText("—"); // Pro (no row = DENY)
+    await expect(apiWriteRow.locator("td").nth(5)).toHaveText("✓"); // Pro Plus
   });
 });


### PR DESCRIPTION
Post-merge main e2e break: clubs W1 (#138) made /admin/entitlements cells DENY-aware (absent row → `—`, present true → `✓`) while the payments wave's `pro-plus-tier.spec.ts` — merged the same hour — still asserted the old `false`/`true` text. The suites never ran together until the main push.

Received value confirmed from the failed run (29675552023): expected `false`, got `—` at spec line 431.

Remaining main-e2e item watched separately: `board-v3.spec.ts:298` stale-client toast failed through retry — realtime/timing territory, not touched by either wave; will observe on this PR's post-merge run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)