### PR TITLE
fix(engine): volleyball takes beach pairs, not just indoor teams

### DIFF
--- a/packages/engine/src/sport/entrant-model.test.ts
+++ b/packages/engine/src/sport/entrant-model.test.ts
@@ -55,10 +55,19 @@ describe("effectiveEntrantModel", () => {
     expect(entrantKindCap("team", { maxTeamMembers: 26 })).toBe(26);
   });
 
-  it("setbased kernel threads entrantModel (badminton pair, volleyball team)", () => {
+  it("setbased kernel threads entrantModel (badminton pair, volleyball team+pair)", () => {
     expect(badminton.entrantModel?.kinds).toEqual(["individual", "pair"]);
-    expect(volleyball.entrantModel?.kinds).toEqual(["team"]);
+    expect(volleyball.entrantModel?.kinds).toEqual(["team", "pair"]);
     expect(volleyball.entrantModel?.team?.captain).toBe(true);
     expect(tabletennis.entrantModel?.kinds).toEqual(["individual", "pair"]);
+  });
+
+  // The entrant model is declared per sport, not per variant, so volleyball has
+  // to admit both shapes: indoor 6v6 teams and the `beach` variant's 2v2 pairs.
+  // Default stays `team` — indoor is the module default (spec 04 §3.1).
+  it("volleyball takes beach pairs without a division override", () => {
+    const eff = effectiveEntrantModel(volleyball.entrantModel);
+    expect(eff.kinds).toContain("pair");
+    expect(eff.defaultKind).toBe("team");
   });
 });

--- a/packages/engine/src/sports/setbased/volleyball.ts
+++ b/packages/engine/src/sports/setbased/volleyball.ts
@@ -49,7 +49,14 @@ export const volleyball = makeSetBasedModule({
   officialLabel: { scorer: "Referee" }, // doc 13 §1
   coarseEventType: "set.summary",
   rallyEntitlement: "scoring.rally_by_rally", // doc 10 / volleyball.md §3
-  entrantModel: { kinds: ["team"], defaultKind: "team", team: { squadNumbers: true, captain: true } },
+  // Entrant shapes are declared per sport, not per variant: indoor is 6v6 teams
+  // (the default), `beach` is 2v2 pairs. Both kinds stay open at the sport level
+  // and a division narrows them via config.entrants when the organiser wants.
+  entrantModel: {
+    kinds: ["team", "pair"],
+    defaultKind: "team",
+    team: { squadNumbers: true, captain: true },
+  },
 });
 
 // Jul3/06 §3 — the 12-Jun scoresheet: point-by-point columns per set,


### PR DESCRIPTION
## Root cause

`Help screenshots` run [29725523974](https://github.com/ashokhein/seazn.club/actions/runs/29725523974/job/88309982264) failed in `Seed demo data`:

```
Error: POST /api/v1/divisions/…/entrants → 422
{"code":"ENTRANT_KIND_NOT_ALLOWED","message":"this division doesn't take 'pair' entrants"}
  at scripts/seed-demo.ts:448
```

- `scripts/seed-demo.ts:335` seeds `{ name: "Beach Pairs", sport: "volleyball", variant: "beach", kind: "pair" }`.
- `apps/web/src/server/usecases/entrants.ts:254` gates every entrant against the division's effective entrant model.
- `packages/engine/src/sport/entrant-model.ts` resolves that model from the sport module only — the variant is never consulted.
- `packages/engine/src/sports/setbased/volleyball.ts` declared `kinds: ["team"]`, while the `beach` variant is 2v2 pairs.

So volleyball/beach + `pair` was permanently rejected. Latent since #136 (2026-07-19) landed the gate; the help-screenshots workflow last ran 2026-07-13, so today's run is the first to hit it. Not caused by #173.

## Fix

Volleyball declares `kinds: ["team", "pair"]` with `team` (indoor) as the default. A division still narrows the list through `config.entrants`. Volleyball was the only sport whose variants imply an entrant shape its module did not admit.

## Test

`packages/engine/src/sport/entrant-model.test.ts` — asserts volleyball's effective model contains `pair` and keeps `team` as the default. Fails without the fix:

```
AssertionError: expected [ 'team' ] to include 'pair'
```

## Verification

- `npx tsc --noEmit` (apps/web + packages/engine): no errors
- `npm test`: 1558 passed / 585 skipped (web, DB-backed suites skipped locally), 903 passed (engine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)