### PR TITLE
chore(schedule): retire the flexible scheduling mode

### DIFF
--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -129,8 +129,6 @@ export const PatchDivision = z
     status: DivisionStatus,
     /** Hide official names on all public reads (Jul3/02, 25 Jun). */
     officials_hide_names: z.boolean(),
-    /** Jul3/04 §4: 'flexible' = ordered fixtures, no clock. */
-    scheduling_mode: z.enum(["timed", "flexible"]),
     /** Jul3/08 §5: progression fires without a button (Pro formats.advanced). */
     auto_progress: z.boolean(),
     /** SPEC-2: draft a news post when results land (Pro `news.auto` on write). */

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
@@ -81,7 +81,6 @@ function teamsPack(): { pack: SchedulePack; movable: Set<string> } {
       name: "Saturday League",
       sport: "generic",
       tz: "Europe/London",
-      scheduling_mode: "timed",
     },
     settings: {
       matchMinutes: 30,
@@ -147,7 +146,6 @@ function individualsPack(): { pack: SchedulePack; movable: Set<string> } {
       name: "Club Championship",
       sport: "generic",
       tz: "Europe/London",
-      scheduling_mode: "timed",
     },
     settings: {
       matchMinutes: 45,

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-pack.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-pack.test.ts
@@ -234,16 +234,23 @@ describe.skipIf(!HAS_DB)("buildSchedulePack (v4/01 §2)", () => {
     ).rejects.toMatchObject({ status: 422, message: "AI_PLAN_EMPTY_SCOPE" });
   });
 
-  it("flexible division is 409 AI_PLAN_UNSUPPORTED", async () => {
+  // `scheduling_mode` used to gate this with a 409. The mode was never
+  // selectable — absent from the creation flow and from every screen, reachable
+  // only by hand-patching the API — so it shipped as three dead buttons for
+  // anyone who reached it. The column survives (dormant) until a later
+  // migration drops it; this proves nothing reads it any more.
+  it("packs a division regardless of the dormant scheduling_mode column", async () => {
     const comp = await createCompetition(auth, { name: "Flex", visibility: "public", branding: {} });
     const flex = await createDivision(auth, comp.id, {
       name: "Flexi", slug: "flexi", sport_key: "generic", variant_key: "score",
       config: GENERIC_CONFIG, eligibility: [],
     });
     await sql`update divisions set scheduling_mode = 'flexible' where id = ${flex.id}`;
+    // No fixtures, so the pack refuses on emptiness — not on the mode. Any
+    // outcome other than AI_PLAN_UNSUPPORTED proves the guard is gone.
     await expect(
       buildSchedulePack(auth, flex.id, { mode: "generate", instruction: "x" }),
-    ).rejects.toMatchObject({ status: 409, message: "AI_PLAN_UNSUPPORTED" });
+    ).rejects.not.toMatchObject({ message: "AI_PLAN_UNSUPPORTED" });
   });
 });
 

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -34,7 +34,7 @@ const E = (n: number) => `${n}${n}${n}${n}${n}${n}${n}${n}-${n}${n}${n}${n}-4${n
 function makePack(overrides: Partial<SchedulePack> = {}): SchedulePack {
   return {
     mode: "generate",
-    division: { id: "d1", name: "Open", sport: "generic", tz: "Europe/London", scheduling_mode: "timed" },
+    division: { id: "d1", name: "Open", sport: "generic", tz: "Europe/London" },
     settings: {
       matchMinutes: 30,
       gapMinutes: 0,

--- a/apps/web/src/server/usecases/__tests__/schedule-plus.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-plus.test.ts
@@ -7,11 +7,11 @@ import { sql } from "@/lib/db";
 import { invalidateOrgEntitlements } from "@/lib/entitlements";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { createCompetition } from "../competitions";
-import { createDivision, patchDivision } from "../divisions";
+import { createDivision } from "../divisions";
 import { createEntrants } from "../entrants";
 import { createStages, generateStageFixtures } from "../stages";
 import { patchFixture } from "../fixtures";
-import { putScheduleSettings, autoSchedule } from "../schedule";
+import { putScheduleSettings } from "../schedule";
 import { PutScheduleSettings } from "@/server/api-v1/schemas";
 import { undoDivision } from "../history";
 import {
@@ -114,7 +114,7 @@ describe.skipIf(!HAS_DB)("scheduling constraints v2 (Jul3/04)", () => {
     expect(report.worst[0]).toMatchObject({ display_name: "A", maxGapMinutes: 270 });
   });
 
-  it("constraint fields on schedule-settings are Pro; flexible mode blocks auto-scheduling", async () => {
+  it("constraint fields on schedule-settings are Pro", async () => {
     const { auth: freeAuth } = await seedOrg("community");
     const { division: freeDiv } = await seedDivision(freeAuth);
     await expect(
@@ -127,10 +127,5 @@ describe.skipIf(!HAS_DB)("scheduling constraints v2 (Jul3/04)", () => {
         }),
       ),
     ).rejects.toMatchObject({ featureKey: "scheduling.constraints" });
-
-    const { auth } = await seedOrg();
-    const { division, stage } = await seedDivision(auth);
-    await patchDivision(auth, division.id, { scheduling_mode: "flexible" });
-    await expect(autoSchedule(auth, stage.id, true)).rejects.toThrow(/flexible scheduling/);
   });
 });

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -180,7 +180,7 @@ export interface PackAssignment {
 
 export interface SchedulePack {
   mode: "generate" | "refine" | "repair";
-  division: { id: string; name: string; sport: string; tz: string; scheduling_mode: string };
+  division: { id: string; name: string; sport: string; tz: string };
   settings: PackSettings;
   entrants: PackEntrant[];
   people: PackPerson[];
@@ -228,7 +228,6 @@ function byAssignment(a: PackAssignment, b: PackAssignment): number {
  *
  * @returns the pack plus the set of fixture ids the LLM may place — later tasks
  *   reject any assignment id outside `movableIds`.
- * @throws HttpError 409 AI_PLAN_UNSUPPORTED (flexible division — no timetable),
  *   422 AI_PLAN_TOO_LARGE (>500 movable), 422 AI_PLAN_EMPTY_SCOPE (repair scope
  *   matched nothing), 400 (scope names a court that is not in settings.courts).
  */
@@ -243,17 +242,11 @@ export async function buildSchedulePack(
 
   return withTenant(auth.orgId, async (tx) => {
     const [division] = await tx<
-      { id: string; name: string; sport_key: string; scheduling_mode: string; competition_id: string }[]
+      { id: string; name: string; sport_key: string; competition_id: string }[]
     >`
