### PR TITLE
build(docker): skip Next type-check phase in image builds — builder VMs OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ ENV SENTRY_ORG=$SENTRY_ORG
 ENV SENTRY_PROJECT=$SENTRY_PROJECT
 ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
+# Builder VMs OOM-SIGKILL Next's type-check phase (the compile itself passes
+# in ~70s; tsc then grinds for 40min and dies even with a 6GB old-space cap).
+# CI type-checks every PR, so the image build skips the phase entirely.
+ENV SKIP_BUILD_TYPECHECK=1
 RUN npm run build --workspace apps/web
 
 # ── Stage 2: minimal production image ────────────────────────────────────────

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -27,6 +27,10 @@ const securityHeaders = [
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  // Fly/depot builder VMs OOM-SIGKILL the type-check build phase (compile
+  // itself passes in ~70s). CI type-checks every PR, so image builds may skip
+  // the phase — only when the Dockerfile sets this flag, never locally.
+  typescript: { ignoreBuildErrors: process.env.SKIP_BUILD_TYPECHECK === "1" },
   // Don't advertise the framework (removes the `X-Powered-By: Next.js` header).
   poweredByHeader: false,
   // Monorepo: trace from the workspace root so hoisted node_modules land in


### PR DESCRIPTION
## Problem

Three consecutive stg deploys (`fly deploy -c fly.stg.toml --depot`) died inside `next build`:

- Compile: ✓ in ~70s every time
- "Running TypeScript" phase: SIGKILL after 6–40 min of grinding — with **and without** `NODE_OPTIONS=--max-old-space-size=6144`

The builder VM's RAM is the ceiling; no heap flag fixes that.

## Fix

- `next.config.js`: `typescript.ignoreBuildErrors` wired to `SKIP_BUILD_TYPECHECK === "1"`
- `Dockerfile`: sets `ENV SKIP_BUILD_TYPECHECK=1` in the builder stage

Only image builds skip the phase. Local `next build`, `npm run tsc`, and CI (Unit + typecheck job — the real gate, green on every PR) are unchanged.

## Verification

- Stg deploy running with exactly this working-tree diff — build passes the previously fatal phase (log: compile ~70s, no tsc grind)
- CI on this PR exercises the unchanged type-check path

🤖 Generated with [Claude Code](https://claude.com/claude-code)