### PR TITLE
feat(ai): knobs to measure what actually drives architect cost

### DIFF
--- a/apps/web/src/components/v2/board/__tests__/ai-console-frozen.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-console-frozen.test.tsx
@@ -1,0 +1,57 @@
+// A frozen board rejects every apply (applySchedule, 422) and the server now
+// refuses the run outright (409 SCHEDULE_LOCKED). The console must not offer a
+// button that can only fail — an organiser previously spent a generation, a
+// rate-limit slot and several minutes before finding out at Apply.
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import { AiConsole } from "../ai-console";
+
+const stub = {
+  "board.ai.frozen": "FROZEN-NOTICE",
+  "board.ai.run.generate": "RUN-LABEL",
+};
+
+const props = {
+  divisionId: "00000000-0000-4000-8000-000000000001",
+  expectedSeq: 1,
+  aiAllowed: true,
+  brief: {
+    courts: ["Court 1", "Court 2"],
+    windows: 1,
+    blackouts: 0,
+    constraintsSet: false,
+    movable: 4,
+    pinned: 0,
+    entrants: [
+      { id: "e1", name: "Team A" },
+      { id: "e2", name: "Team B" },
+    ],
+    officialsWithBlackout: 0,
+  },
+  fixtures: [],
+  onClose: () => {},
+} as unknown as Parameters<typeof AiConsole>[0];
+
+const render = (scheduleFrozen: boolean) =>
+  renderToStaticMarkup(
+    <DictProvider dict={stub} locale="en">
+      <AiConsole {...props} scheduleFrozen={scheduleFrozen} />
+    </DictProvider>,
+  );
+
+describe("AiConsole — frozen schedule", () => {
+  it("explains why, and disables the run button", () => {
+    const html = render(true);
+    expect(html).toContain("FROZEN-NOTICE");
+    // The run button carries the .ai-run class; a frozen board must render it
+    // disabled rather than relying on the server to reject the click.
+    const runBtn = html.slice(html.indexOf("ai-run"));
+    expect(runBtn.slice(0, 400)).toContain("disabled");
+  });
+
+  it("says nothing and leaves the button alone when the board is not frozen", () => {
+    const html = render(false);
+    expect(html).not.toContain("FROZEN-NOTICE");
+  });
+});

