### PR TITLE
fix(wizard): stop the division wizard silently dropping its scheduling step

### DIFF
--- a/apps/web/content/help/getting-started/generate-fixtures.md
+++ b/apps/web/content/help/getting-started/generate-fixtures.md
@@ -12,7 +12,7 @@ Generating is **idempotent**: pressing it again after adding two late entrants o
 
 ## Times and courts
 
-Generated fixtures have an order but no clock until you schedule them. Use the **schedule board** to drag matches onto courts and times, or **Auto-schedule** to lay the whole day out in one pass, then fine-tune. Play hours, court counts and rest gaps live in the division's schedule settings. More in [The schedule board](/help/scheduling/board).
+Generated fixtures have an order but no clock until you schedule them. Use the **schedule board** to drag matches onto courts and times, or **Auto-schedule** to lay the whole day out in one pass, then fine-tune. Courts, match length and the start/end dates come from the **Scheduling** step you filled in when creating the division; play hours and rest gaps live in the division's schedule settings. More in [The schedule board](/help/scheduling/board).
 
 ## Common questions
 

--- a/apps/web/content/help/scheduling/constraints.md
+++ b/apps/web/content/help/scheduling/constraints.md
@@ -4,16 +4,17 @@ description: Play hours, rest gaps, court preferences — the rules Auto-schedul
 order: 4
 ---
 
-Constraints are the rules the auto-scheduler plays by. They live in the division's **schedule settings**.
+Constraints are the rules the auto-scheduler plays by. They live in the division's **schedule settings**. Courts, match length and the start/end dates are also asked once on the **Scheduling** step when you create the division — the settings panel is where you change them afterwards.
 
 ## The basics (all plans)
 
 - **Play hours** — when the venue is yours, per day.
-- **Courts** — how many, and what they're called.
+- **Courts** — what your court is called. More than one court in parallel is Pro.
 - **Match length** — how long a fixture blocks a court, derived from the sport but overridable.
 
 ## Finer control (Pro)
 
+- **Multiple courts** — run matches in parallel across a venue.
 - **Rest gaps** — minimum minutes between an entrant's matches.
 - **Unavailability** — "Rockets can't play before 10am Saturday".
 - **Court preferences** — finals on Court 1, wheelchairs on the accessible court.

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/new/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/new/page.tsx
@@ -5,6 +5,7 @@ import { requireCompetitionPage } from "@/server/page-auth";
 import { routes } from "@/lib/routes";
 import { getCompetition } from "@/server/usecases/competitions";
 import { withTenant } from "@/lib/db";
