### PR TITLE
fix(payments): unmatched charge.dispute.created fails the event for sweeper retry

### DIFF
--- a/apps/web/src/server/usecases/__tests__/dispute-unmatched-retry.test.ts
+++ b/apps/web/src/server/usecases/__tests__/dispute-unmatched-retry.test.ts
@@ -1,0 +1,103 @@
+// Dispute-before-activation race (stg repro 2026-07-19): Stripe can deliver
+// charge.dispute.created BEFORE checkout.session.completed — the sponsor order
+// (or registration/pass) doesn't carry its payment_intent_id yet, all three
+// dispute handlers miss, and the event used to be ACKed as processed: the
+// dispute silently never flagged anything. Now an unmatched dispute THROWS, so
+// the ledger keeps the event unprocessed and the stuck-event sweeper (or a
+// manual /admin/billing-events replay) re-runs it once the money row knows its
+// intent. Real Postgres required; skipped without DATABASE_URL.
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
+
+vi.mock("@/lib/email", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/email")>()),
+  sendSponsorDisputeAlertEmail: vi.fn().mockResolvedValue(true),
+  sendStaffDisputeAlertEmail: vi.fn().mockResolvedValue(true),
+}));
+
+import { sql } from "@/lib/db";
+import { processStripeEvent } from "@/server/usecases/billing-events";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 12);
+
+function disputeEvent(intent: string, disputeId: string): Stripe.Event {
+  return {
+    id: `evt_${uniq()}`,
+    type: "charge.dispute.created",
+    data: {
+      object: {
+        id: disputeId,
+        object: "dispute",
+        status: "needs_response",
+        payment_intent: intent,
+        charge: `ch_${uniq()}`,
+        amount: 1000,
+        currency: "gbp",
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+/** Sponsor order mid-checkout: row exists, payment_intent_id NOT yet written. */
+async function seedPendingSponsorOrder(): Promise<{ orderId: string; orgId: string }> {
+  const suffix = uniq();
+  const [{ id: ownerId }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`race-${suffix}@test.local`}, 'Race Owner', true) returning id`;
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, stripe_account_id, stripe_charges_enabled, created_by)
+    values (${"Race Org " + suffix}, ${"race-org-" + suffix}, ${"acct_" + suffix}, true, ${ownerId})
+    returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  const [{ id: packageId }] = await sql<{ id: string }[]>`
+    insert into sponsor_packages (org_id, name, price_cents, currency)
+    values (${orgId}, 'Perimeter', 1000, 'gbp') returning id`;
+  const [{ id: orderId }] = await sql<{ id: string }[]>`
+    insert into sponsor_orders (org_id, package_id, sponsor_name, sponsor_email, amount_cents, currency, status)
+    values (${orgId}, ${packageId}, 'Race Sponsor', ${"sponsor-" + suffix + "@test.local"}, 1000, 'gbp', 'pending')
+    returning id`;
+  return { orderId, orgId };
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("unmatched disputes stay unprocessed for retry", () => {
+  it("dispute racing ahead of checkout completion throws, then flags on the retry", async () => {
+    const { orderId } = await seedPendingSponsorOrder();
+    const intent = `pi_race_${uniq()}`;
+    const did = `dp_race_${uniq()}`;
+
+    // Dispute lands FIRST — nothing carries the intent yet: must throw so the
+    // ledger keeps the event unprocessed (sweeper/replay territory).
+    await expect(processStripeEvent(disputeEvent(intent, did))).rejects.toThrow(/dispute/i);
+    const [before] = await sql<{ disputed_at: string | null }[]>`
+      select disputed_at from sponsor_orders where id = ${orderId}`;
+    expect(before.disputed_at).toBeNull();
+
+    // Checkout completes: the order learns its intent…
+    await sql`update sponsor_orders
+              set payment_intent_id = ${intent}, status = 'paid', paid_at = now()
+              where id = ${orderId}`;
+
+    // …and the replay (sweeper or admin button) now matches and flags.
+    await processStripeEvent(disputeEvent(intent, did));
+    const [after] = await sql<{ disputed_at: string | null; dispute_id: string | null }[]>`
+      select disputed_at, dispute_id from sponsor_orders where id = ${orderId}`;
+    expect(after.disputed_at).not.toBeNull();
+    expect(after.dispute_id).toBe(did);
+  });
+
+  it("a dispute matching nothing at all is surfaced (throws), never silently ACKed", async () => {
+    await expect(
+      processStripeEvent(disputeEvent(`pi_ghost_${uniq()}`, `dp_ghost_${uniq()}`)),
+    ).rejects.toThrow(/dispute/i);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/platform-dispute.test.ts
+++ b/apps/web/src/server/usecases/__tests__/platform-dispute.test.ts
@@ -346,17 +346,28 @@ describe.skipIf(!HAS_DB)("platform-charge disputes — Event Pass", () => {
 });
 
 describe.skipIf(!HAS_DB)("platform-charge disputes — routing", () => {
-  it("no-ops on a charge that is neither a subscription nor a pass", async () => {
-    // A customer matching no subscription + an intent matching no pass.
+  it("a created dispute matching neither a subscription nor a pass THROWS (kept for sweeper retry)", async () => {
+    // A customer matching no subscription + an intent matching no pass. Since
+    // the dispute-before-activation race fix, an unmatched CREATED must fail
+    // the event (ledger keeps it unprocessed; sweeper retries) instead of
+    // being silently ACKed. Nothing is written and no alert goes out.
     const ev = subDisputeEvent("created", `cus_nobody_${uniq()}`, "dp_" + uniq());
+    await expect(processStripeEvent(ev)).rejects.toThrow(/matched no/);
+    expect(emailMock.staff).not.toHaveBeenCalled();
+  });
+
+  it("an unmatched CLOSED stays a silent no-op (deleted-pass replays depend on it)", async () => {
+    const ev = subDisputeEvent("closed", `cus_nobody_${uniq()}`, "dp_" + uniq());
     await expect(processStripeEvent(ev)).resolves.toBeUndefined();
     expect(emailMock.staff).not.toHaveBeenCalled();
   });
 
-  it("keyless: a real webhook charge id string can't resolve a customer → sub no-op", async () => {
+  it("keyless: a real webhook charge id string can't resolve a customer → event kept for retry", async () => {
     // Seed a sub, but send the dispute with the charge as an opaque id string
     // (as Stripe really does). With no STRIPE_SECRET_KEY the charge can't be
-    // retrieved, so the subscription branch cannot identify the org and no-ops.
+    // retrieved, so the subscription branch cannot identify the org — the
+    // event now FAILS (retryable) rather than being silently ACKed, and the
+    // subscription row stays untouched.
     const { orgId, customer } = await seedSubOrg("pro");
     void customer;
     const ev = {
@@ -372,7 +383,7 @@ describe.skipIf(!HAS_DB)("platform-charge disputes — routing", () => {
         },
       },
     } as unknown as Stripe.Event;
-    await expect(processStripeEvent(ev)).resolves.toBeUndefined();
+    await expect(processStripeEvent(ev)).rejects.toThrow(/matched no/);
     const [s] = await sql<{ disputed_at: Date | null; plan_key: string }[]>`
       select disputed_at, plan_key from subscriptions where org_id = ${orgId}`;
     expect(s.disputed_at).toBeNull(); // untouched — couldn't be identified

--- a/apps/web/src/server/usecases/__tests__/sponsor-dispute.test.ts
+++ b/apps/web/src/server/usecases/__tests__/sponsor-dispute.test.ts
@@ -176,10 +176,10 @@ describe.skipIf(!HAS_DB)("handleSponsorDispute", () => {
     expect(emailMock.lost).not.toHaveBeenCalled(); // a win is not a loss
   });
 
-  it("ignores non-sponsor intents", async () => {
+  it("ignores non-sponsor intents (reports no match)", async () => {
     await expect(
       handleSponsorDispute(disputeFor("pi_not_sponsor_" + uniq(), "dp_" + uniq()), "created"),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(false);
     expect(emailMock.alert).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -300,7 +300,7 @@ async function notifyStaffDispute(
 async function handlePlatformDispute(
   dispute: Stripe.Dispute,
   phase: "created" | "closed",
-): Promise<void> {
+): Promise<boolean> {
   const intent =
     typeof dispute.payment_intent === "string" ? dispute.payment_intent : dispute.payment_intent?.id;
 
@@ -314,16 +314,16 @@ async function handlePlatformDispute(
         await invalidateOrgEntitlements(pass.org_id);
       }
       await notifyStaffDispute("event_pass", pass.org_id, dispute, phase);
-      return;
+      return true;
     }
   }
 
   // Subscription charge? Matched by the Stripe customer on the charge.
   const customer = await disputeCustomerId(dispute);
-  if (!customer) return;
+  if (!customer) return false;
   const [sub] = await sql<{ org_id: string }[]>`
     select org_id from subscriptions where stripe_customer_id = ${customer}`;
-  if (!sub) return; // not a platform subscription charge
+  if (!sub) return false; // not a platform subscription charge
 
   if (phase === "created") {
     // coalesce keeps the FIRST flag time so a duplicate created (or a manual
@@ -345,6 +345,7 @@ async function handlePlatformDispute(
     await invalidateOrgEntitlements(sub.org_id);
   }
   await notifyStaffDispute("subscription", sub.org_id, dispute, phase);
+  return true;
 }
 
 /** The dispatch table (formerly inline in the webhook route). Unhandled
@@ -385,20 +386,33 @@ export async function processStripeEvent(event: Stripe.Event): Promise<void> {
       await syncConnectAccount(event.data.object as Stripe.Account);
       break;
     case "charge.dispute.created":
+    case "charge.dispute.closed": {
       // Entry-fee, sponsor-order AND platform (subscription / Event Pass)
       // chargebacks (spec issue #5, P0-2, Task 7 P1-4): flag + alert. Each
       // handler no-ops on the others' charges, same pattern as charge.refunded;
       // the platform handler runs LAST (the destination-charge handlers write
       // nothing on a platform charge).
-      await handleRegistrationDispute(event.data.object as Stripe.Dispute, "created");
-      await handleSponsorDispute(event.data.object as Stripe.Dispute, "created");
-      await handlePlatformDispute(event.data.object as Stripe.Dispute, "created");
+      const dispute = event.data.object as Stripe.Dispute;
+      const phase = event.type === "charge.dispute.created" ? "created" : "closed";
+      const matched =
+        (await handleRegistrationDispute(dispute, phase)) ||
+        (await handleSponsorDispute(dispute, phase)) ||
+        (await handlePlatformDispute(dispute, phase));
+      // Dispute-before-activation race (stg 2026-07-19): Stripe can deliver
+      // the dispute BEFORE checkout.session.completed writes the money row's
+      // payment_intent_id. An unmatched CREATED must FAIL the event so the
+      // ledger keeps it unprocessed — the stuck-event sweeper (or an admin
+      // replay) re-runs it once the row knows its intent. CLOSED stays a
+      // silent no-op: it trails created by days (no race window), and a
+      // replayed closed-lost legitimately matches nothing once the pass row
+      // was deleted by the first run.
+      if (!matched && phase === "created") {
+        throw new Error(
+          `dispute ${dispute.id} matched no registration/sponsor/platform charge yet — retry via sweeper`,
+        );
+      }
       break;
-    case "charge.dispute.closed":
-      await handleRegistrationDispute(event.data.object as Stripe.Dispute, "closed");
-      await handleSponsorDispute(event.data.object as Stripe.Dispute, "closed");
-      await handlePlatformDispute(event.data.object as Stripe.Dispute, "closed");
-      break;
+    }
     case "charge.refunded":
       // Refunds made in the Stripe dashboard still show on the console.
       // Registration, sponsor and Event Pass charges share the event type; each

--- a/apps/web/src/server/usecases/registrations.ts
+++ b/apps/web/src/server/usecases/registrations.ts
@@ -1115,16 +1115,16 @@ async function confirmPaidRegistration(
 export async function handleRegistrationDispute(
   dispute: Stripe.Dispute,
   phase: "created" | "closed",
-): Promise<void> {
+): Promise<boolean> {
   const intent =
     typeof dispute.payment_intent === "string"
       ? dispute.payment_intent
       : dispute.payment_intent?.id;
-  if (!intent) return;
+  if (!intent) return false;
   const [reg] = await sql<RegistrationRow[]>`
     select ${sql(REG_COLS as unknown as string[])} from registrations
     where payment_intent_id = ${intent}`;
-  if (!reg) return; // not an entry-fee charge
+  if (!reg) return false; // not an entry-fee charge (or intent not written yet)
   const ctx = await divisionCtx(sql, reg.division_id);
 
   if (phase === "created") {
@@ -1148,7 +1148,7 @@ export async function handleRegistrationDispute(
         refCode: reg.ref_code,
       }).catch(() => {});
     }
-    return;
+    return true;
   }
   if (dispute.status === "won") {
     await sql`update registrations set disputed_at = null, updated_at = now()
@@ -1190,6 +1190,7 @@ export async function handleRegistrationDispute(
       }
     }
   }
+  return true;
 }
 
 /** Current owner via org_members, NOT organizations.created_by — ownership

--- a/apps/web/src/server/usecases/sponsors.ts
+++ b/apps/web/src/server/usecases/sponsors.ts
@@ -706,10 +706,10 @@ async function recoverSponsorDispute(
 export async function handleSponsorDispute(
   dispute: Stripe.Dispute,
   phase: "created" | "closed",
-): Promise<void> {
+): Promise<boolean> {
   const intent =
     typeof dispute.payment_intent === "string" ? dispute.payment_intent : dispute.payment_intent?.id;
-  if (!intent) return;
+  if (!intent) return false;
   const [order] = await sql<
     (SponsorOrderRow & {
       org_id: string;
@@ -722,7 +722,7 @@ export async function handleSponsorDispute(
            (select competition_id from sponsor_packages p where p.id = sponsor_orders.package_id)
              as competition_id
     from sponsor_orders where payment_intent_id = ${intent}`;
-  if (!order) return; // not a sponsor charge
+  if (!order) return false; // not a sponsor charge (or it doesn't know its intent YET)
 
   if (phase === "created") {
     // A replayed created event re-stamps nothing new: coalesce keeps the first
@@ -748,7 +748,7 @@ export async function handleSponsorDispute(
       }
     }
     bustPublicSponsors(order.org_id);
-    return;
+    return true;
   }
 
   if (dispute.status === "won") {
@@ -757,7 +757,7 @@ export async function handleSponsorDispute(
       await sql`update sponsors set status = 'active' where id = ${order.sponsor_id}`;
     }
     bustPublicSponsors(order.org_id);
-    return;
+    return true;
   }
 
   if (dispute.status === "lost") {
@@ -786,4 +786,5 @@ export async function handleSponsorDispute(
     }
     bustPublicSponsors(order.org_id);
   }
+  return true;
 }


### PR DESCRIPTION
## The bug (live stg repro, 2026-07-19)

Stripe delivered `charge.dispute.created` **275ms before** `checkout.session.completed` for the same payment (sponsor order "ashok", £10, org `org-9a53eecb0d`). At that instant the sponsor order didn't know its `payment_intent_id` yet, so all three dispute handlers (registration / sponsor / platform) missed, the event was ACKed as processed, and the dispute silently flagged **nothing** — the order stayed "paid", the placement stayed live.

Timeline from stg forensics:
- `11:56:15.905` — `evt_1TutKNAy22H0xqqxkOgexiZr` (`charge.dispute.created`, `pi_3TutKKAy22H0xqqx1RjVjShs`) processed, matched nothing
- `11:56:16.183` — checkout completion writes `payment_intent_id` onto the order

## The fix

All three dispute handlers now report whether they matched (`Promise<boolean>`). The dispatch:

- **Unmatched `created` → throws.** The billing-events ledger keeps the event unprocessed, so the hourly stuck-event sweeper (or a manual `/admin/billing-events` replay) re-runs it once the money row knows its intent. Existing capped-retry + staff-alert machinery applies.
- **Unmatched `closed` stays a silent no-op** — a closed-lost replay after a pass revocation/deletion legitimately matches nothing and must not wedge the ledger.

No schema change, no new surface. The help promise ("flagged the moment Stripe tells us") now holds even when the dispute wins the race.

## Tests

- **New** `dispute-unmatched-retry.test.ts` — full race repro: pending sponsor order (no intent) → created-dispute event **rejects**; checkout completes; replay of the same event flags the order (`disputed_at`, `dispute_id`). Plus: ghost dispute matching nothing rejects.
- `platform-dispute.test.ts` — unmatched-created expectations flipped to `rejects.toThrow(/matched no/)`; new "unmatched CLOSED stays a silent no-op" test.
- `sponsor-dispute.test.ts` — non-sponsor intent now asserts `resolves.toBe(false)`.

## Verification

- Dispute suites 79/0; usecases+lib 1005 pass; tsc clean
- e2e wall vs prod build (`E2E_PROD_TARGET=1`, fresh DB): parallel 165 pass, serial 45/45, mobile 16/16. Two parallel-phase flakes (board-v3 legend, news scorebug) both green on serial rerun — pre-existing contention/timing, unrelated to this diff (server-side webhook dispatch only).
- Local-only note: 2 AI-unit + 6 smoke-matrix reds on the shared dev DB come from the parallel `v4-ai-architect` worktree's V297 migration (AI quotas for all plans) — not this branch. CI's fresh container DB is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)