### PR TITLE
fix(console): MOTM feed rows name the player, not 'Unknown'

### DIFF
--- a/apps/web/src/components/v2/fixture-console.tsx
+++ b/apps/web/src/components/v2/fixture-console.tsx
@@ -303,9 +303,14 @@ export function FixtureConsole({
   const started = live.status !== "scheduled";
 
   const sides = { home, away };
+  // Feed name map: entrant ids AND every rostered person, so person-carrying
+  // events (core.award MOTM, cards, subs) render names instead of "Unknown".
   const entrantNames: Record<string, string> = {};
   if (home) entrantNames[home.id] = home.name;
   if (away) entrantNames[away.id] = away.name;
+  for (const side of [home, away]) {
+    for (const m of side?.members ?? []) entrantNames[m.person_id] = m.full_name;
+  }
   const lastVoidable = [...events]
     .reverse()
     .find((e) => e.type !== "core.void" && !events.some((v) => v.voids_event_id === e.id));

--- a/apps/web/src/lib/__tests__/event-copy.test.ts
+++ b/apps/web/src/lib/__tests__/event-copy.test.ts
@@ -1,0 +1,32 @@
+// core.award rendering: the canonical engine payload is { person, key }
+// (Jul3/07 §4) — the feed showed "Awarded to Unknown" for every MOTM because
+// the renderer read a `to` field that only legacy rows carry.
+import { describe, expect, it } from "vitest";
+import { describeEvent } from "../event-copy";
+
+const NAMES = { p1: "Ashokkumar K S", e1: "Lions U12" };
+
+describe("describeEvent core.award", () => {
+  it("renders MOTM from the canonical { person, key } payload", () => {
+    const d = describeEvent("core.award", { person: "p1", key: "motm" }, NAMES);
+    expect(d.label).toBe("MOTM");
+    expect(d.text).toBe("Man of the match — Ashokkumar K S");
+    expect(d.tone).toBe("admin");
+  });
+
+  it("prettifies other award keys", () => {
+    const d = describeEvent("core.award", { person: "p1", key: "player_of_series" }, NAMES);
+    expect(d.label).toBe("Award");
+    expect(d.text).toBe("Player of series — Ashokkumar K S");
+  });
+
+  it("keeps the legacy { to } fallback working", () => {
+    const d = describeEvent("core.award", { to: "e1" }, NAMES);
+    expect(d.text).toContain("Lions U12");
+  });
+
+  it("degrades to Unknown only when the id is truly absent from the map", () => {
+    const d = describeEvent("core.award", { person: "ghost", key: "motm" }, NAMES);
+    expect(d.text).toBe("Man of the match — Unknown");
+  });
+});

--- a/apps/web/src/lib/event-copy.ts
+++ b/apps/web/src/lib/event-copy.ts
@@ -74,8 +74,18 @@ export function describeEvent(
         text: `Match abandoned${p.reason ? ` — ${p.reason}` : ""}`,
         tone: "admin",
       };
-    case "core.award":
-      return { label: "Awarded", text: `Awarded to ${name(names, p.to)}`, tone: "admin" };
+    case "core.award": {
+      // Canonical CoreAward is { person, key } (Jul3/07 §4 — MOTM/MVP and
+      // friends); `to` is a legacy fallback so old ledger rows keep a name.
+      const who = name(names, p.person ?? p.to);
+      const key = typeof p.key === "string" ? p.key : null;
+      if (key === "motm") return { label: "MOTM", text: `Man of the match — ${who}`, tone: "admin" };
+      return {
+        label: "Award",
+        text: `${key ? prettify(`award.${key}`) : "Awarded"} — ${who}`,
+        tone: "admin",
+      };
+    }
 
     // ── football ──
     case "football.goal": {


### PR DESCRIPTION
## Why

Awarding MOTM produced feed rows like `Awarded · Awarded to Unknown (Ashokkumar K S)` — the renderer read `p.to`, but the canonical `CoreAward` payload is `{ person, key }`, so the name lookup never matched; the parenthetical was just the recorder attribution.

## What

- `event-copy.ts` `core.award`: canonical shape → `MOTM · Man of the match — <player>`; other keys prettified (`Player of series — …`); legacy `{ to }` fallback kept for old ledger rows.
- `fixture-console.tsx`: the feed's name map held only the two entrant ids — person-carrying events (award, and any future person-labelled copy) could never resolve. It now merges every rostered person from both sides.

## Verify

- New `event-copy.test.ts` (4 cases: canonical MOTM, prettified key, legacy fallback, unknown-id degrade)
- tsc clean; full vitest **2140 passed / 0 failed** (local DB migrated to V302 for the new AI-architect suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)