### PR TITLE
fix(ai): run cost accuracy, provider-outage handling, and defaults that survive a real league

### DIFF
--- a/apps/web/src/lib/__tests__/ai-pricing.test.ts
+++ b/apps/web/src/lib/__tests__/ai-pricing.test.ts
@@ -1,21 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { aiRunCostUsd } from "../ai-pricing";
+import { aiRate, aiRunCostUsd } from "../ai-pricing";
+
+// Dates are pinned explicitly: these assertions must not change meaning when
+// the sonnet-5 introductory window lapses on 2026-09-01.
+const DURING_INTRO = new Date("2026-07-20T12:00:00Z");
+const AFTER_INTRO = new Date("2026-09-01T00:00:00Z");
 
 describe("aiRunCostUsd", () => {
-  it("prices sonnet-5 at $3/$15 per 1M", () => {
-    // 5,212 in + 26,917 out — the measured live run from 2026-07-19.
-    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917)).toBe(0.4194);
+  // 5,212 in + 26,917 out — the measured live run from 2026-07-19.
+  it("prices sonnet-5 at the $2/$10 introductory rate during the window", () => {
+    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917, DURING_INTRO)).toBe(0.2796);
   });
 
-  it("prices opus-4-8 at $5/$25 per 1M", () => {
-    expect(aiRunCostUsd("claude-opus-4-8", 1_000_000, 1_000_000)).toBe(30);
+  it("prices sonnet-5 at the $3/$15 list rate once the window lapses", () => {
+    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917, AFTER_INTRO)).toBe(0.4194);
+  });
+
+  it("intro window is inclusive of its final day", () => {
+    const lastMoment = new Date("2026-08-31T23:59:59Z");
+    expect(aiRate("claude-sonnet-5", lastMoment)).toEqual({ input: 2, output: 10 });
+    expect(aiRate("claude-sonnet-5", AFTER_INTRO)).toEqual({ input: 3, output: 15 });
+  });
+
+  it("models without an intro window are date-independent", () => {
+    expect(aiRunCostUsd("claude-opus-4-8", 1_000_000, 1_000_000, DURING_INTRO)).toBe(30);
+    expect(aiRunCostUsd("claude-opus-4-8", 1_000_000, 1_000_000, AFTER_INTRO)).toBe(30);
   });
 
   it("zero tokens cost zero (solver draft)", () => {
-    expect(aiRunCostUsd("claude-sonnet-5", 0, 0)).toBe(0);
+    expect(aiRunCostUsd("claude-sonnet-5", 0, 0, DURING_INTRO)).toBe(0);
   });
 
   it("unknown model → null, never a guessed price", () => {
-    expect(aiRunCostUsd("some-custom-model", 1000, 1000)).toBeNull();
+    expect(aiRunCostUsd("some-custom-model", 1000, 1000, DURING_INTRO)).toBeNull();
+    expect(aiRate("some-custom-model", DURING_INTRO)).toBeNull();
   });
 });

--- a/apps/web/src/lib/ai-pricing.ts
+++ b/apps/web/src/lib/ai-pricing.ts
@@ -1,25 +1,47 @@
 // USD list pricing per 1M tokens for the models the architect can run on
 // (schedule-ai.ts / officials-ai.ts — SCHEDULING_AI_MODEL). Isomorphic: the
 // server stamps cost onto telemetry + the run ledger, /admin/ai-runs renders
