### PR TITLE
fix(marketing): let signed-in visitors read the home page

### DIFF
--- a/apps/web/src/app/[lang]/(marketing)/__tests__/home-signed-in.test.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/__tests__/home-signed-in.test.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+// prerender, not renderToStaticMarkup: the page nests async server components
+// (MarketingNav awaits getCurrentUser), and the synchronous renderer cannot
+// await those — it throws "a component suspended while responding to
+// synchronous input".
+import { prerender } from "react-dom/static";
+
+// The home page used to redirect signed-in visitors to /dashboard, which made
+// it unreachable once you had an account: no way to re-read the pitch, check
+// what a prospect sees, or follow your own marketing link. These tests pin the
+// page open for both states — a returning redirect would fail them loudly
+// rather than quietly bouncing users again.
+// Hoisted: vi.mock factories run before module-level consts initialise.
+const { getCurrentUser, redirect } = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  redirect: vi.fn(() => {
+    throw new Error("redirect() must not be called from the marketing home");
+  }),
+}));
+
+// next/font/google needs the Next build pipeline; the shell only uses the
+// returned CSS-variable name.
+vi.mock("next/font/google", () => ({
+  Barlow_Condensed: () => ({ variable: "--mk-font-display", className: "" }),
+}));
+vi.mock("@/lib/auth", () => ({ getCurrentUser }));
+// The footer mounts the LocaleSwitcher, a client island using router hooks;
+// stub them so this stays router-free (same approach as marketing-shell.test).
+vi.mock("next/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/navigation")>();
+  return {
+    ...actual,
+    redirect,
+    useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+    usePathname: () => "/en",
+    useSearchParams: () => new URLSearchParams(),
+  };
+});
+
+import HomePage from "../page";
+
+async function render(): Promise<string> {
+  const element = await HomePage({ params: Promise.resolve({ lang: "en" }) });
+  const { prelude } = await prerender(element);
+  const reader = (prelude as ReadableStream<Uint8Array>).getReader();
+  const decoder = new TextDecoder();
+  let html = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    html += decoder.decode(value, { stream: true });
+  }
+  return html;
+}
+
+// Without this the redirect spy carries calls between cases, so a case that
+// asserts "not called" passes or fails depending on what ran before it. That
+// only shows up when a redirect actually exists — i.e. exactly when the test is
+// supposed to be catching one.
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("marketing home — signed in", () => {
+  it("renders for a signed-in visitor instead of redirecting to the dashboard", async () => {
+    getCurrentUser.mockResolvedValue({ id: "u1", email: "organiser@example.com" });
+    const html = await render();
+    expect(redirect).not.toHaveBeenCalled();
+    // The hero's secondary CTA points at the console, not a signup form.
+    expect(html).toContain('href="/dashboard"');
+    expect(html).not.toContain('href="/login?tab=signup"');
+  });
+
+  it("still asks an anonymous visitor to create an account", async () => {
+    getCurrentUser.mockResolvedValue(null);
+    const html = await render();
+    expect(redirect).not.toHaveBeenCalled();
+    expect(html).toContain('href="/login?tab=signup"');
+  });
+
+  it("survives an auth lookup failure — the page is public, so it renders anyway", async () => {
+    getCurrentUser.mockRejectedValue(new Error("session store down"));
+    const html = await render();
+    expect(html).toContain('href="/login?tab=signup"');
+  });
+});

--- a/apps/web/src/app/[lang]/(marketing)/page.tsx
+++ b/apps/web/src/app/[lang]/(marketing)/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "@/components/ui/console-link";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
 import { getCurrentUser } from "@/lib/auth";
 import { getDiscoveryLive, getDiscoveryThisWeek } from "@/server/public-site/discovery";
 import { ThisWeekSection } from "@/components/discovery-cards";
