### PR TITLE
fix(clubs): create-toggle highlight, standard buttons, standalone→club adopt

### DIFF
--- a/apps/web/e2e/clubs.spec.ts
+++ b/apps/web/e2e/clubs.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Locator } from "@playwright/test";
-import { TAG } from "./helpers";
+import { TAG, apiJson } from "./helpers";
 
 // W1 clubs & teams: the thin Directory → Clubs & Teams list creates a club
 // through an in-app inline form (never a native prompt) and lands on the club's
@@ -111,4 +111,31 @@ test("club controls clear the 44px touch target at 375px", async ({ page }) => {
   await teamToggle.click();
   await page.getByPlaceholder("Find player…").fill(`E2E NoMatch ${Date.now()}`);
   await atLeast44(page.getByRole("button", { name: /as a new player/ }), "Quick-add button");
+});
+
+test("standalone team joins a club from the directory list", async ({ page, request }) => {
+  // Seed one club and one standalone team over the API, then adopt via the UI.
+  const tag = stamp();
+  const club = (await apiJson<{ id: string; name: string }>(request, "/api/v1/clubs", "POST", {
+    name: `Adopt FC ${tag}`,
+  })).data!;
+  const team = (await apiJson<{ id: string }>(request, "/api/v1/teams", "POST", {
+    name: `Wanderers ${tag}`,
+  })).data!;
+
+  await page.goto("/directory?tab=clubs");
+  const row = page.getByRole("row", { name: new RegExp(`Wanderers ${tag}`) });
+  await expect(row.getByText("standalone")).toBeVisible();
+
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes(`/api/v1/teams/${team.id}`) && r.request().method() === "PATCH" && r.ok(),
+    ),
+    row.getByRole("combobox", { name: `Add ${`Wanderers ${tag}`} to a club` }).selectOption(club.id),
+  ]);
+
+  // The team leaves the standalone section; its club now counts one team.
+  await expect(page.getByRole("row", { name: new RegExp(`Wanderers ${tag}`) })).toHaveCount(0);
+  const clubRow = page.getByRole("row", { name: new RegExp(`Adopt FC ${tag}`) });
+  await expect(clubRow.getByRole("cell").nth(1)).toHaveText("1");
 });