-// it. Prices are list rates (cache reads/writes not modelled — the runner's
-// usage counters are raw input/output tokens).
-const PER_MILLION: Record<string, { input: number; output: number }> = {
-  "claude-sonnet-5": { input: 3, output: 15 },
-  "claude-sonnet-4-6": { input: 3, output: 15 },
-  "claude-opus-4-8": { input: 5, output: 25 },
-  "claude-opus-4-7": { input: 5, output: 25 },
-  "claude-opus-4-6": { input: 5, output: 25 },
-  "claude-haiku-4-5": { input: 1, output: 5 },
+// it. Cache reads/writes are not modelled — the runner's usage counters are
+// raw input/output tokens.
+//
+// Some models carry a time-boxed introductory rate. Cost is stamped at run
+// time, so the rate in force *at that moment* is the correct one and the
+// window expires on its own — no dated constant to remember to delete.
+type Rate = { input: number; output: number };
+
+const PRICING: Record<string, { list: Rate; intro?: { untilIso: string; rate: Rate } }> = {
+  "claude-sonnet-5": {
+    list: { input: 3, output: 15 },
+    // Introductory pricing runs through 2026-08-31 inclusive; `untilIso` is the
+    // first instant the list rate applies again.
+    intro: { untilIso: "2026-09-01T00:00:00Z", rate: { input: 2, output: 10 } },
+  },
+  "claude-sonnet-4-6": { list: { input: 3, output: 15 } },
+  "claude-opus-4-8": { list: { input: 5, output: 25 } },
+  "claude-opus-4-7": { list: { input: 5, output: 25 } },
+  "claude-opus-4-6": { list: { input: 5, output: 25 } },
+  "claude-haiku-4-5": { list: { input: 1, output: 5 } },
 };
 
+/** The per-1M rate in force for `model` at `at`. Exported for /admin surfaces
+ *  that want to show the rate alongside the stamped cost. */
+export function aiRate(model: string, at: Date = new Date()): Rate | null {
+  const entry = PRICING[model];
+  if (!entry) return null;
+  if (entry.intro && at.getTime() < Date.parse(entry.intro.untilIso)) return entry.intro.rate;
+  return entry.list;
+}
+
 /** Estimated USD cost of one architect run; null when the model is unknown
- *  (custom SCHEDULING_AI_MODEL) — never guess a price. */
+ *  (custom SCHEDULING_AI_MODEL) — never guess a price. `at` defaults to now
+ *  and exists so tests can pin a date either side of an intro window. */
 export function aiRunCostUsd(
   model: string,
   inputTokens: number,
   outputTokens: number,
+  at: Date = new Date(),
 ): number | null {
-  const p = PER_MILLION[model];
+  const p = aiRate(model, at);
   if (!p) return null;
   const usd = (inputTokens * p.input + outputTokens * p.output) / 1_000_000;
   return Math.round(usd * 10_000) / 10_000;

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
@@ -1,0 +1,265 @@
+// LIVE cost/quality bench for the architect's `effort` setting — NOT a unit test.
+//
+// Output tokens are ~96% of a run's cost (5,212 in / 26,917 out on the
+// 2026-07-19 measurement), and `effort` is the direct knob on thinking depth.
+// This file measures what dropping high → medium actually costs in plan
+// quality, on packs materially larger than that 17-fixture baseline.
+//
+// Skipped unless AI_AB_LIVE=1 — it makes real, billed Anthropic calls. Run:
+//   AI_AB_LIVE=1 npx vitest run --root apps/web \
+//     src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+//
+// Both arms see a byte-identical pack (ids are deterministic), so the only
+// variable is `effort`. The deterministic referee verifies every proposal, so
+// a thinner plan shows up as repair rounds / residual conflicts — never as a
+// silently bad schedule.
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { runAiPlan, schedulingAiModel } from "../schedule-ai";
+import type { PackFixture, PackPerson, SchedulePack } from "../schedule-ai";
+
+// vitest does not read .env.local; load just the key we need if absent.
+if (!process.env.ANTHROPIC_API_KEY) {
+  for (const rel of ["../../../../.env.local", "../../../../../../.env.local"]) {
+    const p = path.resolve(__dirname, rel);
+    if (!fs.existsSync(p)) continue;
+    const m = fs.readFileSync(p, "utf8").match(/^ANTHROPIC_API_KEY=(.+)$/m);
+    if (m) {
+      process.env.ANTHROPIC_API_KEY = m[1].trim().replace(/^["']|["']$/g, "");
+      break;
+    }
+  }
+}
+
+const LIVE = process.env.AI_AB_LIVE === "1";
+
+// --- deterministic ids -----------------------------------------------------
+const uuid = (tag: string, n: number) =>
+  `00000000-0000-4000-8000-${`${tag}${n}`.padStart(12, "0").slice(-12)}`;
+
+// --- Pack A: 15 teams, 3 pools of 5, round robin within pool = 30 fixtures --
+function teamsPack(): { pack: SchedulePack; movable: Set<string> } {
+  const pools = ["Pool A", "Pool B", "Pool C"];
+  const entrants = pools.flatMap((pool, p) =>
+    Array.from({ length: 5 }, (_, t) => ({
+      id: uuid("e", p * 5 + t),
+      name: `${pool} Team ${t + 1}`,
+      pool,
+      seed: t + 1,
+    })),
+  );
+
+  const movable: PackFixture[] = [];
+  let n = 0;
+  pools.forEach((pool, p) => {
+    const ids = Array.from({ length: 5 }, (_, t) => uuid("e", p * 5 + t));
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        movable.push({
+          id: uuid("f", n),
+          ext_key: `rr-${p}-${i}-${j}`,
+          round: 1,
+          seq: n,
+          pool,
+          home: ids[i],
+          away: ids[j],
+          feeds: { winner_to: null, after: [] },
+          current: { at: null, court: null },
+          pinned: false,
+        });
+        n++;
+      }
+    }
+  });
+
+  const pack: SchedulePack = {
+    mode: "generate",
+    division: {
+      id: "ab-teams",
+      name: "Saturday League",
+      sport: "generic",
+      tz: "Europe/London",
+      scheduling_mode: "timed",
+    },
+    settings: {
+      matchMinutes: 30,
+      gapMinutes: 10,
+      courts: ["Court 1", "Court 2", "Court 3"],
+      sessionWindows: [{ from: "2026-08-01T09:00:00+01:00", to: "2026-08-01T21:00:00+01:00" }],
+      blackouts: [{ court: "Court 3", from: "2026-08-01T12:00:00+01:00", to: "2026-08-01T13:30:00+01:00" }],
+      constraints: {
+        restMin: 60,
+        noBackToBack: true,
+        startWindows: [],
+        fieldFairness: "balance",
+        parallelism: "mixed",
+        crossPersonClash: "hard",
+      },
+    },
+    entrants,
+    people: [],
+    fixtures: { movable, obstacles: [] },
+    draft: [],
+    instruction:
+      "Schedule all pool matches on Saturday. Every team needs at least 60 minutes between its matches, no team plays back-to-back, and Court 3 is unavailable 12:00-13:30 for maintenance. Spread each team's matches across courts where you can.",
+    prior: null,
+    officials: [],
+  };
+  return { pack, movable: new Set(movable.map((f) => f.id)) };
+}
+
+// --- Pack B: 50 individual entrants, R1 knockout = 25 fixtures -------------
+//     10 people are entered twice (multi-event), so crossPersonClash bites.
+function individualsPack(): { pack: SchedulePack; movable: Set<string> } {
+  const entrants = Array.from({ length: 50 }, (_, i) => ({
+    id: uuid("e", i),
+    name: `Player ${i + 1}`,
+    pool: null,
+    seed: i + 1,
+  }));
+
+  const movable: PackFixture[] = Array.from({ length: 25 }, (_, i) => ({
+    id: uuid("f", i),
+    ext_key: `r1-${i + 1}`,
+    round: 1,
+    seq: i,
+    pool: null,
+    home: uuid("e", 2 * i),
+    away: uuid("e", 2 * i + 1),
+    feeds: { winner_to: null, after: [] },
+    current: { at: null, court: null },
+    pinned: false,
+  }));
+
+  // Ten dual-entered people: entrant k and entrant k+25 are the same human, so
+  // fixture floor(k/2) and fixture floor((k+25)/2) must not overlap.
+  const people: PackPerson[] = Array.from({ length: 10 }, (_, k) => ({
+    person_id: uuid("p", k),
+    entrant_ids: [uuid("e", k), uuid("e", k + 25)],
+  }));
+
+  const pack: SchedulePack = {
+    mode: "generate",
+    division: {
+      id: "ab-individuals",
+      name: "Club Championship",
+      sport: "generic",
+      tz: "Europe/London",
+      scheduling_mode: "timed",
+    },
+    settings: {
+      matchMinutes: 45,
+      gapMinutes: 0,
+      courts: ["Court 1", "Court 2", "Court 3", "Court 4"],
+      sessionWindows: [{ from: "2026-08-01T09:00:00+01:00", to: "2026-08-01T18:00:00+01:00" }],
+      blackouts: [],
+      constraints: {
+        restMin: 30,
+        noBackToBack: false,
+        startWindows: [],
+        fieldFairness: "balance",
+        parallelism: "mixed",
+        crossPersonClash: "hard",
+      },
+    },
+    entrants,
+    people,
+    fixtures: { movable, obstacles: [] },
+    draft: [],
+    instruction:
+      "Schedule all 25 first-round matches in one day across four courts. Ten players are entered in two events each and must never be double-booked; give every player at least 30 minutes between matches. Finish as early in the day as possible.",
+    prior: null,
+    officials: [],
+  };
+  return { pack, movable: new Set(movable.map((f) => f.id)) };
+}
+
+// --- cost -------------------------------------------------------------------
+// Sonnet 5 list is $3/$15 per MTok; introductory $2/$10 runs through
+// 2026-08-31, so today's real spend is the `intro` column.
+const usd = (i: number, o: number, inRate: number, outRate: number) =>
+  Math.round(((i * inRate + o * outRate) / 1_000_000) * 10_000) / 10_000;
+
+type Row = {
+  pack: string;
+  effort: string;
+  secs: number;
+  rounds: number;
+  in: number;
+  out: number;
+  listUsd: number;
+  introUsd: number;
+  blocking: number;
+  warnings: number;
+  unschedulable: number;
+  placed: number;
+  error: string;
+};
+
+const rows: Row[] = [];
+
+async function bench(name: string, build: () => { pack: SchedulePack; movable: Set<string> }, effort: string) {
+  process.env.SCHEDULING_AI_EFFORT = effort;
+  const { pack, movable } = build();
+  const t0 = Date.now();
+  const row: Row = {
+    pack: name,
+    effort,
+    secs: 0,
+    rounds: 0,
+    in: 0,
+    out: 0,
+    listUsd: 0,
+    introUsd: 0,
+    blocking: -1,
+    warnings: -1,
+    unschedulable: -1,
+    placed: -1,
+    error: "",
+  };
+  try {
+    const res = await runAiPlan(pack, movable);
+    row.rounds = res.usage.repair_rounds;
+    row.in = res.usage.input_tokens;
+    row.out = res.usage.output_tokens;
+    row.blocking = res.blocking.length;
+    row.warnings = res.warnings.length;
+    row.unschedulable = res.unschedulable.length;
+    row.placed = res.proposal.length;
+  } catch (err) {
+    row.error = err instanceof Error ? `${(err as { code?: string }).code ?? ""} ${err.message}`.trim() : String(err);
+  }
+  row.secs = Math.round((Date.now() - t0) / 100) / 10;
+  row.listUsd = usd(row.in, row.out, 3, 15);
+  row.introUsd = usd(row.in, row.out, 2, 10);
+  rows.push(row);
+  process.stdout.write(
+    `\n[${name} / effort=${effort}] ${row.secs}s  rounds=${row.rounds}  in=${row.in} out=${row.out}  ` +
+      `list=$${row.listUsd} intro=$${row.introUsd}  blocking=${row.blocking} warnings=${row.warnings} ` +
+      `unsched=${row.unschedulable} placed=${row.placed}${row.error ? `  ERROR: ${row.error}` : ""}\n`,
+  );
+  // A swallowed error is worse than a red test: it looks like a cheap run.
+  expect(row.error, `${name}/${effort} failed`).toBe("");
+  return row;
+}
+
+describe.skipIf(!LIVE)("effort A/B (live, billed)", () => {
+  const T = 3_300_000; // up to 3 rounds at the configured round timeout, plus slack
+
+  it("teams-15 @ high", async () => { await bench("teams-15", teamsPack, "high"); }, T);
+  it("teams-15 @ medium", async () => { await bench("teams-15", teamsPack, "medium"); }, T);
+  it("individuals-50 @ high", async () => { await bench("individuals-50", individualsPack, "high"); }, T);
+  it("individuals-50 @ medium", async () => { await bench("individuals-50", individualsPack, "medium"); }, T);
+
+  it("summary", () => {
+    const roundMs = Number(process.env.SCHEDULING_AI_ROUND_TIMEOUT_MS) || 300_000;
+    process.stdout.write(`\n===== effort A/B — model=${schedulingAiModel()} roundTimeout=${roundMs / 1000}s =====\n`);
+    for (const r of rows) process.stdout.write(`${JSON.stringify(r)}\n`);
+    const total = rows.reduce((s, r) => s + r.introUsd, 0);
+    process.stdout.write(`total spend this bench (intro rates): $${Math.round(total * 10000) / 10000}\n`);
+    expect(rows.length).toBe(4);
+    expect(rows.every((r) => r.error === "")).toBe(true);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-route.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-route.test.ts
@@ -9,9 +9,21 @@ import { randomUUID } from "node:crypto";
 
 // Hoisted mock handles — referenced from vi.mock factories (which hoist above
 // imports), so they must be created with vi.hoisted.
-const { parse, isServerFeatureEnabled, captureServer, incrWindow, rlCounts } = vi.hoisted(() => {
+const { parse, isServerFeatureEnabled, captureServer, incrWindow, rlCounts, MockAPIError } = vi.hoisted(() => {
   const rlCounts = new Map<string, number>();
+  // The real SDK exposes `Anthropic.APIError`; schedule-ai.ts branches on it to
+  // tell a provider outage (billing/rate-limit/overload) from a planning
+  // failure. The mock must carry it or that branch is unreachable under test.
+  class MockAPIError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.name = "APIError";
+      this.status = status;
+    }
+  }
   return {
+    MockAPIError,
     parse: vi.fn(),
     isServerFeatureEnabled: vi.fn(),
     captureServer: vi.fn(),
@@ -25,9 +37,12 @@ const { parse, isServerFeatureEnabled, captureServer, incrWindow, rlCounts } = v
 });
 
 vi.mock("@anthropic-ai/sdk", () => ({
-  default: class Anthropic {
-    messages = { parse };
-  },
+  default: Object.assign(
+    class Anthropic {
+      messages = { parse };
+    },
+    { APIError: MockAPIError },
+  ),
 }));
 vi.mock("@/lib/posthog-server", () => ({ isServerFeatureEnabled, captureServer }));
 // Keep the real cache-aside helpers (entitlements resolution) but drive the
@@ -458,5 +473,42 @@ describe.skipIf(!HAS_DB)("aiPlanForDivision coverage + telemetry (v4/03 §2, 00 
       select count(*)::int as n from competition_events
       where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}`;
     expect(n).toBe(0);
+  });
+
+  // Regression (observed live 2026-07-20): an exhausted credit balance made the
+  // SDK throw a 400 APIError. It matched neither failure branch, propagated raw
+  // out of aiPlanForDivision as a 500, and left no ledger row — so a billing
+  // lapse took AI scheduling down silently. It must now be a 503 with its own
+  // outcome, and the provider's message must never reach the tenant.
+  it("a provider APIError → 503 AI_PROVIDER_UNAVAILABLE, metered, message not leaked", async () => {
+    const auth = await seedPlusOrg();
+    const { divisionId } = await seedPlannable(auth);
+    const providerMessage = "Your credit balance is too low to access the Anthropic API.";
+    parse.mockRejectedValueOnce(new MockAPIError(400, providerMessage));
+
+    const err = await aiPlanForDivision(auth, divisionId, { instruction: "plan", mode: "generate" }).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toMatchObject({ status: 503, code: "AI_PROVIDER_UNAVAILABLE" });
+    // Billing state is ours, not the tenant's.
+    expect((err as Error).message).not.toContain("credit balance");
+
+    expect(captureServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "ai_plan_run",
+        properties: expect.objectContaining({ outcome: "provider_error", provider_status: 400 }),
+      }),
+    );
+    // The outage is auditable, and it never consumes a generation.
+    const [failed] = await sql<{ payload: { outcome: string; provider_status: number } }[]>`
+      select payload from competition_events
+      where type = 'schedule.ai_failed' and payload->>'division_id' = ${divisionId}
+      order by created_at desc limit 1`;
+    expect(failed?.payload.outcome).toBe("provider_error");
+    expect(failed?.payload.provider_status).toBe(400);
+    const [{ n: generated }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from competition_events
+      where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}`;
+    expect(generated).toBe(0);
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -183,6 +183,32 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     expect(body.model).toBe("claude-sonnet-5");
   });
 
+  // 2026-07-20 live 2x2 (sonnet-5, 25- and 30-fixture packs): medium returned an
+  // engine-CLEAN plan in one round on every arm, 5.1x/1.9x faster than high
+  // (high needed 1095s on the 30-fixture pack — an unshippable wait). The
+  // referee checks every proposal regardless of effort.
+  it("defaults to effort:medium when SCHEDULING_AI_EFFORT is unset", async () => {
+    delete process.env.SCHEDULING_AI_EFFORT;
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds);
+    const body = parse.mock.calls[0][0] as { output_config: { effort: string } };
+    expect(body.output_config.effort).toBe("medium");
+  });
+
+  it("SCHEDULING_AI_EFFORT overrides the default; an unknown value falls back to medium", async () => {
+    process.env.SCHEDULING_AI_EFFORT = "xhigh";
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds);
+    expect((parse.mock.calls[0][0] as { output_config: { effort: string } }).output_config.effort).toBe("xhigh");
+
+    parse.mockClear();
+    process.env.SCHEDULING_AI_EFFORT = "turbo";
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds);
+    expect((parse.mock.calls[0][0] as { output_config: { effort: string } }).output_config.effort).toBe("medium");
+    delete process.env.SCHEDULING_AI_EFFORT;
+  });
+
   it("client is constructed with an explicit timeout — without one the SDK refuses non-streaming max_tokens:32000 calls", async () => {
     parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
     await runAiPlan(pack, movableIds);

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -592,10 +592,12 @@ export function refereeOfficialsPlan(
 // (503 when unconfigured, SCHEDULING_AI_BASE_URL escape hatch).
 // ===========================================================================
 
-// 300s to match schedule-ai's ROUND_TIMEOUT_MS — live rounds with adaptive
-// thinking exceed 120s well before the 500-fixture cap (see 2026-07-19 note
-// there).
-const OFFICIALS_ROUND_TIMEOUT_MS = 300_000;
+// Matches schedule-ai's ROUND_TIMEOUT_MS (same env var, same 600s default) —
+// raised from 300s on 2026-07-20 after a 30-fixture Phase A round measured
+// 1095s at effort:high and 422'd against the old ceiling. Phase B was not
+// benched, so it keeps effort:high below and inherits the safer timeout rather
+// than an unmeasured cost change.
+const OFFICIALS_ROUND_TIMEOUT_MS = Number(process.env.SCHEDULING_AI_ROUND_TIMEOUT_MS) || 600_000;
 const OFFICIALS_MAX_REPAIR_ROUNDS = 2;
 
 /** A conflict the LLM can plausibly repair by re-choosing officials. `role_unfilled`

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -607,7 +607,19 @@ export async function buildSchedulePack(
 // per round even at ~17 movable fixtures (measured 2026-07-19: opus round 1
 // >120s, sonnet ~4 rounds ≈ 480s). The abort must outlast a real round or
 // every sizable live run dies as AI_PLAN_TIMEOUT.
-const ROUND_TIMEOUT_MS = 300_000;
+// 600s. Measured 2026-07-20 on a 30-fixture pack with dense constraints
+// (round-robin + 60m rest + no-back-to-back + a court blackout): effort:high
+// needed 1095s and never returned inside the old 300s, so the run 422'd having
+// spent a full generation it could neither bill nor show; effort:medium took
+// 213s and 194s across two runs — under 300s, but with <30% headroom against
+// observed ~2x run-to-run variance in adaptive thinking, so a slow sample of a
+// passing config would still 422.
+//
+// Raising this does NOT make the model generate more: the abort is client-side
+// and only decides whether we receive the round. It does make repair rounds 2-3
+// reachable, and each round re-sends the prior round's output as input — so the
+// worst case gets more expensive even though the per-round cost is unchanged.
+const ROUND_TIMEOUT_MS = Number(process.env.SCHEDULING_AI_ROUND_TIMEOUT_MS) || 600_000;
 const MAX_REPAIR_ROUNDS = 2;
 
 /**
@@ -624,6 +636,35 @@ const MAX_REPAIR_ROUNDS = 2;
  *  still overrides. */
 export function schedulingAiModel(): string {
   return process.env.SCHEDULING_AI_MODEL ?? "claude-sonnet-5";
+}
+
+/** Effort hint for the architect call. Output tokens are ~96% of a run's cost,
+ *  and effort is the direct knob on thinking depth — so this is the cost lever,
+ *  not prompt caching (input is <4% of spend).
+ *
+ *  Default "medium" since 2026-07-20, on a live 2x2 (sonnet-5, two packs, both
+ *  efforts). Every arm returned an engine-verified CLEAN plan in one round —
+ *  medium cost no measurable quality:
+ *
+ *    pack (fixtures)   high              medium
+ *    teams-15 (30)     1095s / 27.3k out  213s / 22.5k out
+ *    individuals-50    159s / 16.9k out    84s /  9.9k out
+ *
+ *  The decisive term is latency, not money: medium is 5.1x / 1.9x faster, and
+ *  18 minutes is not a viable wait at any price. Treat the cost delta (17-39%)
+ *  as directional only — a repeated cell varied 2.1x run-to-run, so a single
+ *  sample cannot size it. SCHEDULING_AI_EFFORT overrides.
+ *
+ *  Phase B (officials-ai.ts) is deliberately still "high": it was not measured.
+ *
+ *  The deterministic referee verifies every proposal regardless, so a thinner
+ *  plan surfaces as repair rounds, never as a silently bad schedule. */
+export function schedulingAiEffort(): "low" | "medium" | "high" | "xhigh" | "max" {
+  const raw = process.env.SCHEDULING_AI_EFFORT;
+  const allowed = ["low", "medium", "high", "xhigh", "max"] as const;
+  return (allowed as readonly string[]).includes(raw ?? "")
+    ? (raw as (typeof allowed)[number])
+    : "medium";
 }
 
 export function anthropicClient(): Anthropic {
@@ -804,7 +845,7 @@ async function callModel(
         model,
         max_tokens: 32_000,
         thinking: { type: "adaptive" },
-        output_config: { effort: "high", format: zodOutputFormat(AiSchedulePlan) },
+        output_config: { effort: schedulingAiEffort(), format: zodOutputFormat(AiSchedulePlan) },
         system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
         messages: [...messages],
       },
@@ -1101,13 +1142,25 @@ export async function aiPlanForDivision(
     // in analytics or the run ledger. The failure row uses its own event type
     // ('schedule.ai_failed'): the quota above counts 'schedule.ai_generated'
     // only, so failures never consume a generation.
-    if (err instanceof HttpError && (err.code === "AI_PLAN_FAILED" || err.code === "AI_PLAN_TIMEOUT")) {
-      const usage = (err.extra?.usage ?? {}) as {
+    // An Anthropic.APIError (billing 400, auth 401, rate-limit 429, overloaded
+    // 529, upstream 5xx) is NOT a planning failure — the provider is unusable
+    // right now. Before 2026-07-20 it matched neither branch below: it was
+    // rethrown raw from callModel, surfaced to the tenant as a 500, and left no
+    // ledger row. Observed live during the effort bench, where an exhausted
+    // credit balance took AI scheduling down with no diagnostic. Meter it under
+    // its own outcome and translate it to a 503 — the provider's message can
+    // carry our billing state and must never reach a tenant.
+    const providerErr = Anthropic.APIError && err instanceof Anthropic.APIError ? err : null;
+    const planErr =
+      err instanceof HttpError && (err.code === "AI_PLAN_FAILED" || err.code === "AI_PLAN_TIMEOUT") ? err : null;
+
+    if (planErr || providerErr) {
+      const usage = (planErr?.extra?.usage ?? {}) as {
         input_tokens?: number;
         output_tokens?: number;
         repair_rounds?: number;
       };
-      const outcome = err.code === "AI_PLAN_TIMEOUT" ? "timeout" : "failed";
+      const outcome = providerErr ? "provider_error" : planErr!.code === "AI_PLAN_TIMEOUT" ? "timeout" : "failed";
       const cost_usd = aiRunCostUsd(model, usage.input_tokens ?? 0, usage.output_tokens ?? 0);
       await withTenant(auth.orgId, async (tx) => {
         await tx`
@@ -1125,6 +1178,11 @@ export async function aiPlanForDivision(
                       repair_rounds: usage.repair_rounds ?? 0,
                     },
                     cost_usd,
+                    // Provider diagnostics stay server-side (ops needs the real
+                    // status; the tenant gets a bare 503).
+                    ...(providerErr
+                      ? { provider_status: providerErr.status ?? null, provider_type: providerErr.name }
+                      : {}),
                   } as never)}, ${auth.userId})`;
       });
       await captureServer({
@@ -1142,8 +1200,12 @@ export async function aiPlanForDivision(
           cost_usd,
           blocking: 0,
           outcome,
+          ...(providerErr ? { provider_status: providerErr.status ?? null } : {}),
         },
       });
+    }
+    if (providerErr) {
+      throw new HttpError(503, "AI scheduling is temporarily unavailable; please retry", "AI_PROVIDER_UNAVAILABLE");
     }
     throw err;
   }


### PR DESCRIPTION
Three defects found by running the schedule architect against packs larger than the 17-fixture one the current defaults were tuned on.

## 1. Run cost was overstated ~33%

`ai-pricing.ts` hardcoded sonnet-5 at `$3/$15`. Its introductory `$2/$10` rate runs through **2026-08-31**, so every stamped cost since the model landed has been wrong — including the run-budget UI (#173) and `/admin/ai-runs`.

Rates now carry an optional window and cost is stamped at whatever is in force at run time, so the window expires by itself instead of becoming the next stale constant. Tests pin both sides of the boundary.

The measured 2026-07-19 run reprices **$0.4194 → $0.2796**.

## 2. A provider outage took the feature down silently

`Anthropic.APIError` (billing 400, auth 401, 429, 529) matched neither failure branch in `aiPlanForDivision` — it propagated raw as a **500 with no ledger row**. This was not theoretical: the API credit balance ran out mid-bench and AI scheduling went down with no diagnostic and nothing in the audit trail.

Now `503 AI_PROVIDER_UNAVAILABLE`, metered under `outcome: "provider_error"` with the upstream status, never consuming quota. The provider's message stays server-side — it carries our billing state, not the tenant's.

## 3. Defaults that a normal league size defeats

**Timeout 300s → 600s.** A 15-team division (30 movable fixtures, round-robin + 60m rest + no-back-to-back + a court blackout) needed **1095s** at `effort:high` and 422'd, having spent a full generation it could neither bill nor show. `officials-ai.ts` tracked the same 300s via an explicit "match schedule-ai" comment, so it now reads the same env var rather than diverging silently.

Raising it does *not* make the model generate more — the abort is client-side and only decides whether we receive the round — but it does make repair rounds 2-3 reachable, and each round re-sends the prior round's output as input.

**Effort high → medium.** Full 2×2, sonnet-5, every arm engine-verified CLEAN in one round:

| pack (fixtures) | high | medium |
|---|---|---|
| teams-15 (30) | 1095s / 27.3k out | 213s / 22.5k out |
| individuals-50 (25) | 159s / 16.9k out | 84s / 9.9k out |

The decisive term is **latency, not money** — 5.1× / 1.9× faster. An 18-minute wait is not shippable at any price.

## What this evidence does not support

The cost delta (17–39%) is **directional only**. A repeated cell varied **2.1×** run-to-run — same pack, same effort, same model — so a single sample per cell cannot size it. Anyone wanting a defensible percentage needs 3–5 repeats per cell (~$4–8).

Phase B (`officials-ai.ts`) keeps `effort:high` deliberately: it was never benched. It inherits only the timeout fix.

## Verification

- `2142 passed` across the web suite. Two pre-existing flaky failures in `org-posts.test.ts` / `registrations.test.ts` reproduce on clean `main` with these changes stashed — unrelated to this branch.
- `tsc --noEmit` clean.
- Both fixes ship a regression test verified to fail without the fix (the APIError test was confirmed red with the branch disabled).
- Bench ships as `schedule-ai-effort-ab.live.test.ts`, skipped unless `AI_AB_LIVE=1`, so CI never spends.

## Follow-ups not in this PR

- Adaptive effort by *constraint density* — the data says density drives spend, not fixture count (`teams-15` has 5 more fixtures than `individuals-50` but 2.3× the tokens at medium).
- Repeats to size the cost delta properly.
- Bench `officials-ai.ts` Phase B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)