### PR TITLE
test(e2e): follow the plan labels #196 introduced

### DIFF
--- a/apps/web/e2e/payments-hardening.spec.ts
+++ b/apps/web/e2e/payments-hardening.spec.ts
@@ -652,7 +652,7 @@ test.describe("T7 · platform disputes truth-up entitlements", () => {
     await loginAsOwner(page, org.ownerEmail);
     await page.goto(`/o/${org.orgSlug}/settings/billing`);
     await expect(
-      page.locator('[data-tour="billing-plan"]').getByText("pro", { exact: true }),
+      page.locator('[data-tour="billing-plan"]').getByText("Pro", { exact: true }),
     ).toBeVisible({ timeout: 20_000 });
 
     // The dispute is lost → auto-downgrade to Community.
@@ -671,7 +671,7 @@ test.describe("T7 · platform disputes truth-up entitlements", () => {
 
     await page.reload();
     await expect(
-      page.locator('[data-tour="billing-plan"]').getByText("community", { exact: true }),
+      page.locator('[data-tour="billing-plan"]').getByText("Community", { exact: true }),
     ).toBeVisible({ timeout: 20_000 });
   });
 

--- a/apps/web/e2e/pro-plus-tier.spec.ts
+++ b/apps/web/e2e/pro-plus-tier.spec.ts
@@ -227,9 +227,11 @@ test.describe("Pro Plus · billing surface", () => {
     await loginAsOwner(page, org.ownerEmail);
     await page.goto(`/o/${org.orgSlug}/settings/billing`);
 
-    // Current-plan panel names the tier (raw key, capitalised by CSS).
+    // Current-plan panel names the tier. It used to render the raw plan key
+    // under a CSS `capitalize` — which reads "Pro_plus" — so this asserted
+    // "pro_plus"; planLabel() now supplies the product name (#196).
     await expect(
-      page.locator('[data-tour="billing-plan"]').getByText("pro_plus", { exact: true }),
+      page.locator('[data-tour="billing-plan"]').getByText("Pro Plus", { exact: true }),
     ).toBeVisible({ timeout: 20_000 });
     // A paid tier never sees the Community upgrade/compare grid …
     await expect(page.getByRole("heading", { name: "Upgrade to Pro" })).toHaveCount(0);


### PR DESCRIPTION
Main's E2E went red on #196: the billing page stopped rendering the raw `plan_key`, so the DOM text changed from `pro` / `pro_plus` to `Pro` / `Pro Plus`, and three assertions matched the old text with `{ exact: true }` — which is case-sensitive.

| spec | was | now |
|---|---|---|
| `payments-hardening.spec.ts:656` | `getByText("pro")` | `"Pro"` |
| `payments-hardening.spec.ts:675` | `getByText("community")` | `"Community"` |
| `pro-plus-tier.spec.ts:232` | `getByText("pro_plus")` | `"Pro Plus"` |

The pro-plus comment also said "raw key, capitalised by CSS" — it now names `planLabel()`, so the next reader isn't told the old story.

## Verification

Local production build on a V305 database, with the CI webhook secret (`whsec_e2e_payments`) so the signed-webhook harness is live:

```
29 passed
1 failed  — T12 Connect health banner
```

T12 needs Connect credentials this machine does not have and was green on CI in the same run that caught these three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)