### PR TITLE
fix(pad): load saved lineups on the device score pad

### DIFF
--- a/apps/web/src/app/score/[token]/page.tsx
+++ b/apps/web/src/app/score/[token]/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 // `Authorization: Bearer dl_…`. The token lives in this tab only — never
 // localStorage.
 import { resolveDeviceLinkToken } from "@/server/usecases/device-links";
-import { getFixtureState, listEvents } from "@/server/usecases/fixtures";
+import { getFixtureState, getLineup, listEvents } from "@/server/usecases/fixtures";
 import { getEntrant } from "@/server/usecases/entrants";
 import { withTenant } from "@/lib/db";
 import { resolveModule } from "@/server/engine-db";
@@ -95,12 +95,18 @@ export default async function ScorePadPage({
 
   async function side(entrantId: string | null): Promise<PadSideInfo | null> {
     if (!entrantId) return null;
-    const entrant = await getEntrant(read, entrantId);
+    // Same pair the fixture console loads — a lineup saved there must reach
+    // the pad's picker (this read is the trusted server ctx, not the
+    // device-link API surface getLineup's rejectDeviceLink guards).
+    const [entrant, lineup] = await Promise.all([
+      getEntrant(read, entrantId),
+      getLineup(read, fixture.id, entrantId),
+    ]);
     return {
       id: entrant.id,
       name: entrant.display_name,
       members: entrant.members as PadSideInfo["members"],
-      lineup: [],
+      lineup: lineup.slots as PadSideInfo["lineup"],
     };
   }
   const [home, away] = await Promise.all([

--- a/apps/web/src/components/v2/__tests__/lineup-editor-prefill.test.tsx
+++ b/apps/web/src/components/v2/__tests__/lineup-editor-prefill.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { LineupEditor } from "@/components/v2/lineup-editor";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import uiEn from "@/dictionaries/en/ui.json";
+import type { Dict } from "@/lib/i18n-constants";
+import type { SideInfo } from "@/components/v2/fixture-console";
+
+const dict = uiEn as unknown as Dict;
+const wrap = (node: React.ReactNode) =>
+  renderToStaticMarkup(
+    <DictProvider dict={dict} locale="en">
+      {node}
+    </DictProvider>,
+  );
+
+function member(i: number): SideInfo["members"][number] {
+  return {
+    person_id: `00000000-0000-0000-0000-00000000000${i}`,
+    full_name: `Player ${i}`,
+    squad_number: i,
+    default_position_key: null,
+    is_captain: i === 1,
+    roles: [],
+  };
+}
+
+function side(overrides: Partial<SideInfo>): SideInfo {
+  return {
+    id: "e1",
+    name: "Home",
+    members: [member(1), member(2), member(3)],
+    lineup: [],
+    ...overrides,
+  };
+}
+
+const base = {
+  fixtureId: "f1",
+  positionGroups: [],
+  roles: [],
+  lineupSize: 2,
+  onSaved: () => {},
+};
+
+// "Slot for {name}" is the aria-label a LINEUP ROW's slot select carries — the
+// add-picker below lists roster names too, so bare name matching can't tell a
+// prefilled row from a pickable member.
+describe("LineupEditor roster auto-prefill", () => {
+  it("prefills a draft from the roster when nothing is saved: first lineupSize start, rest bench", () => {
+    const html = wrap(<LineupEditor {...base} side={side({})} canEdit={true} />);
+    expect(html).toContain("Slot for Player 1");
+    expect(html).toContain("Slot for Player 2");
+    expect(html).toContain("Slot for Player 3");
+    expect(html).toContain("2/2 starting");
+    expect(html).not.toContain("No lineup submitted");
+  });
+
+  it("keeps the honest empty state for read-only viewers", () => {
+    const html = wrap(<LineupEditor {...base} side={side({})} canEdit={false} />);
+    expect(html).toContain("No lineup submitted.");
+    expect(html).not.toContain("Slot for Player 1");
+  });
+
+  it("a saved lineup wins over the roster prefill", () => {
+    const html = wrap(
+      <LineupEditor
+        {...base}
+        canEdit={true}
+        side={side({
+          lineup: [
+            {
+              person_id: member(2).person_id,
+              full_name: "Player 2",
+              slot: "starting",
+              position_key: null,
+              order_no: 1,
+              roles: [],
+            },
+          ],
+        })}
+      />,
+    );
+    expect(html).toContain("Slot for Player 2");
+    expect(html).not.toContain("Slot for Player 1");
+    expect(html).toContain("1/2 starting");
+  });
+});

--- a/apps/web/src/components/v2/lineup-editor.tsx
+++ b/apps/web/src/components/v2/lineup-editor.tsx
@@ -99,16 +99,31 @@ export function LineupEditor({
   availability = {},
 }: Props) {
   const msg = useMsg();
-  const [slots, setSlots] = useState<SlotDraft[]>(() =>
-    side.lineup.map((s: LineupSlotIn, i) => ({
-      person_id: s.person_id,
-      full_name: s.full_name,
-      slot: s.slot,
-      position_key: s.position_key,
-      order_no: s.order_no ?? i + 1,
-      roles: s.roles ?? [],
-    })),
-  );
+  const [slots, setSlots] = useState<SlotDraft[]>(() => {
+    if (side.lineup.length > 0) {
+      return side.lineup.map((s: LineupSlotIn, i) => ({
+        person_id: s.person_id,
+        full_name: s.full_name,
+        slot: s.slot,
+        position_key: s.position_key,
+        order_no: s.order_no ?? i + 1,
+        roles: s.roles ?? [],
+      }));
+    }
+    // Nothing saved yet → auto-populate a DRAFT from the roster (first
+    // `lineupSize` start, rest bench) so matchday is one Save, not N taps.
+    // Draft only: nothing persists (and the engine reads nothing) until
+    // Save. Read-only viewers keep the honest empty state instead.
+    if (!canEdit) return [];
+    return side.members.map((m, i) => ({
+      person_id: m.person_id,
+      full_name: m.full_name,
+      slot: i < lineupSize ? ("starting" as const) : ("bench" as const),
+      position_key: m.default_position_key,
+      order_no: i + 1,
+      roles: m.roles ?? [],
+    }));
+  });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -3853,6 +3853,31 @@ async function gapSuite(admin: Session, org1Id: string, proOrgId: string): Promi
   });
   const dlSecret = v1data<{ secret: string }>(dl).secret ?? "";
   check("gap device link minted (dl_)", dl.status === 201 && dlSecret.startsWith("dl_"));
+
+  // Saved lineups must reach the account-less pad: /score/[token] once
+  // rendered `lineup: []`, so fixture-console saves never showed courtside.
+  // Runs before the scoring event below — lineups lock once in_play. The
+  // name lands in the pad payload twice (roster prop + lineup prop); the
+  // roster alone would make a bare includes() pass even without the fix.
+  const fx0 = v1data<{ home_entrant_id: string }>(
+    await v1(admin, `/api/v1/fixtures/${fixtureId}`, "GET"),
+  );
+  const padPerson = v1data<{ id: string }>(
+    await v1(admin, "/api/v1/persons", "POST", { full_name: `Pad Lineup ${tag}` }),
+  );
+  await v1(admin, `/api/v1/entrants/${fx0.home_entrant_id}`, "PATCH", {
+    members: [{ person_id: padPerson.id }],
+  });
+  const luPut = await v1(
+    admin,
+    `/api/v1/fixtures/${fixtureId}/lineups/${fx0.home_entrant_id}`,
+    "PUT",
+    { slots: [{ person_id: padPerson.id, slot: "starting", order_no: 1 }] },
+  );
+  check("gap lineup saved while scheduled", luPut.status === 200);
+  const luPadHtml = await (await fetch(`${BASE}/score/${dlSecret}`)).text();
+  const luHits = luPadHtml.split(`Pad Lineup ${tag}`).length - 1;
+  check("gap device pad carries the saved lineup (roster + lineup props)", luHits >= 2);
   const bare = newSession(); // no cookies — the token is the credential
   const dlState = await v1(bare, `/api/v1/fixtures/${fixtureId}/state`, "GET", undefined, {
     Authorization: `Bearer ${dlSecret}`,


### PR DESCRIPTION
Two halves of "lineup doesn't populate in the score pad":

**1. Device pad never loaded saved lineups.** \`/score/[token]\` built side info with hardcoded \`lineup: []\` — a lineup saved in the fixture console never reached the account-less pad. Now loads the same \`getEntrant\` + \`getLineup\` pair the fixture-console page loads, on the pad's trusted server read ctx (\`rejectDeviceLink\` guards the HTTP surface, not this server render).

**2. Lineup editor started empty until every player was added by hand.** When no lineup is saved and the viewer can edit, the editor now prefills a **draft** from the roster — first \`lineupSize\` starting, rest bench. Nothing persists (and the engine reads nothing) until Save; read-only viewers keep the honest "No lineup submitted" state. Covers the fixture console pad and (via the same component) any surface that mounts the editor.

Score pads themselves already fall back lineup→roster for the attribution picker (football/period/cricket), so the picker was never blank when a roster exists — the gaps were the two above.

**Tests**
- Smoke (gap suite): save a one-slot lineup while the fixture is still scheduled (lineups lock once in_play), assert the name lands in the pad payload twice — roster prop AND lineup prop (roster alone made a bare \`includes()\` pass pre-fix).
- \`lineup-editor-prefill.test.tsx\`: "Slot for {name}" aria-label marks a lineup ROW (picker lists the same names) + "{n}/{total} starting" pins the split; saved lineups win over prefill; read-only stays empty.
- tsc clean, targeted units green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)