### PR TITLE
fix(console): double-elim passes the fixtures-tab bracket gate

### DIFF
--- a/apps/web/e2e/knockout.spec.ts
+++ b/apps/web/e2e/knockout.spec.ts
@@ -102,3 +102,34 @@ test("scoring rejects a stale expected_seq with 409 SEQ_CONFLICT", async ({ requ
   expect(stale.status).toBe(409);
   expect(stale.error?.code).toBe("SEQ_CONFLICT");
 });
+
+test("double-elim division renders the two-lane bracket on the fixtures tab (console gate)", async ({
+  page,
+  request,
+}) => {
+  // Same rig as the knockout seed, but a double_elim stage — the page gate
+  // regressed once by only admitting kind === "knockout".
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `DE ${TAG}-${Math.random().toString(36).slice(2, 6)}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    {
+      name: "DE Cup",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    },
+  );
+  const divisionId = div.data!.id;
+  await addEntrantsViaApi(request, divisionId, ["A", "B", "C", "D"]);
+  await createStageAndGenerate(request, divisionId, { kind: "double_elim", name: "DE" });
+
+  await page.goto(`/divisions/${divisionId}?tab=fixtures`);
+  await expect(page.getByTestId("bracket-panel-de")).toBeVisible({ timeout: 20_000 });
+  await expect(page.getByText("Winners bracket")).toBeVisible();
+  await expect(page.getByText("Losers bracket")).toBeVisible();
+});

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/page.tsx
@@ -81,7 +81,8 @@ export default async function DivisionPage({
   // by the entrants panel (add form + roster editor) and the Settings tab.
   const entrantModel = effectiveEntrantModel(sportModule.entrantModel ?? null, division.config);
   const entrantNames = Object.fromEntries(entrants.map((e) => [e.id, e.display_name]));
-  const hasKnockout = stages.some((s) => s.kind === "knockout");
+  const BRACKET_STAGE_KINDS = new Set(["knockout", "double_elim"]);
+  const hasKnockout = stages.some((s) => BRACKET_STAGE_KINDS.has(s.kind));
   // Badge chips on standings rows (v3/03 §5) — resolved once per render.
   // PROMPT-62: the bracket panel on the fixtures tab shows them too.
   const entrantLogos =
@@ -229,7 +230,7 @@ export default async function DivisionPage({
                 flat list (which keeps scheduling + Documents). Renders nothing
                 until the bracket is generated or for non-single-elim shapes. */}
             {stages
-              .filter((st) => st.kind === "knockout")
+              .filter((st) => BRACKET_STAGE_KINDS.has(st.kind))
               .map((st) => (
                 <div key={st.id} className="mb-6">
                   <BracketPanel


### PR DESCRIPTION
Good catch on the fixtures page: the console page still gated the bracket panel (and its badge/headline fetches) on `kind === "knockout"`, so the two-lane double-elim view from #137 was unreachable. Both gates widened; e2e regression added (DE division → fixtures tab → `bracket-panel-de` + lane labels visible). knockout.spec 5/5 locally, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)