### PR TITLE
fix(connect): Express dashboard link under restricted keys — fallback + sanitized errors

### DIFF
--- a/apps/web/src/server/usecases/__tests__/stripe-connect.test.ts
+++ b/apps/web/src/server/usecases/__tests__/stripe-connect.test.ts
@@ -139,6 +139,41 @@ describe.skipIf(!HAS_DB)("Express dashboard login link", () => {
       status: 403,
     });
   });
+
+  it("restricted key (login links fenced) falls back to Stripe's Express login page", async () => {
+    const { owner, orgId } = await seedProOrg();
+    await sql`update organizations set stripe_account_id = ${"acct_rk_" + orgId.slice(0, 8)}
+              where id = ${orgId}`;
+    // Stripe rejects createLoginLink for rk_ keys with a PermissionError —
+    // not a grantable scope, the endpoint requires a full secret key.
+    stripeMock.loginLinkCreate.mockRejectedValue(
+      Object.assign(new Error("This is a restricted API key"), {
+        type: "StripePermissionError",
+        statusCode: 403,
+      }),
+    );
+    const { url } = await createConnectDashboardLink(owner, orgId);
+    expect(url).toBe("https://connect.stripe.com/express_login");
+  });
+
+  it("other Stripe failures become a clean 502 — no key material in the message", async () => {
+    const { owner, orgId } = await seedProOrg();
+    await sql`update organizations set stripe_account_id = ${"acct_bad_" + orgId.slice(0, 8)}
+              where id = ${orgId}`;
+    stripeMock.loginLinkCreate.mockRejectedValue(
+      Object.assign(
+        new Error(
+          "The provided key 'rk_test_abc123' does not have access to account 'acct_nope'",
+        ),
+        { type: "StripeInvalidRequestError", statusCode: 400 },
+      ),
+    );
+    const err = (await createConnectDashboardLink(owner, orgId).catch((e) => e)) as Error & {
+      status?: number;
+    };
+    expect(err.status).toBe(502);
+    expect(String(err.message)).not.toMatch(/rk_test|acct_/);
+  });
 });
 
 describe.skipIf(!HAS_DB)("Connect health mirror (P1-8)", () => {

--- a/apps/web/src/server/usecases/stripe-connect.ts
+++ b/apps/web/src/server/usecases/stripe-connect.ts
@@ -147,6 +147,10 @@ export async function createConnectOnboardingLink(
  * and Stripe's own "more information needed" prompts live there). Fresh per
  * click — the URLs are single-use and short-lived.
  */
+/** Stripe's own Express login page (email/OTP) — works for every Express
+ *  account with no API call; the fallback when login links can't be minted. */
+const EXPRESS_LOGIN_URL = "https://connect.stripe.com/express_login";
+
 export async function createConnectDashboardLink(
   auth: AuthCtx,
   orgId: string,
@@ -157,8 +161,23 @@ export async function createConnectDashboardLink(
   if (!accountId) {
     throw new HttpError(409, "Connect Stripe first — this organization has no Stripe account");
   }
-  const link = await getStripe().accounts.createLoginLink(accountId);
-  return { url: link.url };
+  try {
+    const link = await getStripe().accounts.createLoginLink(accountId);
+    return { url: link.url };
+  } catch (err) {
+    // Restricted (rk_) keys cannot mint login links at all — Stripe fences
+    // the endpoint to full secret keys, it's not a grantable scope. Send the
+    // owner to Stripe's own Express login page instead of failing.
+    const type = (err as { type?: string }).type;
+    const status = (err as { statusCode?: number }).statusCode;
+    if (type === "StripePermissionError" || status === 403) {
+      return { url: EXPRESS_LOGIN_URL };
+    }
+    // Anything else: log the detail, answer clean — Stripe's raw message
+    // names the platform key and account id and must never reach a client.
+    console.error("createConnectDashboardLink failed", err);
+    throw new HttpError(502, "Stripe couldn't create a dashboard link for this account");
+  }
 }
 
 /** Mirror Stripe's account flags (account.updated webhook + refresh path). */


### PR DESCRIPTION
Stg repro (owner report): clicking **Open Stripe dashboard** on a real connected account returned 500 with Stripe's raw message — key prefix and account id included. Root cause: Stripe forbids `accounts.createLoginLink` for restricted (`rk_`) keys entirely; it is not a grantable scope.

- Permission-fenced mint → falls back to Stripe's own Express login page (`connect.stripe.com/express_login`, email/OTP, works for every Express account). Same button, still lands in the dashboard.
- Any other Stripe failure → detail logged server-side, client gets a clean 502; no key material or account ids in any envelope.
- Red-first tests: rk_ fallback URL + 502 message carries no `rk_test`/`acct_` fragments (9/9 suite green).

No migration. Follow-up to #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)