### PR TITLE
test(e2e): follow #189 — retired scheduling_mode, moved exports, new rules copy

### DIFF
--- a/apps/web/e2e/schedule-board.spec.ts
+++ b/apps/web/e2e/schedule-board.spec.ts
@@ -333,7 +333,14 @@ test.describe.serial("schedule board", () => {
     expect(started.data!.status).toBe("active");
   });
 
-  test("flexible divisions have no timetable to solve (422 on auto)", async ({ request }) => {
+  // `scheduling_mode` is retired (#189): no screen ever offered it, so the
+  // only way to reach 'flexible' was to hand-patch the v1 API — which then
+  // dead-ended Auto-schedule (422) and AI Schedule (409) while the board let
+  // you hand-build a timetable anyway. PatchDivision no longer accepts the
+  // field, and auto treats every division alike.
+  test("scheduling_mode is retired: the PATCH is rejected and auto still solves", async ({
+    request,
+  }) => {
     const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
       name: `Flex ${TAG}`,
       visibility: "private",
@@ -353,7 +360,7 @@ test.describe.serial("schedule board", () => {
     const patched = await apiJson(request, `/api/v1/divisions/${div.data!.id}`, "PATCH", {
       scheduling_mode: "flexible",
     });
-    expect(patched.status).toBe(200);
+    expect(patched.status).toBe(400);
     const stage = await apiJson<{ id: string }>(request, `/api/v1/divisions/${div.data!.id}/stages`, "POST", {
       seq: 1,
       kind: "league",
@@ -362,7 +369,7 @@ test.describe.serial("schedule board", () => {
     await apiJson(request, `/api/v1/stages/${stage.data!.id}/generate`, "POST");
 
     const auto = await apiJson(request, `/api/v1/stages/${stage.data!.id}/schedule/auto`, "POST", {});
-    expect(auto.status).toBe(422);
+    expect(auto.status).toBe(200);
   });
 });
 

--- a/apps/web/e2e/schedule-panels.spec.ts
+++ b/apps/web/e2e/schedule-panels.spec.ts
@@ -4,12 +4,20 @@ import { apiJson, seedScoredDivision, setOrgPlanBySql, TAG } from "./helpers";
 // PROMPT-22/23/24/26 schedule console (now tabbed): each panel mounts on its
 // tab AND its core interaction works end-to-end (real POSTs, not just render).
 
-test("tabs mount: board exports + each panel", async ({ page, request }) => {
+test("tabs mount: board + each panel, exports in the Documents menu", async ({ page, request }) => {
   const { divisionId } = await seedScoredDivision(request);
 
   await page.goto(`/divisions/${divisionId}/schedule?tab=board`);
-  await expect(page.getByRole("link", { name: /timetable pdf/i })).toBeVisible({ timeout: 20_000 });
-  await expect(page.getByRole("link", { name: /participants xlsx/i })).toBeVisible();
+  await expect(page.getByRole("group", { name: /board density/i })).toBeVisible({ timeout: 20_000 });
+
+  // #189 moved the five loose export buttons off this header into the
+  // Documents menu on the fixtures view — one home for every document — so
+  // that is where the timetable and the participants sheet now live.
+  await page.goto(`/divisions/${divisionId}`);
+  await page.getByTestId("documents-menu-trigger").click();
+  const documents = page.getByRole("menu", { name: /documents/i });
+  await expect(documents.getByText("Order of play")).toBeVisible({ timeout: 20_000 });
+  await expect(documents.getByText("Participants")).toBeVisible();
 
   await page.goto(`/divisions/${divisionId}/schedule?tab=officials`);
   await expect(page.getByRole("heading", { name: "Officials", exact: true })).toBeVisible();
@@ -74,7 +82,7 @@ test("constraints (PROMPT-24): edits save and persist across reload", async ({ p
   const { divisionId } = await seedScoredDivision(request);
   await page.goto(`/divisions/${divisionId}/schedule?tab=constraints`);
 
-  const clash = page.getByLabel(/never be in two matches at once/i);
+  const clash = page.getByLabel(/never in two matches at once/i);
   const rest = page.getByRole("spinbutton", { name: /minimum rest/i });
   await expect(clash).toBeVisible({ timeout: 20_000 });
   const startChecked = await clash.isChecked();
@@ -91,7 +99,7 @@ test("constraints (PROMPT-24): edits save and persist across reload", async ({ p
 
   // persisted server-side: a fresh load reflects both edits
   await page.reload();
-  await expect(page.getByLabel(/never be in two matches at once/i)).toBeChecked({
+  await expect(page.getByLabel(/never in two matches at once/i)).toBeChecked({
     checked: !startChecked,
     timeout: 20_000,
   });


### PR DESCRIPTION
Main's E2E run ([29783945673](https://github.com/ashokhein/seazn.club/actions/runs/29783945673)) failed on three specs. All three are assertions #189 deliberately invalidated — no product bug.

| Spec | Was | Now |
|---|---|---|
| `schedule-board.spec.ts:336` | `PATCH {scheduling_mode:"flexible"}` → 200, `auto` → 422 | 400 and 200 — the field left `PatchDivision` and the guard left `autoSchedule` |
| `schedule-panels.spec.ts:7` | "Timetable PDF" / "Participants XLSX" links in the schedule header | board tab asserts the board mounted; exports asserted in the Documents menu where they moved |
| `schedule-panels.spec.ts:73` | "A player **can** never be in two matches at once" | "A player **is** never in two matches at once" (Constraints rebuilt as a rules sheet) |

The retired-mode test keeps its shape and pins the retirement instead of deleting the coverage: the PATCH is rejected, and auto solves a division that used to dead-end.

The Documents menu had no e2e coverage at all before this — it is now opened for real and its rows asserted.

## Verification

Local production build (`next build` + `next start`) against a V305 database:

```
18 passed (12.2s)
```

both specs, `--project=parallel`. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)