### PR TITLE
docs(v4): prompt caching already works — correct the claim that it doesn't

### DIFF
--- a/design/v4/04-architect-benchmarks.md
+++ b/design/v4/04-architect-benchmarks.md
@@ -50,10 +50,19 @@ thinking  24,761  = 90.5%
 
 Consequences, in order of how much they change what we should do:
 
-- **Prompt caching is not the lever.** Input is under 4% of spend. `schedule-ai.ts` already
-  sets `cache_control` on the system prompt, and that prompt is ~1,200 tokens — under the
-  2,048-token minimum cacheable prefix, so it is likely a silent no-op. Worth fixing only
-  for multi-round runs; worth nothing for the common single-round case.
+- **Prompt caching is not the lever — and it already works.** Measured 2026-07-20 on
+  sonnet-5: the system prompt is 1,292 tokens and DOES cache (call 1
+  `cache_write=1286`, call 2 `cache_read=1286`). An earlier draft of this document
+  claimed it was "likely a silent no-op, under the 2,048-token minimum" — wrong; sonnet-5's
+  minimum cacheable prefix is lower than that tier. The economics are the point: at
+  1,286 cached tokens against a $0.465 run, a cache read saves **0.75%** and a wasted
+  cache write (TTL expired before a second run) costs **0.21%**. Noise in both directions.
+
+  Caching only becomes material on REPAIR rounds, where the conversation is re-sent as
+  input — the no-think arm reached 65,015 input tokens over 3 rounds, and breakpoints on
+  the growing conversation would cut ~47% off such a run. But there were **zero repair
+  rounds across all 12 baseline runs** at effort:high, so that is optimising a path that
+  does not execute.
 - **Schema changes are capped at 9.5%**, no matter how aggressive:
 
   | candidate | saving | % of output |
@@ -211,7 +220,10 @@ On a repair-spiralling run input became 57% of cost.
 4. **Record `thinking_tokens`** instead of inferring it.
 5. **Bench Phase B.** `runOfficialsAiPlan(pack)` is pure over its pack, and the knob now
    exists — the Phase A harness is the template.
-6. **Fix or remove the system-prompt `cache_control`.** Likely a silent no-op today.
+6. ~~Fix or remove the system-prompt `cache_control`.~~ **Resolved 2026-07-20:** it works
+   (1,286 tokens written then read on back-to-back calls). Left as is — worth 0.75% at
+   best, -0.21% at worst. Do not extend caching to the repair loop without first seeing
+   repair rounds actually occur in production; they were 0/12 in the bench.
 
 ---
 


### PR DESCRIPTION
Doc-only. Corrects a wrong claim I put in `04-architect-benchmarks.md`.

## What was wrong

The doc said the system prompt's `cache_control` was *"likely a silent no-op, under the 2,048-token minimum."* Measured on sonnet-5, it is not:

```
SYSTEM_PROMPT ≈ 1,292 tokens

call 1   input=11   cache_write=1286   cache_read=0
call 2   input=11   cache_write=0      cache_read=1286
```

Sonnet-5's minimum cacheable prefix is lower than the tier I assumed. Caching works today.

## Why it still isn't a lever

The conclusion doesn't change, but the reasoning behind it does — and the doc exists precisely so nobody has to re-derive this.

| | rate | cost on 1,286 tokens |
|---|---|---|
| uncached | $3/M | $0.00386 |
| cache read | $0.30/M (0.1×) | $0.00039 — **saves 0.75%** of a $0.465 run |
| cache write | $3.75/M (1.25×) | $0.00482 — **costs 0.21%** if never read |

Noise in both directions. Left as is.

## Where caching would pay, and why it's still not worth building

Repair rounds re-send the conversation as input. The no-think arm reached **65,015 input tokens** across 3 rounds, ~47% of which would be cacheable with breakpoints on the growing conversation.

But there were **zero repair rounds across all 12 baseline runs** at `effort: high`. That's optimising a path that doesn't execute — recorded in the doc so the idea doesn't get re-proposed without first checking whether repair rounds actually occur in production.

## No code change

`schedule-ai.ts` is untouched. The existing `cache_control` stays exactly where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)