### PR TITLE
ci(e2e): AI fixture env for the workflow-booted server

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,6 +83,14 @@ jobs:
       # prices, so the Stripe-gated billing specs stay skipped as before).
       STRIPE_SECRET_KEY: sk_test_ci_e2e_dummy
       STRIPE_WEBHOOK_SECRET: whsec_e2e_payments
+      # v4 AI architect e2e (ai-architect.spec.ts): the spec starts a model
+      # fixture server on 4319; the app server must point anthropicClient()
+      # at it and carry a non-empty key so the ai-plan routes never 503.
+      # Mirrors playwright.config.ts webServer.env, which only applies when
+      # Playwright boots the server itself — here the workflow boots it.
+      # CI-only dummy; no real Anthropic call is made.
+      SCHEDULING_AI_BASE_URL: "http://127.0.0.1:4319"
+      ANTHROPIC_API_KEY: sk-ant-e2e-fixture
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
e2e.yml boots `next start` itself, so `playwright.config.ts` webServer.env never applies on CI. The v4 ai-architect specs need the app server pointed at the spec's model fixture (`SCHEDULING_AI_BASE_URL=127.0.0.1:4319`) with a non-empty dummy `ANTHROPIC_API_KEY` — without them the happy flow times out waiting for `CLEAN · 0 blocking` (main run 29705893562, first-ever CI execution of these specs; PR CI doesn't run e2e.yml).

Two CI-only dummy env vars, mirroring the local recipe. No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)