### PR TITLE
fix(engine): make the placer and the verifier agree about constraints

### DIFF
--- a/apps/web/src/server/usecases/__tests__/__snapshots__/schedule-ai-pack.test.ts.snap
+++ b/apps/web/src/server/usecases/__tests__/__snapshots__/schedule-ai-pack.test.ts.snap
@@ -765,6 +765,7 @@ exports[`buildSchedulePack (v4/01 §2) > pack is deterministic and matches the 0
     ],
     "gapMinutes": 0,
     "matchMinutes": 30,
+    "perEntrantMinRest": 20,
     "sessionWindows": [
       {
         "from": "2026-08-01T10:00:00+01:00",

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
@@ -86,6 +86,7 @@ function teamsPack(): { pack: SchedulePack; movable: Set<string> } {
     settings: {
       matchMinutes: 30,
       gapMinutes: 10,
+      perEntrantMinRest: 0,
       courts: ["Court 1", "Court 2", "Court 3"],
       sessionWindows: [{ from: "2026-08-01T09:00:00+01:00", to: "2026-08-01T21:00:00+01:00" }],
       blackouts: [{ court: "Court 3", from: "2026-08-01T12:00:00+01:00", to: "2026-08-01T13:30:00+01:00" }],
@@ -152,6 +153,7 @@ function individualsPack(): { pack: SchedulePack; movable: Set<string> } {
     settings: {
       matchMinutes: 45,
       gapMinutes: 0,
+      perEntrantMinRest: 0,
       courts: ["Court 1", "Court 2", "Court 3", "Court 4"],
       sessionWindows: [{ from: "2026-08-01T09:00:00+01:00", to: "2026-08-01T18:00:00+01:00" }],
       blackouts: [],

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -38,6 +38,7 @@ function makePack(overrides: Partial<SchedulePack> = {}): SchedulePack {
     settings: {
       matchMinutes: 30,
       gapMinutes: 0,
+      perEntrantMinRest: 0,
       courts: ["Court 1", "Court 2"],
       sessionWindows: [{ from: "2026-08-01T09:00:00+01:00", to: "2026-08-01T18:00:00+01:00" }],
       blackouts: [],

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -124,6 +124,11 @@ export interface PackConstraints {
 export interface PackSettings {
   matchMinutes: number;
   gapMinutes: number;
+  /** The Settings-tab rest. Absent from the pack until now, which is how the
+   *  referee came to enforce only `constraints.restMin` — a division whose rest
+   *  was set in Settings had it silently ignored by AI Schedule while
+   *  Auto-schedule honoured it. Both the model and the referee need it. */
+  perEntrantMinRest: number;
   courts: string[];
   sessionWindows: { from: string; to: string }[];
   blackouts: { court?: string; from: string; to: string }[];
@@ -532,6 +537,7 @@ export async function buildSchedulePack(
     const settingsOut: PackSettings = {
       matchMinutes,
       gapMinutes: config.gapMinutes,
+      perEntrantMinRest: config.perEntrantMinRest,
       // v15 venues: when venue_courts lands, this builder is the single
       // place court_label strings become venue-scoped (design/v15-venue).
       courts,
@@ -850,9 +856,36 @@ function toObstacleAssignments(pack: SchedulePack): Assignment[] {
   }));
 }
 
-function verifyConfig(pack: SchedulePack): Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts" | "sessionWindows"> {
+function verifyConfig(
+  pack: SchedulePack,
+): Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts" | "sessionWindows"> &
+  Partial<Pick<SlotConfig, "matchMinutes" | "constraints">> {
   return {
-    perEntrantMinRest: pack.settings.constraints?.restMin ?? 0,
+    // Both rest sources, plus the match length noBackToBack needs: the engine's
+    // effectiveRestMinutes takes the strictest, exactly as the solver does.
+    perEntrantMinRest: pack.settings.perEntrantMinRest,
+    matchMinutes: pack.settings.matchMinutes,
+    // Only the rest-bearing fields: the pack's startWindows carry ISO strings
+    // (the model reads them), while the engine wants epoch ms. Window
+    // validation is a separate piece of work — carrying them across here would
+    // silently compare the wrong units.
+    ...(pack.settings.constraints !== null
+      ? {
+          constraints: {
+            ...(pack.settings.constraints.restMin !== undefined
+              ? { restMin: pack.settings.constraints.restMin }
+              : {}),
+            ...(pack.settings.constraints.restByGroup !== undefined
+              ? { restByGroup: pack.settings.constraints.restByGroup }
+              : {}),
+            noBackToBack: pack.settings.constraints.noBackToBack,
+            startWindows: [],
+            fieldFairness: "off" as const,
+            parallelism: "mixed" as const,
+            crossPersonClash: "warn" as const,
+          },
+        }
+      : {}),
     gapMinutes: pack.settings.gapMinutes,
     blackouts: pack.settings.blackouts.map((b) => ({
       ...(b.court !== undefined ? { court: b.court } : {}),

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -319,13 +319,25 @@ export function toSlotConfig(settings: ScheduleSettingsOut, now: number): SlotCo
 // panel maps blocking-row reasons through the exact same map client-side.
 // ---------------------------------------------------------------------------
 
-function mapConflicts(conflicts: readonly Conflict[]): ScheduleConflict[] {
+function mapConflicts(
+  conflicts: readonly Conflict[],
+  crossPersonClash?: "warn" | "hard",
+): ScheduleConflict[] {
+  // crossPersonClash="hard" (Jul3/04 §2) means the organiser asked for a person
+  // double-booking to be refused, not badged. The solver already refuses to
+  // place one — but the board accepted a hand-placed clash, because blocking
+  // was decided here without ever consulting the setting. Default stays "warn",
+  // so only organisations that opted in see the change.
+  const personBlocks = crossPersonClash === "hard";
   return conflicts.map((c) => ({
     fixture_id: c.fixtureId,
     code: REASON_CODE[c.reason],
     // conflict.court blocks (physically impossible); warn.order blocks for
     // direct feeds; everything else is a badge (doc 12 §2).
-    blocking: c.reason === "court" || (c.reason === "order" && c.direct === true),
+    blocking:
+      c.reason === "court" ||
+      (c.reason === "order" && c.direct === true) ||
+      (c.reason === "person_overlap" && personBlocks),
     ...(c.detail !== undefined ? { detail: c.detail } : {}),
   }));
 }
@@ -510,6 +522,7 @@ export async function applySchedule(
         [...untouched, ...siblings],
         feedDependencies(all),
       ),
+      settings.config.constraints?.crossPersonClash,
     );
     assertNoBlocking(conflicts);
 
@@ -714,6 +727,7 @@ export async function moveFixture(
           [...others, ...siblings],
           feedDependencies(all),
         ),
+        settings.config.constraints?.crossPersonClash,
       );
       assertNoBlocking(conflicts);
     }

--- a/packages/engine/src/scheduling/calendar-rest-unify.test.ts
+++ b/packages/engine/src/scheduling/calendar-rest-unify.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+import { slotFixtures, validateAssignments, type Assignment } from "./calendar";
+
+const MIN = 60_000;
+
+// Rest is stored in two places — `perEntrantMinRest` (the Settings tab, the
+// shape of the day) and `constraints.restMin` (the Constraints tab, a rule
+// about entrants) — and three call sites used to resolve it differently:
+//
+//   slotFixtures        max(both, restByGroup, noBackToBack)   correct
+//   board validation    perEntrantMinRest only                 ignored restMin
+//   AI referee          constraints.restMin only               ignored the other
+//
+// So the same timetable was legal or illegal depending on which door it came
+// through. The placer and the verifier now share one resolver, which is what
+// these pin: everything the solver refuses to place, the verifier must refuse
+// to accept.
+
+/** Two matches for entrant A, `gapMinutes` apart, each 30 minutes long. */
+function backToBack(gapMinutes: number): Assignment[] {
+  return [
+    { fixtureId: "x", court: "C1", startAt: 0, endAt: 30 * MIN, entrants: ["A"], people: [] },
+    {
+      fixtureId: "y",
+      court: "C2",
+      startAt: (30 + gapMinutes) * MIN,
+      endAt: (60 + gapMinutes) * MIN,
+      entrants: ["A"],
+      people: [],
+    },
+  ];
+}
+const rests = (cs: ReturnType<typeof validateAssignments>) => cs.filter((c) => c.reason === "rest");
+
+describe("validateAssignments — rest resolved the same way the solver resolves it", () => {
+  it("honours constraints.restMin when the Settings field is unset", () => {
+    // The AI referee's exact configuration. Before the fix this returned no
+    // conflicts, so the model could hand back a plan breaking the organiser's
+    // stated rest and the referee would wave it through.
+    const conflicts = validateAssignments(backToBack(10), {
+      perEntrantMinRest: 0,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints: { restMin: 60, noBackToBack: false, startWindows: [] },
+    });
+    expect(rests(conflicts)).not.toHaveLength(0);
+  });
+
+  it("still honours perEntrantMinRest when the Constraints field is unset", () => {
+    // The board's configuration — this always worked, and must keep working.
+    const conflicts = validateAssignments(backToBack(10), {
+      perEntrantMinRest: 60,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints: { restMin: 0, noBackToBack: false, startWindows: [] },
+    });
+    expect(rests(conflicts)).not.toHaveLength(0);
+  });
+
+  it("takes the stricter of the two when both are set", () => {
+    const conflicts = validateAssignments(backToBack(40), {
+      perEntrantMinRest: 20,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints: { restMin: 90, noBackToBack: false, startWindows: [] },
+    });
+    expect(rests(conflicts)).not.toHaveLength(0);
+  });
+
+  it("enforces noBackToBack as a full match plus gap", () => {
+    // 15 minutes between matches clears any explicit rest (there is none) but
+    // not "at least one fixture between", which is matchMinutes + gapMinutes.
+    const conflicts = validateAssignments(backToBack(15), {
+      perEntrantMinRest: 0,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints: { restMin: 0, noBackToBack: true, startWindows: [] },
+    });
+    expect(rests(conflicts)).not.toHaveLength(0);
+  });
+
+  it("applies a restByGroup override to assignments that name their division", () => {
+    const assignments = backToBack(30).map((a) => ({ ...a, divisionId: "d1" }));
+    const conflicts = validateAssignments(assignments, {
+      perEntrantMinRest: 0,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints: {
+        restMin: 0,
+        noBackToBack: false,
+        startWindows: [],
+        restByGroup: { d1: 45 },
+      },
+    });
+    expect(rests(conflicts)).not.toHaveLength(0);
+  });
+
+  it("stays quiet when the gap satisfies every rest source", () => {
+    const conflicts = validateAssignments(backToBack(90), {
+      perEntrantMinRest: 20,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints: { restMin: 60, noBackToBack: true, startWindows: [] },
+    });
+    expect(rests(conflicts)).toHaveLength(0);
+  });
+
+  it("still works for callers that pass no constraints at all", () => {
+    // Every existing call site outside the scheduler does this.
+    expect(rests(validateAssignments(backToBack(10), { perEntrantMinRest: 60, gapMinutes: 0 }))).not
+      .toHaveLength(0);
+    expect(rests(validateAssignments(backToBack(90), { perEntrantMinRest: 60, gapMinutes: 0 })))
+      .toHaveLength(0);
+  });
+});
+
+describe("placer and verifier agree", () => {
+  it("accepts what slotFixtures produces under the same constraints", () => {
+    // The property that matters: a schedule the solver built must never be
+    // reported as broken by the validator it is checked against.
+    const constraints = {
+      restMin: 45,
+      noBackToBack: true,
+      startWindows: [],
+    };
+    const result = slotFixtures({
+      fixtures: [
+        { id: "f1", home: "A", away: "B" },
+        { id: "f2", home: "A", away: "C" },
+        { id: "f3", home: "B", away: "C" },
+      ],
+      config: {
+        startAt: 0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        courts: ["C1", "C2"],
+        perEntrantMinRest: 20,
+        blackouts: [],
+        sessionWindows: [],
+        constraints,
+      },
+    });
+    expect(result.conflicts.filter((c) => c.reason === "rest")).toHaveLength(0);
+
+    const conflicts = validateAssignments(result.assignments, {
+      perEntrantMinRest: 20,
+      gapMinutes: 0,
+      matchMinutes: 30,
+      constraints,
+    });
+    expect(rests(conflicts)).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/scheduling/calendar-rest-unify.test.ts
+++ b/packages/engine/src/scheduling/calendar-rest-unify.test.ts
@@ -30,6 +30,20 @@ function backToBack(gapMinutes: number): Assignment[] {
     },
   ];
 }
+
+/** The engine's SchedulingConstraints has required fields with zod defaults;
+ *  these tests only care about the rest-bearing ones, so fill the rest. */
+function cons(partial: Record<string, unknown>) {
+  return {
+    noBackToBack: false,
+    startWindows: [],
+    fieldFairness: "off" as const,
+    parallelism: "mixed" as const,
+    crossPersonClash: "warn" as const,
+    ...partial,
+  };
+}
+
 const rests = (cs: ReturnType<typeof validateAssignments>) => cs.filter((c) => c.reason === "rest");
 
 describe("validateAssignments — rest resolved the same way the solver resolves it", () => {
@@ -41,7 +55,7 @@ describe("validateAssignments — rest resolved the same way the solver resolves
       perEntrantMinRest: 0,
       gapMinutes: 0,
       matchMinutes: 30,
-      constraints: { restMin: 60, noBackToBack: false, startWindows: [] },
+      constraints: cons({ restMin: 60, noBackToBack: false, startWindows: [] }),
     });
     expect(rests(conflicts)).not.toHaveLength(0);
   });
@@ -52,7 +66,7 @@ describe("validateAssignments — rest resolved the same way the solver resolves
       perEntrantMinRest: 60,
       gapMinutes: 0,
       matchMinutes: 30,
-      constraints: { restMin: 0, noBackToBack: false, startWindows: [] },
+      constraints: cons({ restMin: 0, noBackToBack: false, startWindows: [] }),
     });
     expect(rests(conflicts)).not.toHaveLength(0);
   });
@@ -62,7 +76,7 @@ describe("validateAssignments — rest resolved the same way the solver resolves
       perEntrantMinRest: 20,
       gapMinutes: 0,
       matchMinutes: 30,
-      constraints: { restMin: 90, noBackToBack: false, startWindows: [] },
+      constraints: cons({ restMin: 90, noBackToBack: false, startWindows: [] }),
     });
     expect(rests(conflicts)).not.toHaveLength(0);
   });
@@ -74,7 +88,7 @@ describe("validateAssignments — rest resolved the same way the solver resolves
       perEntrantMinRest: 0,
       gapMinutes: 0,
       matchMinutes: 30,
-      constraints: { restMin: 0, noBackToBack: true, startWindows: [] },
+      constraints: cons({ restMin: 0, noBackToBack: true, startWindows: [] }),
     });
     expect(rests(conflicts)).not.toHaveLength(0);
   });
@@ -85,12 +99,12 @@ describe("validateAssignments — rest resolved the same way the solver resolves
       perEntrantMinRest: 0,
       gapMinutes: 0,
       matchMinutes: 30,
-      constraints: {
+      constraints: cons({
         restMin: 0,
         noBackToBack: false,
         startWindows: [],
         restByGroup: { d1: 45 },
-      },
+      }),
     });
     expect(rests(conflicts)).not.toHaveLength(0);
   });
@@ -100,7 +114,7 @@ describe("validateAssignments — rest resolved the same way the solver resolves
       perEntrantMinRest: 20,
       gapMinutes: 0,
       matchMinutes: 30,
-      constraints: { restMin: 60, noBackToBack: true, startWindows: [] },
+      constraints: cons({ restMin: 60, noBackToBack: true, startWindows: [] }),
     });
     expect(rests(conflicts)).toHaveLength(0);
   });
@@ -118,11 +132,7 @@ describe("placer and verifier agree", () => {
   it("accepts what slotFixtures produces under the same constraints", () => {
     // The property that matters: a schedule the solver built must never be
     // reported as broken by the validator it is checked against.
-    const constraints = {
-      restMin: 45,
-      noBackToBack: true,
-      startWindows: [],
-    };
+    const constraints = cons({ restMin: 45, noBackToBack: true });
     const result = slotFixtures({
       fixtures: [
         { id: "f1", home: "A", away: "B" },

--- a/packages/engine/src/scheduling/calendar-windows.test.ts
+++ b/packages/engine/src/scheduling/calendar-windows.test.ts
@@ -14,6 +14,20 @@ const at = (startMin: number, extra: Partial<Assignment> = {}): Assignment[] => 
     ...extra,
   },
 ];
+
+/** The engine's SchedulingConstraints has required fields with zod defaults;
+ *  these tests only care about the rest-bearing ones, so fill the rest. */
+function cons(partial: Record<string, unknown>) {
+  return {
+    noBackToBack: false,
+    startWindows: [],
+    fieldFairness: "off" as const,
+    parallelism: "mixed" as const,
+    crossPersonClash: "warn" as const,
+    ...partial,
+  };
+}
+
 const windows = (cs: ReturnType<typeof validateAssignments>) =>
   cs.filter((c) => c.reason === "start_window");
 
@@ -23,12 +37,11 @@ const windows = (cs: ReturnType<typeof validateAssignments>) =>
 // match and ignored when someone dragged one, or when the AI referee checked a
 // plan the model produced.
 describe("validateAssignments — start windows", () => {
-  const constraints = {
-    noBackToBack: false,
+  const constraints = cons({
     startWindows: [
       { target: { kind: "entrant" as const, id: "A" }, notBefore: 60 * MIN, notAfter: 180 * MIN },
     ],
-  };
+  });
 
   it("flags a fixture starting before its entrant's window opens", () => {
     expect(windows(validateAssignments(at(30), { ...base, constraints }))).not.toHaveLength(0);
@@ -48,18 +61,16 @@ describe("validateAssignments — start windows", () => {
   });
 
   it("ignores windows aimed at somebody else", () => {
-    const other = {
-      noBackToBack: false,
+    const other = cons({
       startWindows: [{ target: { kind: "entrant" as const, id: "B" }, notBefore: 60 * MIN }],
-    };
+    });
     expect(windows(validateAssignments(at(0), { ...base, constraints: other }))).toHaveLength(0);
   });
 
   it("applies a pool-targeted window to assignments in that pool", () => {
-    const pooled = {
-      noBackToBack: false,
+    const pooled = cons({
       startWindows: [{ target: { kind: "pool" as const, id: "p1" }, notBefore: 60 * MIN }],
-    };
+    });
     expect(
       windows(validateAssignments(at(0, { poolId: "p1" }), { ...base, constraints: pooled })),
     ).not.toHaveLength(0);
@@ -69,20 +80,19 @@ describe("validateAssignments — start windows", () => {
   });
 
   it("takes the tightest bound when several windows target the same fixture", () => {
-    const stacked = {
-      noBackToBack: false,
+    const stacked = cons({
       startWindows: [
         { target: { kind: "entrant" as const, id: "A" }, notBefore: 60 * MIN },
         { target: { kind: "division" as const, id: "d1" }, notBefore: 120 * MIN },
       ],
-    };
+    });
     const a = at(90, { divisionId: "d1" });
     expect(windows(validateAssignments(a, { ...base, constraints: stacked }))).not.toHaveLength(0);
   });
 
   it("says nothing when no windows are configured", () => {
     expect(
-      windows(validateAssignments(at(0), { ...base, constraints: { noBackToBack: false, startWindows: [] } })),
+      windows(validateAssignments(at(0), { ...base, constraints: cons({}) })),
     ).toHaveLength(0);
   });
 });

--- a/packages/engine/src/scheduling/calendar-windows.test.ts
+++ b/packages/engine/src/scheduling/calendar-windows.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { validateAssignments, type Assignment } from "./calendar";
+
+const MIN = 60_000;
+const base = { perEntrantMinRest: 0, gapMinutes: 0, matchMinutes: 30 };
+const at = (startMin: number, extra: Partial<Assignment> = {}): Assignment[] => [
+  {
+    fixtureId: "x",
+    court: "C1",
+    startAt: startMin * MIN,
+    endAt: (startMin + 30) * MIN,
+    entrants: ["A"],
+    people: [],
+    ...extra,
+  },
+];
+const windows = (cs: ReturnType<typeof validateAssignments>) =>
+  cs.filter((c) => c.reason === "start_window");
+
+// startWindows are a hard bound in the solver — it refuses to place a fixture
+// outside its target's window (calendar.ts, `windowFor`). The verifier never
+// looked at them, so the same bound was enforced when Auto-schedule placed a
+// match and ignored when someone dragged one, or when the AI referee checked a
+// plan the model produced.
+describe("validateAssignments — start windows", () => {
+  const constraints = {
+    noBackToBack: false,
+    startWindows: [
+      { target: { kind: "entrant" as const, id: "A" }, notBefore: 60 * MIN, notAfter: 180 * MIN },
+    ],
+  };
+
+  it("flags a fixture starting before its entrant's window opens", () => {
+    expect(windows(validateAssignments(at(30), { ...base, constraints }))).not.toHaveLength(0);
+  });
+
+  it("flags a fixture starting after its entrant's window closes", () => {
+    expect(windows(validateAssignments(at(240), { ...base, constraints }))).not.toHaveLength(0);
+  });
+
+  it("accepts a fixture inside the window", () => {
+    expect(windows(validateAssignments(at(90), { ...base, constraints }))).toHaveLength(0);
+  });
+
+  it("bounds the START, not the finish — a match may run past notAfter", () => {
+    // Mirrors the solver, which compares `start > window.notAfter`.
+    expect(windows(validateAssignments(at(170), { ...base, constraints }))).toHaveLength(0);
+  });
+
+  it("ignores windows aimed at somebody else", () => {
+    const other = {
+      noBackToBack: false,
+      startWindows: [{ target: { kind: "entrant" as const, id: "B" }, notBefore: 60 * MIN }],
+    };
+    expect(windows(validateAssignments(at(0), { ...base, constraints: other }))).toHaveLength(0);
+  });
+
+  it("applies a pool-targeted window to assignments in that pool", () => {
+    const pooled = {
+      noBackToBack: false,
+      startWindows: [{ target: { kind: "pool" as const, id: "p1" }, notBefore: 60 * MIN }],
+    };
+    expect(
+      windows(validateAssignments(at(0, { poolId: "p1" }), { ...base, constraints: pooled })),
+    ).not.toHaveLength(0);
+    expect(
+      windows(validateAssignments(at(0, { poolId: "p2" }), { ...base, constraints: pooled })),
+    ).toHaveLength(0);
+  });
+
+  it("takes the tightest bound when several windows target the same fixture", () => {
+    const stacked = {
+      noBackToBack: false,
+      startWindows: [
+        { target: { kind: "entrant" as const, id: "A" }, notBefore: 60 * MIN },
+        { target: { kind: "division" as const, id: "d1" }, notBefore: 120 * MIN },
+      ],
+    };
+    const a = at(90, { divisionId: "d1" });
+    expect(windows(validateAssignments(a, { ...base, constraints: stacked }))).not.toHaveLength(0);
+  });
+
+  it("says nothing when no windows are configured", () => {
+    expect(
+      windows(validateAssignments(at(0), { ...base, constraints: { noBackToBack: false, startWindows: [] } })),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -426,7 +426,34 @@ export function validateAssignments(
   const board = [...existing, ...assignments];
   const byId = new Map(board.map((a) => [a.fixtureId, a]));
 
+  // startWindows (Jul3/04 §3) are a hard bound the solver refuses to place
+  // outside — so the verifier has to know them too, or the same rule holds for
+  // Auto-schedule and evaporates the moment somebody drags a card.
+  const windowFor = (a: Assignment): { notBefore: number; notAfter: number } => {
+    let notBefore = -Infinity;
+    let notAfter = Infinity;
+    for (const w of config.constraints?.startWindows ?? []) {
+      const hits =
+        (w.target.kind === "entrant" && a.entrants.includes(w.target.id)) ||
+        (w.target.kind === "pool" && a.poolId === w.target.id) ||
+        (w.target.kind === "division" && a.divisionId === w.target.id);
+      if (!hits) continue;
+      if (w.notBefore !== undefined) notBefore = Math.max(notBefore, w.notBefore);
+      if (w.notAfter !== undefined) notAfter = Math.min(notAfter, w.notAfter);
+    }
+    return { notBefore, notAfter };
+  };
+
   for (const a of assignments) {
+    // Bounds the START, matching the solver's `start > window.notAfter`.
+    const window = windowFor(a);
+    if (a.startAt < window.notBefore || a.startAt > window.notAfter) {
+      conflicts.push({
+        fixtureId: a.fixtureId,
+        reason: "start_window",
+        detail: "outside the target's start window",
+      });
+    }
     // Court clash / blackout — check against everything else on the board.
     const others = board.filter((o) => o !== a);
     if (courtBlocked(a.court, a.startAt, a.endAt - a.startAt, gapMs, others, blackouts) === "court") {

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -72,7 +72,11 @@ export interface Assignment {
  *  `constraints.restMin` — so whether a timetable was legal depended on which
  *  code path asked. */
 export function effectiveRestMinutes(
-  config: Pick<SlotConfig, "perEntrantMinRest" | "matchMinutes" | "gapMinutes" | "constraints">,
+  // matchMinutes is optional: validateAssignments is called with configs that
+  // carry no match length (the board's own callers, and every pre-existing
+  // caller), and noBackToBack is the only rule that needs it.
+  config: Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "constraints"> &
+    Partial<Pick<SlotConfig, "matchMinutes">>,
   group?: { poolId?: string; divisionId?: string },
 ): number {
   const c = config.constraints;

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -54,6 +54,40 @@ export interface Assignment {
   endAt: number;
   entrants: EntrantId[];
   people: string[];
+  poolId?: string; // restByGroup targeting when validating (Jul3/04 §3)
+  divisionId?: string;
+}
+
+/** The rest an entrant owes between two matches, in minutes — the strictest of
+ *  every source that can demand one:
+ *
+ *    perEntrantMinRest   the Settings tab ("the shape of the day")
+ *    constraints.restMin the Constraints tab ("a rule about entrants")
+ *    restByGroup         a per-pool / per-division override
+ *    noBackToBack        at least one whole fixture in between
+ *
+ *  Exported because the placer and the verifier must answer this question
+ *  identically. They used to disagree: `slotFixtures` took the max, the board's
+ *  validation read only `perEntrantMinRest`, and the AI referee read only
+ *  `constraints.restMin` — so whether a timetable was legal depended on which
+ *  code path asked. */
+export function effectiveRestMinutes(
+  config: Pick<SlotConfig, "perEntrantMinRest" | "matchMinutes" | "gapMinutes" | "constraints">,
+  group?: { poolId?: string; divisionId?: string },
+): number {
+  const c = config.constraints;
+  let minutes = config.perEntrantMinRest;
+  if (c?.restMin !== undefined) minutes = Math.max(minutes, c.restMin);
+  const byGroup =
+    (group?.poolId !== undefined ? c?.restByGroup?.[group.poolId] : undefined) ??
+    (group?.divisionId !== undefined ? c?.restByGroup?.[group.divisionId] : undefined);
+  if (byGroup !== undefined) minutes = Math.max(minutes, byGroup);
+  // "One fixture between" is only meaningful once we know how long a fixture
+  // is; callers that validate without a match length simply don't get it.
+  if (c?.noBackToBack && config.matchMinutes !== undefined) {
+    minutes = Math.max(minutes, config.matchMinutes + config.gapMinutes);
+  }
+  return minutes;
 }
 
 export type ConflictReason =
@@ -210,18 +244,9 @@ export function slotFixtures(input: SlotInput): SlotResult {
   const lastCourt = new Map<EntrantId, string>(); // fieldFairness=rotate
   const c = config.constraints;
 
-  // Jul3/04 §3: effective per-fixture rest — the strictest of the base rest,
-  // restMin, the fixture's group override, and the no-back-to-back gap.
-  const restForMs = (f: SchedulableFixture): number => {
-    let minutes = config.perEntrantMinRest;
-    if (c?.restMin !== undefined) minutes = Math.max(minutes, c.restMin);
-    const byGroup =
-      (f.poolId !== undefined ? c?.restByGroup?.[f.poolId] : undefined) ??
-      (f.divisionId !== undefined ? c?.restByGroup?.[f.divisionId] : undefined);
-    if (byGroup !== undefined) minutes = Math.max(minutes, byGroup);
-    if (c?.noBackToBack) minutes = Math.max(minutes, config.matchMinutes + config.gapMinutes);
-    return minutes * MS_PER_MIN;
-  };
+  // Jul3/04 §3 — shared with validateAssignments so the placer and the verifier
+  // can never drift apart on what "enough rest" means.
+  const restForMs = (f: SchedulableFixture): number => effectiveRestMinutes(config, f) * MS_PER_MIN;
 
   // startWindows (Jul3/04 §3): hard lower/upper bounds per entrant/pool/division.
   const windowFor = (f: SchedulableFixture): { notBefore: number; notAfter: number } => {
@@ -389,11 +414,11 @@ export function slotFixtures(input: SlotInput): SlotResult {
 // the same report.
 export function validateAssignments(
   assignments: readonly Assignment[],
-  config: Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts" | "sessionWindows">,
+  config: Pick<SlotConfig, "perEntrantMinRest" | "gapMinutes" | "blackouts" | "sessionWindows"> &
+    Partial<Pick<SlotConfig, "matchMinutes" | "constraints">>,
   existing: readonly Assignment[] = [],
   dependencies: readonly OrderDependency[] = [],
 ): Conflict[] {
-  const restMs = config.perEntrantMinRest * MS_PER_MIN;
   const gapMs = config.gapMinutes * MS_PER_MIN;
   const blackouts = config.blackouts ?? [];
   const windows = config.sessionWindows ?? [];
@@ -426,6 +451,8 @@ export function validateAssignments(
         if (overlaps(a.startAt, a.endAt, other.startAt, other.endAt)) {
           conflicts.push({ fixtureId: a.fixtureId, reason: "person_overlap", detail: `entrant ${e} overlap` });
         } else {
+          // Resolved per assignment: restByGroup can differ pool to pool.
+          const restMs = effectiveRestMinutes(config, a) * MS_PER_MIN;
           const gap = a.startAt >= other.endAt ? a.startAt - other.endAt : other.startAt - a.endAt;
           if (gap < restMs) {
             conflicts.push({ fixtureId: a.fixtureId, reason: "rest", detail: `entrant ${e} below rest` });


### PR DESCRIPTION
There are two engines. `slotFixtures` **places** fixtures; `validateAssignments` **verifies** them. The placer honoured the full constraint set; the verifier implemented a subset — and the verifier is what guards the board and the AI referee.

So the same timetable was legal or illegal depending on which door it came through.

### Rest was resolved three different ways

Rest is stored twice — `perEntrantMinRest` (Settings, the shape of the day) and `constraints.restMin` (Constraints, a rule about entrants):

| path | rest used | |
|---|---|---|
| `slotFixtures` | `max(both, restByGroup, noBackToBack)` | correct |
| board validation | `perEntrantMinRest` only | ignored `restMin` |
| AI referee | `constraints.restMin` only | ignored the other |

Mirror-image bugs, one cause. Set rest in Settings alone and **AI Schedule silently ignored it** while Auto-schedule enforced it; set it in Constraints alone and the board ignored it.

`effectiveRestMinutes` is now exported from the engine and used by both, so they cannot drift. `noBackToBack` and `restByGroup` come along free — the verifier never checked either.

The board needed **no change**: it already passes the whole `SlotConfig`, so widening the parameter type was enough. The AI pack did — it had no rest field at all, which is exactly how the referee ended up reading only one of the two.

### Start windows were placement-only

A hard bound in the solver, never read by the verifier. So the bound held when Auto-schedule placed a match and evaporated the moment somebody dragged one. Bounds the START, matching the solver, and takes the tightest of every window targeting the fixture (entrant, pool or division).

### crossPersonClash="hard" wasn't honoured

The organiser asked for a person double-booking to be *refused*, not badged. The solver refuses to place one; the board accepted a hand-placed clash, because `mapConflicts` decided blocking from the reason alone and never consulted the setting. Default is `warn`, so only orgs that opted in are affected.

### Not in this PR

`parallelism: "block"` (a division holding exclusive slots against siblings). It needs a `ConflictReason` the taxonomy doesn't have, pulling in a `REASON_CODE` entry and client labels in four locales — its own change.

Longer term the two rest fields should collapse into one, but only once the engine agrees, not before.

---

**Rollout note:** this surfaces violations that currently pass silently. That's correct but will read as a regression on existing schedules. Start windows report as a badge; only `crossPersonClash: "hard"` newly *blocks*, and only where it was explicitly set.

**Verified:** tsc clean; 108 engine tests, 470 web server tests. 16 new tests, 8 of which fail without the change (proven by stashing). The one `key-scopes.test.ts` failure fails identically on clean `main` — it's what #183 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)