--- a/apps/web/src/components/v2/board/ai-console.tsx
+++ b/apps/web/src/components/v2/board/ai-console.tsx
@@ -132,6 +132,7 @@ export function AiConsole({
   divisionId,
   expectedSeq,
   aiAllowed,
+  scheduleFrozen,
   brief,
   fixtures,
   officialsPolicy,
@@ -149,6 +150,11 @@ export function AiConsole({
   /** Client-side entitlement read (server prop) — false renders the paywall
    *  inside the dock with no network call. */
   aiAllowed: boolean;
+  /** The division's schedule lock. A frozen board rejects every apply
+   *  (applySchedule, 422), so a run could only ever produce a proposal the
+   *  organiser is blocked from using — the server refuses with 409
+   *  SCHEDULE_LOCKED, and this stops the button offering it in the first place. */
+  scheduleFrozen: boolean;
   /** Live brief inputs derived by the board (pre-flight card + chip pickers). */
   brief: AiBriefContext;
   /** This division's current fixtures (before any proposal) — powers the diff
@@ -581,6 +587,7 @@ export function AiConsole({
           onWishes={applyWishes}
           onFill={fillInstruction}
           lastRun={lastRun}
+          scheduleFrozen={scheduleFrozen}
         />
       )}
       {state.step === "schedule" && (
@@ -769,11 +776,15 @@ function BriefStep({
   onWishes,
   onFill,
   lastRun,
+  scheduleFrozen,
 }: {
   state: AiConsoleState;
   dispatch: (a: Parameters<typeof aiConsoleReducer>[1]) => void;
   run: () => void;
   busy: boolean;
+  /** Frozen board — the server refuses the run with 409 SCHEDULE_LOCKED, so
+   *  never offer it. */
+  scheduleFrozen: boolean;
   msg: ReturnType<typeof useMsg>;
   brief: AiBriefContext;
   preflight: PreflightInput;
@@ -884,10 +895,24 @@ function BriefStep({
         </p>
       )}
 
+      {/* A frozen board rejects every apply, so a run could only ever produce a
+          proposal the organiser is then blocked from using. Say so where the
+          decision is made, rather than letting them spend a generation and
+          several minutes to find out at Apply. */}
+      {scheduleFrozen && (
+        <p
+          role="status"
+          className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200"
+        >
+          <span aria-hidden>❄</span>
+          {msg("board.ai.frozen")}
+        </p>
+      )}
+
       <button
         type="button"
         onClick={run}
-        disabled={tooShort || busy}
+        disabled={tooShort || busy || scheduleFrozen}
         className="ai-run inline-flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-to-br from-violet-600 to-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {busy ? (

--- a/apps/web/src/components/v2/schedule-board.tsx
+++ b/apps/web/src/components/v2/schedule-board.tsx
@@ -850,6 +850,9 @@ export function ScheduleBoard({
           divisionId={single.id}
           expectedSeq={single.seq}
           aiAllowed={aiAllowed}
+          // Absent lock state reads as unfrozen: the server is the authority
+          // (409 SCHEDULE_LOCKED), so a missing field must not hide the button.
+          scheduleFrozen={single.schedule_locked ?? false}
           brief={aiBrief}
           fixtures={aiFixtures}
           prefillRepair={aiRepairScope}

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -30,7 +30,7 @@
   "board.ai.run.repair": "Repair schedule",
   "board.ai.running": "Working on your schedule…",
   "board.ai.flagged": "Engine flagged the draft — repairing…",
-  "board.ai.elapsed": "{elapsed} · usually under 4 min",
+  "board.ai.elapsed": "{elapsed} · usually 1–5 minutes",
   "board.ai.frozen": "This schedule is frozen. Unfreeze it to plan with AI.",
   "board.ai.errorLabel": "Couldn't finish.",
   "board.ai.errorGeneric": "Something went wrong. Try again.",

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Repair schedule",
   "board.ai.running": "Working on your schedule…",
   "board.ai.flagged": "Engine flagged the draft — repairing…",
+  "board.ai.frozen": "This schedule is frozen. Unfreeze it to plan with AI.",
   "board.ai.errorLabel": "Couldn't finish.",
   "board.ai.errorGeneric": "Something went wrong. Try again.",
   "board.ai.error.upgrade": "AI scheduling needs a Pro plan.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -30,7 +30,7 @@
   "board.ai.run.repair": "Corregir calendario",
   "board.ai.running": "Trabajando en tu calendario…",
   "board.ai.flagged": "El motor marcó el borrador: corrigiendo…",
-  "board.ai.elapsed": "{elapsed} · normalmente menos de 4 min",
+  "board.ai.elapsed": "{elapsed} · normalmente entre 1 y 5 minutos",
   "board.ai.frozen": "Este calendario está congelado. Descongélalo para planificar con IA.",
   "board.ai.errorLabel": "No se pudo completar.",
   "board.ai.errorGeneric": "Algo salió mal. Inténtalo de nuevo.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Corregir calendario",
   "board.ai.running": "Trabajando en tu calendario…",
   "board.ai.flagged": "El motor marcó el borrador: corrigiendo…",
+  "board.ai.frozen": "Este calendario está congelado. Descongélalo para planificar con IA.",
   "board.ai.errorLabel": "No se pudo completar.",
   "board.ai.errorGeneric": "Algo salió mal. Inténtalo de nuevo.",
   "board.ai.error.upgrade": "La programación con IA necesita un plan Pro.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -30,7 +30,7 @@
   "board.ai.run.repair": "Corriger le calendrier",
   "board.ai.running": "Planification de votre calendrier…",
   "board.ai.flagged": "Le moteur a signalé le brouillon — correction…",
-  "board.ai.elapsed": "{elapsed} · généralement moins de 4 min",
+  "board.ai.elapsed": "{elapsed} · généralement 1 à 5 minutes",
   "board.ai.frozen": "Ce calendrier est gelé. Dégelez-le pour planifier avec l’IA.",
   "board.ai.errorLabel": "Impossible de terminer.",
   "board.ai.errorGeneric": "Une erreur s'est produite. Réessayez.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Corriger le calendrier",
   "board.ai.running": "Planification de votre calendrier…",
   "board.ai.flagged": "Le moteur a signalé le brouillon — correction…",
+  "board.ai.frozen": "Ce calendrier est gelé. Dégelez-le pour planifier avec l’IA.",
   "board.ai.errorLabel": "Impossible de terminer.",
   "board.ai.errorGeneric": "Une erreur s'est produite. Réessayez.",
   "board.ai.error.upgrade": "La planification IA nécessite un forfait Pro.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -30,7 +30,7 @@
   "board.ai.run.repair": "Schema herstellen",
   "board.ai.running": "Bezig met je schema…",
   "board.ai.flagged": "Motor markeerde het concept — herstellen…",
-  "board.ai.elapsed": "{elapsed} · meestal minder dan 4 min",
+  "board.ai.elapsed": "{elapsed} · meestal 1–5 minuten",
   "board.ai.frozen": "Dit schema is bevroren. Ontdooi het om met AI te plannen.",
   "board.ai.errorLabel": "Kon niet voltooien.",
   "board.ai.errorGeneric": "Er ging iets mis. Probeer opnieuw.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -30,6 +30,7 @@
   "board.ai.run.repair": "Schema herstellen",
   "board.ai.running": "Bezig met je schema…",
   "board.ai.flagged": "Motor markeerde het concept — herstellen…",
+  "board.ai.frozen": "Dit schema is bevroren. Ontdooi het om met AI te plannen.",
   "board.ai.errorLabel": "Kon niet voltooien.",
   "board.ai.errorGeneric": "Er ging iets mis. Probeer opnieuw.",
   "board.ai.error.upgrade": "AI-planning vereist een Pro-abonnement.",

--- a/apps/web/src/lib/__tests__/ai-pricing.test.ts
+++ b/apps/web/src/lib/__tests__/ai-pricing.test.ts
@@ -1,38 +1,43 @@
 import { describe, expect, it } from "vitest";
 import { aiRate, aiRunCostUsd } from "../ai-pricing";
 
-// Dates are pinned explicitly: these assertions must not change meaning when
-// the sonnet-5 introductory window lapses on 2026-09-01.
-const DURING_INTRO = new Date("2026-07-20T12:00:00Z");
-const AFTER_INTRO = new Date("2026-09-01T00:00:00Z");
+// Dates are pinned so these assertions cannot drift with the clock.
+const JULY = new Date("2026-07-20T12:00:00Z");
+const SEPTEMBER = new Date("2026-09-01T00:00:00Z");
 
 describe("aiRunCostUsd", () => {
   // 5,212 in + 26,917 out — the measured live run from 2026-07-19.
-  it("prices sonnet-5 at the $2/$10 introductory rate during the window", () => {
-    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917, DURING_INTRO)).toBe(0.2796);
+  //
+  // Billed at LIST. An introductory $2/$10 rate was briefly applied here and
+  // reverted on 2026-07-20: reconciling the real account balance against 28
+  // benched runs showed list-rate billing, so the intro rate had made the
+  // ledger understate by 33%. The date argument stays because the mechanism
+  // still supports a window — it is just not in use.
+  it("prices sonnet-5 at list, and does not vary with the date", () => {
+    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917, JULY)).toBe(0.4194);
+    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917, SEPTEMBER)).toBe(0.4194);
   });
 
-  it("prices sonnet-5 at the $3/$15 list rate once the window lapses", () => {
-    expect(aiRunCostUsd("claude-sonnet-5", 5212, 26917, AFTER_INTRO)).toBe(0.4194);
+  it("prices haiku-4-5 at $1/$5 — the cheap-model escalation target", () => {
+    // The 2026-07-20 sparse-pack measurement: 8,511 in + 4,629 out.
+    expect(aiRunCostUsd("claude-haiku-4-5", 8511, 4629, JULY)).toBe(0.0317);
   });
 
-  it("intro window is inclusive of its final day", () => {
-    const lastMoment = new Date("2026-08-31T23:59:59Z");
-    expect(aiRate("claude-sonnet-5", lastMoment)).toEqual({ input: 2, output: 10 });
-    expect(aiRate("claude-sonnet-5", AFTER_INTRO)).toEqual({ input: 3, output: 15 });
+  it("prices opus-4-8 at $5/$25 per 1M", () => {
+    expect(aiRunCostUsd("claude-opus-4-8", 1_000_000, 1_000_000, JULY)).toBe(30);
   });
 
-  it("models without an intro window are date-independent", () => {
-    expect(aiRunCostUsd("claude-opus-4-8", 1_000_000, 1_000_000, DURING_INTRO)).toBe(30);
-    expect(aiRunCostUsd("claude-opus-4-8", 1_000_000, 1_000_000, AFTER_INTRO)).toBe(30);
+  it("aiRate reports the rate a cost was stamped at", () => {
+    expect(aiRate("claude-sonnet-5", JULY)).toEqual({ input: 3, output: 15 });
+    expect(aiRate("claude-haiku-4-5", JULY)).toEqual({ input: 1, output: 5 });
   });
 
   it("zero tokens cost zero (solver draft)", () => {
-    expect(aiRunCostUsd("claude-sonnet-5", 0, 0, DURING_INTRO)).toBe(0);
+    expect(aiRunCostUsd("claude-sonnet-5", 0, 0, JULY)).toBe(0);
   });
 
   it("unknown model → null, never a guessed price", () => {
-    expect(aiRunCostUsd("some-custom-model", 1000, 1000, DURING_INTRO)).toBeNull();
-    expect(aiRate("some-custom-model", DURING_INTRO)).toBeNull();
+    expect(aiRunCostUsd("some-custom-model", 1000, 1000, JULY)).toBeNull();
+    expect(aiRate("some-custom-model", JULY)).toBeNull();
   });
 });

--- a/apps/web/src/lib/ai-pricing.ts
+++ b/apps/web/src/lib/ai-pricing.ts
@@ -4,18 +4,21 @@
 // it. Cache reads/writes are not modelled — the runner's usage counters are
 // raw input/output tokens.
 //
-// Some models carry a time-boxed introductory rate. Cost is stamped at run
-// time, so the rate in force *at that moment* is the correct one and the
-// window expires on its own — no dated constant to remember to delete.
+// The mechanism supports a time-boxed introductory rate (cost is stamped at run
+// time, so the rate in force *at that moment* is the correct one and a window
+// expires on its own). No model currently uses one.
+//
+// 2026-07-20: sonnet-5 was briefly given Anthropic's published $2/$10
+// introductory rate. That was wrong for this account — reconciling the real
+// balance against 28 benched runs ($15 -> $9 observed, ~$5.6 predicted at list
+// vs $3.4 at intro) showed billing at LIST. Applying a published rate without
+// checking the account made the ledger understate by 33%, the same bug it was
+// meant to fix, in the opposite direction. Do not re-add an intro rate here
+// without confirming it against console.anthropic.com -> Plans & Billing.
 type Rate = { input: number; output: number };
 
 const PRICING: Record<string, { list: Rate; intro?: { untilIso: string; rate: Rate } }> = {
-  "claude-sonnet-5": {
-    list: { input: 3, output: 15 },
-    // Introductory pricing runs through 2026-08-31 inclusive; `untilIso` is the
-    // first instant the list rate applies again.
-    intro: { untilIso: "2026-09-01T00:00:00Z", rate: { input: 2, output: 10 } },
-  },
+  "claude-sonnet-5": { list: { input: 3, output: 15 } },
   "claude-sonnet-4-6": { list: { input: 3, output: 15 } },
   "claude-opus-4-8": { list: { input: 5, output: 25 } },
   "claude-opus-4-7": { list: { input: 5, output: 25 } },

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -237,6 +237,7 @@ export type DictionaryKey =
   | "board.ai.errorGeneric"
   | "board.ai.errorLabel"
   | "board.ai.flagged"
+  | "board.ai.frozen"
   | "board.ai.ghost.aria"
   | "board.ai.instructionHint"
   | "board.ai.instructionLabel"

--- a/apps/web/src/server/usecases/__tests__/officials-ai-route.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-route.test.ts
@@ -181,6 +181,11 @@ describe.skipIf(!HAS_DB)("officialsAiPlanForDivision — runner (v4/03 §2)", ()
     const callOpts = parse.mock.calls[0]![1] as { timeout?: number; signal?: unknown };
     expect(callOpts.timeout).toBeTypeOf("number");
     expect(callOpts.timeout!).toBeGreaterThan(0);
+    // Phase B stays on effort:high while Phase A moved to medium — that move
+    // was justified by a bench over SCHEDULE packs, and officials has never
+    // been measured. Guards against someone "harmonising" the two defaults.
+    const body = parse.mock.calls[0]![0] as { output_config: { effort: string } };
+    expect(body.output_config.effort).toBe("high");
     const lockedRow = out.assignments.find((a) => a.fixtureId === fixtureIds[0] && a.officialId === refA);
     expect(lockedRow).toMatchObject({ roleKey: "referee", locked: true });
     expect(out.usage.repair_rounds).toBe(0);

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
@@ -200,13 +200,22 @@ type Row = {
 
 const rows: Row[] = [];
 
-async function bench(name: string, build: () => { pack: SchedulePack; movable: Set<string> }, effort: string) {
+async function bench(
+  name: string,
+  build: () => { pack: SchedulePack; movable: Set<string> },
+  effort: string,
+  thinking: "adaptive" | "disabled" = "adaptive",
+) {
   process.env.SCHEDULING_AI_EFFORT = effort;
+  process.env.SCHEDULING_AI_THINKING = thinking;
+  // Label the cell by both knobs, so a no-thinking arm never aggregates into
+  // the adaptive arm that shares its effort level.
+  const cellEffort = thinking === "disabled" ? `${effort}/no-think` : effort;
   const { pack, movable } = build();
   const t0 = Date.now();
   const row: Row = {
     pack: name,
-    effort,
+    effort: cellEffort,
     secs: 0,
     rounds: 0,
     in: 0,
@@ -236,30 +245,89 @@ async function bench(name: string, build: () => { pack: SchedulePack; movable: S
   row.introUsd = usd(row.in, row.out, 2, 10);
   rows.push(row);
   process.stdout.write(
-    `\n[${name} / effort=${effort}] ${row.secs}s  rounds=${row.rounds}  in=${row.in} out=${row.out}  ` +
+    `\n[${name} / effort=${cellEffort}] ${row.secs}s  rounds=${row.rounds}  in=${row.in} out=${row.out}  ` +
       `list=$${row.listUsd} intro=$${row.introUsd}  blocking=${row.blocking} warnings=${row.warnings} ` +
       `unsched=${row.unschedulable} placed=${row.placed}${row.error ? `  ERROR: ${row.error}` : ""}\n`,
   );
   // A swallowed error is worse than a red test: it looks like a cheap run.
-  expect(row.error, `${name}/${effort} failed`).toBe("");
+  expect(row.error, `${name}/${cellEffort} failed`).toBe("");
   return row;
 }
 
-describe.skipIf(!LIVE)("effort A/B (live, billed)", () => {
-  const T = 3_300_000; // up to 3 rounds at the configured round timeout, plus slack
+// Adaptive thinking is noisy: a repeated cell varied 2.1x run-to-run on
+// 2026-07-20 (individuals-50 @ high, 7,911 vs 16,923 output tokens for a
+// byte-identical pack). One sample per cell can order the arms but cannot size
+// the gap between them, so REPEATS>1 is what turns the cost delta from
+// directional into quotable.
+const REPEATS = Math.max(1, Number(process.env.AI_AB_REPEATS) || 1);
 
-  it("teams-15 @ high", async () => { await bench("teams-15", teamsPack, "high"); }, T);
-  it("teams-15 @ medium", async () => { await bench("teams-15", teamsPack, "medium"); }, T);
-  it("individuals-50 @ high", async () => { await bench("individuals-50", individualsPack, "high"); }, T);
-  it("individuals-50 @ medium", async () => { await bench("individuals-50", individualsPack, "medium"); }, T);
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/** mean / min / max of one field across a cell's repeats. */
+function agg(cell: Row[], pick: (r: Row) => number) {
+  const xs = cell.map(pick);
+  const mean = xs.reduce((s, x) => s + x, 0) / xs.length;
+  return { mean: round2(mean), min: round2(Math.min(...xs)), max: round2(Math.max(...xs)) };
+}
+
+describe.skipIf(!LIVE)("effort A/B (live, billed)", () => {
+  // Worst observed cell is ~1095s; leave room for REPEATS of it plus repairs.
+  const T = Math.max(3_300_000, REPEATS * 1_400_000);
+
+  const cell = (
+    name: string,
+    build: () => { pack: SchedulePack; movable: Set<string> },
+    effort: string,
+    thinking: "adaptive" | "disabled" = "adaptive",
+  ) =>
+    it(`${name} @ ${effort}${thinking === "disabled" ? "/no-think" : ""} x${REPEATS}`, async () => {
+      for (let i = 0; i < REPEATS; i++) await bench(name, build, effort, thinking);
+    }, T);
+
+  cell("teams-15", teamsPack, "high");
+  cell("teams-15", teamsPack, "medium");
+  cell("individuals-50", individualsPack, "high");
+  cell("individuals-50", individualsPack, "medium");
+
+  // The 90.5% arm. Measured 2026-07-20: of a 27,349-token response only 2,588
+  // was the plan — the rest was thinking. Turning thinking off is the only
+  // lever of that magnitude, and it is only safe to try because the engine
+  // referee re-checks every proposal and the repair loop re-prompts on
+  // blocking conflicts. Watch `rounds`: the trade is fewer thinking tokens per
+  // round against possibly more rounds, and each repair re-sends the prior
+  // round's output as input.
+  cell("teams-15", teamsPack, "low", "disabled");
+  cell("individuals-50", individualsPack, "low", "disabled");
 
   it("summary", () => {
     const roundMs = Number(process.env.SCHEDULING_AI_ROUND_TIMEOUT_MS) || 300_000;
-    process.stdout.write(`\n===== effort A/B — model=${schedulingAiModel()} roundTimeout=${roundMs / 1000}s =====\n`);
+    process.stdout.write(
+      `\n===== effort A/B — model=${schedulingAiModel()} roundTimeout=${roundMs / 1000}s repeats=${REPEATS} =====\n`,
+    );
     for (const r of rows) process.stdout.write(`${JSON.stringify(r)}\n`);
+
+    // Per-cell aggregates. Spread (max/min) is the number that says whether the
+    // between-effort gap is bigger than the within-effort noise.
+    const keys = [...new Set(rows.map((r) => `${r.pack}|${r.effort}`))];
+    process.stdout.write(`\n--- per cell (n=${REPEATS}) ---\n`);
+    for (const k of keys) {
+      const [pack, effort] = k.split("|");
+      const c = rows.filter((r) => `${r.pack}|${r.effort}` === k);
+      const secs = agg(c, (r) => r.secs);
+      const out = agg(c, (r) => r.out);
+      const cost = agg(c, (r) => r.introUsd);
+      const spread = out.min > 0 ? round2(out.max / out.min) : 0;
+      const clean = c.filter((r) => r.blocking === 0 && r.warnings === 0 && r.unschedulable === 0).length;
+      process.stdout.write(
+        `${pack} @ ${effort}: secs mean=${secs.mean} [${secs.min}-${secs.max}] | ` +
+          `out mean=${out.mean} [${out.min}-${out.max}] spread=${spread}x | ` +
+          `$intro mean=${cost.mean} [${cost.min}-${cost.max}] | clean ${clean}/${c.length}\n`,
+      );
+    }
+
     const total = rows.reduce((s, r) => s + r.introUsd, 0);
-    process.stdout.write(`total spend this bench (intro rates): $${Math.round(total * 10000) / 10000}\n`);
-    expect(rows.length).toBe(4);
+    process.stdout.write(`\ntotal spend this bench (intro rates): $${Math.round(total * 10000) / 10000}\n`);
+    expect(rows.length).toBe(6 * REPEATS);
     expect(rows.every((r) => r.error === "")).toBe(true);
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-route.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-route.test.ts
@@ -4,7 +4,7 @@
 // on a 422. The Anthropic SDK, PostHog, and the Redis window counter are mocked;
 // everything else (entitlements, the pack builder) hits real Postgres, so the
 // suite is skipped without DATABASE_URL.
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 
 // Hoisted mock handles — referenced from vi.mock factories (which hoist above
@@ -383,6 +383,123 @@ describe.skipIf(!HAS_DB)("aiPlanForDivision gates (v4/00 §5, quotas V302)", () 
     parse.mockResolvedValueOnce(planResponse(legalPlan(fixtureIds)));
     const out = await aiPlanForDivision(auth, divisionId, { instruction: "plan it", mode: "generate" });
     expect(out.proposal.length).toBeGreaterThan(0);
+  });
+
+  // Runtime model escalation: try a cheap model, keep it only if the referee
+  // says the plan is good enough, otherwise re-run on the primary. Opt-in via
+  // SCHEDULING_AI_CHEAP_MODEL, so the default path is untouched.
+  describe("cheap-model escalation", () => {
+    afterEach(() => {
+      delete process.env.SCHEDULING_AI_CHEAP_MODEL;
+      delete process.env.SCHEDULING_AI_ESCALATE_WARN_RATIO;
+    });
+
+    it("keeps the cheap plan when the referee is happy — one call, no escalation", async () => {
+      process.env.SCHEDULING_AI_CHEAP_MODEL = "claude-haiku-4-5";
+      // legalPlan is conflict-free but not warning-free: it packs fixtures 30
+      // minutes apart at matchMinutes:30, so entrants get zero rest against the
+      // 20-minute minimum. A tolerant ratio isolates what this test is about
+      // (an acceptable plan is kept) from the warning threshold, which the
+      // sibling tests exercise.
+      process.env.SCHEDULING_AI_ESCALATE_WARN_RATIO = "999";
+      const auth = await seedPlusOrg();
+      const { divisionId, fixtureIds } = await seedPlannable(auth);
+      parse.mockResolvedValueOnce(planResponse(legalPlan(fixtureIds)));
+
+      const out = await aiPlanForDivision(auth, divisionId, { instruction: "plan", mode: "generate" });
+
+      expect(parse).toHaveBeenCalledTimes(1);
+      expect((parse.mock.calls[0][0] as { model: string }).model).toBe("claude-haiku-4-5");
+      expect(out.proposal.length).toBe(fixtureIds.length);
+    });
+
+    // A cheap model that gives up entirely must not surface as a 422 — an
+    // opt-in cost optimisation that lowers success rate is not a trade worth
+    // making. Its spent tokens still ride on the escalated run's bill.
+    it("escalates when the cheap model fails outright, and still bills its tokens", async () => {
+      process.env.SCHEDULING_AI_CHEAP_MODEL = "claude-haiku-4-5";
+      const auth = await seedPlusOrg();
+      const { divisionId, fixtureIds } = await seedPlannable(auth);
+
+      // Refusal → runAiPlan throws 422 AI_PLAN_FAILED carrying usage.
+      parse.mockResolvedValueOnce({
+        parsed_output: null, stop_reason: "refusal", usage: { input_tokens: 100, output_tokens: 50 }, content: [],
+      });
+      parse.mockResolvedValueOnce(planResponse(legalPlan(fixtureIds), { input_tokens: 700, output_tokens: 300 }));
+
+      const out = await aiPlanForDivision(auth, divisionId, { instruction: "plan", mode: "generate" });
+      expect(out.proposal.length).toBe(fixtureIds.length);
+
+      const models = parse.mock.calls.map((c) => (c[0] as { model: string }).model);
+      expect(models).toEqual(["claude-haiku-4-5", "claude-sonnet-5"]);
+
+      const [row] = await sql<{ payload: { usage: { input_tokens: number; output_tokens: number }; escalated_from?: string } }[]>`
+        select payload from competition_events
+        where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}
+        order by created_at desc limit 1`;
+      expect(row?.payload.escalated_from).toBe("claude-haiku-4-5");
+      // 100+700 in, 50+300 out — the abandoned attempt is not free.
+      expect(row!.payload.usage.input_tokens).toBe(800);
+      expect(row!.payload.usage.output_tokens).toBe(350);
+    });
+
+    it("escalates on blocking conflicts, and bills BOTH attempts", async () => {
+      process.env.SCHEDULING_AI_CHEAP_MODEL = "claude-haiku-4-5";
+      const auth = await seedPlusOrg();
+      const { divisionId, fixtureIds } = await seedPlannable(auth);
+
+      // Otherwise-legal plan with ONE court double-booking: fixture[1] is moved
+      // onto fixture[0]'s exact slot and court. Structurally valid (every
+      // movable id appears once) so it reaches the verifier, which reports a
+      // blocking court conflict — the condition escalation exists for.
+      const legal = legalPlan(fixtureIds) as { assignments: { fixture_id: string; scheduled_at: string; court_label: string }[] };
+      const clash = {
+        ...legal,
+        assignments: legal.assignments.map((a, i) =>
+          i === 1 ? { ...a, scheduled_at: legal.assignments[0].scheduled_at, court_label: legal.assignments[0].court_label } : a,
+        ),
+      };
+      // Persistent fallback is the clean plan; the first three calls (the cheap
+      // model's initial attempt + MAX_REPAIR_ROUNDS) are the clash. Written this
+      // way so the test does not depend on the exact call count of the repair
+      // loop — only on "cheap keeps failing, primary succeeds".
+      parse.mockResolvedValue(planResponse(legal, { input_tokens: 700, output_tokens: 300 }));
+      for (let i = 0; i < 3; i++) {
+        parse.mockResolvedValueOnce(planResponse(clash, { input_tokens: 100, output_tokens: 50 }));
+      }
+
+      const out = await aiPlanForDivision(auth, divisionId, { instruction: "plan", mode: "generate" }).catch(
+        () => null,
+      );
+
+      // Both models were tried: cheap first, primary second.
+      const models = parse.mock.calls.map((c) => (c[0] as { model: string }).model);
+      expect(models[0]).toBe("claude-haiku-4-5");
+      expect(models).toContain("claude-sonnet-5");
+
+      // A wasted cheap attempt is real spend. If the ledger only counted the
+      // winning half it would under-report every escalated run.
+      if (out) {
+        const [row] = await sql<{ payload: { usage: { input_tokens: number }; escalated_from?: string } }[]>`
+          select payload from competition_events
+          where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}
+          order by created_at desc limit 1`;
+        expect(row?.payload.escalated_from).toBe("claude-haiku-4-5");
+        // Strictly more than any single attempt spent.
+        expect(row!.payload.usage.input_tokens).toBeGreaterThan(100);
+      }
+    });
+
+    it("unset cheap model → single call on the primary (default behaviour)", async () => {
+      const auth = await seedPlusOrg();
+      const { divisionId, fixtureIds } = await seedPlannable(auth);
+      parse.mockResolvedValueOnce(planResponse(legalPlan(fixtureIds)));
+
+      await aiPlanForDivision(auth, divisionId, { instruction: "plan", mode: "generate" });
+
+      expect(parse).toHaveBeenCalledTimes(1);
+      expect((parse.mock.calls[0][0] as { model: string }).model).toBe("claude-sonnet-5");
+    });
   });
 
   it("6th call in the hour → 429", async () => {

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-route.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-route.test.ts
@@ -356,6 +356,35 @@ describe.skipIf(!HAS_DB)("aiPlanForDivision gates (v4/00 §5, quotas V302)", () 
     expect(parse).not.toHaveBeenCalled();
   });
 
+  // A frozen division rejects every applied plan (applySchedule, 422), so a run
+  // could only ever produce a proposal the organiser is then blocked from
+  // using — and that block landed at Apply, minutes and one paid generation
+  // later. The guard belongs ahead of the quota and spend gates.
+  it("frozen division → 409 SCHEDULE_LOCKED, before any spend", async () => {
+    const auth = await seedPlusOrg();
+    const { divisionId, fixtureIds } = await seedPlannable(auth);
+    await sql`update divisions set schedule_locked = true where id = ${divisionId}`;
+
+    await expect(
+      aiPlanForDivision(auth, divisionId, { instruction: "plan it", mode: "generate" }),
+    ).rejects.toMatchObject({ status: 409, code: "SCHEDULE_LOCKED" });
+
+    // No model call, no generation consumed, no rate-limit slot burned.
+    expect(parse).not.toHaveBeenCalled();
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from competition_events
+      where payload->>'division_id' = ${divisionId}
+        and type in ('schedule.ai_generated', 'schedule.ai_failed')`;
+    expect(n).toBe(0);
+    expect(rlCounts.size).toBe(0);
+
+    // Unfreezing restores the normal path — the guard gates on state, not identity.
+    await sql`update divisions set schedule_locked = false where id = ${divisionId}`;
+    parse.mockResolvedValueOnce(planResponse(legalPlan(fixtureIds)));
+    const out = await aiPlanForDivision(auth, divisionId, { instruction: "plan it", mode: "generate" });
+    expect(out.proposal.length).toBeGreaterThan(0);
+  });
+
   it("6th call in the hour → 429", async () => {
     const auth = await seedPlusOrg();
     const { divisionId, fixtureIds } = await seedPlannable(auth);

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -195,6 +195,32 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     expect(body.output_config.effort).toBe("medium");
   });
 
+  // Thinking is ~90% of a run's output tokens (only 2,588 of 27,349 was the
+  // plan on the 2026-07-20 measurement), so this knob dwarfs every schema
+  // change. It stays on until the bench says otherwise — the engine referee
+  // makes a thin plan safe to attempt, not free.
+  it("thinks adaptively by default; SCHEDULING_AI_THINKING=disabled turns it off", async () => {
+    delete process.env.SCHEDULING_AI_THINKING;
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds);
+    expect((parse.mock.calls[0][0] as { thinking: { type: string } }).thinking.type).toBe("adaptive");
+
+    parse.mockClear();
+    process.env.SCHEDULING_AI_THINKING = "disabled";
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds);
+    expect((parse.mock.calls[0][0] as { thinking: { type: string } }).thinking.type).toBe("disabled");
+
+    // Anything but the exact opt-out keeps thinking on: a typo must not
+    // silently halve the reasoning behind every schedule.
+    parse.mockClear();
+    process.env.SCHEDULING_AI_THINKING = "off";
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds);
+    expect((parse.mock.calls[0][0] as { thinking: { type: string } }).thinking.type).toBe("adaptive");
+    delete process.env.SCHEDULING_AI_THINKING;
+  });
+
   it("SCHEDULING_AI_EFFORT overrides the default; an unknown value falls back to medium", async () => {
     process.env.SCHEDULING_AI_EFFORT = "xhigh";
     parse.mockResolvedValueOnce(planResponse(finishBy18Plan));

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -183,16 +183,17 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     expect(body.model).toBe("claude-sonnet-5");
   });
 
-  // 2026-07-20 live 2x2 (sonnet-5, 25- and 30-fixture packs): medium returned an
-  // engine-CLEAN plan in one round on every arm, 5.1x/1.9x faster than high
-  // (high needed 1095s on the 30-fixture pack — an unshippable wait). The
-  // referee checks every proposal regardless of effort.
-  it("defaults to effort:medium when SCHEDULING_AI_EFFORT is unset", async () => {
+  // Stays "high". The 2026-07-20 A/B (n=3 per cell) was run to justify lowering
+  // this and concluded against: quality was identical across all 12 runs (0
+  // blocking, 0 warnings, 0 repair rounds), so the only axes left were latency
+  // and money — and on the dense pack medium is 2.2x SLOWER to save $0.135.
+  // An n=1 pass had suggested medium was faster; that was an outlier.
+  it("defaults to effort:high when SCHEDULING_AI_EFFORT is unset", async () => {
     delete process.env.SCHEDULING_AI_EFFORT;
     parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
     await runAiPlan(pack, movableIds);
     const body = parse.mock.calls[0][0] as { output_config: { effort: string } };
-    expect(body.output_config.effort).toBe("medium");
+    expect(body.output_config.effort).toBe("high");
   });
 
   // Thinking is ~90% of a run's output tokens (only 2,588 of 27,349 was the
@@ -221,7 +222,7 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     delete process.env.SCHEDULING_AI_THINKING;
   });
 
-  it("SCHEDULING_AI_EFFORT overrides the default; an unknown value falls back to medium", async () => {
+  it("SCHEDULING_AI_EFFORT overrides the default; an unknown value falls back to high", async () => {
     process.env.SCHEDULING_AI_EFFORT = "xhigh";
     parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
     await runAiPlan(pack, movableIds);
@@ -231,7 +232,7 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     process.env.SCHEDULING_AI_EFFORT = "turbo";
     parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
     await runAiPlan(pack, movableIds);
-    expect((parse.mock.calls[0][0] as { output_config: { effort: string } }).output_config.effort).toBe("medium");
+    expect((parse.mock.calls[0][0] as { output_config: { effort: string } }).output_config.effort).toBe("high");
     delete process.env.SCHEDULING_AI_EFFORT;
   });
 
@@ -257,7 +258,7 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     // Modern models keep the adaptive + effort shape.
     const sonnet = aiReasoningParams("claude-sonnet-5");
     expect(sonnet.thinking).toEqual({ type: "adaptive" });
-    expect(sonnet.effort).toBe("medium");
+    expect(sonnet.effort).toBe("high");
 
     process.env.SCHEDULING_AI_THINKING = "disabled";
     expect(aiReasoningParams("claude-sonnet-5").thinking).toEqual({ type: "disabled" });

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -36,7 +36,7 @@ import { captureServer, isServerFeatureEnabled } from "@/lib/posthog-server";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import type { AiOfficialsPlanRequest, AiOfficialsPlanResponse } from "@/server/api-v1/schemas";
 import { AiOfficialsPlan, OFFICIALS_SYSTEM_PROMPT } from "./officials-ai-prompt";
-import { anthropicClient, schedulingAiModel, zonedIso } from "./schedule-ai";
+import { anthropicClient, parseAiEffort, schedulingAiModel, zonedIso, type AiEffort } from "./schedule-ai";
 import { aiRunCostUsd } from "@/lib/ai-pricing";
 import { divisionFixtures, loadSettings } from "./schedule";
 import {
@@ -598,6 +598,16 @@ export function refereeOfficialsPlan(
 // benched, so it keeps effort:high below and inherits the safer timeout rather
 // than an unmeasured cost change.
 const OFFICIALS_ROUND_TIMEOUT_MS = Number(process.env.SCHEDULING_AI_ROUND_TIMEOUT_MS) || 600_000;
+
+/** Effort for the officials (Phase B) call. Deliberately still "high" while
+ *  Phase A moved to "medium" on 2026-07-20: that move was justified by a live
+ *  2x2 over schedule packs, and Phase B has never been benched. A separate env
+ *  var (rather than reusing SCHEDULING_AI_EFFORT) is the point — it lets Phase
+ *  B be measured on its own before its default changes, instead of inheriting
+ *  a conclusion drawn from a different workload. */
+export function officialsAiEffort(): AiEffort {
+  return parseAiEffort(process.env.OFFICIALS_AI_EFFORT, "high");
+}
 const OFFICIALS_MAX_REPAIR_ROUNDS = 2;
 
 /** A conflict the LLM can plausibly repair by re-choosing officials. `role_unfilled`
@@ -761,7 +771,7 @@ async function callOfficialsModel(
         model,
         max_tokens: 32_000,
         thinking: { type: "adaptive" },
-        output_config: { effort: "high", format: zodOutputFormat(AiOfficialsPlan) },
+        output_config: { effort: officialsAiEffort(), format: zodOutputFormat(AiOfficialsPlan) },
         system: [{ type: "text", text: OFFICIALS_SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
         messages: [...messages],
       },

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -659,12 +659,19 @@ export function schedulingAiModel(): string {
  *
  *  The deterministic referee verifies every proposal regardless, so a thinner
  *  plan surfaces as repair rounds, never as a silently bad schedule. */
-export function schedulingAiEffort(): "low" | "medium" | "high" | "xhigh" | "max" {
-  const raw = process.env.SCHEDULING_AI_EFFORT;
-  const allowed = ["low", "medium", "high", "xhigh", "max"] as const;
-  return (allowed as readonly string[]).includes(raw ?? "")
-    ? (raw as (typeof allowed)[number])
-    : "medium";
+export function schedulingAiEffort(): AiEffort {
+  return parseAiEffort(process.env.SCHEDULING_AI_EFFORT, "medium");
+}
+
+export type AiEffort = "low" | "medium" | "high" | "xhigh" | "max";
+
+const AI_EFFORTS: readonly AiEffort[] = ["low", "medium", "high", "xhigh", "max"];
+
+/** Shared by both architect phases, which carry DIFFERENT defaults on purpose:
+ *  Phase A is benched, Phase B is not. An unset or unrecognised value falls back
+ *  rather than throwing — a typo'd env var must not take AI scheduling down. */
+export function parseAiEffort(raw: string | undefined, fallback: AiEffort): AiEffort {
+  return (AI_EFFORTS as readonly string[]).includes(raw ?? "") ? (raw as AiEffort) : fallback;
 }
 
 export function anthropicClient(): Anthropic {

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -674,6 +674,25 @@ export function parseAiEffort(raw: string | undefined, fallback: AiEffort): AiEf
   return (AI_EFFORTS as readonly string[]).includes(raw ?? "") ? (raw as AiEffort) : fallback;
 }
 
+/** Thinking mode for the architect call.
+ *
+ *  Measured 2026-07-20: the structured plan is only ~2,588 tokens of a 27,349
+ *  token response — 90.5% of what a run costs is thinking, not output. So this
+ *  is the largest single cost lever available, an order of magnitude bigger
+ *  than any schema change (short ids save 2.1%, diff-from-draft 7.5%).
+ *
+ *  Default stays "adaptive". Turning it off is only defensible because the
+ *  deterministic referee verifies every proposal and the repair loop re-prompts
+ *  on blocking conflicts — a thin plan gets caught, never shipped. Whether that
+ *  actually wins is an open question: fewer thinking tokens per round, but
+ *  possibly more rounds, and each round re-sends the prior output as input.
+ *  SCHEDULING_AI_THINKING=disabled exists so the bench can settle it. */
+export type AiThinking = "adaptive" | "disabled";
+
+export function schedulingAiThinking(): AiThinking {
+  return process.env.SCHEDULING_AI_THINKING === "disabled" ? "disabled" : "adaptive";
+}
+
 export function anthropicClient(): Anthropic {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
@@ -851,7 +870,7 @@ async function callModel(
       {
         model,
         max_tokens: 32_000,
-        thinking: { type: "adaptive" },
+        thinking: schedulingAiThinking() === "disabled" ? { type: "disabled" } : { type: "adaptive" },
         output_config: { effort: schedulingAiEffort(), format: zodOutputFormat(AiSchedulePlan) },
         system: [{ type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } }],
         messages: [...messages],

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -638,29 +638,35 @@ export function schedulingAiModel(): string {
   return process.env.SCHEDULING_AI_MODEL ?? "claude-sonnet-5";
 }
 
-/** Effort hint for the architect call. Output tokens are ~96% of a run's cost,
- *  and effort is the direct knob on thinking depth — so this is the cost lever,
- *  not prompt caching (input is <4% of spend).
+/** Effort hint for the architect call.
  *
- *  Default "medium" since 2026-07-20, on a live 2x2 (sonnet-5, two packs, both
- *  efforts). Every arm returned an engine-verified CLEAN plan in one round —
- *  medium cost no measurable quality:
+ *  Stays "high". A live A/B (2026-07-20, sonnet-5, two packs, n=3 per cell)
+ *  was run specifically to justify lowering it, and concluded against:
  *
- *    pack (fixtures)   high              medium
- *    teams-15 (30)     1095s / 27.3k out  213s / 22.5k out
- *    individuals-50    159s / 16.9k out    84s /  9.9k out
+ *    pack             effort   secs mean            out mean   warnings
+ *    teams-15 (30)    high     276.8 [268.5-282.9]   29,858       0
+ *    teams-15 (30)    medium   616.1 [291.4-808.3]   20,411       0
+ *    individuals-50   high      97.6 [ 73.4-142.7]   11,510       0
+ *    individuals-50   medium    80.0 [ 55.8- 98.0]    9,460       0
  *
- *  The decisive term is latency, not money: medium is 5.1x / 1.9x faster, and
- *  18 minutes is not a viable wait at any price. Treat the cost delta (17-39%)
- *  as directional only — a repeated cell varied 2.1x run-to-run, so a single
- *  sample cannot size it. SCHEDULING_AI_EFFORT overrides.
+ *  Quality is identical — all 12 runs returned an engine-verified plan with
+ *  zero blocking, zero warnings, zero repair rounds. So the only live axes are
+ *  latency and money, and on the dense pack medium is 2.2x SLOWER to save
+ *  $0.135. Against a lifetime quota of 20-50 runs per division that is a few
+ *  dollars, traded for ~5.6 extra minutes of an organiser watching a spinner.
+ *
+ *  An n=1 pass had briefly suggested the opposite (medium "5.1x faster") — that
+ *  was a 1095s outlier on the high side; with n=3 high never exceeded 283s on
+ *  that pack. Recorded here because the wrong conclusion shipped for a day.
+ *
+ *  Effort escalation is NOT viable for the same reason: medium never produced a
+ *  degraded plan, so the referee has nothing to escalate on. Cheap-MODEL
+ *  escalation is a different matter — see runAiPlanEscalating.
  *
  *  Phase B (officials-ai.ts) is deliberately still "high": it was not measured.
- *
- *  The deterministic referee verifies every proposal regardless, so a thinner
- *  plan surfaces as repair rounds, never as a silently bad schedule. */
+ *  Full write-up: design/v4/04-architect-benchmarks.md. */
 export function schedulingAiEffort(): AiEffort {
-  return parseAiEffort(process.env.SCHEDULING_AI_EFFORT, "medium");
+  return parseAiEffort(process.env.SCHEDULING_AI_EFFORT, "high");
 }
 
 export type AiEffort = "low" | "medium" | "high" | "xhigh" | "max";

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -1110,7 +1110,8 @@ function isoConstraintSuggestions(
  * still metered.
  *
  * @throws HttpError 403 FEATURE_DISABLED (kill switch), 402 (paid gate or
- *   over-quota run cap), 429 (rate limit), plus everything
+ *   over-quota run cap), 409 SCHEDULE_LOCKED (frozen division — refused before
+ *   the quota and spend gates), 429 (rate limit), plus everything
  *   buildSchedulePack/runAiPlan raise (409/422/400/503).
  */
 export async function aiPlanForDivision(
@@ -1136,16 +1137,34 @@ export async function aiPlanForDivision(
   // and refuse the (cap+1)th here, before the LLM call, so an over-quota org
   // never burns a request.
   const gate = await withTenant(auth.orgId, async (tx) => {
-    const [division] = await tx<{ competition_id: string }[]>`
-      select competition_id from divisions where id = ${divisionId}`;
+    const [division] = await tx<{ competition_id: string; schedule_locked: boolean }[]>`
+      select competition_id, schedule_locked from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
     const [row] = await tx<{ n: number }[]>`
       select count(*)::int as n from competition_events
       where competition_id = ${division.competition_id}
         and type = 'schedule.ai_generated'
         and payload->>'division_id' = ${divisionId}`;
-    return { competitionId: division.competition_id, priorRuns: row?.n ?? 0 };
+    return {
+      competitionId: division.competition_id,
+      priorRuns: row?.n ?? 0,
+      frozen: division.schedule_locked ?? false,
+    };
   });
+
+  // A frozen division rejects every applied plan (schedule.ts applySchedule,
+  // 422 "the division schedule is locked"). Running the architect anyway spends
+  // a generation, a rate-limit slot and real tokens to produce a proposal the
+  // organiser is then blocked from using — the failure only surfaced at Apply,
+  // several minutes and one paid run later. Refuse here, ahead of the quota and
+  // spend gates, so a frozen board costs nothing.
+  if (gate.frozen) {
+    throw new HttpError(
+      409,
+      "the division schedule is frozen — unfreeze it to plan with AI",
+      "SCHEDULE_LOCKED",
+    );
+  }
   const cap = await withinLimit(
     auth.orgId,
     "scheduling.ai.runs_per_division.max",

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -950,9 +950,13 @@ async function callModel(
  * @throws HttpError 503 (no ANTHROPIC_API_KEY), 422 AI_PLAN_FAILED (model
  *   refusal, or an un-correctable structural violation), 422 AI_PLAN_TIMEOUT.
  */
-export async function runAiPlan(pack: SchedulePack, movableIds: Set<string>): Promise<AiPlanResult> {
+export async function runAiPlan(
+  pack: SchedulePack,
+  movableIds: Set<string>,
+  modelOverride?: string,
+): Promise<AiPlanResult> {
   const client = anthropicClient(); // 503 before any network if unconfigured
-  const model = schedulingAiModel();
+  const model = modelOverride ?? schedulingAiModel();
 
   const conversation: Anthropic.MessageParam[] = [{ role: "user", content: JSON.stringify(pack) }];
   const config = verifyConfig(pack);
@@ -1141,6 +1145,99 @@ function isoConstraintSuggestions(
   };
 }
 
+/** Opt-in cheaper first-attempt model. Unset (the default) means no escalation
+ *  and behaviour is exactly as before. */
+export function schedulingAiCheapModel(): string | null {
+  return process.env.SCHEDULING_AI_CHEAP_MODEL || null;
+}
+
+/** Warnings-per-movable-fixture above which a cheap plan is rejected and the
+ *  primary model re-runs.
+ *
+ *  UNCALIBRATED. Measured 2026-07-20 (n=3 per cell): sonnet-5 scored 0 warnings
+ *  on both benched packs; haiku-4-5 scored 0 on the sparse pack and 20/43/100
+ *  on the dense one — 0.67, 1.43 and 3.33 per fixture. The default of 1.0 sits
+ *  inside that observed range rather than at a boundary derived from real
+ *  divisions, so it will need tuning against production data before this is
+ *  trusted. That is exactly why escalation is opt-in. */
+function escalationWarningRatio(): number {
+  const n = Number(process.env.SCHEDULING_AI_ESCALATE_WARN_RATIO);
+  return Number.isFinite(n) && n >= 0 ? n : 1.0;
+}
+
+/** Is a plan good enough to ship without re-running on the primary model?
+ *  Blocking conflicts are never acceptable — the engine says the schedule is
+ *  physically impossible. Warnings are soft (rest, blackout, session window,
+ *  cross-person), so they are judged against pack size rather than absolutely. */
+function planIsAcceptable(result: AiPlanResult, movableCount: number): boolean {
+  if (result.blocking.length > 0) return false;
+  if (movableCount === 0) return true;
+  return result.warnings.length / movableCount <= escalationWarningRatio();
+}
+
+/**
+ * Run the architect, optionally trying a cheaper model first.
+ *
+ * This deliberately ESCALATES on evidence rather than PREDICTING from the pack.
+ * Choosing a model up front needs a "density" metric, and the 2026-07-20 bench
+ * could not supply one: its two packs differ on structure, court ratio, rest,
+ * no-back-to-back, blackouts and cross-person links simultaneously, so which
+ * factor degrades a cheap model is unknown. The referee already measures the
+ * thing that actually matters — plan quality — so let it decide.
+ *
+ * Failure mode is bounded: a wasted cheap attempt costs ~11% on top of the
+ * primary run (measured: $0.05 + $0.465 vs $0.465), and can never ship a worse
+ * plan than the primary model would have. A mispredicting router, by contrast,
+ * hands the organiser a degraded schedule with no signal at all.
+ *
+ * Usage from BOTH attempts is summed — an escalated run costs what it costs,
+ * and the ledger must not report only the half that happened to win.
+ */
+async function runAiPlanEscalating(
+  pack: SchedulePack,
+  movableIds: Set<string>,
+): Promise<AiPlanResult & { escalated_from?: string }> {
+  const cheap = schedulingAiCheapModel();
+  const primary = schedulingAiModel();
+  if (!cheap || cheap === primary) return runAiPlan(pack, movableIds);
+
+  // A cheap model can fail two ways: return a poor-but-usable plan, or give up
+  // entirely (AI_PLAN_FAILED / AI_PLAN_TIMEOUT). Both must escalate — letting a
+  // thrown cheap failure surface as a 422 would make an opt-in cost optimisation
+  // *reduce* success rate, which is never an acceptable trade. Provider outages
+  // (503 / APIError) still propagate: retrying a different model against a
+  // broken provider only burns another call.
+  let first: AiPlanResult | null = null;
+  let spent = { input_tokens: 0, output_tokens: 0, repair_rounds: 0 };
+  try {
+    first = await runAiPlan(pack, movableIds, cheap);
+    spent = first.usage;
+    if (planIsAcceptable(first, movableIds.size)) return first;
+  } catch (err) {
+    const recoverable =
+      err instanceof HttpError && (err.code === "AI_PLAN_FAILED" || err.code === "AI_PLAN_TIMEOUT");
+    if (!recoverable) throw err;
+    // Tokens the failed attempt already spent ride on the error's extra.
+    const u = (err.extra?.usage ?? {}) as Partial<typeof spent>;
+    spent = {
+      input_tokens: u.input_tokens ?? 0,
+      output_tokens: u.output_tokens ?? 0,
+      repair_rounds: u.repair_rounds ?? 0,
+    };
+  }
+
+  const second = await runAiPlan(pack, movableIds, primary);
+  return {
+    ...second,
+    escalated_from: cheap,
+    usage: {
+      input_tokens: spent.input_tokens + second.usage.input_tokens,
+      output_tokens: spent.output_tokens + second.usage.output_tokens,
+      repair_rounds: spent.repair_rounds + second.usage.repair_rounds,
+    },
+  };
+}
+
 /**
  * POST /divisions/{id}/schedule/ai-plan orchestrator. Gate order is deliberate
  * (design/v4/00 §5): the staged-rollout kill switch (fail-open) → the paid gate
@@ -1220,9 +1317,9 @@ export async function aiPlanForDivision(
   const { pack, movableIds } = await buildSchedulePack(auth, divisionId, input);
 
   const model = schedulingAiModel();
-  let result: AiPlanResult;
+  let result: AiPlanResult & { escalated_from?: string };
   try {
-    result = await runAiPlan(pack, movableIds);
+    result = await runAiPlanEscalating(pack, movableIds);
   } catch (err) {
     // Meter a refused / un-correctable / timed-out run's token spend too —
     // usage rides on the 422 extra so a failed architect call is not invisible
@@ -1310,6 +1407,17 @@ export async function aiPlanForDivision(
                 model,
                 usage: result.usage,
                 cost_usd,
+                // Escalation telemetry: which cheap model was tried and
+                // rejected, and the warning ratio that rejected it. The
+                // threshold is uncalibrated (see escalationWarningRatio), so
+                // the ledger has to carry what it would take to tune it.
+                ...(result.escalated_from
+                  ? {
+                      escalated_from: result.escalated_from,
+                      warnings: result.warnings.length,
+                      movable: movableIds.size,
+                    }
+                  : {}),
               } as never)}, ${auth.userId})`;
   });
 

--- a/design/v4/04-architect-benchmarks.md
+++ b/design/v4/04-architect-benchmarks.md
@@ -1,8 +1,9 @@
 # 04 — Architect benchmarks: what the defaults are, and why
 
-> **Status (2026-07-20):** first live measurements. `SCHEDULING_AI_EFFORT` default moved
-> `high` → `medium`; `ROUND_TIMEOUT_MS` 300s → 600s. Repeats run partially complete —
-> **the cost delta is not yet quotable** (see §5). Phase B (officials) unmeasured.
+> **Status (2026-07-20, final):** 28 live runs across 6 arms. `ROUND_TIMEOUT_MS` 300s → 600s
+> (kept). `SCHEDULING_AI_EFFORT` briefly moved to `medium` and was **reverted to `high`** —
+> the repeats concluded against the change they were run to justify (§4a). Phase B
+> (officials) still unmeasured.
 
 The v4 README says *"Token spend is acceptable: a couple of runs per division, quality over
 cost."* That was the right call with no data. This document is the data, and it changes the
@@ -110,6 +111,53 @@ Two results that invert the original read:
 
 ---
 
+## 4a. Final aggregates (n=3) — and the reversal
+
+| pack | effort | secs mean [min–max] | out mean | warnings | $ list |
+|---|---|---|---|---|---|
+| teams-15 | high | 276.8 [268.5–282.9] | 29,858 | 0 | $0.465 |
+| teams-15 | medium | 616.1 [291.4–808.3] | 20,411 | 0 | $0.330 |
+| individuals-50 | high | 97.6 [73.4–142.7] | 11,510 | 0 | $0.195 |
+| individuals-50 | medium | 80.0 [55.8–98.0] | 9,460 | 0 | $0.165 |
+
+**All 12 runs: zero blocking, zero warnings, zero repair rounds.** Quality is not a
+variable between effort levels — which removes the argument the change was made on.
+
+With quality equal, only latency and money remain. On the dense pack `medium` is **2.2×
+slower to save $0.135**; on the sparse pack the two overlap on both axes. Against a
+lifetime quota of 20–50 runs per division, the saving is a few dollars ever, traded for
+~5.6 extra minutes of an organiser watching a spinner. **Reverted to `high`.**
+
+The n=1 pass had claimed the opposite — "medium is 5.1× faster" — from a single `high` run
+of 1094.9s. With n=3, `high` never exceeded 282.9s on that pack. That outlier drove a
+default change that shipped for a day. It is the clearest argument in this document for
+n>1 before acting on a measurement.
+
+**Effort escalation is not viable**, for the same reason the revert happened: `medium`
+never produced a degraded plan, so the referee has nothing to escalate on. A gate would
+never fire, making it equivalent to setting `medium` always. Cheap-*model* escalation is a
+different case — §4b.
+
+## 4b. Cheap models (n=3)
+
+| pack | arm | rounds | blocking | warnings | $ list |
+|---|---|---|---|---|---|
+| teams-15 | haiku-4-5 + budget 8k | 0,0,0 | 0,0,0 | 43,100,20 | $0.050 |
+| teams-15 | sonnet no-think | 2,0,2 | 8,0,2 | 56,57,59 | $0.205 |
+| individuals-50 | haiku-4-5 + budget 8k | 0,0,0 | 0,0,0 | 0,0,0 | $0.043 |
+| individuals-50 | sonnet no-think | 0,0,1 | 0,0,0 | 0,0,0 | $0.071 |
+
+**Haiku matches sonnet exactly on the sparse pack** — 4.5× cheaper, no measurable
+difference, no port (same SDK, same `zodOutputFormat`, same `parsed_output`). On the dense
+pack it stays *legal* but ignores soft constraints: 20–100 warnings where sonnet scored 0.
+
+**No-thinking sonnet fails on dense packs.** Two of three runs exhausted the repair loop
+and still left blocking conflicts. Input ballooned 7–12× as each repair re-sent the prior
+round's output, so the failures cost *more* than a clean `high` run.
+
+Note the caveat this creates for §2: "input is <4% of spend" holds **only at `rounds=0`**.
+On a repair-spiralling run input became 57% of cost.
+
 ## 5. What the evidence supports, and what it does not
 
 **Supported:**
@@ -124,12 +172,18 @@ Two results that invert the original read:
 
 **Not supported — do not quote these:**
 
-- **A specific cost percentage.** The 17–39% figure from the single-sample 2×2 sits inside
-  the within-cell spread now being measured. Sizing it needs the repeats to finish.
-- **"`medium` is 5.1× faster."** That compared one outlier `high` run against one fast
-  `medium` run. On repeats, `medium` is *not* reliably faster and was sometimes slower.
-  This was stated in an earlier commit message and is corrected here.
+- **A specific cost percentage — now settled (§4a).** medium is 32% cheaper on the dense
+  pack and 18% on the sparse one. Not worth taking: the saving only exists where medium is
+  also 2.2x slower.
+- **"medium is 5.1x faster" — false.** It compared one outlier `high` run (1094.9s) against
+  one fast `medium` run. At n=3 `medium` is the SLOWER arm on the dense pack, 616s vs 277s.
+  This shipped as a default for a day before the repeats caught it.
 - **Anything at all about Phase B.** `officials-ai.ts` has never been benched.
+- **A density metric.** The two packs differ simultaneously in structure, court ratio,
+  rest minutes, no-back-to-back, blackouts and cross-person links, so which factor
+  degrades a cheap model is unknown. That is why model selection escalates on referee
+  output rather than predicting from the pack, and why the escalation threshold is
+  uncalibrated. Isolating it needs one-factor-off variants of `teams-15` (~$0.30).
 
 ---
 
@@ -137,11 +191,11 @@ Two results that invert the original read:
 
 | default | value | basis |
 |---|---|---|
-| `SCHEDULING_AI_EFFORT` | `medium` | Fewer output tokens on every paired observation, with no quality cost across 4 cells. **Weaker than first claimed** — the latency argument did not survive repeats. One env var to revert. |
+| `SCHEDULING_AI_EFFORT` | `high` | Quality identical across all 12 runs, so only latency and money remain — and `medium` is 2.2x slower on dense packs to save $0.135 against a lifetime-capped quota. Briefly set to `medium` on an n=1 outlier; reverted (§4a). |
 | `SCHEDULING_AI_ROUND_TIMEOUT_MS` | 600s | A 1095s round exists. Raising it does not increase generation (the abort is client-side; it only decides whether we *receive* the round) but does make repair rounds 2–3 reachable, and each round re-sends the prior output as input. |
 | `OFFICIALS_AI_EFFORT` | `high` | Deliberately unchanged. Phase B is a different problem shape (role eligibility, per-day caps, blackouts, cross-org busy windows) and inheriting a schedule-pack conclusion would be unjustified. |
-| `SCHEDULING_AI_THINKING` | `adaptive` | The 90.5% lever, untested. Disabling it is only *safe to attempt* because the referee catches thin plans; whether it *wins* is open — fewer thinking tokens per round against possibly more rounds. Bench arms exist at `effort:low` + `thinking:disabled`. |
-| model | `claude-sonnet-5` | Unchanged from the 2026-07-19 measurement. |
+| `SCHEDULING_AI_THINKING` | `adaptive` | Tested and kept. Disabling it left blocking conflicts on 2 of 3 dense runs and cost MORE than a clean run, because repair rounds re-send the prior output as input (§4b). |
+| model | `claude-sonnet-5` | Unchanged. `SCHEDULING_AI_CHEAP_MODEL` enables runtime escalation to haiku-4-5 — opt-in and OFF, because its warning-ratio threshold is uncalibrated (§7). |
 
 ---
 

--- a/design/v4/04-architect-benchmarks.md
+++ b/design/v4/04-architect-benchmarks.md
@@ -1,0 +1,173 @@
+# 04 — Architect benchmarks: what the defaults are, and why
+
+> **Status (2026-07-20):** first live measurements. `SCHEDULING_AI_EFFORT` default moved
+> `high` → `medium`; `ROUND_TIMEOUT_MS` 300s → 600s. Repeats run partially complete —
+> **the cost delta is not yet quotable** (see §5). Phase B (officials) unmeasured.
+
+The v4 README says *"Token spend is acceptable: a couple of runs per division, quality over
+cost."* That was the right call with no data. This document is the data, and it changes the
+picture in one specific way: the spend is **not** where anyone assumed.
+
+---
+
+## 1. How to reproduce
+
+```bash
+AI_AB_LIVE=1 AI_AB_REPEATS=3 SCHEDULING_AI_ROUND_TIMEOUT_MS=900000 \
+  node --env-file=.env.local ../../node_modules/vitest/vitest.mjs run \
+  src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+```
+
+Harness: `apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts`.
+Skipped unless `AI_AB_LIVE=1`, so CI never spends. `runAiPlan(pack, movableIds)` is pure
+over its pack, so the bench needs no database — packs are built in-file with deterministic
+ids, and both arms of a comparison see a byte-identical pack.
+
+Two packs, chosen to differ in **constraint density**, not just size:
+
+| pack | movable | shape | what makes it bite |
+|---|---|---|---|
+| `teams-15` | 30 | 15 teams, 3 pools × 5, round-robin, 3 courts | 60m rest, no back-to-back, court blackout 12:00–13:30 |
+| `individuals-50` | 25 | 50 entrants, R1 knockout, 4 courts | 10 players dual-entered → hard cross-person clash |
+
+---
+
+## 2. The token anatomy — the finding everything else follows from
+
+Measured with `count_tokens` (free) against a realistic 30-fixture plan:
+
+```
+structured plan output    2,588 tokens
+measured total output    27,349 tokens
+
+plan       2,588  =  9.5%
+thinking  24,761  = 90.5%
+```
+
+**Roughly 90% of a run's cost is the model thinking, not the plan it emits.** Cost is
+~96% output tokens overall (input is <4%), so this is the whole picture.
+
+Consequences, in order of how much they change what we should do:
+
+- **Prompt caching is not the lever.** Input is under 4% of spend. `schedule-ai.ts` already
+  sets `cache_control` on the system prompt, and that prompt is ~1,200 tokens — under the
+  2,048-token minimum cacheable prefix, so it is likely a silent no-op. Worth fixing only
+  for multi-round runs; worth nothing for the common single-round case.
+- **Schema changes are capped at 9.5%**, no matter how aggressive:
+
+  | candidate | saving | % of output |
+  |---|---|---|
+  | Short ordinal ids (`f0`) instead of UUIDs | 570 | 2.1% |
+  | Diff-from-draft contract (`{keep_draft, changes[]}`) | 2,052 | 7.5% |
+
+  Dropping effort `high` → `medium` beat both combined. Short ids are still worth doing —
+  UUIDs cost ~15 tokens each and appear in `assignments`, `unschedulable`, `explanations`,
+  the pack, *and* every repair round — but as housekeeping, not as the cost fix.
+- **`thinking_tokens` is directly reportable.** `usage.output_tokens_details.thinking_tokens`
+  exists on the non-beta response type. The 90.5% above was derived by subtraction; the
+  bench should record the reported figure instead. **Not yet wired up.**
+
+---
+
+## 3. The 2×2 (single sample per cell, 2026-07-20)
+
+Every arm returned an engine-verified CLEAN plan in **one round** — zero blocking, zero
+warnings, zero unschedulable, every fixture placed.
+
+| pack | effort | secs | out tokens | $ (intro) |
+|---|---|---|---|---|
+| teams-15 | high | 1094.9 | 27,349 | $0.2848 |
+| teams-15 | medium | 213.2 | 22,463 | $0.2357 |
+| individuals-50 | high | 159.4 | 16,923 | $0.1827 |
+| individuals-50 | medium | 84.3 | 9,880 | $0.1122 |
+
+**Constraint density drives spend, not fixture count.** `teams-15` has five *more* fixtures
+than `individuals-50` but 2.3× the output tokens at medium. Any future adaptive-effort
+heuristic should key on density (rest rules, blackouts, cross-person links, round-robin
+structure), never on `movableIds.size`.
+
+---
+
+## 4. Repeats — why the single sample was misleading
+
+`AI_AB_REPEATS=3`, partial at time of writing:
+
+| pack / effort | out tokens per run | spread | secs per run |
+|---|---|---|---|
+| teams-15 @ high | 29,529 / 29,275 / 30,769 | **1.05×** | 268.5 / 279.1 / 282.9 |
+| teams-15 @ medium | 14,566 / 23,699 / … | **1.63×** so far | 291.4 / 748.5 / … |
+
+Two results that invert the original read:
+
+1. **The 1094.9s `high` run was an outlier.** Three fresh repeats land at 268–283s. The
+   claim "effort:high cannot schedule a 15-team division" was wrong — it usually can,
+   comfortably. What is true is that a run *sometimes* takes 1095s, which is what the
+   timeout change addresses.
+2. **`medium` is the noisy one.** It is cheaper on average but spans 1.63× on tokens and
+   2.6× on latency, and one `medium` sample (748.5s) was slower than every `high` sample.
+   Latency does not track token count — a run producing half the tokens took twice as long.
+   Whatever drives wall-clock here, it is not how much the model thinks.
+
+---
+
+## 5. What the evidence supports, and what it does not
+
+**Supported:**
+
+- *Quality is not the variable.* Every arm, every repeat, produced an engine-clean plan in
+  one round. The deterministic referee re-checks each proposal, so a thinner plan surfaces
+  as repair rounds, never as a bad schedule shipped to an organiser.
+- *300s was too tight.* A 1095s round demonstrably exists. At the old ceiling it 422'd
+  having burned a full generation that could be neither billed nor shown.
+- *`medium` uses meaningfully fewer output tokens.* Every paired observation points the
+  same way.
+
+**Not supported — do not quote these:**
+
+- **A specific cost percentage.** The 17–39% figure from the single-sample 2×2 sits inside
+  the within-cell spread now being measured. Sizing it needs the repeats to finish.
+- **"`medium` is 5.1× faster."** That compared one outlier `high` run against one fast
+  `medium` run. On repeats, `medium` is *not* reliably faster and was sometimes slower.
+  This was stated in an earlier commit message and is corrected here.
+- **Anything at all about Phase B.** `officials-ai.ts` has never been benched.
+
+---
+
+## 6. Why each default is what it is
+
+| default | value | basis |
+|---|---|---|
+| `SCHEDULING_AI_EFFORT` | `medium` | Fewer output tokens on every paired observation, with no quality cost across 4 cells. **Weaker than first claimed** — the latency argument did not survive repeats. One env var to revert. |
+| `SCHEDULING_AI_ROUND_TIMEOUT_MS` | 600s | A 1095s round exists. Raising it does not increase generation (the abort is client-side; it only decides whether we *receive* the round) but does make repair rounds 2–3 reachable, and each round re-sends the prior output as input. |
+| `OFFICIALS_AI_EFFORT` | `high` | Deliberately unchanged. Phase B is a different problem shape (role eligibility, per-day caps, blackouts, cross-org busy windows) and inheriting a schedule-pack conclusion would be unjustified. |
+| `SCHEDULING_AI_THINKING` | `adaptive` | The 90.5% lever, untested. Disabling it is only *safe to attempt* because the referee catches thin plans; whether it *wins* is open — fewer thinking tokens per round against possibly more rounds. Bench arms exist at `effort:low` + `thinking:disabled`. |
+| model | `claude-sonnet-5` | Unchanged from the 2026-07-19 measurement. |
+
+---
+
+## 7. Open questions
+
+1. **Finish the repeats.** Until then the cost delta is directional only.
+2. **Run the no-thinking arms.** Highest-upside untested option by an order of magnitude.
+3. **Task budgets.** Verified working on `claude-sonnet-5` **only with**
+   `betas: ["task-budgets-2026-03-13"]` — without the header the API rejects it with
+   `400 output_config.task_budget: Extra inputs are not permitted`, which reads as "not
+   supported". Costs ~23 input tokens (the countdown marker the model reads). A hard token
+   ceiling may buy *predictability*, which §4 shows is the real weakness of `medium`.
+4. **Record `thinking_tokens`** instead of inferring it.
+5. **Bench Phase B.** `runOfficialsAiPlan(pack)` is pure over its pack, and the knob now
+   exists — the Phase A harness is the template.
+6. **Fix or remove the system-prompt `cache_control`.** Likely a silent no-op today.
+
+---
+
+## 8. Cost accounting note
+
+`ai-pricing.ts` prices sonnet-5 at its **introductory** $2/$10 per MTok through 2026-08-31,
+falling back to $3/$15 automatically. Costs stamped before 2026-07-20 used the list rate
+and overstate spend by ~33%. Dollar figures in this document are intro-rate.
+
+A timed-out run books **$0.00**: the SDK reports no usage on a client abort, so the tokens
+burned before the deadline are unmeasurable. Timeout failures are therefore
+systematically undercounted in the ledger — a reason to prefer a generous timeout over a
+tight one, independent of UX.

--- a/design/v4/README.md
+++ b/design/v4/README.md
@@ -20,6 +20,13 @@ applicable schedule — then refines it in follow-up turns and repairs it after 
 disruptions. Pro-only (`scheduling.ai`). Token spend is acceptable: a couple of runs per
 division, quality over cost.
 
+> **Amended 2026-07-20 by measurement — see `04-architect-benchmarks.md`.** "Quality over
+> cost" still holds, but the cost turned out to sit somewhere nobody assumed: ~90% of a run
+> is the model *thinking*, and only ~10% the plan it emits. That makes effort/thinking the
+> only levers worth pulling, and makes prompt caching and output-schema trimming close to
+> irrelevant. Quality was never the thing being traded — every benched arm produced an
+> engine-clean plan in one round.
+
 **Architecture in one line: solver drafts → AI plans → engine referees.** The LLM is never
 trusted for legality; `validateAssignments` re-checks every proposal server-side and feeds
 conflicts back for repair rounds. Output is the existing `applySchedule` shape, so apply,
@@ -33,6 +40,7 @@ undo, checkpoints, seq-concurrency and the ledger all work unchanged.
 | 01 | `01-llm-contract.md` | The LLM contract: model/params, context-pack format, output schema, verbatim system prompt, repair/refine protocol, eval fixtures | 41, 42 |
 | 02 | `02-board-ux.md` | Board UX design + prototype finding: surface the referee/repair loop, 3-colour state contract, block/summary/instruction decisions, states. Prototype artifact linked. | 43 |
 | 03 | `03-two-phase-officials-and-intake.md` | 2026-07-18 approved revision: Phase B officials (draft→LLM→referee), pre-flight + wish chips, repair nudges, ledger audit, Pro Plus gates + admin override, drift fixes, deferrals | 85, 86, 87 |
+| 04 | `04-architect-benchmarks.md` | Live measurements + the reasoning behind every runtime default (effort, round timeout, thinking, Phase B). Token anatomy: ~90% of spend is thinking, so schema changes cap at 9.5%. States explicitly what the evidence does **not** support. | — |
 
 ## Prompt index (prompts/)
 


### PR DESCRIPTION
Stacked on #175. Two commits, both **default-preserving** — nothing changes in production until a bench says it should.

## The finding that motivates this

Measured 2026-07-20 with `count_tokens` (free, not billed) against a realistic 30-fixture plan:

```
structured plan output    2,588 tokens
measured total output    27,349 tokens

plan       2,588  =  9.5%
thinking  24,761  = 90.5%
```

**90.5% of a run's cost is thinking, not output.** That reframes the whole cost question. Every schema optimisation competes for the remaining 9.5%:

| candidate change | saving | % of output |
|---|---|---|
| Short ordinal ids instead of UUIDs | 570 | 2.1% |
| Diff-from-draft contract | 2,052 | 7.5% |
| *(already shipped)* effort high → medium | ~4,900 | ~18% |

The effort change alone beat both schema ideas combined. So the only lever of the right order of magnitude is thinking itself.

## 1. `SCHEDULING_AI_THINKING` (default `adaptive`)

Adds the switch plus two bench arms at `effort:low` with thinking disabled.

Only worth attempting because the deterministic referee re-checks every proposal and the repair loop re-prompts on blocking conflicts — a thin plan gets caught, not shipped. **Whether it wins is genuinely open:** fewer thinking tokens per round, but possibly more rounds, and each repair re-sends the prior round's output as input. The bench reports `rounds` per arm so that trade is visible rather than assumed.

A typo'd value keeps thinking **on** — it must not silently halve the reasoning behind every schedule. Test pins that.

## 2. `OFFICIALS_AI_EFFORT` (default `high`)

Phase B has never been benched, and couldn't be — the officials call hardcoded `effort:high` with no way to vary it. Separate env var on purpose: reusing `SCHEDULING_AI_EFFORT` would drag Phase B along with a conclusion drawn from schedule packs, and officials assignment is a different problem shape (role eligibility, per-day caps, blackouts, cross-org busy windows).

Test pins Phase B at `high` so a later "harmonise the defaults" cleanup has to argue with a failing assertion.

## Bench harness

Also consolidates the repeats aggregation: `AI_AB_REPEATS=N` runs each cell N times and reports mean/min/max plus a `spread` (max÷min output tokens) — the number that says whether a between-arm gap exceeds within-arm noise. Cell labels carry both knobs (`low/no-think`) so arms never merge.

## Verification

- `55 passed` across the four AI suites.
- `tsc --noEmit` clean.
- Bench still skipped unless `AI_AB_LIVE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)