### PR TITLE
test(e2e): board-v3 timezone-proof slots + storage env stub

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,7 +67,9 @@ jobs:
       DATABASE_SSL: disable
       # Session signing secret (jose HS256) — CI-only dummy.
       AUTH_SECRET: ci-only-insecure-secret-please-change-in-prod-0123456789
-      NEXT_PUBLIC_SUPABASE_URL: ""
+      # Stub, not empty: publicStorageUrl("") hides every badge/crest, making
+      # logo assertions untestable. No real Supabase call rides on it in e2e.
+      NEXT_PUBLIC_SUPABASE_URL: "https://stub.supabase.co"
       NEXT_TELEMETRY_DISABLED: "1"
       # Production build → no dev-exposed `login_url`, so the auth helpers mint
       # login tokens straight in the Postgres service above and skip the specs

--- a/apps/web/e2e/board-v3.spec.ts
+++ b/apps/web/e2e/board-v3.spec.ts
@@ -343,12 +343,16 @@ test.describe.serial("board v3 (PROMPT-33)", () => {
     };
 
     // A's move must COMMIT (2xx) before B writes, so B is provably stale.
-    await moveAndAwait(page, "2026-09-16T18:00", "committed");
+    // datetime-local is the RUNNER's timezone. 16th 18:00 was free on a BST
+    // laptop (17:00Z) but collided with the seeded 18:00Z/P0A fixture on the
+    // UTC runner — the chronic "CI-only" red was a court clash, not a race.
+    // The 18th sits outside the seeded 15th–17th grid in any timezone.
+    await moveAndAwait(page, "2026-09-18T09:00", "committed");
     // A's own board refreshes without complaint.
     await expect(page.getByText("Schedule changed by someone else")).toHaveCount(0);
 
     // Client B still holds the pre-move seq: its write must 409 → toast.
-    await moveAndAwait(pageB, "2026-09-16T19:00", "seq-conflict");
+    await moveAndAwait(pageB, "2026-09-18T10:00", "seq-conflict");
     await expect(pageB.getByText("Schedule changed by someone else — board refreshed.")).toBeVisible(
       { timeout: 15_000 },
     );


### PR DESCRIPTION
The self-reporting assertions from #150 named board-v3's chronic red on their first CI run: **`409 SCHEDULE_CONFLICT — court P0A double-booked`**. Not a race, not a seq bug: the Move dialog's `datetime-local` is interpreted in the runner's timezone. `2026-09-16T18:00` is 17:00Z on a BST laptop (free slot) but 18:00Z on the UTC runner — exactly where the rig seeds a P0A fixture. Every 'CI-only' failure since the 18th was this. Move targets now use the 18th — outside the seeded 15th–17th grid in any timezone. Verified 8/0 locally under `TZ=UTC` (which reproduced the clash on the old slots).

Also: `e2e.yml` set `NEXT_PUBLIC_SUPABASE_URL: ""`, making `publicStorageUrl` return `""` — every resolved badge/crest rendered nothing in CI e2e, so #149's crest-fallback assertion could never pass there. Stubbed with a fake host (job-level env, covers build + run); no e2e path performs a real Supabase call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)