### PR TITLE
test(e2e): finish following the plan labels, and scope the assertions

### DIFF
--- a/apps/web/e2e/billing.spec.ts
+++ b/apps/web/e2e/billing.spec.ts
@@ -42,7 +42,9 @@ test.describe.serial("billing", () => {
   test("a fresh org lands on Community with the trial CTA", async ({ page }) => {
     orgA = await createFreshOrg(page);
     await page.goto("/settings/billing");
-    await expect(page.getByText("community", { exact: true })).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.locator('[data-tour="billing-plan"]').getByText("Community", { exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
     await expect(page.getByRole("button", { name: /start free trial/i })).toBeVisible();
     // Usage card reflects plan limits ("✓ 2 active competitions" also exists
     // in the plan-comparison card — exact match dodges it).
@@ -106,7 +108,9 @@ test.describe.serial("billing", () => {
     // The return URL lands back on the billing page, which reconciles the
     // session server-side (reconcileCheckout) even without webhooks.
     await page.waitForURL(/settings\/billing\?checkout=success/, { timeout: 120_000 });
-    await expect(page.getByText("pro", { exact: true })).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.locator('[data-tour="billing-plan"]').getByText("Pro", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
   });
 
   test("comped Pro downgrade freezes over-quota competitions", async ({ page }) => {
@@ -141,13 +145,17 @@ test.describe.serial("billing", () => {
     // Billing page shows the comped Pro plan with the in-app downgrade button
     // (no Stripe subscription on file).
     await page.goto("/settings/billing");
-    await expect(page.getByText("pro", { exact: true })).toBeVisible({ timeout: 20_000 });
+    await expect(
+      page.locator('[data-tour="billing-plan"]').getByText("Pro", { exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
 
     // PROMPT-32 moved this to the in-app ConfirmDialog (native confirm is
     // lint-banned) — confirm through the dialog.
     await page.getByRole("button", { name: "Downgrade to Community" }).click();
     await page.getByRole("alertdialog").getByRole("button", { name: "Downgrade" }).click();
-    await expect(page.getByText("community", { exact: true })).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.locator('[data-tour="billing-plan"]').getByText("Community", { exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
     await expect(page.getByRole("button", { name: /start free trial/i })).toBeVisible();
 
     // The least-recently-active competition (the first created) freezes:


### PR DESCRIPTION
#197 fixed the parallel-phase specs and missed `billing.spec.ts`, which runs in the **serial** phase — my grep was scoped to the `billing-plan` locator and these four assertions match the page globally. Main's E2E stayed red on `billing.spec.ts:42`.

Two changes per assertion, and the second is the one that matters:

1. `"community"` / `"pro"` → `"Community"` / `"Pro"` — the text `planLabel()` now renders.
2. **Scoped to `[data-tour="billing-plan"]`.** Unscoped, `"Community"` matches the Current plan card *and* the plan-comparison card below it:

```
strict mode violation: getByText('Community', { exact: true }) resolved to 2 elements:
  1) <span class="text-xl font-bold text-slate-800">Community</span>
  2) <p class="mb-1 font-semibold text-slate-700">Community</p>
```

The old lowercase text was accidentally unique — that is the only reason a page-wide match ever worked. The payments-hardening assertions were already scoped this way.

## Verification

Local production build on a V305 database:

```
7 passed, 1 skipped   (--project=serial e2e/billing.spec.ts --workers=1)
```

The skip is the full Stripe checkout flow, which skips itself when Stripe is not configured. A sweep of `apps/web/e2e` for remaining raw plan-key text assertions comes back with only type unions and one comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)