### PR TITLE
fix(console): put a labelled back button on the settings sub-pages

### DIFF
--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -22,6 +22,8 @@ import { EVENTS } from "@/lib/analytics-events";
 import { asCurrency, formatMinor, proPrice, proPlusPrice } from "@/lib/currency";
 import { preferredCurrency } from "@/lib/currency-server";
 import { planLabel } from "@/lib/plan-label";
+import { BackLink } from "@/components/back-link";
+import { routes } from "@/lib/routes";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary, t, plural, type Locale } from "@/lib/i18n";
 
@@ -123,8 +125,14 @@ export default async function BillingPage({
       />
       {orgId && <BillingBanner orgId={orgId} />}
       <main className="mx-auto max-w-3xl px-4 py-8">
-        {/* No back link here: OrgLayout's breadcrumb already carries a
-            clickable "Settings" crumb — the hand-rolled one duplicated it. */}
+        {/* The apron chevron alone was not found: 16px at 70% opacity on the
+            dark bar, label hidden until hover. #190 removed the labelled link
+            as duplication; reported twice as missing, so it is back. */}
+        <BackLink
+          href={routes.orgSettings(orgSlug)}
+          label={t(dict, "action.settings")}
+          emphasis="button"
+        />
         <div className="mb-6">
           <h1 className="page-title">
             {t(dict, "billing.title")}

--- a/apps/web/src/app/o/[orgSlug]/settings/connect/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/connect/page.tsx
@@ -9,6 +9,7 @@ import { sql } from "@/lib/db";
 import { requireOrgPage } from "@/server/page-auth";
 import { routes } from "@/lib/routes";
 import { OrgPaymentInstructions } from "@/components/org-payment-instructions";
+import { BackLink } from "@/components/back-link";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary, t } from "@/lib/i18n";
 
@@ -31,8 +32,12 @@ export default async function ConnectSettingsPage({
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-8">
-      {/* No back link here: OrgLayout's breadcrumb already carries a
-          clickable "Settings" crumb — the hand-rolled one duplicated it. */}
+      {/* Same reason as the billing page: the apron chevron was not found. */}
+      <BackLink
+        href={routes.orgSettings(orgSlug)}
+        label={t(dict, "action.settings")}
+        emphasis="button"
+      />
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-slate-900">{t(dict, "payments.title")}</h1>
         <p className="mt-1 text-sm text-slate-500">

--- a/apps/web/src/components/back-link.tsx
+++ b/apps/web/src/components/back-link.tsx
@@ -3,12 +3,30 @@ import { ArrowLeft } from "lucide-react";
 
 /** Structural back affordance for console pages outside the /o breadcrumb
  *  shell — same contract as the breadcrumb back button: a real parent link,
- *  never history.back(). */
-export function BackLink({ href, label }: { href: string; label: string }) {
+ *  never history.back().
+ *
+ *  `emphasis="button"` gives it the ghost-button chrome. The settings
+ *  sub-pages use it because the breadcrumb apron's chevron was not found:
+ *  16px at 70% opacity on the dark bar, its label hidden until hover, sitting
+ *  beside a text trail. Reported twice as "there is no back button" (user
+ *  picked this treatment over making the apron chevron louder, 2026-07-21). */
+export function BackLink({
+  href,
+  label,
+  emphasis = "quiet",
+}: {
+  href: string;
+  label: string;
+  emphasis?: "quiet" | "button";
+}) {
   return (
     <Link
       href={href}
-      className="-ml-1 mb-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1.5 text-sm text-slate-500 transition hover:text-slate-700"
+      className={
+        emphasis === "button"
+          ? "btn btn-ghost mb-3 inline-flex items-center gap-1.5 text-sm"
+          : "-ml-1 mb-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1.5 text-sm text-slate-500 transition hover:text-slate-700"
+      }
     >
       <ArrowLeft className="h-4 w-4" strokeWidth={1.75} />
       {label}


### PR DESCRIPTION
Reported twice: *"I don't see the back button arrow in connect and billing page."* Both times correct, for different reasons.

- **Connect** had no route back at all until #195 gave it a crumb.
- **Billing** has had the apron chevron since v3/01 and it still was not found. Measured on the live page:

```
color:  cream @ 0.7 opacity      on rgb(29,17,69)
glyph:  16px inside a 44px target
label:  opacity 0  (revealed on hover only)
```

…sitting immediately left of a text trail that starts with the same word. It reads as decoration, not a control.

#190 removed the labelled `← Settings` links from both pages on the grounds that the apron already carried one. It does, technically. Two reports say that is not the same as being findable.

## Choosing the treatment

Three options were mocked on the live page and screenshotted: reveal the apron label, a bordered chip in the apron, or an in-page labelled button. The in-page button was chosen — it is also the only one that does not put "Settings" twice in the apron, two words apart.

`BackLink` gains `emphasis="button"` for the ghost-button chrome. The four existing call sites (clubs, directory, orgs/new, import) keep the quiet text style they already had.

## Verification

Driven in the running app (production build against the local DB): both pages show `← Settings` above the title, linking to `/o/<org>/settings`. Component tests + breadcrumb chain: 67 passed. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)