### PR TITLE
fix(billing): stop sending a param pair Stripe refuses on every plan change

### DIFF
--- a/apps/web/src/lib/__tests__/billing-manage.test.ts
+++ b/apps/web/src/lib/__tests__/billing-manage.test.ts
@@ -40,14 +40,13 @@ describe("buildSetupIntentParams", () => {
 });
 
 describe("buildIntervalPreviewParams / buildIntervalChangeParams", () => {
-  it("previews an immediate anchored switch with the pinned proration_date", () => {
+  it("previews an immediate switch with the pinned proration_date", () => {
     const p = buildIntervalPreviewParams(change);
     expect(p.customer).toBe("cus_1");
     expect(p.subscription).toBe("sub_1");
     expect(p.subscription_details).toEqual({
       items: [{ id: "si_1", price: "price_annual" }],
       proration_behavior: "always_invoice",
-      billing_cycle_anchor: "now",
       proration_date: change.prorationDate,
     });
   });
@@ -56,10 +55,30 @@ describe("buildIntervalPreviewParams / buildIntervalChangeParams", () => {
     const p = buildIntervalChangeParams(change);
     expect(p.items).toEqual([{ id: "si_1", price: "price_annual" }]);
     expect(p.proration_behavior).toBe("always_invoice");
-    expect(p.billing_cycle_anchor).toBe("now");
     expect(p.proration_date).toBe(change.prorationDate);
     expect(p.payment_behavior).toBe("allow_incomplete");
     expect(p.expand).toEqual(["latest_invoice.confirmation_secret"]);
+  });
+
+  // Stripe rejects the pair outright: "You cannot specify `proration_date`
+  // when `billing_cycle_anchor=now`". Both builders shipped it for months —
+  // the shape assertions above were happy, because a param object cannot tell
+  // you the API refuses it. This is the rule itself, stated once.
+  it("never sends billing_cycle_anchor alongside proration_date", () => {
+    for (const params of [
+      buildIntervalPreviewParams(change).subscription_details as Record<string, unknown>,
+      buildIntervalChangeParams(change) as unknown as Record<string, unknown>,
+      buildIntervalPreviewParams({ ...change, trialing: true })
+        .subscription_details as Record<string, unknown>,
+      buildIntervalChangeParams({ ...change, trialing: true }) as unknown as Record<
+        string,
+        unknown
+      >,
+    ]) {
+      expect(
+        params.billing_cycle_anchor !== undefined && params.proration_date !== undefined,
+      ).toBe(false);
+    }
   });
 
   it("switches a trialing sub without prorations or anchor reset (nothing paid yet)", () => {

--- a/apps/web/src/lib/__tests__/billing-proration.live.test.ts
+++ b/apps/web/src/lib/__tests__/billing-proration.live.test.ts
@@ -1,0 +1,82 @@
+// LIVE contract test for the in-app plan-change params — NOT a unit test.
+//
+// The shape assertions in billing-manage.test.ts passed for months while every
+// in-app plan change was dead on arrival: we sent `proration_date` together
+// with `billing_cycle_anchor: "now"`, which Stripe refuses with "You cannot
+// specify `proration_date` when `billing_cycle_anchor=now`". A param object
+// cannot tell you the API rejects it — only the API can. This file asks it.
+//
+// Skipped unless BILLING_LIVE=1. It runs against Stripe TEST mode (the key in
+// .env.local is rk_test_*) and creates + cancels a throwaway customer and
+// subscription; no real money moves. Run:
+//   BILLING_LIVE=1 DATABASE_URL=... npx vitest run --root apps/web \
+//     src/lib/__tests__/billing-proration.live.test.ts
+import { afterAll, describe, expect, it } from "vitest";
+import Stripe from "stripe";
+import postgres from "postgres";
+import { buildIntervalChangeParams, buildIntervalPreviewParams } from "@/lib/billing-manage";
+
+const LIVE = process.env.BILLING_LIVE === "1" && !!process.env.STRIPE_SECRET_KEY;
+
+const cleanup: Array<() => Promise<unknown>> = [];
+afterAll(async () => {
+  for (const fn of cleanup) await fn().catch(() => undefined);
+});
+
+describe.skipIf(!LIVE)("in-app plan change params (live Stripe, test mode)", () => {
+  it("previews and applies a real interval switch without a parameter rejection", async () => {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+    const sql = postgres(process.env.DATABASE_URL!, {
+      connection: { search_path: process.env.DB_SCHEMA ?? "seazn_club" },
+    });
+    const [pro] = await sql<{ monthly: string; annual: string }[]>`
+      select stripe_price_id_monthly as monthly, stripe_price_id_annual as annual
+      from plans where key = 'pro'`;
+    const [plus] = await sql<{ annual: string }[]>`
+      select stripe_price_id_annual as annual from plans where key = 'pro_plus'`;
+    await sql.end();
+    expect(pro?.annual, "plans table needs Stripe price ids").toBeTruthy();
+
+    const customer = await stripe.customers.create({
+      email: `proration-probe-${Date.now()}@example.com`,
+      payment_method: "pm_card_visa",
+      invoice_settings: { default_payment_method: "pm_card_visa" },
+    });
+    cleanup.push(() => stripe.customers.del(customer.id));
+    const sub = await stripe.subscriptions.create({
+      customer: customer.id,
+      items: [{ price: pro.annual }],
+    });
+    cleanup.push(() => stripe.subscriptions.cancel(sub.id));
+
+    const ctx = {
+      customerId: customer.id,
+      subscriptionId: sub.id,
+      itemId: sub.items.data[0].id,
+      trialing: false,
+      prorationDate: Math.floor(Date.now() / 1000),
+    };
+
+    // Every target the console offers: the interval switch and the same-interval
+    // plan upgrade. Both went through the same builders, so both were broken.
+    for (const priceId of [pro.monthly, plus.annual]) {
+      const preview = await stripe.invoices.createPreview(
+        buildIntervalPreviewParams({ ...ctx, priceId }),
+      );
+      expect(typeof preview.total).toBe("number");
+    }
+
+    // The apply call takes the SAME pinned proration_date, and the interval
+    // change must reset the cycle on its own — we no longer ask it to.
+    const updated = await stripe.subscriptions.update(
+      sub.id,
+      buildIntervalChangeParams({ ...ctx, priceId: pro.monthly }),
+    );
+    const item = updated.items.data[0];
+    expect(item.price.recurring?.interval).toBe("month");
+    const start = item.current_period_start;
+    const end = item.current_period_end;
+    const days = (end - start) / 86_400;
+    expect(days, "cycle reset to one month without billing_cycle_anchor").toBeLessThan(32);
+  }, 60_000);
+});

--- a/apps/web/src/lib/billing-manage.ts
+++ b/apps/web/src/lib/billing-manage.ts
@@ -48,15 +48,26 @@ export interface IntervalChangeArgs {
   prorationDate: number;
 }
 
-/** Both directions switch immediately: anchor resets to now and the proration
- *  invoice is issued on the spot, so "charged X today" is literally true;
- *  a downgrade's negative total becomes customer credit balance. */
+/** The change lands immediately: `always_invoice` issues the proration invoice
+ *  on the spot, so "charged X today" is literally true; a downgrade's negative
+ *  total becomes customer credit balance.
+ *
+ *  NO `billing_cycle_anchor: "now"`. Stripe refuses the pair outright — "You
+ *  cannot specify `proration_date` when `billing_cycle_anchor=now`" — on the
+ *  preview call as well as the update, which is every in-app plan change we
+ *  offer. It was also redundant: an INTERVAL change resets the cycle on its
+ *  own (verified in test mode 2026-07-20: an annual sub repriced to monthly
+ *  came back with a period of 2026-07-20 → 2026-08-20), and a same-interval
+ *  plan change must NOT reset it — Pro → Pro Plus mid-year keeps the July
+ *  renewal and bills the difference, which is what the preview shows.
+ *
+ *  The pinned proration_date is the half worth keeping: it is what makes the
+ *  applied proration equal the previewed one. */
 function prorationShape(a: IntervalChangeArgs) {
   return a.trialing
     ? ({ proration_behavior: "none" } as const)
     : ({
         proration_behavior: "always_invoice",
-        billing_cycle_anchor: "now",
         proration_date: a.prorationDate,
       } as const);
 }


### PR DESCRIPTION
Reported from the console: "Switch to monthly billing" and "Upgrade to Pro Plus" both fail on the first click, printing Stripe's raw message under the button:

> You cannot specify `proration_date` when `billing_cycle_anchor=now`

Every in-app plan change goes through one param builder (`prorationShape` in `lib/billing-manage.ts`) and it sent both. The rejection lands on the **preview** call, so nothing ever reaches the apply path — in-app plan management has never worked against real Stripe.

## Evidence (Stripe test mode, real annual subscription)

| shape | interval→monthly | plan→pro_plus |
|---|---|---|
| `anchor` + `proration_date` (shipped) | **REJECTED** | **REJECTED** |
| `proration_date` only | total `-14000 usd` | total `16800 usd` |
| `anchor` only | total `-14000 usd` | total `16800 usd` |

After repricing annual→monthly with **no anchor sent**, the subscription came back with a period of `2026-07-20 → 2026-08-20`. Stripe resets the cycle itself when the interval changes, so the anchor was redundant as well as fatal. A same-interval upgrade must *not* reset it: Pro → Pro Plus mid-year keeps the July renewal and bills the $168 difference — exactly what the preview quotes.

The pinned `proration_date` is the half worth keeping: it makes the applied proration equal the previewed one.

## Why the tests missed it

They asserted the *shape* of the param object, and a param object cannot tell you the API rejects it. The suite was green the whole time.

Two additions:
1. An invariant test — never send `billing_cycle_anchor` alongside `proration_date`, on all four builder outputs.
2. `billing-proration.live.test.ts` — runs the real `invoices.createPreview` and `subscriptions.update` against Stripe **test mode** behind `BILLING_LIVE=1`, creating and cancelling a throwaway customer/subscription. It fails with the exact error above on the previous code.

## Verification

```
npx vitest run src/lib/__tests__/          519 passed, 0 failed
BILLING_LIVE=1 … billing-proration.live    1 passed   (1 failed before the fix)
tsc --noEmit                               clean
```

## Follow-up, not in this PR

The preview route leaks Stripe's raw parameter message to the end user (that is how the screenshot reads). The apply path already maps `StripeInvalidRequestError` to "The preview expired — please review the change again."; the preview path has no such mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)