### PR TITLE
feat(geometry): bracket slides + PDF posters for double-elim and stepladder

### DIFF
--- a/apps/web/content/help/divisions/bracket-view.md
+++ b/apps/web/content/help/divisions/bracket-view.md
@@ -8,8 +8,8 @@ Knockout stages render as the classic **two-sided bracket**: quarter-finals on t
 
 - **Console** — the division's Fixtures tab shows the tree above the match list; each node links to its scoring page, live matches pulse.
 - **Public page** — the shared division page draws the same connected tree, filled from live results (`TBD` until a feed resolves).
-- **Big screen** — the [slideshow](/help/sharing/slideshow) and [presentation mode](/help/sharing/presentation-mode) get a bracket slide.
-- **Poster** — Documents → *Bracket poster* exports a landscape PDF of the tree, scaled to one sheet, with your branding on Pro.
+- **Big screen** — the [slideshow](/help/sharing/slideshow) and [presentation mode](/help/sharing/presentation-mode) get a bracket slide — the tree, the double-elim lanes, or the stepladder rungs, whichever the stage is.
+- **Poster** — Documents → *Bracket poster* exports a landscape PDF scaled to one sheet — all three shapes — with your branding on Pro.
 
 **Double elimination** gets its own geometry — on the console Fixtures tab *and* the public page: the winners bracket on top, the losers bracket beneath it, and the grand final (plus the bracket-reset match, when configured) joining the two lanes on the right. Stepladder stages keep their rung-by-rung view — that ladder *is* their shape.
 

--- a/apps/web/src/components/v2/__tests__/slideshow-rotation.test.ts
+++ b/apps/web/src/components/v2/__tests__/slideshow-rotation.test.ts
@@ -1,7 +1,7 @@
 // In-play pinning rotation (PROMPT-64 / v13): live slide interleaves every
 // other step; plain cycle otherwise.
 import { describe, expect, it } from "vitest";
-import { rotationLength, slideAt, stepFor } from "../slideshow-rotation";
+import { BRACKET_SLIDE_KINDS, bracketSlideLaysOut, rotationLength, slideAt, stepFor } from "../slideshow-rotation";
 
 const plain = [{}, {}, {}];
 const withLive = [{}, { pinned: true }, {}, {}]; // live slide at index 1
@@ -31,5 +31,28 @@ describe("slideshow rotation", () => {
     expect(slideAt(5, [])).toBe(0);
     expect(slideAt(5, [{ pinned: true }])).toBe(0);
     expect(rotationLength([{ pinned: true }])).toBe(1);
+  });
+});
+
+describe("bracketSlideLaysOut (G-audit)", () => {
+  const se = [
+    { id: "a", round_no: 1, seq_in_round: 1 }, { id: "b", round_no: 1, seq_in_round: 2 },
+    { id: "c", round_no: 2, seq_in_round: 1 },
+  ];
+  // 4-team DE persisted numbering: WB 1–2, LB 5–6, GF 9.
+  const de = [
+    { id: "w1", round_no: 1, seq_in_round: 1 }, { id: "w2", round_no: 1, seq_in_round: 2 },
+    { id: "wf", round_no: 2, seq_in_round: 1 }, { id: "l1", round_no: 5, seq_in_round: 1 },
+    { id: "lf", round_no: 6, seq_in_round: 1 }, { id: "gf", round_no: 9, seq_in_round: 1 },
+  ];
+  it("knockout needs the two-sided layout; DE needs the two-lane layout", () => {
+    expect(bracketSlideLaysOut("knockout", se)).toBe(true);
+    expect(bracketSlideLaysOut("knockout", de)).toBe(false);
+    expect(bracketSlideLaysOut("double_elim", de)).toBe(true);
+    expect(bracketSlideLaysOut("double_elim", se)).toBe(false);
+  });
+  it("stepladder always lays out; the kind set covers all three", () => {
+    expect(bracketSlideLaysOut("stepladder", [{ id: "r", round_no: 1, seq_in_round: 1 }])).toBe(true);
+    expect([...BRACKET_SLIDE_KINDS].sort()).toEqual(["double_elim", "knockout", "stepladder"]);
   });
 });

--- a/apps/web/src/components/v2/slideshow-rotation.ts
+++ b/apps/web/src/components/v2/slideshow-rotation.ts
@@ -35,3 +35,19 @@ export function stepFor(slideIndex: number, slides: readonly object[]): number {
   const pos = others.indexOf(slideIndex);
   return pos < 0 ? 0 : 2 * pos + 1;
 }
+
+// G-audit: which bracket-shaped stages earn a slideshow slide, and whether
+// the shape actually lays out. Pure — shared by the server slide builder and
+// its unit tests (stepladder always lays out: the rung list IS the shape).
+import { doubleElimBracket, twoSidedBracket } from "@seazn/engine/scheduling";
+
+export const BRACKET_SLIDE_KINDS = new Set(["knockout", "double_elim", "stepladder"]);
+
+export function bracketSlideLaysOut(
+  kind: string,
+  refs: { id: string; round_no: number; seq_in_round: number }[],
+): boolean {
+  if (kind === "double_elim") return doubleElimBracket(refs).ok;
+  if (kind === "stepladder") return true;
+  return twoSidedBracket(refs).ok;
+}

