### PR TITLE
fix(exports): unoverlap the footer QR, and point it at the public site

### DIFF
--- a/apps/web/src/app/api/v1/competitions/[id]/exports/tickets/route.ts
+++ b/apps/web/src/app/api/v1/competitions/[id]/exports/tickets/route.ts
@@ -18,9 +18,7 @@ export async function GET(req: Request, { params }: Ctx) {
     const url = new URL(req.url);
     const format = url.searchParams.get("format") ?? "pdf";
     if (format !== "pdf") throw new HttpError(400, "format must be pdf");
-    const model = await buildAdmitTicketsDoc(
-      auth, id, { printedAt: new Date().toISOString() }, url.origin,
-    );
+    const model = await buildAdmitTicketsDoc(auth, id, { printedAt: new Date().toISOString() });
     const bytes = await docModelToPdf(model);
     return new NextResponse(new Uint8Array(bytes), {
       headers: {

--- a/apps/web/src/app/api/v1/divisions/[id]/exports/[kind]/route.ts
+++ b/apps/web/src/app/api/v1/divisions/[id]/exports/[kind]/route.ts
@@ -30,7 +30,6 @@ export async function GET(req: Request, { params }: Ctx) {
     }
     const opts = {
       printedAt: new Date().toISOString(),
-      origin: url.origin,
       ...(url.searchParams.get("pageBreaks")
         ? { pageBreaks: Breaks.parse(url.searchParams.get("pageBreaks")) }
         : {}),

--- a/apps/web/src/app/api/v1/me/rota.pdf/route.ts
+++ b/apps/web/src/app/api/v1/me/rota.pdf/route.ts
@@ -9,10 +9,10 @@ import { docModelToPdf } from "@/server/doc-render";
  *  entitlement gate: the officiating portal is free, and the doc is scoped
  *  by getMyOfficiating(userId), never by org membership. Raw file response;
  *  errors keep the v1 envelope. */
-export async function GET(req: Request) {
+export async function GET() {
   try {
     const user = await requireUser();
-    const model = await buildMyRotaDoc(user.id, { printedAt: new Date().toISOString() }, new URL(req.url).origin);
+    const model = await buildMyRotaDoc(user.id, { printedAt: new Date().toISOString() });
     const bytes = await docModelToPdf(model);
     return new NextResponse(new Uint8Array(bytes), {
       headers: {

--- a/apps/web/src/server/__tests__/doc-render-footer-qr.test.ts
+++ b/apps/web/src/server/__tests__/doc-render-footer-qr.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The stock doc-render spy throws geometry away, which is exactly what this
+// bug lives in — so this one records the x/y/width of every draw.
+interface TextCall { s: string; x?: number; y?: number; opts?: { width?: number; align?: string } }
+interface ImageCall { x: number; y: number; width?: number }
+const rec = { text: [] as TextCall[], images: [] as ImageCall[] };
+
+vi.mock("pdfkit", () => {
+  class FakeDoc {
+    page = { width: 595.28, height: 841.89 };
+    y = 40;
+    private endCb?: () => void;
+    on(ev: string, cb: () => void) { if (ev === "end") this.endCb = cb; return this; }
+    registerFont() { return this; }
+    font() { return this; } fontSize() { return this; }
+    fillColor() { return this; } strokeColor() { return this; } lineWidth() { return this; }
+    text(s: unknown, x?: number, y?: number, opts?: TextCall["opts"]) {
+      rec.text.push({ s: String(s), ...(x !== undefined ? { x } : {}), ...(y !== undefined ? { y } : {}), ...(opts ? { opts } : {}) });
+      return this;
+    }
+    image(_b: unknown, x: number, y: number, opts?: { width?: number }) {
+      rec.images.push({ x, y, ...(opts?.width !== undefined ? { width: opts.width } : {}) });
+      return this;
+    }
+    rect() { return this; } roundedRect() { return this; } circle() { return this; }
+    moveTo() { return this; } lineTo() { return this; } stroke() { return this; }
+    fill() { return this; }
+    dash() { return this; } undash() { return this; } moveDown() { return this; }
+    addPage() { return this; } switchToPage() { return this; }
+    widthOfString() { return 10; }
+    bufferedPageRange() { return { start: 0, count: 1 }; }
+    end() { this.endCb?.(); }
+  }
+  return { default: FakeDoc };
+});
+
+import { docModelToPdf } from "../doc-render";
+import type { DocModel } from "@seazn/engine/exports";
+
+const MARGIN = 40;
+const PAGE_W = 595.28;
+
+const model = (liveUrl?: string): DocModel => ({
+  kind: "timetable",
+  title: "Summer League — Div 1",
+  meta: { printedAt: "2026-07-19", ...(liveUrl !== undefined ? { liveUrl } : {}) },
+  sections: [{ table: { columns: ["Time", "Home"], rows: [["09:00", "Falcons"]] } }],
+  pageBreaks: "auto",
+});
+
+async function render(m: DocModel) {
+  rec.text = [];
+  rec.images = [];
+  await docModelToPdf(m);
+  return rec;
+}
+
+// The live-page QR is drawn at the bottom-right of every page, and so is the
+// "Powered by seazn.club" attribution — both anchored to the same right edge,
+// at overlapping heights. On any export with a public live page the QR sat on
+// top of the wordmark, which is both ugly and a scanning risk: an obscured
+// finder pattern is a QR that phones refuse to read.
+describe("doc-render footer — QR and attribution", () => {
+  it("keeps the attribution clear of the QR when one is drawn", async () => {
+    const r = await render(model("https://seazn.club/shared/o/c/d"));
+    expect(r.images).toHaveLength(1);
+    const qr = r.images[0]!;
+    const qrLeft = qr.x;
+
+    const attribution = r.text.find((t) => t.s.includes("Powered by"));
+    expect(attribution).toBeDefined();
+    // Right-aligned inside a box starting at MARGIN, so its right edge is
+    // MARGIN + width. That edge must stop before the QR begins.
+    const right = (attribution!.x ?? 0) + (attribution!.opts?.width ?? 0);
+    expect(right).toBeLessThanOrEqual(qrLeft);
+  });
+
+  it("still uses the full width when there is no QR", async () => {
+    // Private competitions get no QR (the /shared page 404s), and the
+    // attribution should not be needlessly indented on those.
+    const r = await render(model());
+    expect(r.images).toHaveLength(0);
+    const attribution = r.text.find((t) => t.s.includes("Powered by"));
+    expect(attribution!.opts?.width).toBe(PAGE_W - MARGIN * 2);
+  });
+
+  it("draws the QR inside the page, above the footer baseline", async () => {
+    const r = await render(model("https://seazn.club/shared/o/c/d"));
+    const qr = r.images[0]!;
+    expect(qr.x + (qr.width ?? 0)).toBeLessThanOrEqual(PAGE_W - MARGIN);
+    expect(qr.y).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/server/doc-render.ts
+++ b/apps/web/src/server/doc-render.ts
@@ -448,10 +448,16 @@ export async function docModelToPdf(model: DocModel): Promise<Buffer> {
       MARGIN, fy, { width: doc.page.width - MARGIN * 2 - 90, lineBreak: false },
     );
     // platform attribution — every tier, every page (free tier otherwise
-    // carries no SEAZN identity at all since the masthead wordmark is Pro-only)
+    // carries no SEAZN identity at all since the masthead wordmark is Pro-only).
+    // Both this and the QR hang off the same right edge, and the QR's box
+    // (fy - 22, 28 wide) reaches past this baseline — so without giving way the
+    // code printed straight through the wordmark. An obscured finder pattern is
+    // also a QR that phones refuse to scan.
+    const qrGutter = qrPng ? 34 : 0; // 28pt code + 6pt breathing room
     doc.font(FONT.body).fontSize(7).fillColor(PALETTE.mute).text(
       "Powered by seazn.club",
-      MARGIN, fy, { width: doc.page.width - MARGIN * 2, align: "right", lineBreak: false },
+      MARGIN, fy,
+      { width: doc.page.width - MARGIN * 2 - qrGutter, align: "right", lineBreak: false },
     );
   }
   doc.end();

--- a/apps/web/src/server/usecases/__tests__/exports.test.ts
+++ b/apps/web/src/server/usecases/__tests__/exports.test.ts
@@ -180,19 +180,18 @@ describe.skipIf(!HAS_DB)("rich exports (Jul3/06)", () => {
       select slug from organizations where id = ${auth.orgId}`;
 
     // seedDivision creates the competition as visibility: "private" — its
-    // /shared/... page 404s, so no QR should be set even with an origin.
+    // /shared/... page 404s, so no QR belongs on it.
     const privateModel = await buildDivisionDocModel(auth, division.id, "timetable", {
-      printedAt: PRINTED, origin: "https://seazn.club",
+      printedAt: PRINTED,
     });
     expect(privateModel.meta.liveUrl).toBeUndefined();
 
-    // no origin at all (e.g. a test/caller that never threads one): still no QR.
+    // The origin is no longer threaded from the request: a QR is scanned by a
+    // phone that has to reach the public site, so it comes from siteOrigin()
+    // and visibility is the only thing that decides whether one is drawn.
     await sql`update competitions set visibility = 'public' where id = ${comp.id}`;
-    const noOrigin = await buildDivisionDocModel(auth, division.id, "timetable", { printedAt: PRINTED });
-    expect(noOrigin.meta.liveUrl).toBeUndefined();
-
     const model = await buildDivisionDocModel(auth, division.id, "timetable", {
-      printedAt: PRINTED, origin: "https://seazn.club",
+      printedAt: PRINTED,
     });
     expect(model.meta.liveUrl).toBe(
       `https://seazn.club/shared/${orgSlug}/${comp.slug}/${division.slug}`,
@@ -230,9 +229,7 @@ describe.skipIf(!HAS_DB)("rich exports (Jul3/06)", () => {
          ${randomUUID()}, ${"TIX-" + suffix})
       returning ref_code`;
 
-    const model = await buildAdmitTicketsDoc(
-      auth, comp.id, { printedAt: PRINTED }, "https://example.seazn.club",
-    );
+    const model = await buildAdmitTicketsDoc(auth, comp.id, { printedAt: PRINTED });
     expect(model.kind).toBe("admit_ticket");
     const ticket = model.sections[0]!.ticket!;
     expect(ticket.maskedName).toBeTruthy();
@@ -241,7 +238,7 @@ describe.skipIf(!HAS_DB)("rich exports (Jul3/06)", () => {
   });
 
   it("buildMyRotaDoc: SEAZN-neutral — no org branding", async () => {
-    const model = await buildMyRotaDoc(randomUUID(), { printedAt: PRINTED }, "https://example.seazn.club");
+    const model = await buildMyRotaDoc(randomUUID(), { printedAt: PRINTED });
     expect(model.kind).toBe("officials_rota");
     expect(model.branding).toBeUndefined();
   });
@@ -251,7 +248,7 @@ describe.skipIf(!HAS_DB)("rich exports (Jul3/06)", () => {
     const { division: freeDiv, comp: freeComp } = await seedDivision(freeAuth);
     const freeRota = await buildOfficialsRotaDoc(freeAuth, freeDiv.id, { printedAt: PRINTED });
     expect(freeRota.branding).toBeUndefined();
-    const freeTickets = await buildAdmitTicketsDoc(freeAuth, freeComp.id, { printedAt: PRINTED }, "https://example.seazn.club");
+    const freeTickets = await buildAdmitTicketsDoc(freeAuth, freeComp.id, { printedAt: PRINTED });
     expect(freeTickets.branding).toBeUndefined();
 
     const { auth: proAuth } = await seedOrg("pro");
@@ -260,7 +257,7 @@ describe.skipIf(!HAS_DB)("rich exports (Jul3/06)", () => {
       buildOfficialsRotaDoc(proAuth, proDiv.id, { printedAt: PRINTED }),
     ).resolves.toBeTruthy();
     await expect(
-      buildAdmitTicketsDoc(proAuth, proComp.id, { printedAt: PRINTED }, "https://example.seazn.club"),
+      buildAdmitTicketsDoc(proAuth, proComp.id, { printedAt: PRINTED }),
     ).resolves.toBeTruthy();
   });
 
@@ -295,7 +292,7 @@ describe.skipIf(!HAS_DB)("rich exports (Jul3/06)", () => {
     const a = await makeLinkedOfficial("Rota User A", fixtures[0]!.id); // Court 1
     await makeLinkedOfficial("Rota User B", fixtures[1]!.id); // Court 2
 
-    const model = await buildMyRotaDoc(a.userId, { printedAt: PRINTED }, "https://example.seazn.club");
+    const model = await buildMyRotaDoc(a.userId, { printedAt: PRINTED });
     const flat = JSON.stringify(model.sections);
     // A's own duty (Court 1) shows; B's fixture (Court 2) never leaks in.
     expect(flat).toContain("Court 1");

--- a/apps/web/src/server/usecases/exports.ts
+++ b/apps/web/src/server/usecases/exports.ts
@@ -37,6 +37,7 @@ import { participantRows } from "./clubs";
 import { resolveSponsors } from "./sponsors";
 import { getMyOfficiating } from "./me-officiating";
 import { eventRecorderNames, type AuditLedger } from "./fixtures";
+import { siteOrigin } from "@/lib/site-origin";
 
 type Tx = postgres.TransactionSql;
 
@@ -45,9 +46,6 @@ export interface ExportOpts {
   landscape?: boolean;
   blank?: boolean;
   printedAt: string; // request time — injected, never Date.now() in the engine
-  /** Request origin (Task 16) — used to build the `/shared/...` live-page
-   *  QR link on timetable/standings. Absent in tests that don't care. */
-  origin?: string;
 }
 
 interface DivisionMeta {
@@ -84,9 +82,9 @@ async function divisionMeta(tx: Tx, divisionId: string): Promise<DivisionMeta> {
 // v12/Task 16: the live-page QR only points somewhere reachable — a
 // `private` competition's `/shared/...` page 404s (V230 public_competitions_v
 // gate), so no QR when private. `public`/`unlisted` both resolve.
-function liveUrlFor(meta: DivisionMeta, origin: string | undefined): string | undefined {
-  if (origin === undefined || meta.visibility === "private") return undefined;
-  return `${origin}/shared/${meta.org_slug}/${meta.comp_slug}/${meta.div_slug}`;
+export function liveUrlFor(meta: Pick<DivisionMeta, "visibility" | "org_slug" | "comp_slug" | "div_slug">): string | undefined {
+  if (meta.visibility === "private") return undefined;
+  return `${siteOrigin()}/shared/${meta.org_slug}/${meta.comp_slug}/${meta.div_slug}`;
 }
 
 // Jul3/06 §6 / v12: branding (club colours, sponsor logos, tournament
@@ -211,7 +209,7 @@ export async function buildDivisionDocModel(
       ...(opts.landscape !== undefined ? { landscape: opts.landscape } : {}),
     };
 
-    const liveUrl = liveUrlFor(meta, opts.origin);
+    const liveUrl = liveUrlFor(meta);
 
     switch (kind) {
       case "timetable": {
@@ -561,7 +559,6 @@ export async function buildAdmitTicketsDoc(
   auth: AuthCtx,
   competitionId: string,
   opts: ExportOpts,
-  origin: string,
 ): Promise<DocModel> {
   await requireFeature(auth.orgId, "exports", competitionId);
   return withTenant(auth.orgId, async (tx) => {
@@ -575,7 +572,7 @@ export async function buildAdmitTicketsDoc(
       dates,
       ref: r.ref_code,
       status: r.status.toUpperCase(),
-      qrUrl: `${origin}/r/${r.ref_code}`,
+      qrUrl: `${siteOrigin()}/r/${r.ref_code}`,
       seq: i + 1,
     }));
     return buildAdmitTickets(meta.name, tickets, {
@@ -592,9 +589,7 @@ export async function buildAdmitTicketsDoc(
 export async function buildMyRotaDoc(
   userId: string,
   opts: ExportOpts,
-  origin: string,
 ): Promise<DocModel> {
-  void origin; // no per-fixture links in this doc yet — kept for signature parity
   const { assignments } = await getMyOfficiating(userId);
   const byOfficial = new Map<string, ExportOfficialSchedule>();
   for (const a of assignments) {


### PR DESCRIPTION
Two defects in the same PDF footer.

### The QR printed through the wordmark

The live-page QR is drawn at `(page.width - MARGIN - 28, fy - 22)`; the "Powered by seazn.club" attribution is right-aligned to the same edge at `fy`. Measured: the attribution's right edge landed at **555.28**, the QR started at **527.28** — a 28pt collision on every export with a public live page.

The attribution now yields 34pt (28pt code + 6pt gutter) when a QR is present, and keeps the full width when it isn't. Beyond looking wrong, an obscured finder pattern is a QR phones refuse to scan.

### The QR pointed at the wrong host

URLs were built from the request origin (`url.origin`), so a PDF generated in dev encoded `http://localhost:3000`, and one generated behind a proxy encodes whatever host the proxy presents. **A QR is scanned by a phone that has to reach the public site, so the request can never be the authority.**

Both the division live-page link and the admit-ticket `/r/<ref>` link now use `siteOrigin()` — the same `OAUTH_BASE_URL` / `NEXT_PUBLIC_BASE_URL` resolution the emails and canonicals already trust.

`origin` leaves `ExportOpts` and three route call sites entirely; one (`buildMyRotaDoc`) had been carrying it as `void origin` for "signature parity" without ever using it.

---

**Contract change:** `liveUrl` no longer depends on a caller threading an origin, so visibility alone decides whether a QR is drawn. Private competitions still get none — their `/shared` page 404s. The exports test asserting "no origin, no QR" is updated to match.

**Verified:** tsc clean, eslint clean, 55 server tests. The overlap test fails without the fix (proven by stashing) — the stock doc-render spy discards geometry, so this one records x/y/width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)