### PR TITLE
test(e2e): news spec targets the result draft by title, not .first()

### DIFF
--- a/apps/web/e2e/news.spec.ts
+++ b/apps/web/e2e/news.spec.ts
@@ -65,25 +65,36 @@ test.describe.serial("org news", () => {
       payload: { p1Score: 3, p2Score: 1 },
     });
 
-    // Console News tab: the ⚡ auto draft is queued.
+    // Console News tab: the ⚡ auto RESULT draft is queued. Deciding the only
+    // fixture also completes the round, so a round_recap draft lands in the
+    // SAME transaction — identical created_at, uuid tiebreak, random order.
+    // Select by the auto result title ("Alpha … 3–1 Beta …"), never .first():
+    // publishing the recap by accident yields a post with kind=round_recap,
+    // which renders no scorebug/story card and fails the second test.
     await page.goto(`/o/${orgSlug}/settings?tab=news`);
     await expect(page.getByTestId("news-tab")).toBeVisible();
-    const draft = page.getByTestId("draft-row").first();
+    const draft = page
+      .getByTestId("draft-row")
+      .filter({ hasText: `Alpha ${TAG} 3–1 Beta ${TAG}` });
     await expect(draft).toBeVisible();
     await expect(draft.getByTestId("auto-chip")).toBeVisible();
 
     // Edit the headline (keep it a scoreline so it still renders a scorebug).
     await draft.getByRole("button", { name: /edit/i }).click();
     await expect(page.getByTestId("news-composer")).toBeVisible();
-    await page.getByTestId("composer-title").fill(`Alpha ${TAG} 2–0 Beta ${TAG}`);
+    const editedTitle = `Alpha ${TAG} 2–0 Beta ${TAG}`;
+    await page.getByTestId("composer-title").fill(editedTitle);
     await page.getByTestId("composer-save").click();
 
-    // Publish from the drafts queue.
-    await page.getByTestId("draft-row").first().getByTestId("draft-publish").click();
-    await expect(page.getByTestId("published-row").first()).toBeVisible();
-    postSlug = await page
-      .getByTestId("published-row")
-      .first()
+    // Publish from the drafts queue — the result row now wears the edited title.
+    await page
+      .getByTestId("draft-row")
+      .filter({ hasText: editedTitle })
+      .getByTestId("draft-publish")
+      .click();
+    const published = page.getByTestId("published-row").filter({ hasText: editedTitle });
+    await expect(published).toBeVisible();
+    postSlug = await published
       .getByRole("link")
       .first()
       .getAttribute("href")


### PR DESCRIPTION
## What

The news e2e published `draft-row.first()`. Deciding the only fixture of the one-round league creates **two** auto drafts in the same transaction — the result post and the round recap — with identical `created_at`, so list order falls to the uuid tiebreak. When the recap sorted first, the test edited + published the recap; its kind renders no scorebug and no story-card download, and the public-page assertions failed. This is the last red in main e2e run 29686675204 (post-#153): the failure snapshot shows the **Recap** eyebrow over the scoreline headline.

## Fix

Select rows by title: the auto result title (`Alpha TAG 3–1 Beta TAG`) before the edit, the edited title after, for both the publish click and the published-row slug read. Test-only change; also immunises the spec against draft residue on shared local DBs.

## Verify

- `playwright test e2e/news.spec.ts --project=parallel --repeat-each=3` vs a prod build of this branch on :3200 (fresh DB at V295, fresh .auth): **8/8 pass**
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)