### PR TITLE
test(e2e): log the claiming player in the way the claim page does

### DIFF
--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -89,13 +89,24 @@ export async function mintLoginPathBySql(email: string): Promise<string> {
  * Requests a magic link and opens the dev-exposed URL to establish the session;
  * an unknown email auto-creates the account. Production targets skip the route
  * (it would email a real — bouncing — address) and mint the token in the DB.
+ *
+ * `next` is the post-login redirect, and it is not cosmetic: a bare login runs
+ * the org-resolution branch, which auto-provisions "My organization" for a user
+ * who belongs to none. Every real entry point that logs someone in on their way
+ * somewhere (claim, join, invite pages) carries one, so a spec that skips it
+ * quietly turns its player into an organiser.
  */
-export async function loginUi(page: Page, email: string): Promise<void> {
+export async function loginUi(page: Page, email: string, next?: string): Promise<void> {
   let loginUrl: string | undefined;
   if (PROD_TARGET) {
+    // mintLoginPathBySql writes the token row only; the route appends `next`
+    // to the URL it emails, so do the same here.
     loginUrl = await mintLoginPathBySql(email);
+    if (next) loginUrl += `&next=${encodeURIComponent(next)}`;
   } else {
-    const res = await page.request.post("/api/auth/magic-link", { data: { email } });
+    const res = await page.request.post("/api/auth/magic-link", {
+      data: next ? { email, next } : { email },
+    });
     loginUrl = ((await res.json()) as { data?: { login_url?: string } }).data?.login_url;
   }
   if (!loginUrl) throw new Error("magic-link login_url missing — dev server required");

--- a/apps/web/e2e/player-accounts.spec.ts
+++ b/apps/web/e2e/player-accounts.spec.ts
@@ -117,7 +117,12 @@ test.describe("player accounts (PROMPT-53)", () => {
     const viewport = playerPage.viewportSize()!;
     expect(Math.abs(cardBox.x + cardBox.width / 2 - viewport.width / 2)).toBeLessThan(3);
 
-    await loginUi(playerPage, playerEmail);
+    // The claim page's AuthForm carries next=/claim/<token>, and that is what
+    // keeps a claiming player player-only: a login with no `next` falls
+    // through to the org-resolution branch and hands them "My organization"
+    // (the person link they are about to make does not exist yet, so
+    // isPlayerOnly is false at this moment). Mirror the real flow.
+    await loginUi(playerPage, playerEmail, claimUrl.slice(claimUrl.indexOf("/claim/")));
     await playerPage.goto(claimUrl);
     await playerPage.getByRole("button", { name: /This is me/ }).click();
     await playerPage.waitForURL(/\/me\?claimed=1/);


### PR DESCRIPTION
`player-accounts.spec.ts:249` (growth nudge) has failed on **every** main E2E run since #171 gated the `/me` nudges on "user has no org" — [#183](https://github.com/ashokhein/seazn.club/actions/runs/29778884709), [#182](https://github.com/ashokhein/seazn.club/actions/runs/29746856210), [#191](https://github.com/ashokhein/seazn.club/actions/runs/29783007847). It was never a flake, and #192 only unblocked the parallel phase, so it is next in line.

## Root cause

`loginUi` mints a bare magic link — no `next`. A bare login falls through to the org-resolution branch in `resolveLoginLanding`, which auto-provisions "My organization" for a user who belongs to none. The player-only escape hatch above it cannot fire yet: it asks `isPlayerOnly`, which needs a `persons` row linked to the user, and the claim that creates that link is the *very next step*.

So the spec's player reached `/me` holding an org, and the nudge was correctly hidden. The failure screenshot shows a `← Console` link in her header — the tell.

**Nothing is broken in the product.** The real claim page renders `<AuthForm next={/claim/${token}} />`, and a login carrying `next` returns early without provisioning anything. The spec just wasn't logging in the way the page it tests does.

## Fix

`loginUi` takes an optional `next` — the route already accepts one, the SQL-mint lane appends it to the URL the same way — and the claim spec passes the claim path. Other callers are unchanged.

## Verification

Local production build (`next build` + `next start`) against a V305 database:

```
10 passed (11.3s)
```

`--project=serial e2e/player-accounts.spec.ts --workers=1`, growth nudge included. Fails without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)