### PR TITLE
feat(trust): 'Payments secured by Stripe' footer line + deploy-context fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ development/
 engine/
 *.md
 !README.md
+.claude/

--- a/apps/web/content/help/registration/card-payments.md
+++ b/apps/web/content/help/registration/card-payments.md
@@ -4,7 +4,7 @@ description: From connecting Stripe to money in your bank — holds, reminders, 
 order: 2
 ---
 
-Card entry fees run on **Stripe Connect**: registrants pay at sign-up, the money settles into *your* Stripe account, and Seazn Club never holds your funds. Here's the whole journey.
+Card entry fees run on **Stripe Connect**: registrants pay at sign-up, the money settles into *your* Stripe account, and Seazn Club never holds your funds. Once your account is live, your public pages carry a **"Payments secured by Stripe"** line in the footer, so registrants see it too. Here's the whole journey.
 
 ## 1. Connect and verify (one-time)
 

--- a/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
@@ -11,6 +11,7 @@ import { notFound, permanentRedirect } from "next/navigation";
 import Image from "next/image";
 import { Barlow_Condensed } from "next/font/google";
 import { AttributionLink } from "@/components/attribution-link";
+import { StripeBadge } from "@/components/stripe-badge";
 import { isReservedSlug } from "@/lib/public-site";
 import { publicThemeStyle } from "@/lib/public-theme";
 import { getPublicOrg } from "@/server/public-site/data";