--- a/apps/web/src/components/v2/club-hub/overview-tab.tsx
+++ b/apps/web/src/components/v2/club-hub/overview-tab.tsx
@@ -472,25 +472,35 @@ function CrestCard({
     <section className="card space-y-3 p-4" aria-label={msg("clubs.crest.title")}>
       <h2 className="text-sm font-semibold text-slate-900">{msg("clubs.crest.title")}</h2>
       <div className="flex flex-wrap items-center gap-4">
-        {logoPath ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={`${storageBase}/${logoPath}`}
-            alt={msg("clubs.crest.title")}
-            className="h-16 w-16 rounded-lg border border-slate-200 object-contain"
-          />
-        ) : (
-          <div className="flex h-16 w-16 items-center justify-center rounded-lg border border-dashed border-slate-300 text-[10px] uppercase tracking-wide text-slate-400">
-            {msg("clubs.crest.emptyTile")}
-          </div>
-        )}
+        {/* The tile itself is the primary upload target — click to pick a file. */}
+        <button
+          type="button"
+          disabled={!canEdit || busy}
+          onClick={() => inputRef.current?.click()}
+          aria-label={logoPath ? msg("clubs.crest.replace") : msg("clubs.crest.upload")}
+          className="group relative rounded-lg focus-visible:ring-2 focus-visible:ring-purple-400 disabled:cursor-default"
+        >
+          {logoPath ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={`${storageBase}/${logoPath}`}
+              alt={msg("clubs.crest.title")}
+              className="h-16 w-16 rounded-lg border border-slate-200 object-contain"
+            />
+          ) : (
+            <span className="flex h-16 w-16 flex-col items-center justify-center gap-0.5 rounded-lg border border-dashed border-slate-300 text-slate-400 group-hover:border-purple-400 group-hover:text-purple-500">
+              <span aria-hidden className="text-lg leading-none">+</span>
+              <span className="text-[9px] uppercase tracking-wide">{msg("clubs.crest.emptyTile")}</span>
+            </span>
+          )}
+        </button>
         <div className="min-w-0 flex-1 space-y-2">
           <p className="text-sm text-slate-500">{msg("clubs.crest.hint")}</p>
           {canEdit && (
             <div className="flex flex-wrap items-center gap-3">
               <button
                 type="button"
-                className="btn btn-primary min-h-[44px] text-sm"
+                className="btn btn-primary min-h-[44px] text-sm sm:min-h-0"
                 disabled={busy}
                 onClick={() => inputRef.current?.click()}
               >
@@ -513,7 +523,7 @@ function CrestCard({
               {logoPath && (
                 <button
                   type="button"
-                  className="btn min-h-[44px] text-sm"
+                  className="btn min-h-[44px] text-sm sm:min-h-0"
                   disabled={busy}
                   onClick={() => void remove()}
                 >

--- a/apps/web/src/components/v2/clubs-teams-list.tsx
+++ b/apps/web/src/components/v2/clubs-teams-list.tsx
@@ -98,6 +98,23 @@ export function ClubsTeamsList({
     setPaywall(null);
   }
 
+  // Adopt a standalone team into a club (the reverse of the hub's Detach).
+  async function attachToClub(teamId: string, clubId: string) {
+    setBusy(true);
+    setError(null);
+    setPaywall(null);
+    try {
+      await apiV1(`/api/v1/teams/${teamId}`, { method: "PATCH", json: { club_id: clubId } });
+      router.refresh();
+    } catch (err) {
+      if (err instanceof ApiV1Error && err.code === "PAYMENT_REQUIRED")
+        setPaywall(String(err.extra.feature_key ?? ""));
+      else setError(err instanceof Error ? err.message : "Failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function submitCreate(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const name = draft.trim();
@@ -139,9 +156,11 @@ export function ClubsTeamsList({
         <div className="flex-1" />
         {canEdit && (
           <>
+            {/* The active kind carries btn-primary — the highlight follows the
+                open form instead of sitting on New club permanently. */}
             <button
               type="button"
-              className="btn btn-primary min-h-[44px]"
+              className={`btn min-h-[44px] sm:min-h-0 ${creating === "club" ? "btn-primary" : ""}`}
               disabled={busy}
               aria-expanded={creating === "club"}
               onClick={() => startCreate("club")}
@@ -150,7 +169,7 @@ export function ClubsTeamsList({
             </button>
             <button
               type="button"
-              className="btn min-h-[44px]"
+              className={`btn min-h-[44px] sm:min-h-0 ${creating === "team" ? "btn-primary" : ""}`}
               disabled={busy}
               aria-expanded={creating === "team"}
               onClick={() => startCreate("team")}
@@ -177,10 +196,19 @@ export function ClubsTeamsList({
               aria-label={msg(creating === "club" ? "clubs.list.newClubPrompt" : "clubs.list.newTeamPrompt")}
             />
           </label>
-          <button type="submit" className="btn btn-primary min-h-[44px]" disabled={busy || !draft.trim()}>
+          <button
+            type="submit"
+            className="btn btn-primary min-h-[44px] sm:min-h-0"
+            disabled={busy || !draft.trim()}
+          >
             {msg("clubs.list.create")}
           </button>
-          <button type="button" className="btn min-h-[44px]" disabled={busy} onClick={() => setCreating(null)}>
+          <button
+            type="button"
+            className="btn min-h-[44px] sm:min-h-0"
+            disabled={busy}
+            onClick={() => setCreating(null)}
+          >
             {msg("clubs.list.cancel")}
           </button>
         </form>
@@ -237,6 +265,28 @@ export function ClubsTeamsList({
                       {msg("clubs.list.standalone")}
                     </span>
                   </button>
+                  {canEdit && clubs.length > 0 && (
+                    <div className="mt-1 pl-8">
+                      {/* The ladder's missing rung: PATCH club_id adopts the
+                          standalone team into a club (detach lives on the hub). */}
+                      <select
+                        className="input min-h-[44px] w-auto max-w-full text-sm sm:min-h-0"
+                        aria-label={msg("clubs.list.addToClubAria", { name: t.name })}
+                        value=""
+                        disabled={busy}
+                        onChange={(e) => {
+                          if (e.target.value) void attachToClub(t.id, e.target.value);
+                        }}
+                      >
+                        <option value="">{msg("clubs.list.addToClub")}</option>
+                        {clubs.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {c.name}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
                   {openTeam === t.id && (
                     <div className="mt-2">
                       <TeamSquadPanel teamId={t.id} canEdit={canEdit} />

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -563,6 +563,8 @@
   "clubs.list.create": "Create",
   "clubs.list.cancel": "Cancel",
   "clubs.list.standalone": "standalone",
+  "clubs.list.addToClub": "Add to club…",
+  "clubs.list.addToClubAria": "Add {name} to a club",
   "clubs.list.col.teams": "Teams",
   "clubs.list.col.contact": "Contact",
   "clubs.list.noMatch": "No clubs or teams match your search.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -563,6 +563,8 @@
   "clubs.list.create": "Crear",
   "clubs.list.cancel": "Cancelar",
   "clubs.list.standalone": "independiente",
+  "clubs.list.addToClub": "Añadir a un club…",
+  "clubs.list.addToClubAria": "Añadir {name} a un club",
   "clubs.list.col.teams": "Equipos",
   "clubs.list.col.contact": "Contacto",
   "clubs.list.noMatch": "Ningún club o equipo coincide con tu búsqueda.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -563,6 +563,8 @@
   "clubs.list.create": "Créer",
   "clubs.list.cancel": "Annuler",
   "clubs.list.standalone": "indépendante",
+  "clubs.list.addToClub": "Ajouter à un club…",
+  "clubs.list.addToClubAria": "Ajouter {name} à un club",
   "clubs.list.col.teams": "Équipes",
   "clubs.list.col.contact": "Contact",
   "clubs.list.noMatch": "Aucun club ni équipe ne correspond à votre recherche.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -563,6 +563,8 @@
   "clubs.list.create": "Aanmaken",
   "clubs.list.cancel": "Annuleren",
   "clubs.list.standalone": "zelfstandig",
+  "clubs.list.addToClub": "Aan een club toevoegen…",
+  "clubs.list.addToClubAria": "{name} aan een club toevoegen",
   "clubs.list.col.teams": "Teams",
   "clubs.list.col.contact": "Contact",
   "clubs.list.noMatch": "Geen clubs of teams komen overeen met je zoekopdracht.",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -417,6 +417,8 @@ export type DictionaryKey =
   | "clubs.hub.tab.entries"
   | "clubs.hub.tab.overview"
   | "clubs.hub.tab.teams"
+  | "clubs.list.addToClub"
+  | "clubs.list.addToClubAria"
   | "clubs.list.cancel"
   | "clubs.list.col.contact"
   | "clubs.list.col.teams"


### PR DESCRIPTION
User-reported polish on the clubs directory + crest card:

1. **New club stayed highlighted when New team was open** — `btn-primary` was hardcoded on New club. The primary style now follows whichever form is open, and clicking the active toggle closes it.
2. **Fat buttons** — list + crest buttons matched the 44px mobile mandate on desktop too. Now `min-h-[44px] sm:min-h-0`: standard `.btn` height on desktop, 44px touch target on mobile (the 375px e2e gate still passes).
3. **"Can't see where to upload the crest"** — the crest tile itself is now the upload target (click-to-pick, hover + focus affordances) alongside the slimmer Upload/Replace buttons.
4. **Standalone → club** — the missing rung of the ladder: standalone rows get **Add to club…** (`PATCH /teams/:id {club_id}`), the reverse of the hub's Detach. New e2e: seed club + standalone team → adopt via UI → row leaves the standalone section and the club's team count ticks up.

i18n +2 keys ×4 locales (real translations). Gates: tsc clean · club-hub/directory units 72/0 · eslint clean · parity ×4 · clubs e2e 5/5 vs prod build (incl. new adopt test). No API/schema changes — attach reuses the existing PATCH; no cap check needed (team count is org-wide, unchanged by adoption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)