### PR TITLE
feat(board): show elapsed time while the AI architect is running

### DIFF
--- a/apps/web/src/components/v2/board/__tests__/run-elapsed.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/run-elapsed.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import { RunElapsed, formatElapsed } from "../run-elapsed";
+
+// The elapsed line is a translated template, not a bare number — the separator
+// and the "usually under N min" calibration belong to the locale.
+const stub = { "board.ai.elapsed": "T={elapsed} HINT" };
+
+describe("formatElapsed", () => {
+  it("pads seconds so the line never jitters between :9 and :10", () => {
+    expect(formatElapsed(0)).toBe("0:00");
+    expect(formatElapsed(9)).toBe("0:09");
+    expect(formatElapsed(10)).toBe("0:10");
+  });
+
+  it("rolls into minutes at the measured run lengths (84s, 213s)", () => {
+    expect(formatElapsed(60)).toBe("1:00");
+    expect(formatElapsed(84)).toBe("1:24");
+    expect(formatElapsed(213)).toBe("3:33");
+  });
+});
+
+const render = () =>
+  renderToStaticMarkup(
+    <DictProvider dict={stub} locale="en">
+      <RunElapsed />
+    </DictProvider>,
+  );
+
+describe("RunElapsed", () => {
+  it("starts at zero on mount — the caller mounts it per run, so the clock resets itself", () => {
+    expect(render()).toContain("T=0:00 HINT");
+  });
+
+  it("interpolates the clock into the locale template rather than printing the placeholder", () => {
+    const html = render();
+    expect(html).toContain("T=0:00 HINT");
+    expect(html).not.toContain("{elapsed}");
+  });
+
+  it("is a timer that does not narrate every tick to screen readers", () => {
+    const html = render();
+    // The run button already announces "Working on your schedule…"; a live
+    // region here would talk over the rest of the page once a second.
+    expect(html).toContain('role="timer"');
+    expect(html).toContain('aria-live="off"');
+  });
+});

--- a/apps/web/src/components/v2/board/ai-console.tsx
+++ b/apps/web/src/components/v2/board/ai-console.tsx
@@ -17,6 +17,7 @@ import { useMsg } from "@/components/i18n/dict-provider";
 import type { MessageKey } from "@/lib/messages";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { PlanBadge } from "@/components/plan-badge";
+import { RunElapsed } from "./run-elapsed";
 import type {
   AiPlanRequest,
   AiPlanResponse,
@@ -902,6 +903,10 @@ function BriefStep({
           </>
         )}
       </button>
+      {/* Below the button, not inside it: a per-second counter on a gradient
+          fill would jitter the label, and gray would not read on violet.
+          Mounted only while busy — the unmount is what resets the clock. */}
+      {busy && <RunElapsed />}
     </div>
   );
 }