@@ -53,8 +53,14 @@ export default async function HomePage({ params }: { params: Promise<{ lang: str
   const { lang } = await params;
   if (!hasLocale(lang)) notFound();
 
+  // Signed-in visitors see the marketing home like anyone else. It used to
+  // redirect them to /dashboard, which made the page unreachable once you had
+  // an account — no way to re-read the pitch, check pricing copy, or send
+  // someone a link and see what they see. MarketingNav already swaps its
+  // sign-in pair for a "Dashboard →" button when there's a session, so the way
+  // back is on screen. Note /login still redirects: a signed-in user has no
+  // business on the login form, but every reason to visit the home page.
   const user = await getCurrentUser().catch(() => null);
-  if (user) redirect("/dashboard");
 
   const d = await getDictionary(lang, "marketing");
   const audiences = [
@@ -192,6 +198,10 @@ export default async function HomePage({ params }: { params: Promise<{ lang: str
             </h2>
             <p className="mb-10 text-sm text-[#b7aede]">{t(d, "home.finale.subhead")}</p>
             <TicketStubs currency={currency} />
+            {/* "Create free account" is the wrong ask of someone who already
+                has one, so the signed-in pair leads with the console instead.
+                Starting a tournament stays available — an existing organiser is
+                exactly who does that next. */}
             <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
               <Link
                 href="/start"
@@ -200,10 +210,10 @@ export default async function HomePage({ params }: { params: Promise<{ lang: str
                 {t(d, "home.cta.start")}
               </Link>
               <Link
-                href="/login?tab=signup"
+                href={user ? "/dashboard" : "/login?tab=signup"}
                 className="rounded-xl border border-[#4a3885] px-6 py-3 text-sm text-[var(--mk-cream)]"
               >
-                {t(d, "home.cta.signup")}
+                {user ? `${t(d, "nav.dashboard")} →` : t(d, "home.cta.signup")}
               </Link>
             </div>
           </div>


### PR DESCRIPTION
## The bug

`[lang]/(marketing)/page.tsx:57` redirected anyone with a session to `/dashboard`, so the home page was unreachable once you had an account — no way to re-read the pitch, check what a prospect sees, or follow your own marketing link.

## Two of the three asks already existed

They were just hidden behind that redirect:

- **The Dashboard button.** `marketing-nav.tsx:57` has swapped its sign-in pair for a `Dashboard →` button when there's a session since it was written. Nobody could see it, because the page never rendered for a signed-in user.
- **Logout landing home.** `logout-button.tsx:29` already pushes to `/`, with a comment stating that intent — *"signing out is 'leave the console', not 'start a new session'"*. It worked, because `destroySession()` clears the cookie before the push so the redirect didn't fire. But the destination only becomes a real page now.

## The one genuine gap

The hero's secondary CTA said **"Create free account"** — the wrong ask of someone who has one. It now points at the console when signed in:

```
anonymous:  [ Start your tournament → ]  [ Create free account ]
signed in:  [ Start your tournament → ]  [ Dashboard → ]
```

"Start your tournament" stays for both. An existing organiser is exactly who does that next.

## What deliberately did not change

`/login` still redirects a signed-in user away. There's no reason to show the login form to someone already in, and every reason to show them the home page — different situations, kept different.

## Tests

Three cases pinning the page open: signed-in, anonymous, and auth-lookup-failure (the page is public, so a session-store outage must not take it down).

Two things worth flagging in how they're written:

- **`react-dom/static`'s `prerender`, not `renderToStaticMarkup`.** The page nests async server components (`MarketingNav` awaits `getCurrentUser`) and the synchronous renderer throws *"a component suspended while responding to synchronous input"*. This is why `marketing-shell.test.tsx` previously punted full-page rendering to e2e.
- **`beforeEach(vi.clearAllMocks)` is load-bearing.** Without it the `redirect` spy carries calls between cases, so an assertion of "not called" passes or fails depending on ordering — and that only surfaces when a redirect actually exists, i.e. exactly when the test is meant to catch one. Verified by putting the redirect back: precisely one case fails, the right one.

## Verification

- `416 passed` across 97 files.
- `tsc --noEmit` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)