### PR TITLE
fix(billing): say the plan the org actually holds

### DIFF
--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -21,6 +21,7 @@ import { TrackOnMount } from "@/components/analytics-track-mount";
 import { EVENTS } from "@/lib/analytics-events";
 import { asCurrency, formatMinor, proPrice, proPlusPrice } from "@/lib/currency";
 import { preferredCurrency } from "@/lib/currency-server";
+import { planLabel } from "@/lib/plan-label";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary, t, plural, type Locale } from "@/lib/i18n";
 
@@ -137,7 +138,7 @@ export default async function BillingPage({
 
         {justCheckedOut && (
           <div className="mb-6 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
-            {t(dict, "billing.checkoutComplete")} <span className="font-semibold capitalize">{planKey}</span>
+            {t(dict, "billing.checkoutComplete")} <span className="font-semibold">{planLabel(planKey)}</span>
             {status === "trialing" ? t(dict, "billing.trialSuffix") : ""}.
           </div>
         )}
@@ -150,8 +151,8 @@ export default async function BillingPage({
           <div className="flex items-center justify-between gap-4">
             <div>
               <div className="flex items-center gap-2">
-                <span className="text-xl font-bold text-slate-800 capitalize">
-                  {planKey}
+                <span className="text-xl font-bold text-slate-800">
+                  {planLabel(planKey)}
                 </span>
                 <span className={`badge ${STATUS_BADGE[status] ?? "bg-slate-100 text-slate-500"}`}>
                   {t(dict, `billing.status.${status}`)}
@@ -168,7 +169,10 @@ export default async function BillingPage({
               {sub?.current_period_end && status === "active" && (
                 <p className="mt-1 text-sm text-slate-500">
                   {sub.cancel_at_period_end
-                    ? t(dict, "billing.proUntil", { date: fmt(sub.current_period_end, locale) ?? "" })
+                    ? t(dict, "billing.proUntil", {
+                        plan: planLabel(planKey),
+                        date: fmt(sub.current_period_end, locale) ?? "",
+                      })
                     : `${t(dict, "billing.renews", { date: fmt(sub.current_period_end, locale) ?? "" })}${
                         overview?.interval
                           ? ` · ${overview.interval === "annual" ? t(dict, "billing.billedYearly") : t(dict, "billing.billedMonthly")}`
@@ -219,10 +223,10 @@ export default async function BillingPage({
                   <PlanIntervalSwitcher current={overview.interval} />
                 )}
                 {sub?.cancel_at_period_end ? (
-                  <ResumeSubscriptionButton />
+                  <ResumeSubscriptionButton planKey={planKey} />
                 ) : (
                   status !== "past_due" && (
-                    <CancelSubscriptionButton periodEnd={sub?.current_period_end ?? null} />
+                    <CancelSubscriptionButton periodEnd={sub?.current_period_end ?? null} planKey={planKey} />
                   )
                 )}
               </div>

--- a/apps/web/src/components/billing-manage.tsx
+++ b/apps/web/src/components/billing-manage.tsx
@@ -13,6 +13,7 @@ import { stripeAppearance, stripePromise } from "@/lib/stripe-browser";
 import { useConfirm } from "@/components/ui/confirm-provider";
 import { useMsg } from "@/components/i18n/dict-provider";
 import { asCurrency, formatMinor } from "@/lib/currency";
+import { planLabel } from "@/lib/plan-label";
 import {
   TAX_ID_TYPES,
   type DiscountSummary,
@@ -490,21 +491,30 @@ const CANCEL_REASONS = [
   "Other",
 ] as const;
 
-export function CancelSubscriptionButton({ periodEnd }: { periodEnd: string | null }) {
+export function CancelSubscriptionButton({
+  periodEnd,
+  planKey,
+}: {
+  periodEnd: string | null;
+  /** Say the plan the org actually holds — a Pro Plus subscriber was being
+   *  asked to cancel "Pro". */
+  planKey: string;
+}) {
   const confirm = useConfirm();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const reasonRef = useRef<string>("");
+  const plan = planLabel(planKey);
 
   async function go() {
     reasonRef.current = "";
     const ok = await confirm({
-      title: "Cancel your Pro subscription?",
+      title: `Cancel your ${plan} subscription?`,
       body: (
         <div className="space-y-3">
           <p>
-            Pro stays active until{" "}
+            {plan} stays active until{" "}
             <span className="font-semibold">{fmtDate(periodEnd) ?? "the end of the period"}</span>,
             then the club moves to Community. Nothing is deleted.
           </p>
@@ -549,7 +559,7 @@ export function CancelSubscriptionButton({ periodEnd }: { periodEnd: string | nu
   );
 }
 
-export function ResumeSubscriptionButton() {
+export function ResumeSubscriptionButton({ planKey }: { planKey: string }) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -565,8 +575,11 @@ export function ResumeSubscriptionButton() {
 
   return (
     <div>
+      {/* Resume un-cancels the subscription the org HOLDS. Labelled "Keep Pro"
+          for everyone, it promised Pro to a Pro Plus subscriber and then
+          restored Pro Plus — the button lied about its own effect. */}
       <button className="btn btn-primary" onClick={go} disabled={loading}>
-        {loading ? "Resuming…" : "Keep Pro"}
+        {loading ? "Resuming…" : `Keep ${planLabel(planKey)}`}
       </button>
       {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
     </div>

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -522,7 +522,7 @@
   "billing.trialRemaining.one": "{count} day remaining in trial",
   "billing.trialRemaining.other": "{count} days remaining in trial",
   "billing.trialEnded": "Trial ended",
-  "billing.proUntil": "Pro until {date} — then Community",
+  "billing.proUntil": "{plan} until {date} — then Community",
   "billing.renews": "Renews {date}",
   "billing.billedYearly": "billed yearly",
   "billing.billedMonthly": "billed monthly",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -522,7 +522,7 @@
   "billing.trialRemaining.one": "{count} día restante de prueba",
   "billing.trialRemaining.other": "{count} días restantes de prueba",
   "billing.trialEnded": "Prueba finalizada",
-  "billing.proUntil": "Pro hasta el {date} — luego Community",
+  "billing.proUntil": "{plan} hasta el {date} — luego Community",
   "billing.renews": "Se renueva el {date}",
   "billing.billedYearly": "facturación anual",
   "billing.billedMonthly": "facturación mensual",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -522,7 +522,7 @@
   "billing.trialRemaining.one": "{count} jour restant dans l'essai",
   "billing.trialRemaining.other": "{count} jours restants dans l'essai",
   "billing.trialEnded": "Essai terminé",
-  "billing.proUntil": "Pro jusqu'au {date} — puis Community",
+  "billing.proUntil": "{plan} jusqu'au {date} — puis Community",
   "billing.renews": "Renouvellement le {date}",
   "billing.billedYearly": "facturé annuellement",
   "billing.billedMonthly": "facturé mensuellement",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -522,7 +522,7 @@
   "billing.trialRemaining.one": "{count} dag over in proefperiode",
   "billing.trialRemaining.other": "{count} dagen over in proefperiode",
   "billing.trialEnded": "Proefperiode beëindigd",
-  "billing.proUntil": "Pro tot {date} — daarna Community",
+  "billing.proUntil": "{plan} tot {date} — daarna Community",
   "billing.renews": "Verlengt {date}",
   "billing.billedYearly": "jaarlijks gefactureerd",
   "billing.billedMonthly": "maandelijks gefactureerd",

--- a/apps/web/src/lib/__tests__/plan-label.test.ts
+++ b/apps/web/src/lib/__tests__/plan-label.test.ts
@@ -1,0 +1,30 @@
+// Plan display names. The billing page rendered the raw `plan_key` under a CSS
+// `capitalize`, so a Pro Plus org's Current plan card read "Pro_plus"; the
+// cancel dialog and the resume button said "Pro" to that same subscriber, and
+// "Keep Pro" actually restored Pro Plus.
+import { describe, expect, it } from "vitest";
+import { planLabel } from "@/lib/plan-label";
+
+describe("planLabel", () => {
+  it("spells the paid plans the way the product does", () => {
+    expect(planLabel("pro_plus")).toBe("Pro Plus");
+    expect(planLabel("pro")).toBe("Pro");
+    expect(planLabel("community")).toBe("Community");
+  });
+
+  it("never leaks a raw key: an unmapped plan is title-cased, not shown as-is", () => {
+    expect(planLabel("pro_ultra")).toBe("Pro Ultra");
+  });
+
+  it("treats a missing plan as Community — a row with no subscription is free", () => {
+    expect(planLabel(null)).toBe("Community");
+    expect(planLabel(undefined)).toBe("Community");
+    expect(planLabel("")).toBe("Community");
+  });
+
+  // CSS `capitalize` is what produced "Pro_plus"; it also cannot fix it, since
+  // it only touches the first letter of a whitespace-delimited word.
+  it("produces a label that needs no CSS capitalize to read correctly", () => {
+    expect(planLabel("pro_plus")).not.toContain("_");
+  });
+});

--- a/apps/web/src/lib/plan-label.ts
+++ b/apps/web/src/lib/plan-label.ts
@@ -1,0 +1,25 @@
+/** Display names for the paid plans. Plan names are product names — they are
+ *  the same in every locale (like "Connect"), so they live here and not in the
+ *  dictionaries.
+ *
+ *  Exists because the billing page rendered the raw `plan_key` under a CSS
+ *  `capitalize`, which turns `pro_plus` into "Pro_plus", and because several
+ *  strings around cancel/resume said "Pro" to a Pro Plus subscriber. */
+const LABELS: Record<string, string> = {
+  community: "Community",
+  pro: "Pro",
+  pro_plus: "Pro Plus",
+};
+
+/** `pro_plus` → "Pro Plus". An unknown key is title-cased rather than shown
+ *  raw, so a plan added to the DB before this map is still legible. */
+export function planLabel(planKey: string | null | undefined): string {
+  if (!planKey) return LABELS.community;
+  return (
+    LABELS[planKey] ??
+    planKey
+      .split("_")
+      .map((w) => (w ? w[0]!.toUpperCase() + w.slice(1) : w))
+      .join(" ")
+  );
+}


### PR DESCRIPTION
Reported from a Pro Plus org: the Current plan card reads **"Pro_plus"**, and cancelling offers **"Keep Pro"** — which restores Pro Plus.

Three faults, one cause: the billing surface knew the plan key and never turned it into a name.

| where | was | now |
|---|---|---|
| Current plan card | raw key under CSS `capitalize` → "Pro_plus" | "Pro Plus" |
| Cancel dialog | "Cancel your **Pro** subscription?" / "**Pro** stays active until…" | names the held plan |
| Resume button | "Keep **Pro**" for everyone | "Keep Pro Plus" for a Pro Plus org |
| `billing.proUntil` | "Pro until {date} — then Community" | "{plan} until {date} — then Community" |

`capitalize` could never have fixed the first one — it only touches the first letter of a whitespace-delimited word.

The resume button is worth calling out: resume un-cancels the subscription the org **holds**, so "Keep Pro" genuinely restored Pro Plus. The effect was right; the label lied about it.

## Change

`planLabel()` in `lib/plan-label.ts` is the single place a key becomes a name. Plan names are product names — the same in every locale, like "Connect" — so they live in code, not the dictionaries. An unmapped key is title-cased rather than shown raw, so a plan added to the DB before the map is still legible.

`billing.proUntil` gains a `{plan}` placeholder in all four locales.

## Verification

`plan-label.test.ts` covers the paid plans, the unmapped-key fallback, the null/empty case, and that the output needs no CSS `capitalize`. `tsc` clean, i18n parity clean across es/fr/nl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)