@@ -104,7 +105,7 @@ export default async function PublicOrgLayout({
         <div aria-hidden className="h-0.5 bg-accent" />
       </header>
       <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-6">{children}</main>
-      <footer className="mt-8 py-6 text-center text-xs text-ink-muted">
+      <footer className="mt-8 space-y-1.5 py-6 text-center text-xs text-ink-muted">
         {/* Doc 09 §4: fixed platform footer for Community; removable for Pro
             (branding entitlement, resolved server-side). */}
         {org.branded ? null : (
@@ -113,6 +114,13 @@ export default async function PublicOrgLayout({
             <AttributionLink surface="badge" />
           </p>
         )}
+        {/* Trust line only where it's true: the org actually takes card entry
+            fees through Stripe. All tiers — payment trust, not platform chrome. */}
+        {org.card_payments ? (
+          <p>
+            <StripeBadge label="Payments secured by" className="hover:text-ink" />
+          </p>
+        ) : null}
       </footer>
     </div>
   );

--- a/apps/web/src/components/marketing-footer.tsx
+++ b/apps/web/src/components/marketing-footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { CookieSettingsButton } from "@/components/cookie-settings-button";
 import { LocaleSwitcher } from "@/components/i18n/locale-switcher";
+import { StripeBadge } from "@/components/stripe-badge";
 import { getDictionary, t } from "@/lib/i18n";
 import { toLocale } from "@/lib/i18n-constants";
 
@@ -79,6 +80,14 @@ export async function MarketingFooter({ lang = "en" }: { lang?: string }) {
           <span>{t(d, "footer.rights", { year: new Date().getFullYear() })}</span>
           <LocaleSwitcher />
           <span className="mk-display tracking-[0.2em]">{t(d, "footer.tagline")}</span>
+        </div>
+        {/* Trust line: entry fees run on Stripe (Checkout + Connect) — say so
+            where the whole site signs off. Quiet by design, dead-centered. */}
+        <div className="mt-4 flex w-full justify-center text-xs text-[#8d7fc0]">
+          <StripeBadge
+            label={t(d, "footer.securePayments")}
+            className="hover:text-[var(--mk-lime)]"
+          />
         </div>
       </div>
     </footer>

--- a/apps/web/src/components/marketing/__tests__/marketing-shell.test.tsx
+++ b/apps/web/src/components/marketing/__tests__/marketing-shell.test.tsx
@@ -26,6 +26,14 @@ describe("marketing shell pieces", () => {
     expect(html).toContain('href="/legal/privacy"');
     expect(html).toContain("ANY SPORT · LIVE IN MINUTES");
   });
+  it("footer carries the Stripe trust line (badge links stripe.com)", async () => {
+    const html = renderToStaticMarkup(await MarketingFooter({ lang: "en" }));
+    expect(html).toContain("Payments secured by");
+    expect(html).toContain('href="https://stripe.com"');
+    // Localized lead-in survives the dictionary round-trip (spot-check fr).
+    const fr = renderToStaticMarkup(await MarketingFooter({ lang: "fr" }));
+    expect(fr).toContain("Paiements sécurisés par");
+  });
   it("funnel night variant adds the dark classes", () => {
     const cls = funnelFormClasses(false, "night");
     expect(cls).toContain("mk-funnel-night");

--- a/apps/web/src/components/stripe-badge.tsx
+++ b/apps/web/src/components/stripe-badge.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+
+// Official Stripe wordmark path (simple-icons, 24×24 viewBox) — fill inherits
+// currentColor so the badge sits quietly in any footer palette.
+const STRIPE_WORDMARK_PATH =
+  "M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 7.218c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 .98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.594-7.305h.003Z";
+
+/**
+ * "Payments secured by Stripe" trust line for footers. The wordmark is the
+ * S-glyph from Stripe's press kit; the visible text comes from the caller so
+ * each surface keeps its own copy/localization.
+ */
+export function StripeBadge({
+  label,
+  className = "",
+}: {
+  /** Localized "Payments secured by" lead-in (the wordmark itself says Stripe). */
+  label: ReactNode;
+  className?: string;
+}) {
+  return (
+    <a
+      href="https://stripe.com"
+      target="_blank"
+      rel="noreferrer"
+      className={`inline-flex items-center gap-1.5 whitespace-nowrap ${className}`}
+    >
+      <span>{label}</span>
+      <svg
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        className="h-[0.9em] w-[0.9em] shrink-0"
+        fill="currentColor"
+      >
+        <path d={STRIPE_WORDMARK_PATH} />
+      </svg>
+      <span className="font-semibold tracking-wide">Stripe</span>
+    </a>
+  );
+}

--- a/apps/web/src/dictionaries/en/marketing.json
+++ b/apps/web/src/dictionaries/en/marketing.json
@@ -300,6 +300,7 @@
   "footer.link.subProcessors": "Sub-processors",
   "footer.cookieSettings": "Cookie settings",
   "footer.rights": "© {year} Seazn Club. All rights reserved.",
+  "footer.securePayments": "Payments secured by",
   "footer.tagline": "ANY SPORT · LIVE IN MINUTES",
   "discover.meta.title": "Discover live tournaments — Seazn Club",
   "discover.meta.description": "Live and upcoming community tournaments running on Seazn Club — cricket, football, volleyball, chess, carrom and more. Follow live scores, or run your own.",

--- a/apps/web/src/dictionaries/es/marketing.json
+++ b/apps/web/src/dictionaries/es/marketing.json
@@ -299,6 +299,7 @@
   "footer.link.subProcessors": "Subprocesadores",
   "footer.cookieSettings": "Configuración de cookies",
   "footer.rights": "© {year} Seazn Club. Todos los derechos reservados.",
+  "footer.securePayments": "Pagos protegidos por",
   "footer.tagline": "CUALQUIER DEPORTE · EN DIRECTO EN MINUTOS",
   "discover.meta.title": "Descubre torneos en vivo — Seazn Club",
   "discover.meta.description": "Torneos comunitarios en vivo y próximos organizados en Seazn Club: cricket, fútbol, voleibol, ajedrez, carrom y más. Sigue los marcadores en vivo o organiza el tuyo.",

--- a/apps/web/src/dictionaries/fr/marketing.json
+++ b/apps/web/src/dictionaries/fr/marketing.json
@@ -299,6 +299,7 @@
   "footer.link.subProcessors": "Sous-traitants",
   "footer.cookieSettings": "Paramètres des cookies",
   "footer.rights": "© {year} Seazn Club. Tous droits réservés.",
+  "footer.securePayments": "Paiements sécurisés par",
   "footer.tagline": "TOUS LES SPORTS · EN DIRECT EN QUELQUES MINUTES",
   "discover.meta.title": "Découvrez les tournois en direct — Seazn Club",
   "discover.meta.description": "Tournois communautaires en direct et à venir sur Seazn Club — cricket, football, volley-ball, échecs, carrom et plus encore. Suivez les scores en direct ou organisez le vôtre.",

--- a/apps/web/src/dictionaries/nl/marketing.json
+++ b/apps/web/src/dictionaries/nl/marketing.json
@@ -299,6 +299,7 @@
   "footer.link.subProcessors": "Subverwerkers",
   "footer.cookieSettings": "Cookie-instellingen",
   "footer.rights": "© {year} Seazn Club. Alle rechten voorbehouden.",
+  "footer.securePayments": "Betalingen beveiligd door",
   "footer.tagline": "ELKE SPORT · LIVE IN ENKELE MINUTEN",
   "discover.meta.title": "Ontdek live toernooien — Seazn Club",
   "discover.meta.description": "Live en aankomende community-toernooien op Seazn Club — cricket, voetbal, volleybal, schaken, carrom en meer. Volg live scores of organiseer je eigen toernooi.",

--- a/apps/web/src/server/public-site/data.ts
+++ b/apps/web/src/server/public-site/data.ts
@@ -45,6 +45,9 @@ export interface PublicOrg {
    *  the page language for every visitor, keeping the page ISR-cacheable (it's
    *  a function of the org, not the request). */
   default_locale: string;
+  /** Live card intake (Connect charges enabled) — gates the Stripe trust
+   *  line in the public footer so cash-only orgs never claim card security. */
+  card_payments: boolean;
 }
 
 export interface PublicCompetition {
@@ -171,6 +174,7 @@ async function loadOrg(orgSlug: string): Promise<PublicOrg | null> {
     (Omit<PublicOrg, "logo"> & { logo_url: string | null; logo_storage_path: string | null })[]
   >`
     select o.id, o.name, o.slug, o.about, o.default_locale,
+           o.stripe_charges_enabled as card_payments,
            org_has_feature(o.id, 'branding') as branded,
            case when org_has_feature(o.id, 'dashboard.branding')
                 then o.branding else '{}'::jsonb end as branding,


### PR DESCRIPTION
Owner ask: show we handle payments securely.

- **Marketing footer**: localized "Payments secured by" + official Stripe wordmark (currentColor, links stripe.com), dead-centered under the sign-off row — verified 0px off viewport center at desktop and 390px, no horizontal scroll.
- **Public org pages** (`/shared/{org}`): same line, but only when the org actually takes card entry fees (`stripe_charges_enabled`) — payment trust, not platform chrome: shows for Pro-branded orgs too, never for cash-only orgs.
- i18n en/fr/es/nl (+ parity green), footer render test asserts the line and the stripe.com link in en + fr, help page mentions the trust line.
- **Deploy fix**: `.dockerignore` now excludes `.claude/` — 12 worktrees were inflating the remote-build context to 246MB and stalling fly deploys.

Verification: tsc clean, unit web 1714/0 + engine 892/0, smoke 433/0, e2e parallel+serial+mobile vs prod build (two parallel-phase CPU-contention flakes green when rerun serial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)