+import { hasFeature } from "@/lib/entitlements";
 import { DivisionBuilder, type SportOption } from "@/components/v2/division-builder";
 
 export default async function NewDivisionPage({
@@ -17,7 +18,12 @@ export default async function NewDivisionPage({
   const { auth, canEdit } = page;
   const id = page.competition.id;
   if (!canEdit) redirect(routes.competition(orgSlug, compSlug));
-  const competition = await getCompetition(auth, id);
+  const [competition, constraintsAllowed] = await Promise.all([
+    getCompetition(auth, id),
+    // A multi-venue schedule seed is Pro (doc 12 §5) — gate the list in the
+    // wizard rather than letting the settings PUT 402 after create.
+    hasFeature(auth.orgId, "scheduling.constraints"),
+  ]);
 
   // Sport catalog + variant presets (system rows are tenant-readable, org
   // presets scoped by RLS — doc 07).
@@ -47,7 +53,13 @@ export default async function NewDivisionPage({
         <p className="mb-6 text-sm text-slate-500">
           in <span className="font-medium">{competition.name}</span>
         </p>
-        <DivisionBuilder competitionId={id} orgSlug={orgSlug} compSlug={compSlug} sports={sports} />
+        <DivisionBuilder
+          competitionId={id}
+          orgSlug={orgSlug}
+          compSlug={compSlug}
+          sports={sports}
+          constraintsAllowed={constraintsAllowed}
+        />
       </main>
     </>
   );

--- a/apps/web/src/components/v2/__tests__/division-builder-schedule-seed.test.tsx
+++ b/apps/web/src/components/v2/__tests__/division-builder-schedule-seed.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { DivisionBuilder, buildScheduleSeed } from "@/components/v2/division-builder";
+import { msg } from "@/lib/messages";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import uiEn from "@/dictionaries/en/ui.json";
+import type { Dict } from "@/lib/i18n-constants";
+
+// Regression: the creation wizard's Scheduling step seeds schedule-settings
+// right after create. Two ways that seed used to be lost silently —
+//   1. the fallback venue was the hardcoded "Court 1", not the sport's noun;
+//   2. a >1 venue list trips usesConstraints() server-side, which 402s the
+//      WHOLE settings PUT for a Community org — so match length, start and end
+//      date were discarded too, with the wizard's `catch {}` hiding it.
+// The wizard now gates the venue list behind the Pro feature AND retries the
+// seed with a single venue if the first PUT fails.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/o/org/c/comp/d/new",
+}));
+
+const SPORTS = [
+  { key: "football", name: "Football", variants: [{ key: "standard", name: "Standard", system: true }] },
+];
+
+function render(constraintsAllowed: boolean): string {
+  return renderToStaticMarkup(
+    <DictProvider dict={uiEn as unknown as Dict} locale="en">
+      <DivisionBuilder
+        competitionId="c1"
+        orgSlug="org"
+        compSlug="comp"
+        sports={SPORTS}
+        constraintsAllowed={constraintsAllowed}
+      />
+    </DictProvider>,
+  );
+}
+
+describe("buildScheduleSeed — wizard schedule-settings seed", () => {
+  const input = {
+    courts: ["Pitch 1", "  Pitch 2  ", "  "],
+    matchMinutes: 90,
+    startAt: "2026-08-01T10:00",
+    endAt: "2026-08-03",
+    venueCap: "Pitch",
+  };
+
+  it("trims the venue list and converts the local inputs to ISO", () => {
+    const seed = buildScheduleSeed(input);
+    expect(seed.courts).toEqual(["Pitch 1", "Pitch 2"]);
+    expect(seed.matchMinutes).toBe(90);
+    expect(seed.startAt).toBe(new Date("2026-08-01T10:00").toISOString());
+    expect(seed.endAt).toBe(new Date("2026-08-03T23:59:00").toISOString());
+  });
+
+  it("falls back to the SPORT's venue noun, not a hardcoded Court 1", () => {
+    expect(buildScheduleSeed({ ...input, courts: ["", "   "] }).courts).toEqual(["Pitch 1"]);
+  });
+
+  it("singleVenue keeps dates + match length while dropping the extra venues", () => {
+    // The retry after a 402: everything the organiser typed survives except
+    // the part the plan actually gates.
+    const seed = buildScheduleSeed(input, { singleVenue: true });
+    expect(seed.courts).toEqual(["Pitch 1"]);
+    expect(seed.matchMinutes).toBe(90);
+    expect(seed.startAt).not.toBeNull();
+    expect(seed.endAt).not.toBeNull();
+  });
+
+  it("leaves unset dates null (a blank scheduling step is still valid)", () => {
+    const seed = buildScheduleSeed({ ...input, startAt: "", endAt: "" });
+    expect(seed.startAt).toBeNull();
+    expect(seed.endAt).toBeNull();
+  });
+});
+
+describe("DivisionBuilder — venue list gate", () => {
+  it("offers Add venue when the org has scheduling.constraints", () => {
+    const html = render(true);
+    expect(html).toContain(msg("boardset.addVenue", { venue: "pitch" }));
+    expect(html).not.toContain(msg("wizard.venuesProHint", { venue: "pitch" }));
+  });
+
+  it("replaces Add venue with the Pro hint + upgrade gate without the feature", () => {
+    const html = render(false);
+    expect(html).not.toContain(msg("boardset.addVenue", { venue: "pitch" }));
+    expect(html).toContain(msg("wizard.venuesProHint", { venue: "pitch" }));
+    // The same paywall component the schedule settings panel uses.
+    expect(html).toContain("/settings/billing");
+  });
+});

--- a/apps/web/src/components/v2/division-builder.tsx
+++ b/apps/web/src/components/v2/division-builder.tsx
@@ -84,17 +84,46 @@ const GENDERS: { key: string; labelKey: "wizard.gender.m" | "wizard.gender.f" | 
   { key: "x", labelKey: "wizard.gender.x" },
 ];
 
+/** The schedule-settings body the wizard seeds right after create (doc 12 §3).
+ *  `singleVenue` collapses the list to the first venue: more than one court
+ *  trips `usesConstraints()` server-side, which 402s the WHOLE PUT — dates and
+ *  match length included — for orgs without `scheduling.constraints`. */
+export function buildScheduleSeed(
+  input: {
+    courts: string[];
+    matchMinutes: number;
+    /** datetime-local value ("" = not set). */
+    startAt: string;
+    /** date value ("" = not set). */
+    endAt: string;
+    venueCap: string;
+  },
+  opts: { singleVenue?: boolean } = {},
+): { courts: string[]; matchMinutes: number; startAt: string | null; endAt: string | null } {
+  const clean = input.courts.map((c) => c.trim()).filter(Boolean);
+  const courts = clean.length > 0 ? clean : [`${input.venueCap} 1`];
+  return {
+    courts: opts.singleVenue ? courts.slice(0, 1) : courts,
+    matchMinutes: input.matchMinutes,
+    startAt: input.startAt ? new Date(input.startAt).toISOString() : null,
+    endAt: input.endAt ? new Date(`${input.endAt}T23:59:00`).toISOString() : null,
+  };
+}
+
 // ---------------------------------------------------------------------------
 export function DivisionBuilder({
   competitionId,
   orgSlug,
   compSlug,
   sports,
+  constraintsAllowed = true,
 }: {
   competitionId: string;
   orgSlug: string;
   compSlug: string;
   sports: SportOption[];
+  /** Pro `scheduling.constraints` — gates a multi-venue list (doc 12 §5). */
+  constraintsAllowed?: boolean;
 }) {
   const msg = useMsg();
   const locale = useLocale();
@@ -212,23 +241,31 @@ export function DivisionBuilder({
         json: stages,
       });
 
-      // Seed scheduling settings (courts / match length / start). Non-fatal:
+      // Seed scheduling settings (courts / match length / start+end). Non-fatal:
       // the board can set these later, so a failure here shouldn't block create.
-      const cleanCourts = courts.map((c) => c.trim()).filter(Boolean);
-      try {
-        await apiV1(`/api/v1/divisions/${division.id}/schedule-settings`, {
+      const seedInput = {
+        courts,
+        matchMinutes,
+        startAt: scheduleStart,
+        endAt: scheduleEnd,
+        venueCap: venueLabel(sportKey),
+      };
+      const putSeed = (config: ReturnType<typeof buildScheduleSeed>) =>
+        apiV1(`/api/v1/divisions/${division.id}/schedule-settings`, {
           method: "PUT",
-          json: {
-            config: {
-              courts: cleanCourts.length ? cleanCourts : ["Court 1"],
-              matchMinutes,
-              startAt: scheduleStart ? new Date(scheduleStart).toISOString() : null,
-              endAt: scheduleEnd ? new Date(`${scheduleEnd}T23:59:00`).toISOString() : null,
-            },
-          },
+          json: { config },
         });
+      try {
+        await putSeed(buildScheduleSeed(seedInput));
       } catch {
-        /* board settings are editable later — ignore */
+        // A multi-venue list needs Pro; without it the PUT 402s and the whole
+        // tab (dates + match length too) would vanish silently. Retry with a
+        // single venue so everything else still lands.
+        try {
+          await putSeed(buildScheduleSeed(seedInput, { singleVenue: true }));
+        } catch {
+          /* board settings are editable later — ignore */
+        }
       }
 
       router.push(routes.division(orgSlug, compSlug, division.slug));
@@ -752,15 +789,24 @@ export function DivisionBuilder({
               </li>
             ))}
           </ul>
-          <button
-            type="button"
-            onClick={() =>
-              setCourts((cs) => (cs.length < 50 ? [...cs, `${VenueCap} ${cs.length + 1}`] : cs))
-            }
-            className="btn btn-ghost mt-2 text-sm"
-          >
-            {msg("boardset.addVenue", { venue })}
-          </button>
+          {constraintsAllowed ? (
+            <button
+              type="button"
+              onClick={() =>
+                setCourts((cs) => (cs.length < 50 ? [...cs, `${VenueCap} ${cs.length + 1}`] : cs))
+              }
+              className="btn btn-ghost mt-2 text-sm"
+            >
+              {msg("boardset.addVenue", { venue })}
+            </button>
+          ) : (
+            // Pre-empt the 402: a >1 venue list is Pro (doc 12 §5), and the
+            // server refuses the whole settings PUT if the wizard sends one.
+            <div className="mt-2 space-y-1">
+              <p className="text-xs text-slate-400">{msg("wizard.venuesProHint", { venue })}</p>
+              <UpgradeGate feature="scheduling.constraints" compact />
+            </div>
+          )}
           <p className="mt-1 text-xs text-slate-400">
             {msg("wizard.venueCount", { n: courts.filter((c) => c.trim()).length || 1, venue })}
           </p>

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -1750,6 +1750,7 @@
   "wizard.schedulingHint": "Courts, match length and a start time for the timetable. You can change these later on the schedule board.",
   "wizard.matchLengthHint": "Pre-filled for the selected sport & variant — adjust if needed.",
   "wizard.endDateHint": "Sets how many days the schedule's week view spans.",
+  "wizard.venuesProHint": "One {venue} to start with — Pro unlocks parallel {venue}s.",
   "wizard.venueCount": "{n} {venue}",
   "wizard.cancel": "Cancel",
   "wizard.back": "Back",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -1705,6 +1705,7 @@
   "wizard.schedulingHint": "Canchas, duración del partido y una hora de inicio para el calendario. Puedes cambiarlo después en el tablero de programación.",
   "wizard.matchLengthHint": "Precargado para el deporte y la variante seleccionados; ajústalo si es necesario.",
   "wizard.endDateHint": "Define cuántos días abarca la vista semanal del calendario.",
+  "wizard.venuesProHint": "Empieza con una {venue}; Pro desbloquea varias {venue}s en paralelo.",
   "wizard.venueCount": "{n} {venue}",
   "wizard.cancel": "Cancelar",
   "wizard.back": "Atrás",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -1750,6 +1750,7 @@
   "wizard.schedulingHint": "Terrains, durée des matchs et heure de début pour le calendrier. Vous pourrez modifier ces éléments plus tard sur le tableau de programmation.",
   "wizard.matchLengthHint": "Pré-rempli selon le sport et la variante sélectionnés — à ajuster si nécessaire.",
   "wizard.endDateHint": "Définit le nombre de jours couverts par la vue hebdomadaire du calendrier.",
+  "wizard.venuesProHint": "Un seul {venue} pour commencer — Pro débloque plusieurs {venue}s en parallèle.",
   "wizard.venueCount": "{n} {venue}",
   "wizard.cancel": "Annuler",
   "wizard.back": "Retour",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -1705,6 +1705,7 @@
   "wizard.schedulingHint": "Velden, wedstrijdduur en een starttijd voor het schema. Je kunt deze later aanpassen op het schemabord.",
   "wizard.matchLengthHint": "Vooraf ingevuld voor de geselecteerde sport & variant — pas aan indien nodig.",
   "wizard.endDateHint": "Bepaalt over hoeveel dagen de weekweergave van het schema loopt.",
+  "wizard.venuesProHint": "Begin met één {venue} — Pro ontgrendelt meerdere {venue}s parallel.",
   "wizard.venueCount": "{n} {venue}",
   "wizard.cancel": "Annuleren",
   "wizard.back": "Terug",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -3131,4 +3131,5 @@ export type DictionaryKey =
   | "wizard.tab.format"
   | "wizard.tab.scheduling"
   | "wizard.variant"
-  | "wizard.venueCount";
+  | "wizard.venueCount"
+  | "wizard.venuesProHint";


### PR DESCRIPTION
The division wizard's Scheduling step collects courts, match length, start date and end date, then seeds them with `PUT /divisions/:id/schedule-settings` right after create.

That PUT is wrapped in a bare `catch { /* board settings are editable later — ignore */ }`.

And `usesConstraints()` (`schedule.ts:81`) returns true when **`config.courts.length > 1`** — a second court is a Pro feature.

So a Community organiser who adds a second venue in the wizard gets a 402 on the whole settings PUT, the catch swallows it, and they lose **match length, start date and end date too** — none of which had anything to do with the Pro gate. Silently, with no error shown.

### Fixed
- venue list gated behind `constraintsAllowed` — an `UpgradeGate` and a hint instead of an "Add venue" button that leads to a silent 402
- the seed retries with a single venue if the PUT fails, so the rest of the step survives
- fallback venue uses the sport's own noun rather than a hardcoded `"Court 1"`
- help pages corrected: they claimed multi-court was available on all plans, and neither mentioned that the wizard's Scheduling step sets these

### Scope note
The original brief asked to *move* these fields from Settings into the wizard. They were already in the wizard — and `board/settings-panel.tsx` is the only post-create editor for them, so removing them there would have left no way to move a rained-off start date or rename a venue. Not done, deliberately.

Play hours deliberately stay out of the wizard: empty means all hours playable, and the answer is better made on the board with the timetable in front of you than guessed before any fixtures exist.

**Wizard field count: 4 before, 4 after.**

---

Spotted, not fixed: the venues label pluralises naively — football renders "Pitchs".

**Verified:** tsc clean; 551 tests pass across `src/lib` and `src/components/v2`. 6 new tests; **5 fail without the fix**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)