### PR TITLE
fix(sponsors): money records survive deletion; disputed orders refuse refunds; absolute receipt links

### DIFF
--- a/apps/web/content/help/registration/card-payments.md
+++ b/apps/web/content/help/registration/card-payments.md
@@ -40,7 +40,9 @@ If a cardholder disputes a payment, the registration is **flagged on your consol
 
 ### Sponsorship chargebacks work the same way
 
-A card sponsorship payment runs on the same Connect rail, so a disputed sponsorship charge follows the same path. The moment Stripe tells us, the sponsor's order is flagged, its **placement comes down** — boards and public pages stop showing it — and you get an alert. Win the dispute and the placement goes back up automatically; lose it and the order is written off, the placement stays down, and the amount is **recovered from your Stripe balance**. Seazn Club absorbs Stripe's dispute fee here too, and you're emailed what moved.
+A card sponsorship payment runs on the same Connect rail, so a disputed sponsorship charge follows the same path. The moment Stripe tells us, the sponsor's order is flagged **Disputed** in your monetization console, its **placement comes down** — boards and public pages stop showing it — and you get an alert. Win the dispute and the placement goes back up automatically; lose it and the order is written off, the placement stays down, and the amount is **recovered from your Stripe balance**. Seazn Club absorbs Stripe's dispute fee here too, and you're emailed what moved.
+
+While an order is disputed you can't refund it — the card networks freeze a charged-back payment, so the money moves with the dispute's outcome instead. The Refund button reappears only if the dispute is won. Payment records themselves are permanent: paid, refunded or disputed sponsorship orders survive even if the package or organisation that produced them is later removed.
 
 ### Event Pass chargebacks are different
 

--- a/apps/web/src/components/sponsor-packages.tsx
+++ b/apps/web/src/components/sponsor-packages.tsx
@@ -32,6 +32,7 @@ interface OrderItem {
   amount_cents: number;
   currency: string;
   status: "pending" | "paid" | "failed" | "refunded";
+  disputed_at: string | null;
   created_at: string;
 }
 
