### PR TITLE
fix(scoring): engine errors name players, not UUIDs

### DIFF
--- a/apps/web/src/server/usecases/__tests__/humanize-engine-message.test.ts
+++ b/apps/web/src/server/usecases/__tests__/humanize-engine-message.test.ts
@@ -1,0 +1,62 @@
+// Engine rejections carry raw UUIDs (the engine is pure and knows no names);
+// scoreEvent swaps person/entrant ids for display names before the message
+// reaches a pad. Real Postgres required.
+import { describe, expect, it, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { humanizeEngineMessage } from "../scoring";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function seed() {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${"Hz " + suffix}, ${"hz-" + suffix}) returning id`;
+  const [{ id: personId }] = await sql<{ id: string }[]>`
+    insert into persons (org_id, full_name, consent)
+    values (${orgId}, 'Alex Morgan', '{}') returning id`;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', '{}')
+    on conflict (key) do nothing`;
+  const [{ id: compId }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug, visibility)
+    values (${orgId}, 'Hz Cup', ${"hz-cup-" + suffix}, 'private') returning id`;
+  const [{ id: divId }] = await sql<{ id: string }[]>`
+    insert into divisions (competition_id, name, slug, sport_key, module_version, variant_key, config)
+    values (${compId}, 'Hz Div', 'hz-div', 'generic', '1.0.0', 'score', '{}') returning id`;
+  const [{ id: entrantId }] = await sql<{ id: string }[]>`
+    insert into entrants (division_id, kind, display_name)
+    values (${divId}, 'team', 'Lions U12') returning id`;
+  return { orgId, personId, entrantId };
+}
+
+describe.skipIf(!HAS_DB)("humanizeEngineMessage", () => {
+  it("swaps person and entrant UUIDs for display names; unknown ids survive", async () => {
+    const { orgId, personId, entrantId } = await seed();
+    const ghost = randomUUID();
+    const msg = `scorer "${personId}" is not on the pitch for "${entrantId}" (ref ${ghost})`;
+    const out = await humanizeEngineMessage(orgId, msg);
+    expect(out).toBe(`scorer Alex Morgan is not on the pitch for Lions U12 (ref ${ghost})`);
+  });
+
+  it("does not leak names across orgs", async () => {
+    const a = await seed();
+    const b = await seed();
+    // Org B asks about org A's person — RLS keeps the UUID opaque.
+    const out = await humanizeEngineMessage(b.orgId, `scorer "${a.personId}" missing`);
+    expect(out).toContain(a.personId);
+    expect(out).not.toContain("Alex Morgan");
+  });
+
+  it("returns the message untouched when it carries no UUIDs", async () => {
+    const { orgId } = await seed();
+    const msg = 'goal not allowed in phase "done"';
+    expect(await humanizeEngineMessage(orgId, msg)).toBe(msg);
+  });
+});
+
+afterAll(async () => {
+  await sql.end({ timeout: 1 });
+});

--- a/apps/web/src/server/usecases/scoring.ts
+++ b/apps/web/src/server/usecases/scoring.ts
@@ -43,6 +43,37 @@ const SCORING_LIMIT = { max: 10, windowSeconds: 1 };
 
 const TABLE_KINDS = new Set(["league", "group", "swiss"]);
 
+const ENGINE_ID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+/** Engine rejections carry raw ids — the engine is pure and knows no names
+ *  ('scorer "9c87…" is not on the pitch for "7b94…"'). Swap person/entrant
+ *  UUIDs in the message for their display names before it reaches a scorer's
+ *  pad; the code and extra stay untouched so clients keep the machine part.
+ *  Best-effort: unknown ids stay as-is, and a lookup failure never masks the
+ *  original error. */
+export async function humanizeEngineMessage(orgId: string, message: string): Promise<string> {
+  const ids = [...new Set((message.match(ENGINE_ID_RE) ?? []).map((m) => m.toLowerCase()))];
+  if (ids.length === 0) return message;
+  try {
+    return await withTenant(orgId, async (tx) => {
+      const persons = await tx<{ id: string; full_name: string }[]>`
+        select id, full_name from persons where id = any(${ids}::uuid[])`;
+      const entrants = await tx<{ id: string; display_name: string }[]>`
+        select id, display_name from entrants where id = any(${ids}::uuid[])`;
+      let out = message;
+      for (const { id, full_name } of persons) {
+        out = out.replaceAll(`"${id}"`, full_name).replaceAll(id, full_name);
+      }
+      for (const { id, display_name } of entrants) {
+        out = out.replaceAll(`"${id}"`, display_name).replaceAll(id, display_name);
+      }
+      return out;
+    });
+  } catch {
+    return message;
+  }
+}
+
 /**
  * Append one score event. 201-shape on success; EngineError SEQ_CONFLICT →
  * 409 (v1 kernel maps it); module rejection → 422, nothing persisted.
@@ -63,18 +94,27 @@ export async function scoreEvent(
   await assertEntitledToScore(auth, fixtureId, input);
   if (input.type === "core.void") await assertUndoTarget(auth, fixtureId, input);
 
-  const result = await appendEvent(auth.orgId, fixtureId, input.expected_seq, {
-    type: input.type,
-    payload: input.payload,
-    // Device links: recorded_by = issued_by (auth.userId carries the issuer,
-    // doc 13 §7) + the device_link_id rider so the ledger distinguishes them.
-    recordedBy: auth.userId,
-    deviceLinkId: auth.deviceLinkId ?? null,
-    ...(input.type === "core.void" &&
-    typeof (input.payload as { event_id?: unknown })?.event_id === "string"
-      ? { voids: (input.payload as { event_id: string }).event_id }
-      : {}),
-  });
+  let result;
+  try {
+    result = await appendEvent(auth.orgId, fixtureId, input.expected_seq, {
+      type: input.type,
+      payload: input.payload,
+      // Device links: recorded_by = issued_by (auth.userId carries the issuer,
+      // doc 13 §7) + the device_link_id rider so the ledger distinguishes them.
+      recordedBy: auth.userId,
+      deviceLinkId: auth.deviceLinkId ?? null,
+      ...(input.type === "core.void" &&
+      typeof (input.payload as { event_id?: unknown })?.event_id === "string"
+        ? { voids: (input.payload as { event_id: string }).event_id }
+        : {}),
+    });
+  } catch (err) {
+    // SEQ_CONFLICT is the hot recovery path and carries no ids — skip it.
+    if (err instanceof EngineError && err.code !== "SEQ_CONFLICT") {
+      err.message = await humanizeEngineMessage(auth.orgId, err.message);
+    }
+    throw err;
+  }
 
   const out: ScoreOutcome = {
     seq: result.seq,


### PR DESCRIPTION
## Why

Score pads surfaced raw engine rejections: `scorer "9c87a562-…" is not on the pitch for "7b94d16c-…"`. The engine is pure (ids only, no DB), so the fix belongs at the scoring door.

## What

`scoreEvent` catches `EngineError` (except `SEQ_CONFLICT` — hot path, no ids), swaps person/entrant UUIDs in the message for `full_name`/`display_name` (org-scoped under RLS), and rethrows. Codes + `extra` untouched. One mechanism covers all 13 `invalid()` sites across every sport module. Best-effort: unknown ids stay, lookup failure never masks the original error.

## Verify

- 3 new DB tests (name swap incl unknown-id survival, cross-org RLS opacity, no-UUID passthrough)
- tsc clean, vitest **1915/0**, smoke **470/0** vs prod build

🤖 Generated with [Claude Code](https://claude.com/claude-code)