### PR TITLE
Charge the currency we quoted: disable Stripe Adaptive Pricing

### DIFF
--- a/apps/web/src/lib/__tests__/billing-checkout.test.ts
+++ b/apps/web/src/lib/__tests__/billing-checkout.test.ts
@@ -34,6 +34,7 @@ import {
 } from "@/lib/currency";
 import { HttpError } from "@/lib/errors";
 import { checkoutSchema } from "@/lib/types";
+import seed from "@/config/stripe-plans.json";
 
 const base = {
   priceId: "price_123",
@@ -80,12 +81,55 @@ describe("buildEmbeddedCheckoutParams", () => {
     expect("customer" in withEmail).toBe(false);
   });
 
-  it("sets the session currency for non-usd, omits it for usd/default", () => {
-    const eur = buildEmbeddedCheckoutParams({ ...base, currency: "eur" });
-    expect(eur.currency).toBe("eur");
-    const usd = buildEmbeddedCheckoutParams({ ...base, currency: "usd" });
-    expect("currency" in usd).toBe(false);
-    expect("currency" in buildEmbeddedCheckoutParams(base)).toBe(false);
+  // The actual fix for the quoted-vs-charged mismatch. Adaptive Pricing is ON
+  // by default and converts at RENDER time from the customer's IP, so a session
+  // created as usd/15900 still displayed £125.00 in the iframe. Verified live
+  // 2026-07-20 that `currency` alone does NOT suppress it — only this flag.
+  it("disables Stripe Adaptive Pricing on both checkout flows", () => {
+    expect(buildEmbeddedCheckoutParams(base).adaptive_pricing).toEqual({ enabled: false });
+    expect(
+      buildPassCheckoutParams({
+        priceId: "price_pass",
+        orgId: "org-abc",
+        competitionId: "comp-1",
+        returnUrl: base.returnUrl,
+        customerEmail: "a@b.com",
+      }).adaptive_pricing,
+    ).toEqual({ enabled: false });
+  });
+
+  // Previously this asserted the opposite for usd — that the key was OMITTED.
+  // Explicitness is not what fixes the bug (see the Adaptive Pricing test
+  // above); it makes the session state the currency WE picked rather than
+  // leaving it implicit.
+  it("always sends an explicit currency, usd included", () => {
+    expect(buildEmbeddedCheckoutParams({ ...base, currency: "eur" }).currency).toBe("eur");
+    expect(buildEmbeddedCheckoutParams({ ...base, currency: "usd" }).currency).toBe("usd");
+    // No currency from the caller still means an explicit usd on the wire, not
+    // an absent key — an absent key is the bug.
+    expect(buildEmbeddedCheckoutParams(base).currency).toBe("usd");
+    expect("currency" in buildEmbeddedCheckoutParams(base)).toBe(true);
+  });
+
+  // Every currency the app can hand these builders must exist in the price's
+  // currency_options, or checkout 400s at runtime. This pins the two lists
+  // together so widening one without the other fails here rather than live.
+  it("only ever sends a currency the seed prices actually define", () => {
+    // Every price the builders can target, not just the first: a currency
+    // missing from ANY of them is a 400 on that specific checkout.
+    const priceOptionSets = [
+      ...seed.plans.flatMap((p) => [p.prices.monthly, p.prices.annual]),
+      ...seed.passes.map((p) => p.price),
+    ].map((p) => new Set([seed.currency, ...Object.keys(p.currency_options)]));
+
+    const missing: string[] = [];
+    for (const c of SUPPORTED_CURRENCIES) {
+      priceOptionSets.forEach((opts, i) => {
+        if (!opts.has(c)) missing.push(`${c} missing from price #${i}`);
+      });
+      expect(buildEmbeddedCheckoutParams({ ...base, currency: c }).currency).toBe(c);
+    }
+    expect(missing).toEqual([]);
   });
 });
 
@@ -142,9 +186,12 @@ describe("buildPassCheckoutParams (v3/07 §3)", () => {
     expect("payment_method_collection" in p).toBe(false);
   });
 
-  it("honours the currency switch like the subscription flow", () => {
+  it("honours the currency switch like the subscription flow, usd included", () => {
     expect(buildPassCheckoutParams({ ...pass, currency: "inr" }).currency).toBe("inr");
-    expect("currency" in buildPassCheckoutParams({ ...pass, currency: "usd" })).toBe(false);
+    // Was asserted absent before; an absent currency is what let Stripe's
+    // adaptive pricing charge a currency the page never quoted.
+    expect(buildPassCheckoutParams({ ...pass, currency: "usd" }).currency).toBe("usd");
+    expect(buildPassCheckoutParams(pass).currency).toBe("usd");
   });
 });
 

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -42,7 +42,7 @@ export function buildEmbeddedCheckoutParams(args: {
   customerId?: string;
   customerEmail?: string;
   /** ISO currency picking one of the price's currency_options (v3/07 §4);
-   *  omit for the price's default (usd). */
+   *  defaults to usd, and is ALWAYS sent — see the note on the field below. */
   currency?: string;
 }): Stripe.Checkout.SessionCreateParams {
   return {
@@ -50,7 +50,21 @@ export function buildEmbeddedCheckoutParams(args: {
     ui_mode: "embedded_page",
     mode: "subscription",
     ...(args.customerId ? { customer: args.customerId } : { customer_email: args.customerEmail }),
-    ...(args.currency && args.currency !== "usd" ? { currency: args.currency } : {}),
+    // Always sent, usd included, so the session states the currency WE chose
+    // via preferredCurrency (subscription → cookie → Accept-Language) instead
+    // of leaving it implicit. Safe for every value isSupportedCurrency accepts:
+    // usd/eur/gbp/inr/aud all exist in every price's currency_options (verified
+    // against live Stripe 2026-07-20). A currency a price LACKS is a 400 at
+    // checkout, so those two lists must stay in step — see stripe-plans.json.
+    currency: args.currency ?? "usd",
+    // This is the one that actually fixes the reported bug. Stripe's Adaptive
+    // Pricing is ON by default and converts at RENDER time from the customer's
+    // IP: the billing page quoted $13.25/mo while the embedded checkout charged
+    // £125.00/yr for a UK visitor. Verified live 2026-07-20 — the session came
+    // back currency=usd amount_total=15900 with the currency both omitted AND
+    // explicitly usd, so setting `currency` alone does NOT stop it. Only this
+    // flag does. We quote in one currency; we must charge in that currency.
+    adaptive_pricing: { enabled: false },
     metadata: { org_id: args.orgId },
     ...(args.trialDays > 0 ? { payment_method_collection: "if_required" as const } : {}),
     subscription_data: {
@@ -133,7 +147,11 @@ export function buildPassCheckoutParams(args: {
     ui_mode: "embedded_page",
     mode: "payment",
     ...(args.customerId ? { customer: args.customerId } : { customer_email: args.customerEmail }),
-    ...(args.currency && args.currency !== "usd" ? { currency: args.currency } : {}),
+    // Both for the same reason as the subscription flow above: state our own
+    // currency, and stop Adaptive Pricing re-quoting the pass at render time in
+    // whatever currency the buyer's IP suggests.
+    currency: args.currency ?? "usd",
+    adaptive_pricing: { enabled: false },
     metadata: { org_id: args.orgId, competition_id: args.competitionId, pass_key: "event_pass" },
     line_items: [{ price: args.priceId, quantity: 1 }],
     return_url: args.returnUrl,


### PR DESCRIPTION
The billing page advertised **$13.25/mo billed yearly** while the embedded checkout it opened charged **£125.00 per year**. Found by driving the real checkout in a browser.

## The cause was not what it looked like

The obvious theory — that we omit `currency` for USD visitors and Stripe fills the gap — is **wrong**, and I verified it against live Stripe before writing the fix:

| session created with | `session.currency` | `amount_total` |
|---|---|---|
| currency omitted | `usd` | 15900 |
| `currency=usd` explicit | `usd` | 15900 |
| `currency=gbp` explicit | `gbp` | 12500 |

The session was **already USD** in both cases. Sending the currency explicitly changes nothing.

The real cause is **Stripe Adaptive Pricing**, which is on by default — sessions come back with `adaptive_pricing: {enabled: true}` — and re-quotes at **render** time from the customer's IP. So a USD session displayed pounds in the iframe. Only `adaptive_pricing.enabled = false` suppresses it.

## What changed

Both checkout builders (`buildEmbeddedCheckoutParams`, `buildPassCheckoutParams`) now:

- set `adaptive_pricing: { enabled: false }` — **this is the fix**;
- send `currency` explicitly including `usd` — *not* what fixes the mismatch, but it makes the session state the currency `preferredCurrency` actually chose (subscription → cookie → Accept-Language) instead of leaving it implicit.

## Safety of always sending a currency

A currency a price doesn't define is a **400 at checkout**, so this only holds while the two lists agree. Verified live: `SUPPORTED_CURRENCIES` is `[usd, eur, gbp, inr, aud]`, and every seeded price carries `currency_options` of exactly `{aud, eur, gbp, inr, usd}`.

A new test pins those together across **every** plan and pass price — not just the first — so widening one list without the other fails in CI rather than at a customer's checkout.

## Tests

- `billing-checkout.test.ts` 20 passed; broader `lib` + `usecases` suites **1136 passed / 0 failed**; `tsc` clean.
- RED proven: reverting the production change fails 3 of the new tests (16 pass / 3 fail).
- Two existing tests asserted the old behaviour — that the `currency` key was *absent* for USD. They now assert the opposite, with the reason recorded inline rather than being deleted.

## Note for review

Disabling Adaptive Pricing is a **product decision**, not just a bug fix: a visitor whose IP suggests one currency but whose `Accept-Language` suggests another will now be quoted and charged in *our* choice, consistently, rather than being shown a locally-converted price at the last step. That consistency is the point — but it does mean fewer buyers see their home currency unless `preferredCurrency` picks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