--- a/apps/web/src/components/v2/board/run-elapsed.tsx
+++ b/apps/web/src/components/v2/board/run-elapsed.tsx
@@ -1,0 +1,59 @@
+"use client";
+// A quiet elapsed-time line for a running AI architect call.
+//
+// Architect runs are long by nature — measured 2026-07-20 on sonnet-5 at
+// effort:medium, a 25-fixture pack took 84s and a 30-fixture pack 213s. Without
+// a ticking number a three-minute wait is indistinguishable from a hang, and
+// organisers retry a run that was going to succeed (burning quota and tokens).
+//
+// It counts UP, not down. A countdown against ROUND_TIMEOUT_MS would grow more
+// alarming the longer a perfectly healthy run took, and most runs finish with
+// most of the budget unspent — the deadline is our implementation detail, not
+// something the organiser can act on.
+import { useEffect, useState } from "react";
+import { useMsg } from "@/components/i18n/dict-provider";
+
+/** Whole seconds since this component mounted.
+ *
+ *  There is deliberately no `active` argument: the caller mounts the timer when
+ *  a run starts and unmounts it when the run ends, so React's own lifecycle
+ *  does the resetting. Threading `active` through instead forces a choice
+ *  between resetting during render (impure — reads the clock) and resetting in
+ *  an effect (renders a stale clock for one frame); mounting sidesteps both. */
+export function useElapsedSeconds(): number {
+  const [seconds, setSeconds] = useState(0);
+  useEffect(() => {
+    // Wall-clock delta rather than a tick count: intervals are throttled in a
+    // background tab, so counting ticks would under-report a long wait.
+    const startedAt = Date.now();
+    const id = setInterval(() => setSeconds(Math.floor((Date.now() - startedAt) / 1000)), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return seconds;
+}
+
+/** m:ss — no hours: a run that reaches 60 minutes has long since hit the
+ *  round timeout and surfaced as AI_PLAN_TIMEOUT. */
+export function formatElapsed(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/** Mount this only while a run is in flight — see useElapsedSeconds. */
+export function RunElapsed(): React.ReactElement {
+  const msg = useMsg();
+  const seconds = useElapsedSeconds();
+  return (
+    // aria-live is off deliberately: the run button already announces
+    // "Planning…", and a per-second live region would talk over everything
+    // else on the page. role="timer" still exposes it on demand.
+    <p
+      role="timer"
+      aria-live="off"
+      className="mt-2 text-center text-xs tabular-nums text-slate-500 dark:text-slate-400"
+    >
+      {msg("board.ai.elapsed", { elapsed: formatElapsed(seconds) })}
+    </p>
+  );
+}

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Repair schedule",
   "board.ai.running": "Working on your schedule…",
   "board.ai.flagged": "Engine flagged the draft — repairing…",
+  "board.ai.elapsed": "{elapsed} · usually under 4 min",
   "board.ai.errorLabel": "Couldn't finish.",
   "board.ai.errorGeneric": "Something went wrong. Try again.",
   "board.ai.error.upgrade": "AI scheduling needs a Pro plan.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Corregir calendario",
   "board.ai.running": "Trabajando en tu calendario…",
   "board.ai.flagged": "El motor marcó el borrador: corrigiendo…",
+  "board.ai.elapsed": "{elapsed} · normalmente menos de 4 min",
   "board.ai.errorLabel": "No se pudo completar.",
   "board.ai.errorGeneric": "Algo salió mal. Inténtalo de nuevo.",
   "board.ai.error.upgrade": "La programación con IA necesita un plan Pro.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Corriger le calendrier",
   "board.ai.running": "Planification de votre calendrier…",
   "board.ai.flagged": "Le moteur a signalé le brouillon — correction…",
+  "board.ai.elapsed": "{elapsed} · généralement moins de 4 min",
   "board.ai.errorLabel": "Impossible de terminer.",
   "board.ai.errorGeneric": "Une erreur s'est produite. Réessayez.",
   "board.ai.error.upgrade": "La planification IA nécessite un forfait Pro.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Schema herstellen",
   "board.ai.running": "Bezig met je schema…",
   "board.ai.flagged": "Motor markeerde het concept — herstellen…",
+  "board.ai.elapsed": "{elapsed} · meestal minder dan 4 min",
   "board.ai.errorLabel": "Kon niet voltooien.",
   "board.ai.errorGeneric": "Er ging iets mis. Probeer opnieuw.",
   "board.ai.error.upgrade": "AI-planning vereist een Pro-abonnement.",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -236,6 +236,7 @@ export type DictionaryKey =
   | "board.ai.error.upgrade"
   | "board.ai.errorGeneric"
   | "board.ai.errorLabel"
+  | "board.ai.elapsed"
   | "board.ai.flagged"
   | "board.ai.ghost.aria"
   | "board.ai.instructionHint"


### PR DESCRIPTION
Stacked on #175 — the "usually under 4 min" calibration only holds once `effort:medium` is the default.

## Why

Architect runs are long by nature. Measured 2026-07-20 at `effort:medium`: a 25-fixture pack took **84s**, a 30-fixture pack **213s**. The run button said *"Working on your schedule…"* and nothing else — so a three-minute wait was indistinguishable from a hang, and the rational organiser move was to retry a run that was about to succeed, burning quota and tokens.

## What

A small gray line under the run button:

```
┌─ AI schedule ──────────────────┐
│                                │
│  ●  Working on your schedule…  │   ← existing button
│     1:47 · usually under 4 min │   ← new, 12px slate-500
│                                │
└────────────────────────────────┘
```

The calibration half is what does the work. A bare counter still leaves a first-time organiser unable to tell `3:00` from broken.

## Decisions worth reviewing

**Counts up, not down.** A countdown against `ROUND_TIMEOUT_MS` grows more alarming the longer a *healthy* run takes, and most runs finish with most of the budget unspent. The deadline is our implementation detail, not something an organiser can act on.

**Below the button, not inside it.** A per-second counter on the gradient fill jitters the label, and gray doesn't read on violet.

**No `active` prop.** The console mounts the timer when a run starts and unmounts it when it ends, so React's lifecycle does the resetting. Threading `active` through forces a choice between resetting during render (impure — reads the clock, trips `react-hooks/purity`) and resetting in an effect (one frame of stale `0:00`, trips `react-hooks/set-state-in-effect`). Mounting sidesteps both.

**Wall-clock delta, not a tick count.** Intervals are throttled in a background tab; counting ticks would under-report exactly the long waits this exists for.

**`role="timer"` + `aria-live="off"`.** The button already announces the run state. A per-second live region would talk over the rest of the page.

## Verification

- `370 passed` across all 81 component test files.
- 5 new tests: `m:ss` padding at the measured run lengths, template interpolation (catches a raw `{elapsed}` leaking to users), and the a11y attributes.
- `tsc --noEmit` clean; new files lint clean. The one remaining `react-hooks/refs` error in `ai-console.tsx` is at line 607 and reproduces at HEAD without this change — pre-existing, untouched.
- `npm run i18n:check`: parity across en/es/fr/nl (3124 keys).

## Not done

Visual sign-off still pending per our usual rule — screenshot coming before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)