@@ -446,11 +447,13 @@ export function SponsorPackages({
                   {money(order.amount_cents, order.currency)}
                 </span>
                 <span
-                  className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ${STATUS_BADGE[order.status]}`}
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase ${
+                    order.disputed_at ? "bg-rose-100 text-rose-700" : STATUS_BADGE[order.status]
+                  }`}
                 >
-                  {msg(STATUS_MSG[order.status])}
+                  {msg(order.disputed_at ? "sponsors.order.status.disputed" : STATUS_MSG[order.status])}
                 </span>
-                {order.status === "paid" ? (
+                {order.status === "paid" && !order.disputed_at ? (
                   <button
                     type="button"
                     disabled={busy}

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -176,6 +176,7 @@
   "sponsors.order.status.pending": "Pending",
   "sponsors.order.status.paid": "Paid",
   "sponsors.order.status.failed": "Failed",
+  "sponsors.order.status.disputed": "Disputed",
   "sponsors.order.status.refunded": "Refunded",
   "sponsors.paidBadge": "Paid",
   "sponsors.deletePaid.title": "Delete a paid placement?",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -176,6 +176,7 @@
   "sponsors.order.status.pending": "Pendiente",
   "sponsors.order.status.paid": "Pagado",
   "sponsors.order.status.failed": "Fallido",
+  "sponsors.order.status.disputed": "En disputa",
   "sponsors.order.status.refunded": "Reembolsado",
   "sponsors.paidBadge": "Pagado",
   "sponsors.deletePaid.title": "¿Eliminar un espacio pagado?",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -176,6 +176,7 @@
   "sponsors.order.status.pending": "En attente",
   "sponsors.order.status.paid": "Payée",
   "sponsors.order.status.failed": "Échouée",
+  "sponsors.order.status.disputed": "Contestée",
   "sponsors.order.status.refunded": "Remboursée",
   "sponsors.paidBadge": "Payé",
   "sponsors.deletePaid.title": "Supprimer un emplacement payé ?",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -176,6 +176,7 @@
   "sponsors.order.status.pending": "In afwachting",
   "sponsors.order.status.paid": "Betaald",
   "sponsors.order.status.failed": "Mislukt",
+  "sponsors.order.status.disputed": "Betwist",
   "sponsors.order.status.refunded": "Terugbetaald",
   "sponsors.paidBadge": "Betaald",
   "sponsors.deletePaid.title": "Betaalde plek verwijderen?",

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -1301,6 +1301,7 @@ export const SponsorOrder = z.object({
   sponsor_id: z.string().nullable(),
   created_at: z.string(),
   paid_at: z.string().nullable(),
+  disputed_at: z.string().nullable(),
 });
 
 export const StartSponsorCheckout = z.object({

--- a/apps/web/src/server/usecases/__tests__/sponsor-checkout.test.ts
+++ b/apps/web/src/server/usecases/__tests__/sponsor-checkout.test.ts
@@ -193,6 +193,12 @@ describe.skipIf(!HAS_DB)("sponsor monetization", () => {
       payment_intent_id: intent.id,
     });
     expect(emailMock.receipt).toHaveBeenCalledOnce();
+    // The "See it live" link must be absolute — mail clients have no origin
+    // to resolve "/shared/…" against (stg regression: NEXT_PUBLIC_APP_URL was
+    // never set anywhere, so every receipt shipped a relative link).
+    expect(emailMock.receipt.mock.calls[0]![0]).toMatchObject({
+      publicUrl: expect.stringMatching(/^https?:\/\/.+\/shared\//),
+    });
 
     // A late failure event never clobbers the paid order.
     await handleSponsorPaymentFailed(intent);

--- a/apps/web/src/server/usecases/__tests__/sponsor-order-delete-guards.test.ts
+++ b/apps/web/src/server/usecases/__tests__/sponsor-order-delete-guards.test.ts
@@ -1,0 +1,129 @@
+// Sponsor orders are money records; V299 flips their org/package FKs from
+// CASCADE to RESTRICT after a live stg incident (2026-07-19): deleting a
+// throwaway org hard-cascaded away a paid + disputed £10 order — the app's
+// only record of the charge, and the dispute became permanently unmatchable.
+// No app surface hard-deletes orgs or packages (both soft-flip), so the only
+// paths that ever fired the cascade are scripts and direct SQL — exactly what
+// a DB-level RESTRICT is for. deleteCompetition (which legitimately cascades
+// its comp-scoped packages) now sweeps intent-less orders itself and refuses
+// while payment-touched rows remain. Real Postgres required.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition, deleteCompetition } from "@/server/usecases/competitions";
+import { refundSponsorOrder } from "@/server/usecases/sponsors";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function seedOrgWithComp(): Promise<{ auth: AuthCtx; orgId: string; compId: string }> {
+  const suffix = uniq();
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${"Restrict " + suffix}, ${"restrict-" + suffix}) returning id`;
+  await sql`
+    insert into subscriptions (org_id, plan_key, status)
+    values (${orgId}, 'pro', 'active')
+    on conflict (org_id) do update set plan_key = 'pro'`;
+  await invalidateOrgEntitlements(orgId);
+  const auth: AuthCtx = { orgId, via: "session", userId: null, role: "owner", keyId: null };
+  const comp = await createCompetition(auth, {
+    name: `Cup ${uniq()}`,
+    visibility: "private",
+    branding: {},
+  });
+  return { auth, orgId, compId: comp.id };
+}
+
+async function seedPackage(orgId: string, compId: string | null): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into sponsor_packages (org_id, competition_id, name, price_cents, currency, tier)
+    values (${orgId}, ${compId}, 'Gold', 25000, 'gbp', 'gold') returning id`;
+  return id;
+}
+
+type OrderSeed = {
+  status?: string;
+  intent?: string | null;
+  disputedAt?: Date | null;
+};
+
+async function seedOrder(orgId: string, packageId: string, o: OrderSeed = {}): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into sponsor_orders (org_id, package_id, sponsor_name, sponsor_email,
+                                amount_cents, currency, status, payment_intent_id,
+                                paid_at, disputed_at)
+    values (${orgId}, ${packageId}, 'S', 's@x.test', 25000, 'gbp',
+            ${o.status ?? "paid"}, ${o.intent === undefined ? "pi_" + uniq() : o.intent},
+            ${o.intent === null ? null : new Date()}, ${o.disputedAt ?? null})
+    returning id`;
+  return id;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("sponsor order delete protection (V299)", () => {
+  it("raw org delete with a paid sponsor order is refused by the DB", async () => {
+    const { orgId } = await seedOrgWithComp();
+    const pkg = await seedPackage(orgId, null);
+    await seedOrder(orgId, pkg);
+    await expect(
+      sql`delete from organizations where id = ${orgId}`,
+    ).rejects.toMatchObject({ code: "23503" });
+  });
+
+  it("raw package delete with a paid sponsor order is refused by the DB", async () => {
+    const { orgId } = await seedOrgWithComp();
+    const pkg = await seedPackage(orgId, null);
+    await seedOrder(orgId, pkg);
+    await expect(
+      sql`delete from sponsor_packages where id = ${pkg}`,
+    ).rejects.toMatchObject({ code: "23503" });
+  });
+
+  it("deleteCompetition sweeps intent-less orders along with its packages", async () => {
+    const { auth, orgId, compId } = await seedOrgWithComp();
+    const pkg = await seedPackage(orgId, compId);
+    const orderId = await seedOrder(orgId, pkg, { status: "pending", intent: null });
+    await deleteCompetition(auth, compId);
+    const [comp] = await sql`select 1 from competitions where id = ${compId}`;
+    expect(comp).toBeUndefined();
+    const [order] = await sql`select 1 from sponsor_orders where id = ${orderId}`;
+    expect(order).toBeUndefined();
+  });
+
+  it("deleteCompetition 409s while a refunded order holds payment history", async () => {
+    const { auth, orgId, compId } = await seedOrgWithComp();
+    const pkg = await seedPackage(orgId, compId);
+    await seedOrder(orgId, pkg, { status: "refunded" });
+    await expect(deleteCompetition(auth, compId)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("deleteCompetition 409s while a disputed order exists", async () => {
+    const { auth, orgId, compId } = await seedOrgWithComp();
+    const pkg = await seedPackage(orgId, compId);
+    await seedOrder(orgId, pkg, { status: "refunded", disputedAt: new Date() });
+    await expect(deleteCompetition(auth, compId)).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("refunding a disputed order 409s in our own words, before Stripe", async () => {
+    const { auth, orgId, compId } = await seedOrgWithComp();
+    const pkg = await seedPackage(orgId, compId);
+    const orderId = await seedOrder(orgId, pkg, { disputedAt: new Date() });
+    // Keyless test env: reaching getStripe() would throw a config error, so a
+    // clean 409 also proves the guard fired before any Stripe call. The
+    // message must be ours — no raw Stripe text (charge ids) leaks.
+    await expect(refundSponsorOrder(auth, orderId)).rejects.toMatchObject({
+      status: 409,
+      message: expect.not.stringContaining("ch_"),
+    });
+  });
+});

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -365,14 +365,25 @@ export async function deleteCompetition(auth: AuthCtx, id: string): Promise<void
     const [paidSponsor] = await tx`
       select 1 from sponsor_orders o
       join sponsor_packages p on p.id = o.package_id
-      where p.competition_id = ${id} and o.status = 'paid'
+      where p.competition_id = ${id}
+        and (o.payment_intent_id is not null
+             or o.disputed_at is not null
+             or o.status in ('paid', 'refunded'))
       limit 1`;
     if (paidSponsor) {
       throw new HttpError(
         409,
-        "competition has a paid sponsorship — refund the order or archive it instead",
+        "competition has sponsorship payment records — refund history is kept; archive it instead",
       );
     }
+    // V299 made sponsor_orders.package_id RESTRICT, so the comp→package
+    // cascade can no longer sweep abandoned checkouts implicitly. The
+    // sponsor_orders_prune policy (V300) fences this delete to rows that
+    // never became money: pending, intent-less, undisputed.
+    await tx`
+      delete from sponsor_orders o
+      using sponsor_packages p
+      where p.id = o.package_id and p.competition_id = ${id}`;
     const deleted = await tx`delete from competitions where id = ${id} returning id`;
     if (deleted.length === 0) throw new HttpError(404, "competition not found");
   });

--- a/apps/web/src/server/usecases/sponsors.ts
+++ b/apps/web/src/server/usecases/sponsors.ts
@@ -354,11 +354,13 @@ export interface SponsorOrderRow {
   sponsor_id: string | null;
   created_at: string;
   paid_at: string | null;
+  disputed_at: string | null;
 }
 
 const ORDER_COLS = [
   "id", "package_id", "sponsor_name", "sponsor_email", "payment_intent_id",
   "amount_cents", "currency", "status", "sponsor_id", "created_at", "paid_at",
+  "disputed_at",
 ] as const;
 
 export async function listSponsorOrders(auth: AuthCtx): Promise<SponsorOrderRow[]> {
@@ -518,7 +520,7 @@ export async function handleSponsorPaymentSucceeded(
     sponsorName: activated.order.sponsor_name,
     amountCents: activated.order.amount_cents,
     currency: activated.order.currency,
-    publicUrl: org ? `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/shared/${org.slug}` : null,
+    publicUrl: org ? `${sponsorEmailOrigin()}/shared/${org.slug}` : null,
   });
 }
 
@@ -554,6 +556,14 @@ export async function refundSponsorOrder(
   });
   if (order.status !== "paid" || !order.payment_intent_id) {
     throw new HttpError(422, "Only a paid order can be refunded");
+  }
+  // Stripe refuses refunds on charged-back charges; surface the state in our
+  // own words before ever calling out (raw Stripe text leaked to the console).
+  if (order.disputed_at) {
+    throw new HttpError(
+      409,
+      "This payment has been charged back — a disputed payment can't be refunded. Respond to the dispute instead.",
+    );
   }
   // Stripe OUTSIDE any sql transaction (house rule).
   await getStripe().refunds.create(
@@ -631,6 +641,18 @@ export async function handleSponsorChargeRefunded(charge: Stripe.Charge): Promis
 // ---------------------------------------------------------------------------
 // Dispute lifecycle (payments-hardening Task 6, P0-2)
 // ---------------------------------------------------------------------------
+
+/** Origin for sponsor emails fired from webhook (request-less) paths — the
+ *  same override order as registrations' fallbackOrigin. NEXT_PUBLIC_APP_URL
+ *  (the previous source) is not set in any environment, so receipts went out
+ *  with relative "/shared/…" links no mail client could open. */
+function sponsorEmailOrigin(): string {
+  return (
+    process.env.OAUTH_BASE_URL ||
+    process.env.NEXT_PUBLIC_BASE_URL ||
+    "http://localhost:3000"
+  ).replace(/\/$/, "");
+}
 
 /** Current owner via org_members, NOT organizations.created_by — an ownership
  *  transfer flips the role but leaves created_by on the original creator. Local

--- a/db/migration/deltas/V299__sponsor_order_delete_restrict.sql
+++ b/db/migration/deltas/V299__sponsor_order_delete_restrict.sql
@@ -1,0 +1,17 @@
+-- Sponsor orders are money records (payments, refunds, disputes — the audit
+-- trail chargebacks are answered with). Both parent FKs were ON DELETE
+-- CASCADE, so hard-deleting an organization or a package silently destroyed
+-- paid orders (live stg incident 2026-07-19: org deleted after a £10 paid +
+-- disputed order — record unrecoverable, dispute permanently unmatchable).
+-- No app surface hard-deletes orgs/packages (both soft-flip), so the cascade
+-- only ever fired from scripts and direct SQL — exactly the paths a DB-level
+-- RESTRICT is for. Deleters must now handle money rows consciously first.
+alter table sponsor_orders
+  drop constraint sponsor_orders_org_id_fkey,
+  add constraint sponsor_orders_org_id_fkey
+    foreign key (org_id) references organizations(id) on delete restrict;
+
+alter table sponsor_orders
+  drop constraint sponsor_orders_package_id_fkey,
+  add constraint sponsor_orders_package_id_fkey
+    foreign key (package_id) references sponsor_packages(id) on delete restrict;

--- a/db/migration/deltas/V300__sponsor_order_prune_policy.sql
+++ b/db/migration/deltas/V300__sponsor_order_prune_policy.sql
@@ -1,0 +1,23 @@
+-- V283 deliberately withheld DELETE on sponsor_orders from app_user: orders
+-- are the money audit trail. V299's RESTRICT FKs mean deleteCompetition can
+-- no longer rely on the comp→package cascade to sweep abandoned checkouts,
+-- so the tenant needs a delete right — but only for rows that never became
+-- money. V283's single FOR ALL policy would OR itself into any new delete
+-- policy (permissive policies combine), so it is split per command and the
+-- delete arm carries the fence: no payment intent, never disputed, still
+-- pending. Paid/refunded/disputed rows stay undeletable for tenants.
+drop policy sponsor_orders_tenant on sponsor_orders;
+
+create policy sponsor_orders_read on sponsor_orders for select to app_user
+  using (org_id = current_org_id());
+create policy sponsor_orders_insert on sponsor_orders for insert to app_user
+  with check (org_id = current_org_id());
+create policy sponsor_orders_write on sponsor_orders for update to app_user
+  using (org_id = current_org_id()) with check (org_id = current_org_id());
+create policy sponsor_orders_prune on sponsor_orders for delete to app_user
+  using (org_id = current_org_id()
+         and payment_intent_id is null
+         and disputed_at is null
+         and status = 'pending');
+
+grant delete on sponsor_orders to app_user;

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -28865,6 +28865,16 @@
                                 "type": "null"
                               }
                             ]
+                          },
+                          "disputed_at": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -28878,7 +28888,8 @@
                           "status",
                           "sponsor_id",
                           "created_at",
-                          "paid_at"
+                          "paid_at",
+                          "disputed_at"
                         ],
                         "additionalProperties": false
                       }
@@ -28903,7 +28914,8 @@
                       "status": "pending",
                       "sponsor_id": "example",
                       "created_at": "example",
-                      "paid_at": "example"
+                      "paid_at": "example",
+                      "disputed_at": "example"
                     }
                   ],
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
@@ -29192,6 +29204,16 @@
                                   "type": "null"
                                 }
                               ]
+                            },
+                            "disputed_at": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
                           },
                           "required": [
@@ -29205,7 +29227,8 @@
                             "status",
                             "sponsor_id",
                             "created_at",
-                            "paid_at"
+                            "paid_at",
+                            "disputed_at"
                           ],
                           "additionalProperties": false
                         },
@@ -29239,7 +29262,8 @@
                       "status": "pending",
                       "sponsor_id": "example",
                       "created_at": "example",
-                      "paid_at": "example"
+                      "paid_at": "example",
+                      "disputed_at": "example"
                     },
                     "checkout_url": "example"
                   },
@@ -29630,6 +29654,16 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "disputed_at": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         }
                       },
                       "required": [
@@ -29643,7 +29677,8 @@
                         "status",
                         "sponsor_id",
                         "created_at",
-                        "paid_at"
+                        "paid_at",
+                        "disputed_at"
                       ],
                       "additionalProperties": false
                     },
@@ -29666,7 +29701,8 @@
                     "status": "pending",
                     "sponsor_id": "example",
                     "created_at": "example",
-                    "paid_at": "example"
+                    "paid_at": "example",
+                    "disputed_at": "example"
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
                 }

--- a/scripts/smoke-sports.ts
+++ b/scripts/smoke-sports.ts
@@ -145,6 +145,11 @@ async function cleanup(): Promise<void> {
   const emails = [`sports_${tag}@example.com`, `community_${tag}@example.com`];
   const sql = db();
   try {
+    // sponsor_orders are RESTRICT (V299): money rows must go before their org.
+    await sql`
+      delete from sponsor_orders
+      where org_id in (select id from organizations
+                       where created_by in (select id from users where email = any(${emails})))`;
     const orgs = await sql`
       delete from organizations
       where created_by in (select id from users where email = any(${emails}))`;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -4445,6 +4445,11 @@ async function cleanup(tag: string): Promise<void> {
     max: 1,
   });
   try {
+    // sponsor_orders are RESTRICT (V299): money rows must go before their org.
+    await sql`
+      delete from sponsor_orders
+      where org_id in (select id from organizations
+                       where created_by in (select id from users where email = any(${emails})))`;
     const orgs = await sql`
       delete from organizations
       where created_by in (select id from users where email = any(${emails}))`;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -486,8 +486,8 @@ async function p72Suite(): Promise<void> {
   await seedPaidSponsorOrder(orgId, sponComp.id);
   const delSpon = await v1(owner, `/api/v1/competitions/${sponComp.id}`, "DELETE");
   check(
-    "p72: delete blocked by a paid sponsorship (409, 'paid sponsorship')",
-    delSpon.status === 409 && delMsg(delSpon).includes("paid sponsorship"),
+    "p72: delete blocked by a paid sponsorship (409, 'sponsorship payment records')",
+    delSpon.status === 409 && delMsg(delSpon).includes("sponsorship payment records"),
   );
 
   // === KEY AUTH: DELETE /competitions/:id is never key-accessible → 403 for


### PR DESCRIPTION
## The incident

Live stg, 2026-07-19: a throwaway org was deleted after paying for (and disputing) a £10 sponsor package. `sponsor_orders.org_id` and `.package_id` were both `ON DELETE CASCADE`, so the paid + disputed order — the app's only record of the charge — was destroyed, and its dispute became permanently unmatchable.

## Fixes

**1. V299 — RESTRICT FKs.** No app surface hard-deletes orgs or packages (both soft-flip: `deleted_at` / `active=false`), so the cascade only ever fired from scripts and raw SQL. The DB now refuses those too: deleting a parent with sponsor orders attached is a `23503`, forcing the operator to deal with money rows consciously.

**2. V300 — fenced tenant prune + comp-delete sweep.** V283 deliberately withheld DELETE on `sponsor_orders` from `app_user` ("orders are the money audit trail"). Its single `FOR ALL` policy is split per command (permissive policies OR together — a naive delete-policy addition would have been swallowed by it), and the new delete arm allows tenants to remove **only rows that never became money**: `pending`, intent-less, undisputed. `deleteCompetition` sweeps abandoned checkouts through that fence explicitly, and its 409 guard broadens from `status='paid'` to any payment-touched order (intent present, disputed, or paid/refunded status) — refund history is part of the audit trail.

**3. Refund-on-disputed UX.** The console surfaced raw Stripe text ("Charge ch_… has been charged back; cannot issue a refund"). `refundSponsorOrder` now pre-checks `disputed_at` and 409s in our own words before any Stripe call; the console shows a **Disputed** badge (en/fr/es/nl) and hides the Refund button while disputed. `disputed_at` added to `SponsorOrderRow`, the API schema, and the regenerated OpenAPI docs.

**4. Absolute receipt links.** "See it live: /shared/org-…" — `NEXT_PUBLIC_APP_URL` is set in **no** environment (v10 ghost var). `sponsorEmailOrigin()` now follows the repo's `OAUTH_BASE_URL || NEXT_PUBLIC_BASE_URL || localhost` chain like every other request-less email path. Stg already sets `OAUTH_BASE_URL`, so links go absolute on deploy with no env work.

## Tests

- NEW `sponsor-order-delete-guards.test.ts`: raw org/package deletes rejected `23503` ×2; comp-delete sweeps intent-less orders; 409 on refunded ×1 / disputed ×1; refund-on-disputed 409s with no `ch_` text (and proves the guard fires before Stripe — the keyless env would throw otherwise).
- `sponsor-checkout.test.ts`: receipt `publicUrl` asserted absolute (`^https?://…/shared/`).
- smoke p72 updated to the broadened message; smoke + smoke-sports cleanups delete `sponsor_orders` before `organizations`.

## Verification

- Guards 10/0, checkout 12/0, dispute suites green, full `src/server src/lib` 1427 pass / 4 fail — all four are the known cross-wave reds on the shared dev DB (3× `scheduling.ai` from the parallel v4-ai-architect worktree's V297; 1× registration-sweep count poisoned by parallel suites, 52/0 solo). CI's fresh container DB is authoritative.
- Full smoke run against a worktree dev server: only the same 6 AI-matrix cross-wave reds + p72 (fixed above, message assertion).
- tsc 0. Help page updated (card-payments §sponsorship: disputed orders can't be refunded; payment records are permanent).

## Deploy note

`db:apply` (V299+V300) before code, as usual. Dev DB already migrated to V300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)