-      select id, name, sport_key, scheduling_mode, competition_id
+      select id, name, sport_key, competition_id
       from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
-    // Flexible divisions are ordered, never clock-slotted (Jul3/04 §4) — there
-    // is no timetable for the architect to solve.
-    if (division.scheduling_mode === "flexible") {
-      throw new HttpError(409, "AI_PLAN_UNSUPPORTED", "AI_PLAN_UNSUPPORTED");
-    }
-
     const settings = await loadSettings(tx, divisionId);
     const config = settings.config;
     const tz = settings.tz;
@@ -571,7 +564,6 @@ export async function buildSchedulePack(
         name: division.name,
         sport: division.sport_key,
         tz,
-        scheduling_mode: division.scheduling_mode,
       },
       settings: settingsOut,
       entrants: packEntrants,

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -359,13 +359,6 @@ export async function autoSchedule(
       from stages s join divisions d on d.id = s.division_id
       where s.id = ${stageId}`;
     if (!stage) throw new HttpError(404, "stage not found");
-    const [divMode] = await tx<{ scheduling_mode: string }[]>`
-      select scheduling_mode from divisions where id = ${stage.division_id}`;
-    if (divMode?.scheduling_mode === "flexible") {
-      // Jul3/04 §4: flexible divisions are ordered, never clock-slotted
-      throw new HttpError(422, "this division uses flexible scheduling — no timetable to solve");
-    }
-
     const settings = await loadSettings(tx, stage.division_id);
     const all = await divisionFixtures(tx, stage.division_id);
     const { scopes } = await divisionLockState(tx, stage.division_id);

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -3478,13 +3478,6 @@
                   "officials_hide_names": {
                     "type": "boolean"
                   },
-                  "scheduling_mode": {
-                    "type": "string",
-                    "enum": [
-                      "timed",
-                      "flexible"
-                    ]
-                  },
                   "auto_progress": {
                     "type": "boolean"
                   },
@@ -51875,6 +51868,13 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 120
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "manual",
+                      "ai"
+                    ]
                   }
                 },
                 "required": [
@@ -51883,7 +51883,8 @@
                 "additionalProperties": false
               },
               "example": {
-                "label": "example"
+                "label": "example",
+                "kind": "manual"
               }
             }
           }
@@ -52053,6 +52054,207 @@
           },
           "404": {
             "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "sessionCookie": []
+          },
+          {
+            "apiKey": []
+          }
+        ]
+      }
+    },
+    "/api/v1/divisions/{id}/checkpoints/{checkpointId}": {
+      "delete": {
+        "summary": "Delete a save point — frees a quota slot when the save point is manual",
+        "tags": [
+          "history"
+        ],
+        "x-required-scope": "none",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "checkpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "data",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": true
+                    },
+                    "data": {},
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "example": {
+                  "ok": true,
+                  "data": {},
+                  "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "error",
+                    "requestId"
+                  ],
+                  "properties": {
+                    "ok": {
+                      "const": false
+                    },
+                    "error": {
+                      "type": "object",
+                      "required": [
+                        "code",
+                        "message"
+                      ],
+                      "properties": {
+                        "code": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "current_seq": {
+                          "type": "integer",
+                          "description": "On SEQ_CONFLICT (409): the ledger tip to resync from"
+                        }
+                      },
+                      "additionalProperties": true
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Error",
             "content": {
               "application/json": {
                 "schema": {

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -3213,13 +3213,6 @@
                   "officials_hide_names": {
                     "type": "boolean"
                   },
-                  "scheduling_mode": {
-                    "type": "string",
-                    "enum": [
-                      "timed",
-                      "flexible"
-                    ]
-                  },
                   "auto_progress": {
                     "type": "boolean"
                   },
@@ -37716,6 +37709,13 @@
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 120
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "manual",
+                      "ai"
+                    ]
                   }
                 },
                 "required": [
@@ -37724,7 +37724,8 @@
                 "additionalProperties": false
               },
               "example": {
-                "label": "example"
+                "label": "example",
+                "kind": "manual"
               }
             }
           }


### PR DESCRIPTION
`scheduling_mode` was never selectable.

It is absent from the division creation flow, absent from the Settings tab, and **no component in the app reads the column**. The only way to reach `'flexible'` was to hand-patch the v1 API.

What an organiser got if they managed it:

| action | behaviour |
|---|---|
| Auto-schedule | 422, does nothing |
| Re-flow remaining | 422, does nothing |
| AI Schedule | 409, does nothing |
| The board | **ignored the mode entirely** — hand-build a timetable anyway |

Three dead buttons and one inconsistency, guarding a mode nobody could choose.

### Removed
- the auto-schedule guard (`schedule.ts`) and the AI pack guard (`schedule-ai.ts`) — those paths now treat every division alike
- `scheduling_mode` from the AI pack, where it was sent to the model as metadata that no longer means anything
- `scheduling_mode` from `PatchDivision`, so nothing can set it again

### Kept
**The column stays, dormant**, until a later migration drops it. Guards are revertible from git; a dropped column with data is not. It remains on `DivisionOut` for the same reason.

This also closes a bug for free: the board never checked the mode, so retiring it makes that inconsistency disappear rather than needing its own fix.

---

**Note on the spec diff:** the regen also picks up pre-existing drift — checkpoint `kind` (`manual|ai`) from #181, which merged without a regen because the openapi gate is path-filtered and skips on `main`. Correct to include, but not part of this change.

**Data:** local dev shows 138 flexible divisions / 557 fixtures / **0 with times**, all of which look like test artifacts. Production was not checked — the user chose to proceed without it.

**Verified:** tsc clean; 470 server tests. The `key-scopes.test.ts` failure fails identically on clean `main` — it's what #183 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)