### PR TITLE
fix(console): stepladder rung list on the fixtures tab

### DIFF
--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/page.tsx
@@ -81,7 +81,7 @@ export default async function DivisionPage({
   // by the entrants panel (add form + roster editor) and the Settings tab.
   const entrantModel = effectiveEntrantModel(sportModule.entrantModel ?? null, division.config);
   const entrantNames = Object.fromEntries(entrants.map((e) => [e.id, e.display_name]));
-  const BRACKET_STAGE_KINDS = new Set(["knockout", "double_elim"]);
+  const BRACKET_STAGE_KINDS = new Set(["knockout", "double_elim", "stepladder"]);
   const hasKnockout = stages.some((s) => BRACKET_STAGE_KINDS.has(s.kind));
   // Badge chips on standings rows (v3/03 §5) — resolved once per render.
   // PROMPT-62: the bracket panel on the fixtures tab shows them too.
@@ -234,6 +234,7 @@ export default async function DivisionPage({
               .map((st) => (
                 <div key={st.id} className="mb-6">
                   <BracketPanel
+                    kind={st.kind}
                     fixtures={fixtures.filter((f) => f.stage_id === st.id)}
                     entrantNames={entrantNames}
                     entrantBadges={entrantLogos}

--- a/apps/web/src/components/v2/__tests__/bracket-panel.test.tsx
+++ b/apps/web/src/components/v2/__tests__/bracket-panel.test.tsx
@@ -89,3 +89,18 @@ describe("BracketPanel", () => {
     expect(html).toContain("<svg");
   });
 });
+
+describe("BracketPanel — stepladder", () => {
+  it("kind=stepladder renders the rung list with labels and fixture links", () => {
+    const rungs = [
+      FIX("r1", 1, 1, "e1", "e2", { kind: "win", winner: "e1" }, "decided", 1),
+      FIX("r2", 2, 1, "e1", "e3", null, "scheduled", 2),
+      FIX("r3", 3, 1, null, "e4", null, "scheduled", 3),
+    ];
+    const html = markup({ kind: "stepladder", fixtures: rungs as never });
+    expect(html).toContain('data-testid="bracket-panel-ladder"');
+    expect((html.match(/bracket\.rung/g) ?? []).length).toBe(3);
+    expect(html).toContain('href="/o/org/c/cup/d/open/f/2"');
+    expect(html).toContain("bracket.tbd"); // unresolved rung-3 slot
+  });
+});

--- a/apps/web/src/components/v2/bracket-panel.tsx
+++ b/apps/web/src/components/v2/bracket-panel.tsx
@@ -30,6 +30,9 @@ interface FixtureLike {
 }
 
 interface Props {
+  /** Stage kind — stepladder gets the rung list; bracket shapes are detected
+   *  structurally from the fixtures. */
+  kind?: string;
   fixtures: FixtureLike[];
   entrantNames: Record<string, string>;
   /** entrant_id → resolved badge URL (PROMPT-60 resolver); null/absent = none. */
@@ -55,6 +58,7 @@ function colX(node: Pick<BracketNode, "side" | "col">, colsPerSide: number): num
 }
 
 export function BracketPanel({
+  kind,
   fixtures,
   entrantNames,
   entrantBadges,
@@ -64,6 +68,19 @@ export function BracketPanel({
   divSlug,
 }: Props) {
   const msg = useMsg();
+  if (kind === "stepladder") {
+    return (
+      <StepladderPanel
+        fixtures={fixtures}
+        entrantNames={entrantNames}
+        {...(entrantBadges === undefined ? {} : { entrantBadges })}
+        {...(headlines === undefined ? {} : { headlines })}
+        orgSlug={orgSlug}
+        compSlug={compSlug}
+        divSlug={divSlug}
+      />
+    );
+  }
   const result = twoSidedBracket(fixtures);
   // G8: double-elim divisions get the two-lane geometry instead of nothing.
   const de = result.ok ? null : doubleElimBracket(fixtures);
@@ -365,6 +382,92 @@ function DoubleElimPanel({
             );
           })}
         </div>
+      </div>
+    </section>
+  );
+}
+
+/** Stepladder — rung-by-rung list (the ladder IS the geometry): challenger
+ *  climbs bottom-up, each rung's winner feeds the next. Night-styled like
+ *  the bracket nodes; rung labels mirror the public view. */
+function StepladderPanel({
+  fixtures,
+  entrantNames,
+  entrantBadges,
+  headlines,
+  orgSlug,
+  compSlug,
+  divSlug,
+}: {
+  fixtures: FixtureLike[];
+  entrantNames: Record<string, string>;
+  entrantBadges?: Record<string, string | null>;
+  headlines?: Record<string, string>;
+  orgSlug: string;
+  compSlug: string;
+  divSlug: string;
+}) {
+  const msg = useMsg();
+  if (fixtures.length === 0) return null;
+  const rungs = [...fixtures].sort((a, b) => a.round_no - b.round_no);
+  const row = (f: FixtureLike, entrantId: string | null) => {
+    const winner = (f.outcome as { winner?: string } | null)?.winner ?? null;
+    const name = entrantId ? (entrantNames[entrantId] ?? entrantId) : null;
+    const badge = entrantId ? entrantBadges?.[entrantId] : null;
+    const isWinner = winner !== null && winner === entrantId;
+    const muted = winner !== null && winner !== entrantId;
+    return (
+      <span className="flex min-w-0 items-center gap-1.5">
+        {badge ? (
+          // eslint-disable-next-line @next/next/no-img-element -- tenant crest
+          <img src={badge} alt="" className="h-3.5 w-3.5 shrink-0 rounded-[3px] object-cover" />
+        ) : null}
+        <span
+          className={`truncate text-xs ${
+            name === null
+              ? "italic text-[color:var(--app-fg-muted,#94a3b8)]"
+              : isWinner
+                ? "font-semibold text-[color:var(--app-fg,#e2e8f0)]"
+                : muted
+                  ? "text-[color:var(--app-fg-muted,#94a3b8)]"
+                  : "text-[color:var(--app-fg,#e2e8f0)]"
+          }`}
+        >
+          {name ?? msg("bracket.tbd")}
+        </span>
+        {f.status === "in_play" && (
+          <span className="animate-live-pulse h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+        )}
+      </span>
+    );
+  };
+  return (
+    <section className="card overflow-hidden" data-testid="bracket-panel-ladder">
+      <header className="border-b border-slate-100 px-4 py-3">
+        <h3 className="text-sm font-semibold text-slate-800">{msg("bracket.title")}</h3>
+      </header>
+      <div className="space-y-3 bg-[color:var(--app-surface,#0f172a)] p-4">
+        {rungs.map((f, i) => (
+          <div key={f.id}>
+            <p className="mb-1 font-display text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--app-fg-muted,#94a3b8)]">
+              {msg("bracket.rung")} {i + 1}
+            </p>
+            <Link
+              href={routes.fixture(orgSlug, compSlug, divSlug, f.fixture_no)}
+              className="relative block max-w-md rounded-lg border border-[color:var(--app-hairline,#334155)] bg-[color:var(--app-card,#1e293b)] px-2.5 py-1.5 shadow-sm transition hover:-translate-y-0.5 hover:shadow"
+            >
+              <span className="flex flex-col gap-0.5">
+                {row(f, f.home_entrant_id)}
+                {row(f, f.away_entrant_id)}
+              </span>
+              {headlines?.[f.id] !== undefined && (
+                <span className="absolute right-2 top-1.5 font-display text-[11px] tabular-nums text-[color:var(--app-fg-muted,#94a3b8)]">
+                  {headlines[f.id]}
+                </span>
+              )}
+            </Link>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -876,6 +876,7 @@
   "bracket.losers": "Losers bracket",
   "bracket.grandFinal": "Grand final",
   "bracket.reset": "Reset",
+  "bracket.rung": "Rung",
   "bracket.tbd": "TBD",
   "stage.addMatch.button": "Add match",
   "stage.addMatch.home": "Home",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -876,6 +876,7 @@
   "bracket.losers": "Cuadro de perdedores",
   "bracket.grandFinal": "Gran final",
   "bracket.reset": "Desempate",
+  "bracket.rung": "Peldaño",
   "bracket.tbd": "Por definir",
   "stage.addMatch.button": "Añadir partido",
   "stage.addMatch.home": "Local",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -876,6 +876,7 @@
   "bracket.losers": "Tableau des repêchages",
   "bracket.grandFinal": "Grande finale",
   "bracket.reset": "Revanche",
+  "bracket.rung": "Échelon",
   "bracket.tbd": "À définir",
   "stage.addMatch.button": "Ajouter un match",
   "stage.addMatch.home": "Domicile",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -876,6 +876,7 @@
   "bracket.losers": "Verliezersronde",
   "bracket.grandFinal": "Grote finale",
   "bracket.reset": "Beslisser",
+  "bracket.rung": "Sport",
   "bracket.tbd": "N.t.b.",
   "stage.addMatch.button": "Wedstrijd toevoegen",
   "stage.addMatch.home": "Thuis",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -308,6 +308,7 @@ export type DictionaryKey =
   | "bracket.grandFinal"
   | "bracket.losers"
   | "bracket.reset"
+  | "bracket.rung"
   | "bracket.tbd"
   | "bracket.title"
   | "bracket.winners"


### PR DESCRIPTION
From the format-geometry audit (below): stepladder was the remaining kind with public geometry but a blank console fixtures tab. BracketPanel gains a `kind` prop and a night-styled rung list; page gate widened. Markup test added (4/4 in the panel suite); tsc 0.

Verified against the live stg showcases: "Stepladder Showcase → Ladder Cup" and the "Group + Ladder (Top 4)" template division.

🤖 Generated with [Claude Code](https://claude.com/claude-code)