### PR TITLE
test(e2e): board-v3 stale-client race — gate moves on PATCH responses

### DIFF
--- a/apps/web/e2e/board-v3.spec.ts
+++ b/apps/web/e2e/board-v3.spec.ts
@@ -311,19 +311,35 @@ test.describe.serial("board v3 (PROMPT-33)", () => {
     await page.goto(filtered);
     await pageB.goto(filtered);
 
-    // Client A moves a fixture through the pick → MovePanel path.
+    // Client A moves a fixture through the pick → MovePanel path. Each move is
+    // gated on its own PATCH landing: on a slow runner an ungated A could still
+    // be in flight when B writes — B's seq would then be VALID, no 409, no
+    // toast, and the test times out (the CI-only failure this replaces).
     const move = async (p: Page, when: string) => {
       await p.locator("[data-fixture-id] button[aria-pressed]").first().click();
       const dialog = p.getByRole("dialog", { name: /^Move / });
       await dialog.locator("input[type=datetime-local]").fill(when);
       await dialog.getByRole("button", { name: "Move", exact: true }).click();
     };
-    await move(page, "2026-09-16T18:00");
+    const moveAndAwait = (p: Page, when: string, wantStatus: (s: number) => boolean) =>
+      Promise.all([
+        p.waitForResponse(
+          (r) =>
+            /\/api\/v1\/fixtures\/[0-9a-f-]+$/.test(r.url()) &&
+            r.request().method() === "PATCH" &&
+            wantStatus(r.status()),
+          { timeout: 20_000 },
+        ),
+        move(p, when),
+      ]);
+
+    // A's move must COMMIT (2xx) before B writes, so B is provably stale.
+    await moveAndAwait(page, "2026-09-16T18:00", (s) => s >= 200 && s < 300);
     // A's own board refreshes without complaint.
     await expect(page.getByText("Schedule changed by someone else")).toHaveCount(0);
 
     // Client B still holds the pre-move seq: its write must 409 → toast.
-    await move(pageB, "2026-09-16T19:00");
+    await moveAndAwait(pageB, "2026-09-16T19:00", (s) => s === 409);
     await expect(pageB.getByText("Schedule changed by someone else — board refreshed.")).toBeVisible(
       { timeout: 15_000 },
     );


### PR DESCRIPTION
Fixes the sole chronic red on main e2e (4 consecutive CI-only failures at `board-v3.spec.ts:298`, never reproducible locally — verified solo 8/0 and full-parallel `--workers=2` green on an M-series machine).

Root cause: the test asserted client A's move only by *absence of a toast* — nothing awaited the PATCH committing. On the 2-core runner, A's request could still be in flight when B wrote; B's `expected_seq` was then valid → no `SEQ_CONFLICT`, no toast, 60s timeout. Locally A always won the race, which is why it never repro'd.

Fix (test-only): both moves gate on their `PATCH /api/v1/fixtures/{id}` response — A on 2xx (stale-ness of B becomes a fact, not a hope), B on the 409 itself before asserting the toast. Local: 8/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)