--- a/apps/web/src/components/v2/slideshow.tsx
+++ b/apps/web/src/components/v2/slideshow.tsx
@@ -18,7 +18,7 @@ import { ArrowLeft } from "lucide-react";
 import { useRouter } from "next/navigation";
 import type { BracketSlideFixture, Slide } from "@/server/slideshow-data";
 import { slideAt, stepFor } from "@/components/v2/slideshow-rotation";
-import { rowCenter, twoSidedBracket } from "@seazn/engine/scheduling";
+import { doubleElimBracket, lbRowUnit, rowCenter, twoSidedBracket } from "@seazn/engine/scheduling";
 
 const SLIDE_MS = 9000;
 const POLL_MS = 45_000;
@@ -233,7 +233,7 @@ export function Slideshow({
             </div>
 
             {slide.kind === "bracket" ? (
-              <BracketSlide fixtures={slide.fixtures} />
+              <BracketSlide fixtures={slide.fixtures} stageKind={slide.stageKind ?? "knockout"} />
             ) : slide.kind === "standings" ? (
               <div>
                 <div className="grid grid-cols-[4rem_minmax(0,1fr)_repeat(4,4rem)_7rem] gap-x-5 px-6 pb-2 font-display text-base font-semibold uppercase tracking-[0.2em] text-court-muted">
@@ -408,9 +408,18 @@ export function Slideshow({
   );
 }
 
-// v13 (PROMPT-64): the knockout tree on the big screen — same shared engine
-// geometry as the console panel / public bracket / PDF poster.
-function BracketSlide({ fixtures }: { fixtures: BracketSlideFixture[] }) {
+// v13 (PROMPT-64) + G-audit: bracket slides for all three shapes — the
+// knockout tree, the double-elim lanes, the stepladder rungs — from the same
+// shared engine geometry as console / public / PDF.
+function BracketSlide({
+  fixtures,
+  stageKind,
+}: {
+  fixtures: BracketSlideFixture[];
+  stageKind: "knockout" | "double_elim" | "stepladder";
+}) {
+  if (stageKind === "stepladder") return <LadderSlide fixtures={fixtures} />;
+  if (stageKind === "double_elim") return <DoubleElimSlide fixtures={fixtures} />;
   const result = twoSidedBracket(fixtures);
   if (!result.ok) return null;
   const layout = result.layout;
@@ -475,6 +484,123 @@ function BracketSlide({ fixtures }: { fixtures: BracketSlideFixture[] }) {
                 </span>
               </div>
             </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Stepladder on the big screen: summit at the top, climbers below.
+function LadderSlide({ fixtures }: { fixtures: BracketSlideFixture[] }) {
+  const rungs = [...fixtures].sort((a, b) => b.round_no - a.round_no);
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      {rungs.map((f, i) => {
+        const live = f.status === "in_play";
+        return (
+          <div key={f.id}>
+            <p className="mb-1 font-display text-sm font-semibold uppercase tracking-[0.18em] text-white/50">
+              Rung {rungs.length - i}
+            </p>
+            <div className={`rounded-lg px-5 py-3 ring-1 ring-inset ring-white/10 ${live ? "bg-white/[0.12]" : "bg-white/[0.05]"}`}>
+              <div className="flex flex-col gap-1 font-display text-2xl font-semibold leading-tight">
+                <span className="flex items-center justify-between gap-3">
+                  <span className="min-w-0 truncate">{f.home ?? "TBD"}</span>
+                  {live && <span className="animate-live-pulse h-2 w-2 shrink-0 rounded-full bg-emerald-400" />}
+                </span>
+                <span className="flex items-center justify-between gap-3 text-white/80">
+                  <span className="min-w-0 truncate">{f.away ?? "TBD"}</span>
+                  {f.line !== null && <span className="shrink-0 font-bold tabular-nums text-accent-line">{f.line}</span>}
+                </span>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Double elimination on the big screen: winners lane over losers lane, grand
+// final (+ reset) joining the lane finals — mirrors the console/public math.
+function DoubleElimSlide({ fixtures }: { fixtures: BracketSlideFixture[] }) {
+  const result = doubleElimBracket(fixtures);
+  if (!result.ok) return null;
+  const layout = result.layout;
+  const byId = new Map(fixtures.map((f) => [f.id, f]));
+  const COL_W = 232;
+  const SLOT_H = 96;
+  const NODE_W = COL_W - 22;
+  const NODE_H = 66;
+  const LANE_GAP = 56;
+  const LABEL_H = 28;
+  const wbH = Math.max(layout.wbRows, 1) * SLOT_H;
+  const lbH = Math.max(layout.lbRows, 0) * SLOT_H;
+  const wbTop = LABEL_H;
+  const lbTop = wbTop + wbH + LANE_GAP + (lbH > 0 ? LABEL_H : 0);
+  const gfX = Math.max(layout.k, layout.lbCols) * COL_W;
+  const totalW = gfX + COL_W * (layout.resetId !== undefined ? 2 : 1);
+  const totalH = lbTop + lbH;
+  const wbY = (col: number, row: number) => wbTop + rowCenter(col, row) * SLOT_H;
+  const lbY = (col: number, row: number) => lbTop + rowCenter(lbRowUnit(col), row) * SLOT_H;
+  const gfY = (wbTop + (lbH > 0 ? lbTop + lbH : wbTop + wbH)) / 2;
+  const label = "absolute font-display text-sm font-semibold uppercase tracking-[0.18em] text-white/50";
+  const node = (f: BracketSlideFixture, left: number, top: number) => {
+    const live = f.status === "in_play";
+    return (
+      <div
+        key={f.id}
+        className={`absolute rounded-lg px-4 py-2 ring-1 ring-inset ring-white/10 ${live ? "bg-white/[0.12]" : "bg-white/[0.05]"}`}
+        style={{ left, top, width: NODE_W, height: NODE_H }}
+      >
+        <div className="flex h-full flex-col justify-center gap-0.5 font-display text-xl font-semibold leading-tight">
+          <span className="flex items-center justify-between gap-2">
+            <span className="min-w-0 truncate">{f.home ?? "TBD"}</span>
+            {live && <span className="animate-live-pulse h-2 w-2 shrink-0 rounded-full bg-emerald-400" />}
+          </span>
+          <span className="flex items-center justify-between gap-2 text-white/80">
+            <span className="min-w-0 truncate">{f.away ?? "TBD"}</span>
+            {f.line !== null && <span className="shrink-0 font-bold tabular-nums text-accent-line">{f.line}</span>}
+          </span>
+        </div>
+      </div>
+    );
+  };
+  return (
+    <div className="overflow-x-auto">
+      <div className="relative mx-auto" style={{ width: totalW, height: totalH }}>
+        <span className={label} style={{ left: 0, top: 0 }}>Winners bracket</span>
+        {lbH > 0 && <span className={label} style={{ left: 0, top: wbTop + wbH + LANE_GAP }}>Losers bracket</span>}
+        <svg aria-hidden className="absolute inset-0" width={totalW} height={totalH} viewBox={`0 0 ${totalW} ${totalH}`}>
+          {layout.connectors.map((c, i) => {
+            const y = c.lane === "WB" ? wbY : lbY;
+            const fx = (c.col - 1) * COL_W + NODE_W;
+            const tx = c.col * COL_W;
+            const fy = y(c.col - 1, c.fromRow);
+            const ty = y(c.col, c.toRow);
+            const midX = (fx + tx) / 2;
+            return <path key={i} d={`M ${fx} ${fy} H ${midX} V ${ty} H ${tx}`} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth="2" />;
+          })}
+          <path d={`M ${(layout.k - 1) * COL_W + NODE_W} ${wbY(layout.k - 1, 0)} H ${gfX - 12} V ${gfY} H ${gfX}`} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth="2" />
+          {layout.lbCols > 0 && (
+            <path d={`M ${(layout.lbCols - 1) * COL_W + NODE_W} ${lbY(layout.lbCols - 1, 0)} H ${gfX - 12} V ${gfY} H ${gfX}`} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth="2" />
+          )}
+        </svg>
+        {layout.nodes.map((n) => {
+          const f = byId.get(n.fixtureId);
+          if (!f) return null;
+          const top = n.lane === "WB" ? wbY(n.col, n.row) - NODE_H / 2 : n.lane === "LB" ? lbY(n.col, n.row) - NODE_H / 2 : gfY - NODE_H / 2;
+          const left = n.lane === "GF" ? gfX + n.col * COL_W : n.col * COL_W;
+          return (
+            <span key={n.fixtureId} data-lane={n.lane} className="contents">
+              {n.lane === "GF" && (
+                <span className={label} style={{ left, top: top - LABEL_H + 6 }}>
+                  {n.col === 0 ? "Grand final" : "Reset"}
+                </span>
+              )}
+              {node(f, left, top)}
+            </span>
           );
         })}
       </div>

--- a/apps/web/src/server/__tests__/doc-bracket-geometry.test.ts
+++ b/apps/web/src/server/__tests__/doc-bracket-geometry.test.ts
@@ -62,3 +62,87 @@ describe("bracketPageGeometry — one-sheet bounds", () => {
     expect(tp.y + tp.h).toBeLessThanOrEqual(BOX.y + BOX.h + 0.01);
   });
 });
+
+// ── Double-elim + stepladder editions (G-audit follow-up) ────────────────────
+import { buildBracketDe, buildLadderPoster, type DocBracketDe, type DocLadder } from "@seazn/engine/exports";
+import { generateDoubleElim } from "@seazn/engine/scheduling";
+import { bracketDePageGeometry, ladderPageGeometry } from "../doc-bracket-geometry";
+
+const LANES = { winners: "Winners bracket", losers: "Losers bracket", grandFinal: "Grand final", reset: "Reset" };
+
+function deFieldOf(n: number, reset = false): DocBracketDe {
+  const entrants = Array.from({ length: n }, (_, i) => `T${i + 1}`);
+  const gen = generateDoubleElim({ entrants, bracketReset: reset });
+  const k = gen.rounds;
+  const counters = new Map<string, number>();
+  const fixtures = gen.fixtures.map((f) => {
+    const lane = f.bracket ?? "WB";
+    const offset = lane === "LB" ? k : lane === "GF" ? 2 * k : 0;
+    const round_no = offset + f.round + 1;
+    const seq = (counters.get(`${lane}:${round_no}`) ?? 0) + 1;
+    counters.set(`${lane}:${round_no}`, seq);
+    return {
+      id: f.id, round_no, seq_in_round: seq,
+      home: f.home ?? null, away: f.away ?? null,
+      headline: null, decided: false,
+    };
+  });
+  return buildBracketDe("DE Cup", fixtures, LANES, { printedAt: "2026-07-19T00:00:00Z" }).bracketDe!;
+}
+
+function inBox(x: number, y: number) {
+  expect(x).toBeGreaterThanOrEqual(BOX.x - 0.01);
+  expect(x).toBeLessThanOrEqual(BOX.x + BOX.w + 0.01);
+  expect(y).toBeGreaterThanOrEqual(BOX.y - 0.01);
+  expect(y).toBeLessThanOrEqual(BOX.y + BOX.h + 0.01);
+}
+
+describe("bracketDePageGeometry — one-sheet bounds", () => {
+  for (const [n, reset] of [[8, false], [8, true], [16, false]] as const) {
+    it(`${n}-team double elim${reset ? " + reset" : ""} stays inside the box`, () => {
+      const g = bracketDePageGeometry(deFieldOf(n, reset), BOX);
+      expect(g.rects.length).toBeGreaterThan(0);
+      for (const r of g.rects) {
+        inBox(r.x, r.y);
+        inBox(r.x + r.w, r.y + r.h);
+      }
+      for (const line of g.lines) for (const [x, y] of line.points) inBox(x, y);
+      for (const l of g.labels) inBox(l.x, l.y);
+    });
+  }
+
+  it("lane labels present (winners, losers, grand final; reset only when configured)", () => {
+    const withReset = bracketDePageGeometry(deFieldOf(8, true), BOX);
+    const texts = withReset.labels.map((l) => l.text);
+    expect(texts).toContain("Winners bracket");
+    expect(texts).toContain("Losers bracket");
+    expect(texts).toContain("Grand final");
+    expect(texts).toContain("Reset");
+    const without = bracketDePageGeometry(deFieldOf(8, false), BOX);
+    expect(without.labels.map((l) => l.text)).not.toContain("Reset");
+  });
+});
+
+describe("ladderPageGeometry — one-sheet bounds", () => {
+  function ladderOf(n: number): DocLadder {
+    const fixtures = Array.from({ length: n }, (_, i) => ({
+      id: `r${i + 1}`, round_no: i + 1, seq_in_round: 1,
+      home: i === 0 ? "Challenger A" : null, away: `Seed ${n + 1 - i}`,
+      headline: i === 0 ? "2–1" : null, decided: i === 0,
+    }));
+    return buildLadderPoster("Ladder", fixtures, (i) => `Rung ${i + 1}`, { printedAt: "2026-07-19T00:00:00Z" }).ladder!;
+  }
+
+  it("7 rungs stay inside the box, summit drawn first (top)", () => {
+    const g = ladderPageGeometry(ladderOf(7), BOX);
+    expect(g.rects).toHaveLength(7);
+    for (const r of g.rects) {
+      inBox(r.x, r.y);
+      inBox(r.x + r.w, r.y + r.h);
+    }
+    for (const line of g.lines) for (const [x, y] of line.points) inBox(x, y);
+    // Top rect is the last rung (the summit), bottom rect is rung 1.
+    expect(g.labels[0]!.text).toBe("Rung 7");
+    expect(g.labels[g.labels.length - 1]!.text).toBe("Rung 1");
+  });
+});

--- a/apps/web/src/server/doc-bracket-geometry.ts
+++ b/apps/web/src/server/doc-bracket-geometry.ts
@@ -116,3 +116,103 @@ export function bracketPageGeometry(b: DocBracket, box: PageBox): BracketPageGeo
 
   return { rects, lines, labels };
 }
+
+// ---------------------------------------------------------------------------
+// Double-elim edition (G-audit follow-up): winners lane above losers lane,
+// grand final (+ reset) joining the lane finals. Same contract as the
+// two-sided geometry — every rect/line/label proven inside the box by test.
+// ---------------------------------------------------------------------------
+import type { DocBracketDe, DocLadder } from "@seazn/engine/exports";
+
+export function bracketDePageGeometry(b: DocBracketDe, box: PageBox): BracketPageGeometry {
+  const cols = Math.max(b.k, b.lbCols) + (b.resetId !== undefined ? 2 : 1);
+  const colW = box.w / cols;
+  const laneGap = 16;
+  const wbRows = Math.max(1, b.wbRows);
+  const lbRows = Math.max(0, b.lbRows);
+  const bodyY = box.y + LABEL_H;
+  const bodyH = box.h - LABEL_H * (lbRows > 0 ? 2 : 1) - (lbRows > 0 ? laneGap : 0);
+  const slotH = bodyH / Math.max(wbRows + lbRows, 2);
+  const nodeH = Math.min(slotH - GAP, 46);
+  const nodeW = colW - GAP * 2;
+  const wbTop = bodyY;
+  const lbTop = wbTop + wbRows * slotH + laneGap + LABEL_H;
+  const gfX = box.x + Math.max(b.k, b.lbCols) * colW + GAP;
+  const lbUnit = (col: number) => 2 ** Math.floor(col / 2);
+  const wbY = (col: number, row: number) => wbTop + (row + 0.5) * 2 ** col * slotH;
+  const lbY = (col: number, row: number) => lbTop + (row + 0.5) * lbUnit(col) * slotH;
+  const gfY = lbRows > 0 ? (wbTop + lbTop + lbRows * slotH) / 2 : wbTop + (wbRows * slotH) / 2;
+
+  const rects: BracketRect[] = b.nodes.map((n) => {
+    const centerY = n.lane === "WB" ? wbY(n.col, n.row) : n.lane === "LB" ? lbY(n.col, n.row) : gfY;
+    const x = n.lane === "GF" ? gfX + n.col * colW : box.x + n.col * colW + GAP;
+    // Clamp inside the box — the reset column may sit at the right edge.
+    const y = Math.min(Math.max(centerY - nodeH / 2, box.y), box.y + box.h - nodeH);
+    return {
+      fixtureId: n.fixtureId,
+      x: Math.min(x, box.x + box.w - nodeW),
+      y, w: nodeW, h: nodeH,
+      home: n.home, away: n.away, headline: n.headline, decided: n.decided,
+      isCenter: n.lane === "GF",
+    };
+  });
+
+  const lines: BracketLine[] = b.connectors.map((c) => {
+    const y = c.lane === "WB" ? wbY : lbY;
+    const fx = box.x + (c.col - 1) * colW + GAP + nodeW;
+    const tx = box.x + c.col * colW + GAP;
+    const fy = y(c.col - 1, c.fromRow);
+    const ty = y(c.col, c.toRow);
+    const midX = (fx + tx) / 2;
+    return { points: [[fx, fy], [midX, fy], [midX, ty], [tx, ty]] };
+  });
+  // Grand-final joins from both lane finals.
+  const wbFx = box.x + (b.k - 1) * colW + GAP + nodeW;
+  lines.push({ points: [[wbFx, wbY(b.k - 1, 0)], [gfX - GAP, wbY(b.k - 1, 0)], [gfX - GAP, gfY], [gfX, gfY]] });
+  if (b.lbCols > 0) {
+    const lbFx = box.x + (b.lbCols - 1) * colW + GAP + nodeW;
+    lines.push({ points: [[lbFx, lbY(b.lbCols - 1, 0)], [gfX - GAP, lbY(b.lbCols - 1, 0)], [gfX - GAP, gfY], [gfX, gfY]] });
+  }
+
+  const labels: BracketLabel[] = [
+    { text: b.laneLabels.winners, x: box.x + GAP, y: box.y, w: colW * 2 },
+    { text: b.laneLabels.grandFinal, x: gfX, y: box.y, w: nodeW },
+  ];
+  if (lbRows > 0) {
+    labels.push({ text: b.laneLabels.losers, x: box.x + GAP, y: lbTop - LABEL_H, w: colW * 2 });
+  }
+  if (b.resetId !== undefined) {
+    labels.push({ text: b.laneLabels.reset, x: gfX + colW, y: box.y, w: nodeW });
+  }
+  return { rects, lines, labels };
+}
+
+// Stepladder edition: rungs stacked top (summit) to bottom, connectors up.
+export function ladderPageGeometry(l: DocLadder, box: PageBox): BracketPageGeometry {
+  const n = Math.max(1, l.rungs.length);
+  const slotH = (box.h - LABEL_H) / n;
+  const nodeH = Math.min(slotH - GAP, 52);
+  const nodeW = Math.min(box.w * 0.6, 360);
+  // Summit last in play order → drawn at the top.
+  const ordered = [...l.rungs].reverse();
+  const rects: BracketRect[] = ordered.map((r, i) => ({
+    fixtureId: r.fixtureId,
+    x: box.x + GAP,
+    y: box.y + LABEL_H + i * slotH + (slotH - nodeH) / 2,
+    w: nodeW, h: nodeH,
+    home: r.home, away: r.away, headline: r.headline, decided: r.decided,
+    isCenter: false,
+  }));
+  const lines: BracketLine[] = rects.slice(0, -1).map((r, i) => {
+    const below = rects[i + 1]!;
+    const x = r.x + nodeW + GAP * 2;
+    return { points: [[below.x + nodeW, below.y + nodeH / 2], [x, below.y + nodeH / 2], [x, r.y + nodeH / 2], [r.x + nodeW, r.y + nodeH / 2]] };
+  });
+  const labels: BracketLabel[] = ordered.map((r, i) => ({
+    text: r.label,
+    x: box.x + GAP,
+    y: box.y + LABEL_H + i * slotH - 2,
+    w: nodeW,
+  }));
+  return { rects, lines, labels };
+}

--- a/apps/web/src/server/doc-render.ts
+++ b/apps/web/src/server/doc-render.ts
@@ -6,7 +6,11 @@ import PDFDocument from "pdfkit";
 import ExcelJS from "exceljs";
 import type { DocModel, DocSection, DocTable } from "@seazn/engine/exports";
 import { PALETTE, FONT, registerFonts, eyebrowFor, qrBuffer } from "./doc-theme";
-import { bracketPageGeometry } from "./doc-bracket-geometry";
+import {
+  bracketDePageGeometry,
+  bracketPageGeometry,
+  ladderPageGeometry,
+} from "./doc-bracket-geometry";
 
 const MARGIN = 40;
 
@@ -94,15 +98,22 @@ function isLandscape(model: DocModel): boolean {
 /** Bracket poster (PROMPT-62 §4): one landscape sheet, scale-to-fit — the
  *  geometry (and its in-box guarantee) lives in doc-bracket-geometry.ts. */
 function drawBracket(doc: PDFKit.PDFDocument, model: DocModel): void {
-  const b = model.bracket;
-  if (!b) return;
+  // One painter, three geometries — single-elim two-sided, double-elim
+  // two-lane, stepladder rungs all emit the same rect/line/label shape.
   const box = {
     x: MARGIN,
     y: doc.y + 6,
     w: doc.page.width - MARGIN * 2,
     h: doc.page.height - MARGIN - 24 - (doc.y + 6),
   };
-  const g = bracketPageGeometry(b, box);
+  const g = model.bracket
+    ? bracketPageGeometry(model.bracket, box)
+    : model.bracketDe
+      ? bracketDePageGeometry(model.bracketDe, box)
+      : model.ladder
+        ? ladderPageGeometry(model.ladder, box)
+        : null;
+  if (!g) return;
   for (const label of g.labels) {
     doc.font(FONT.display).fontSize(8).fillColor(PALETTE.mute)
       .text(label.text.toUpperCase(), label.x, label.y, {
@@ -380,7 +391,7 @@ export async function docModelToPdf(model: DocModel): Promise<Buffer> {
   }
 
   // PROMPT-62 §4: the bracket poster draws its own body (sections are empty).
-  if (model.bracket !== undefined) drawBracket(doc, model);
+  if (model.bracket !== undefined || model.bracketDe !== undefined || model.ladder !== undefined) drawBracket(doc, model);
 
   // columnsHint 2 (12 Jun "two per A4"): pair sections onto one page by
   // separating with a rule instead of a page break.

--- a/apps/web/src/server/slideshow-data.ts
+++ b/apps/web/src/server/slideshow-data.ts
@@ -9,7 +9,7 @@ import { listEntrants } from "@/server/usecases/entrants";
 import { listEntrantLogoUrls } from "@/server/usecases/teams";
 import { hasFeature } from "@/lib/entitlements";
 import { maskDisplayName, resolveNameDisplay } from "@/lib/name-display";
-import { twoSidedBracket } from "@seazn/engine/scheduling";
+import { BRACKET_SLIDE_KINDS, bracketSlideLaysOut } from "@/components/v2/slideshow-rotation";
 import { resolveLogoUrl } from "@/server/public-site/data";
 import type { AuthCtx } from "@/server/api-v1/auth";
 
@@ -61,7 +61,14 @@ export type Slide =
        *  step while matches are in play (slideshow-rotation.ts). */
       pinned?: boolean;
     }
-  | { kind: "bracket"; division: string; title: string; fixtures: BracketSlideFixture[] };
+  | {
+      kind: "bracket";
+      division: string;
+      title: string;
+      /** Which geometry the client draws — absent means knockout (old payloads). */
+      stageKind?: "knockout" | "double_elim" | "stepladder";
+      fixtures: BracketSlideFixture[];
+    };
 
 /**
  * Org chrome for the noticeboard masthead — brand color blob and logo URL,
@@ -191,16 +198,17 @@ export async function buildDivisionSlides(
     slides.push({ kind: "fixtures", division: divisionName, title: "Coming up", items: upcoming });
 
   // ── Bracket — the knockout tree (v13/PROMPT-62 geometry), when it lays out ──
-  for (const stage of stages.filter((s) => s.kind === "knockout")) {
+  for (const stage of stages.filter((s) => BRACKET_SLIDE_KINDS.has(s.kind))) {
     const stageFixtures = fixtures.filter((f) => f.stage_id === stage.id);
     const refs = stageFixtures.map((f) => ({
       id: f.id, round_no: f.round_no, seq_in_round: f.seq_in_round,
     }));
-    if (stageFixtures.length > 0 && twoSidedBracket(refs).ok) {
+    if (stageFixtures.length > 0 && bracketSlideLaysOut(stage.kind, refs)) {
       slides.push({
         kind: "bracket",
         division: divisionName,
         title: stage.name,
+        stageKind: stage.kind as "knockout" | "double_elim" | "stepladder",
         fixtures: stageFixtures.map((f) => ({
           id: f.id,
           round_no: f.round_no,
@@ -295,14 +303,15 @@ export function buildPublicDivisionSlides(data: PublicSlideInput): Slide[] {
   if (upcoming.length > 0)
     slides.push({ kind: "fixtures", division: data.division.name, title: "Coming up", items: upcoming });
 
-  for (const stage of data.stages.filter((s) => s.kind === "knockout")) {
+  for (const stage of data.stages.filter((s) => BRACKET_SLIDE_KINDS.has(s.kind))) {
     const stageFixtures = data.fixtures.filter((f) => f.stage_id === stage.id);
     const refs = stageFixtures.map((f) => ({ id: f.id, round_no: f.round_no, seq_in_round: f.seq_in_round }));
-    if (stageFixtures.length > 0 && twoSidedBracket(refs).ok) {
+    if (stageFixtures.length > 0 && bracketSlideLaysOut(stage.kind, refs)) {
       slides.push({
         kind: "bracket",
         division: data.division.name,
         title: stage.name,
+        stageKind: stage.kind as "knockout" | "double_elim" | "stepladder",
         fixtures: stageFixtures.map((f) => ({
           id: f.id, round_no: f.round_no, seq_in_round: f.seq_in_round,
           home: f.home_entrant_id ? (names[f.home_entrant_id] ?? null) : null,

--- a/apps/web/src/server/usecases/exports.ts
+++ b/apps/web/src/server/usecases/exports.ts
@@ -11,6 +11,8 @@ import {
   buildParticipants,
   buildRoster,
   buildBracket,
+  buildBracketDe,
+  buildLadderPoster,
   buildStandings,
   buildTimetable,
   DocModel,
@@ -347,11 +349,14 @@ export async function buildDivisionDocModel(
         });
       }
       case "bracket": {
-        // PROMPT-62 §4: the first knockout stage's tree as a landscape poster.
-        const [stage] = await tx<{ id: string }[]>`
-          select id from stages where division_id = ${divisionId} and kind = 'knockout'
+        // PROMPT-62 §4 (+G-audit): the first bracket-shaped stage as a
+        // landscape poster — single-elim tree, double-elim lanes, or
+        // stepladder rungs.
+        const [stage] = await tx<{ id: string; kind: string }[]>`
+          select id, kind from stages
+          where division_id = ${divisionId} and kind in ('knockout', 'double_elim', 'stepladder')
           order by seq limit 1`;
-        if (!stage) throw new HttpError(422, "this division has no knockout stage to poster", "BRACKET_NOT_AVAILABLE");
+        if (!stage) throw new HttpError(422, "this division has no bracket stage to poster", "BRACKET_NOT_AVAILABLE");
         const fixtures = await tx<
           {
             id: string; round_no: number; seq_in_round: number;
@@ -366,24 +371,31 @@ export async function buildDivisionDocModel(
           where f.stage_id = ${stage.id}
           order by f.round_no, f.seq_in_round`;
         if (fixtures.length === 0) {
-          throw new HttpError(422, "the knockout bracket hasn't been generated yet", "BRACKET_NOT_AVAILABLE");
+          throw new HttpError(422, "the bracket hasn't been generated yet", "BRACKET_NOT_AVAILABLE");
         }
         const names = await tx<{ id: string; display_name: string }[]>`
           select id, display_name from entrants where division_id = ${divisionId}`;
         const nameById = new Map(names.map((n) => [n.id, n.display_name]));
-        return buildBracket(
-          title,
-          fixtures.map((f) => ({
-            id: f.id,
-            round_no: f.round_no,
-            seq_in_round: f.seq_in_round,
-            home: f.home_entrant_id ? (nameById.get(f.home_entrant_id) ?? null) : null,
-            away: f.away_entrant_id ? (nameById.get(f.away_entrant_id) ?? null) : null,
-            headline: f.headline,
-            decided: f.outcome !== null,
-          })),
-          { ...common, ...(liveUrl !== undefined ? { liveUrl } : {}) },
-        );
+        const exportFixtures = fixtures.map((f) => ({
+          id: f.id,
+          round_no: f.round_no,
+          seq_in_round: f.seq_in_round,
+          home: f.home_entrant_id ? (nameById.get(f.home_entrant_id) ?? null) : null,
+          away: f.away_entrant_id ? (nameById.get(f.away_entrant_id) ?? null) : null,
+          headline: f.headline,
+          decided: f.outcome !== null,
+        }));
+        const buildOpts = { ...common, ...(liveUrl !== undefined ? { liveUrl } : {}) };
+        if (stage.kind === "double_elim") {
+          return buildBracketDe(title, exportFixtures, {
+            winners: "Winners bracket", losers: "Losers bracket",
+            grandFinal: "Grand final", reset: "Reset",
+          }, buildOpts);
+        }
+        if (stage.kind === "stepladder") {
+          return buildLadderPoster(title, exportFixtures, (i) => `Rung ${i + 1}`, buildOpts);
+        }
+        return buildBracket(title, exportFixtures, buildOpts);
       }
     }
   });

--- a/packages/engine/src/exports/build.ts
+++ b/packages/engine/src/exports/build.ts
@@ -14,7 +14,7 @@ import type {
   ExportTicket,
 } from "./types.ts";
 import { EngineError } from "../core/errors.ts";
-import { twoSidedBracket } from "../scheduling/bracket-layout.ts";
+import { doubleElimBracket, twoSidedBracket } from "../scheduling/bracket-layout.ts";
 
 function base(
   kind: DocModel["kind"],
@@ -279,6 +279,70 @@ export function buildBracket(
         bracketRoundLabel(layout.rounds - 1 - i),
       ),
       ...(layout.thirdPlaceId !== undefined ? { thirdPlaceId: layout.thirdPlaceId } : {}),
+    },
+  };
+}
+
+export function buildBracketDe(
+  title: string,
+  fixtures: readonly ExportBracketFixture[],
+  laneLabels: { winners: string; losers: string; grandFinal: string; reset: string },
+  opts: BuildOpts,
+): DocModel {
+  const result = doubleElimBracket(fixtures);
+  if (!result.ok) {
+    throw new EngineError("CONFIG_INVALID", `double-elim poster: ${result.reason}`, {});
+  }
+  const layout = result.layout;
+  const byId = new Map(fixtures.map((f) => [f.id, f]));
+  return {
+    ...base("bracket", title, [], opts),
+    bracketDe: {
+      nodes: layout.nodes.map((n) => {
+        const f = byId.get(n.fixtureId)!;
+        return {
+          fixtureId: n.fixtureId,
+          lane: n.lane,
+          col: n.col,
+          row: n.row,
+          home: f.home ?? "TBD",
+          away: f.away ?? "TBD",
+          headline: f.headline,
+          decided: f.decided,
+        };
+      }),
+      connectors: layout.connectors,
+      k: layout.k,
+      wbRows: layout.wbRows,
+      lbRows: layout.lbRows,
+      lbCols: layout.lbCols,
+      laneLabels,
+      ...(layout.resetId !== undefined ? { resetId: layout.resetId } : {}),
+    },
+  };
+}
+
+export function buildLadderPoster(
+  title: string,
+  fixtures: readonly ExportBracketFixture[],
+  rungLabel: (i: number) => string,
+  opts: BuildOpts,
+): DocModel {
+  if (fixtures.length === 0) {
+    throw new EngineError("CONFIG_INVALID", "stepladder poster: no fixtures", {});
+  }
+  const rungs = [...fixtures].sort((a, b) => a.round_no - b.round_no);
+  return {
+    ...base("bracket", title, [], opts),
+    ladder: {
+      rungs: rungs.map((f, i) => ({
+        fixtureId: f.id,
+        label: rungLabel(i),
+        home: f.home ?? "TBD",
+        away: f.away ?? "TBD",
+        headline: f.headline,
+        decided: f.decided,
+      })),
     },
   };
 }

--- a/packages/engine/src/exports/types.ts
+++ b/packages/engine/src/exports/types.ts
@@ -101,6 +101,53 @@ export const DocBracket = z.object({
 });
 export type DocBracket = z.infer<typeof DocBracket>;
 
+// G-audit follow-up — the double-elim poster payload: the doubleElimBracket
+// two-lane layout with names/headlines resolved. Landscape like the
+// single-elim poster; renderer scales both lanes onto one sheet.
+export const DocBracketDeNode = z.object({
+  fixtureId: z.string(),
+  lane: z.enum(["WB", "LB", "GF"]),
+  col: z.number().int(),
+  row: z.number().int(),
+  home: z.string(),
+  away: z.string(),
+  headline: z.string().nullable(),
+  decided: z.boolean(),
+});
+export type DocBracketDeNode = z.infer<typeof DocBracketDeNode>;
+
+export const DocBracketDe = z.object({
+  nodes: z.array(DocBracketDeNode),
+  connectors: z.array(
+    z.object({
+      lane: z.enum(["WB", "LB"]),
+      col: z.number().int(),
+      fromRow: z.number().int(),
+      toRow: z.number().int(),
+    }),
+  ),
+  k: z.number().int(), // winners-lane depth
+  wbRows: z.number().int(),
+  lbRows: z.number().int(),
+  lbCols: z.number().int(),
+  laneLabels: z.object({ winners: z.string(), losers: z.string(), grandFinal: z.string(), reset: z.string() }),
+  resetId: z.string().optional(),
+});
+export type DocBracketDe = z.infer<typeof DocBracketDe>;
+
+// Stepladder poster: bottom-up rungs, winner climbs. Portrait-friendly list.
+export const DocLadderRung = z.object({
+  fixtureId: z.string(),
+  label: z.string(), // "Rung 1", …
+  home: z.string(),
+  away: z.string(),
+  headline: z.string().nullable(),
+  decided: z.boolean(),
+});
+export type DocLadderRung = z.infer<typeof DocLadderRung>;
+export const DocLadder = z.object({ rungs: z.array(DocLadderRung) });
+export type DocLadder = z.infer<typeof DocLadder>;
+
 export const PageBreaks = z.enum(["auto", "per_pitch", "per_team", "per_division"]);
 export type PageBreaks = z.infer<typeof PageBreaks>;
 
@@ -118,6 +165,11 @@ export const DocModel = z.object({
   pageBreaks: PageBreaks.default("auto"),
   /** PROMPT-62 §4 — set only for kind:"bracket" (sections stay empty). */
   bracket: DocBracket.optional(),
+  /** Double-elim edition of the bracket poster — exactly one of the three
+   *  bracket payloads is set for kind:"bracket". */
+  bracketDe: DocBracketDe.optional(),
+  /** Stepladder edition. */
+  ladder: DocLadder.optional(),
 });
 export type DocModel = z.infer<typeof DocModel>;
 


### PR DESCRIPTION
Closes the last two geometry gaps from the format audit — the slideshow and the Documents poster were single-elim-only.

- **Engine**: `buildBracketDe` + `buildLadderPoster` payloads beside `DocBracket`.
- **Poster**: `bracketDePageGeometry` + `ladderPageGeometry` with the same one-sheet bounds proof (8/16-team DE ± reset, 7-rung ladder — all unit-pinned inside the box); one `drawBracket` painter consumes whichever geometry the model carries; the usecase posters the first bracket-shaped stage (`knockout | double_elim | stepladder`).
- **Slideshow**: bracket slides for all three shapes — `stageKind` rides the slide, client draws tree / lanes / rungs; pure `bracketSlideLaysOut` gate unit-tested.

Battery on the rebased tree (V295 DBs): engine 899/0 · web 1373/0 · smoke 461/0 · e2e 168 passing — 3 remaining fails are other in-flight sessions' specs (news feed card; two Pro-Plus AI-cap rows where the shared dev DB carries 20 vs the spec's 5), domains untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)