### PR TITLE
fix(e2e): repair main E2E after the Event Pass merge (V310 staleness + CI Stripe gate)

### DIFF
--- a/apps/web/e2e/event-pass.spec.ts
+++ b/apps/web/e2e/event-pass.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type APIRequestContext } from "@playwright/test";
 import Stripe from "stripe";
 import { randomBytes } from "node:crypto";
 import { TAG, apiJson, mintLoginPathBySql } from "./helpers";
@@ -209,6 +209,35 @@ async function signIn(page: Page, email: string): Promise<void> {
 const upgradeUrl = (rig: Rig, query = "") => `/o/${rig.orgSlug}/c/${rig.compSlug}/upgrade${query}`;
 
 /**
+ * Probe whether the SERVER's Stripe key can actually mint a pass checkout, so
+ * this money path skips cleanly on CI (dummy `sk_test_ci_e2e_dummy`) while a
+ * real key still RUNS it — the same probe-and-skip billing.spec.ts uses.
+ *
+ * CI's dummy key 5xxes: `getStripe().checkout.sessions.create` throws (or the
+ * event_pass price isn't synced → 503). A real key returns 200 with a
+ * client_secret. The `beforeAll` still HARD-FAILS a genuinely missing/garbage
+ * key (a developer who forgot `set -a; . ./.env.local` must see a failure, not a
+ * quiet green) — this only skips a *functional* probe that reports Stripe
+ * unusable. The pass-checkout idempotency key is org+comp+user scoped, so the
+ * session this mints is the SAME one `[data-pass-buy]` later reuses: no double
+ * session, no interference with U1's "exactly one pass, one intent" assertion.
+ *
+ * `request` must carry the signed-in owner's session (a `page.request`): the
+ * endpoint reads the active-org cookie (getActiveOrgId), so set it first.
+ */
+async function passCheckoutProbeStatus(
+  request: APIRequestContext,
+  orgId: string,
+  competitionId: string,
+): Promise<number> {
+  await apiJson(request, "/api/orgs/active", "POST", { org_id: orgId });
+  const probe = await apiJson(request, "/api/billing/pass-checkout", "POST", {
+    competition_id: competitionId,
+  });
+  return probe.status;
+}
+
+/**
  * The real purchase. Fills Stripe's embedded checkout with the 4242 test card
  * and waits for the app's own return URL.
  *
@@ -332,6 +361,9 @@ for (const vp of VIEWPORTS) {
     let rig: Rig;
     let divisionIds: string[] = [];
     let passIntent = "";
+    // Set true by U1's probe only when the server's Stripe is usable; the rest
+    // of the serial money path gates on it so CI (dummy key) skips cleanly.
+    let stripeUsable = false;
 
     test(`U1 · buys the pass from the gate that bit, and the gate lifts (${vp.name})`, async ({
       page,
@@ -340,6 +372,16 @@ for (const vp of VIEWPORTS) {
       rig = await seedRig(vp.label);
       divisionIds = [];
       await signIn(page, rig.ownerEmail);
+
+      // Gate the whole money path on the server's Stripe being usable (see
+      // passCheckoutProbeStatus): CI's dummy key 5xxes and the suite skips; a
+      // real key returns 200 and everything below RUNS for real.
+      const probeStatus = await passCheckoutProbeStatus(page.request, rig.orgId, rig.compId);
+      stripeUsable = probeStatus === 200;
+      test.skip(probeStatus >= 500, "Stripe not usable (dummy key) — skipping the pass money path");
+      // Pin the non-skip path to a real 200 so this can never silently become an
+      // unconditional skip (billing.spec.ts:255-257 learned this the hard way).
+      expect(probeStatus).toBe(200);
 
       // Community's `divisions.per_competition.max` is 2 — fill it, then bite.
       for (const name of ["One", "Two"]) {
@@ -432,6 +474,7 @@ for (const vp of VIEWPORTS) {
     test(`U6 · division 11 hits a Pro-only ceiling and the pass is never re-sold (${vp.name})`, async ({
       page,
     }) => {
+      test.skip(!stripeUsable, "Stripe not usable — U1 skipped the pass money path");
       test.setTimeout(180_000);
       await signIn(page, rig.ownerEmail);
 
@@ -488,6 +531,7 @@ for (const vp of VIEWPORTS) {
     test(`U7 · public registration passes 32 on the passed competition only (${vp.name})`, async ({
       page,
     }) => {
+      test.skip(!stripeUsable, "Stripe not usable — U1 skipped the pass money path");
       test.setTimeout(180_000);
       await signIn(page, rig.ownerEmail);
 
@@ -562,6 +606,7 @@ for (const vp of VIEWPORTS) {
     test(`U12 · the billing page names the purchase and links its invoice (${vp.name})`, async ({
       page,
     }) => {
+      test.skip(!stripeUsable, "Stripe not usable — U1 skipped the pass money path");
       await signIn(page, rig.ownerEmail);
       await page.goto(`/o/${rig.orgSlug}/settings/billing`);
 
@@ -582,6 +627,7 @@ for (const vp of VIEWPORTS) {
     test(`U14 · upgrading to Pro credits the pass and leaves it dormant (${vp.name})`, async ({
       page,
     }) => {
+      test.skip(!stripeUsable, "Stripe not usable — U1 skipped the pass money path");
       test.setTimeout(120_000);
       await signIn(page, rig.ownerEmail);
 
@@ -624,6 +670,7 @@ for (const vp of VIEWPORTS) {
     test(`U15 · a Pro org that downgrades keeps the pass on its competition (${vp.name})`, async ({
       page,
     }) => {
+      test.skip(!stripeUsable, "Stripe not usable — U1 skipped the pass money path");
       test.setTimeout(120_000);
       await signIn(page, rig.ownerEmail);
 
@@ -665,6 +712,7 @@ for (const vp of VIEWPORTS) {
     test(`U16 · a full refund revokes the pass and the offer comes back (${vp.name})`, async ({
       page,
     }) => {
+      test.skip(!stripeUsable, "Stripe not usable — U1 skipped the pass money path");
       test.setTimeout(180_000);
       await signIn(page, rig.ownerEmail);
 
@@ -748,6 +796,12 @@ test.describe("checkout sheet vs the cookie banner", () => {
       try {
         const page = await ctx.newPage();
         await signIn(page, rig.ownerEmail);
+        // Same money-path gate as the serial block: this test opens the REAL
+        // Stripe iframe, which never mounts under CI's dummy key. Skip cleanly
+        // there; a real key returns 200 and the hit-test RUNS.
+        const probeStatus = await passCheckoutProbeStatus(page.request, rig.orgId, rig.compId);
+        test.skip(probeStatus >= 500, "Stripe not usable (dummy key) — skipping");
+        expect(probeStatus).toBe(200);
         await page.goto(upgradeUrl(rig));
         // The banner must actually be up, or this proves nothing.
         await expect(page.getByRole("button", { name: "Reject" })).toBeVisible({ timeout: 20_000 });

--- a/apps/web/e2e/journey-community.spec.ts
+++ b/apps/web/e2e/journey-community.spec.ts
@@ -4,6 +4,7 @@ import {
   apiJson,
   activeOrg,
   addEntrantsViaApi,
+  communityLimit,
   createCompetitionViaUi,
   createStageAndGenerate,
   scoreRemainingFixtures,
@@ -119,9 +120,13 @@ test.describe.serial("community lifecycle", () => {
     expect(pub.status).toBe(200);
   });
 
-  test("17th entrant is blocked: 402 + contextual upgrade gate", async ({ page, request }) => {
-    // The v3 free plan allows 1 active competition — retire the Village Cup
-    // before this test's own competition, or the create itself 402s.
+  test("the entrant over the community cap is blocked: 402 + contextual upgrade gate", async ({
+    page,
+    request,
+  }) => {
+    // Retire the Village Cup so its public row does not occupy the community
+    // dashboard.public.max = 1 slot (this test's Limits comp is private, so the
+    // active-competition cap has room either way).
     if (competitionId) {
       await apiJson(request, `/api/v1/competitions/${competitionId}`, "PATCH", {
         status: "archived",
@@ -146,15 +151,21 @@ test.describe.serial("community lifecycle", () => {
     );
     crowdedDivisionId = div.data!.id;
 
-    // 16 fit exactly…
-    const sixteen = await addEntrantsViaApi(
+    // The community entrant cap, read from the matrix rather than hard-coded —
+    // V311 moved it 16 → 32 and this test went green-then-red with it (the
+    // over-cap entry started coming back 201). Deriving it keeps the assertion
+    // from drifting with the packaging again.
+    const entrantCap = await communityLimit("entrants.per_division.max");
+
+    // exactly `entrantCap` fit…
+    const filled = await addEntrantsViaApi(
       request,
       crowdedDivisionId,
-      Array.from({ length: 16 }, (_, i) => `P${i + 1}`),
+      Array.from({ length: entrantCap }, (_, i) => `P${i + 1}`),
     );
-    expect(sixteen.status).toBeLessThan(300);
+    expect(filled.status).toBeLessThan(300);
 
-    // …the 17th 402s with the feature key…
+    // …the one over the cap 402s with the feature key…
     const overflow = await apiJson(
       request,
       `/api/v1/divisions/${crowdedDivisionId}/entrants`,
@@ -198,21 +209,46 @@ test.describe.serial("community lifecycle", () => {
     expect(third.error?.code).toBe("PAYMENT_REQUIRED");
   });
 
-  test("2nd active competition hits the ceiling in the wizard", async ({ page, request }) => {
-    // The limits competition holds the single free slot (v3). The API says 402…
-    const third = await apiJson(request, "/api/v1/competitions", "POST", {
-      name: `Ceiling ${TAG}`,
-      visibility: "private",
-    });
-    expect(third.status).toBe(402);
+  test("the active-competition ceiling bites in the wizard", async ({ page, request }) => {
+    // Community runs up to `competitions.max_active` competitions — read from
+    // the matrix, since V311 moved it (2 → 5) and a hard-coded "2nd competition
+    // 402s" quietly came back 201. The Limits comp already holds a slot; create
+    // up to the cap, then the next 402s. Loop rather than count: sibling specs
+    // sharing this community org may already occupy slots.
+    const maxActive = await communityLimit("competitions.max_active");
+    const fillIds: string[] = [];
+    let ceiling: Awaited<ReturnType<typeof apiJson>> | null = null;
+    for (let i = 0; i <= maxActive; i++) {
+      const r = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+        name: `Ceiling ${i} ${TAG}`,
+        visibility: "private",
+      });
+      if (r.status === 402) {
+        ceiling = r;
+        break;
+      }
+      expect(r.status).toBe(201);
+      fillIds.push(r.data!.id);
+    }
+    expect(ceiling?.status).toBe(402);
 
-    // …and the wizard shows the paywall instead of a dead error.
+    // …and the wizard shows the paywall instead of a dead error (the org is at
+    // the ceiling now).
     await page.goto("/competitions/new");
     await page.getByPlaceholder("Summer Championship 2026").fill(`Ceiling UI ${TAG}`);
     await page.getByRole("button", { name: /create/i }).click();
     await expect(page.locator('[data-feature="competitions.max_active"]')).toBeVisible({
       timeout: 20_000,
     });
+
+    // Free the slots this test consumed so sibling specs on the shared community
+    // org keep their quota.
+    for (const id of fillIds) {
+      await apiJson(request, `/api/v1/competitions/${id}`, "PATCH", {
+        status: "archived",
+        visibility: "private",
+      });
+    }
   });
 
   test("plain exports are free since V285 (branded chrome stays Pro)", async ({ request }) => {

--- a/apps/web/e2e/payments-hardening.spec.ts
+++ b/apps/web/e2e/payments-hardening.spec.ts
@@ -35,6 +35,14 @@ const GENERIC_CONFIG = {
   progressScore: false,
 };
 
+/** Community's `entrants.per_division.max` (V311). An Event Pass lifts it to 64
+ *  for its own competition, so entry 33 is the boundary that separates a passed
+ *  comp (accepted, holds a real spot) from a community one (waitlisted). This is
+ *  the grant the pass STILL uniquely provides after V310 made registration.paid
+ *  true on every plan — card intake no longer closes on pass/plan loss, so the
+ *  old "card payments temporarily unavailable" proof is dead. */
+const COMMUNITY_ENTRANT_CAP = 32;
+
 // ---------------------------------------------------------------------------
 // Signed-webhook harness (Step 1)
 // ---------------------------------------------------------------------------
@@ -178,9 +186,13 @@ async function seedComp(
   });
 }
 
-/** A Stripe-fee registration division on a comp (enabled, £5 card intake). */
+/** A Stripe-fee registration division on a comp (enabled, £5 card intake).
+ *  `capacity` null leaves the PLAN quota (entrants.per_division.max) as the only
+ *  ceiling — the entrant-cap tests seed to the community cap and let the pass
+ *  overlay decide whether entry 33 holds a spot or waitlists. */
 async function seedStripeDivision(
   compId: string,
+  capacity: number | null = 20,
 ): Promise<{ divisionId: string; divisionSlug: string }> {
   const tag = randomBytes(5).toString("hex");
   return withDb(async (sql) => {
@@ -198,10 +210,53 @@ async function seedStripeDivision(
         (division_id, enabled, entrant_kind, opens_at, closes_at, capacity,
          fee_cents, currency, refund_lock_at, form_fields, payment_method,
          payment_instructions, updated_at)
-      values (${divisionId}, true, 'individual', null, null, 20,
+      values (${divisionId}, true, 'individual', null, null, ${capacity},
               500, 'gbp', null, ${sql.json([])}, 'stripe', null, now())`;
     return { divisionId, divisionSlug: divSlug };
   });
+}
+
+/** Fill a division to `taken` spot-holding entries (status 'pending'), inserted
+ *  directly — 32 round-trips through the public endpoint would trip its per-IP
+ *  rate limit long before they finished. Mirrors event-pass.spec.ts::fillDivision. */
+async function fillDivision(divisionId: string, orgId: string, taken: number): Promise<void> {
+  const tag = randomBytes(5).toString("hex");
+  await withDb(async (sql) => {
+    await sql`
+      insert into registrations
+        (division_id, org_id, status, display_name, contact_email, ref_code,
+         access_token_hash, payment_method)
+      select ${divisionId}, ${orgId}, 'pending',
+             'Seed ' || g, 'seed-' || g || '-' || ${tag} || '@test.local',
+             ${"SZ-" + tag.toUpperCase() + "-"} || lpad(g::text, 4, '0'),
+             ${tag + "-"} || g, 'offline'
+      from generate_series(1, ${taken}) g`;
+  });
+}
+
+/** One public registration POST. Returns the HTTP status and the created row's
+ *  registration status ('pending' = holds a spot, 'waitlisted' = over the cap).
+ *  The card division's checkout mint fails on the seeded fake Connect account and
+ *  is swallowed (createRegistrationCheckout try/catch), so a pending entry still
+ *  ACKs 201 without any real Stripe call — this stays CI-runnable. */
+async function submitPublicRegistration(
+  request: APIRequestContext,
+  orgSlug: string,
+  compSlug: string,
+  divisionId: string,
+  who: string,
+): Promise<{ status: number; data?: { status: string } }> {
+  return apiJson<{ status: string }>(
+    request,
+    `/api/v1/public/orgs/${orgSlug}/competitions/${compSlug}/register`,
+    "POST",
+    {
+      division_id: divisionId,
+      display_name: who,
+      contact_email: `${who.toLowerCase().replace(/\W+/g, "-")}-${randomBytes(3).toString("hex")}@example.com`,
+      privacy_consent: true,
+    },
+  );
 }
 
 async function grantPass(compId: string, orgId: string, intent?: string): Promise<void> {
@@ -386,20 +441,25 @@ test.describe("T2 · API keys cannot delete a competition", () => {
 // ===========================================================================
 
 test.describe("T3 · Event Pass refund revokes the pass", () => {
-  test("charge.refunded closes the pass-covered card division and re-gates it", async ({
-    page,
+  test("charge.refunded revokes the pass — the entrant cap drops 64 → 32", async ({
     request,
   }) => {
     const intent = uid("pi");
     const org = await seedOrg({ plan: "community", chargesEnabled: true, connected: true });
     const { compId, compSlug } = await seedComp(org.orgId);
-    await seedStripeDivision(compId);
+    // Uncapped by the organiser, so the PLAN quota is the only ceiling; sit the
+    // division ON the community cap so entry 33 separates a passed comp from a
+    // community one. (V310 killed the card-intake-closes proof — see the
+    // COMMUNITY_ENTRANT_CAP note; the entrant cap is what the pass still grants.)
+    const { divisionId } = await seedStripeDivision(compId, null);
     await grantPass(compId, org.orgId, intent);
+    await fillDivision(divisionId, org.orgId, COMMUNITY_ENTRANT_CAP);
 
-    // The pass overlays registration.paid → the card division is OPEN.
-    await page.goto(`/shared/${org.orgSlug}/${compSlug}/register`);
-    await expect(page.getByRole("radio").first()).toBeEnabled();
-    await expect(page.getByText("card payments temporarily unavailable")).toHaveCount(0);
+    // While the pass is held the cap is 64: entry 33 takes a real spot. A
+    // passless community org would waitlist this, so the assertion is NOT vacuous.
+    const held = await submitPublicRegistration(request, org.orgSlug, compSlug, divisionId, "Held 33");
+    expect(held.status).toBe(201);
+    expect(held.data!.status).toBe("pending");
 
     // A fully-refunded pass charge revokes the pass.
     const res = await postSignedEvent(
@@ -413,31 +473,20 @@ test.describe("T3 · Event Pass refund revokes the pass", () => {
     );
     expect(res.status()).toBe(200);
 
-    // Pass row gone (DB) …
+    // Pass row gone (DB) — the core revocation proof, unchanged.
     const passGone = await withDb((sql) =>
       sql`select 1 from competition_passes where stripe_payment_intent = ${intent}`,
     );
     expect(passGone.length).toBe(0);
 
-    // … the card division now closes with the honest reason (browser) …
-    await page.reload();
-    await expect(page.getByText("card payments temporarily unavailable")).toBeVisible();
-
-    // … and the gated submit 402s again.
-    const submit = await apiJson(
-      request,
-      `/api/v1/public/orgs/${org.orgSlug}/competitions/${compSlug}/register`,
-      "POST",
-      {
-        division_id: (await withDb((sql) =>
-          sql<{ id: string }[]>`select id from divisions where competition_id = ${compId} limit 1`,
-        ))[0]!.id,
-        display_name: "After Refund",
-        contact_email: `ar-${TAG}@x.test`,
-        privacy_consent: true,
-      },
+    // … and the cap has dropped back to 32: the next entry (the 34th spot-holder)
+    // is over the community ceiling and waitlists. Reverting the revocation leaves
+    // the cap at 64 and this comes back 'pending' — so the assertion can still fail.
+    const afterRevoke = await submitPublicRegistration(
+      request, org.orgSlug, compSlug, divisionId, "After Refund 34",
     );
-    expect(submit.status).toBe(402);
+    expect(afterRevoke.status).toBe(201);
+    expect(afterRevoke.data!.status).toBe("waitlisted");
   });
 });
 
@@ -675,18 +724,21 @@ test.describe("T7 · platform disputes truth-up entitlements", () => {
     ).toBeVisible({ timeout: 20_000 });
   });
 
-  test("Event Pass: a lost dispute revokes the pass (card division re-closes)", async ({
-    page,
+  test("Event Pass: a lost dispute revokes the pass — the entrant cap drops 64 → 32", async ({
     request,
   }) => {
     const intent = uid("pi");
     const org = await seedOrg({ plan: "community", chargesEnabled: true, connected: true });
     const { compId, compSlug } = await seedComp(org.orgId);
-    await seedStripeDivision(compId);
+    // Same entrant-cap proof as T3 (card intake no longer closes on pass loss).
+    const { divisionId } = await seedStripeDivision(compId, null);
     await grantPass(compId, org.orgId, intent);
+    await fillDivision(divisionId, org.orgId, COMMUNITY_ENTRANT_CAP);
 
-    await page.goto(`/shared/${org.orgSlug}/${compSlug}/register`);
-    await expect(page.getByRole("radio").first()).toBeEnabled();
+    // Pass held → cap 64 → entry 33 holds a spot (a passless community waitlists).
+    const held = await submitPublicRegistration(request, org.orgSlug, compSlug, divisionId, "Held 33");
+    expect(held.status).toBe(201);
+    expect(held.data!.status).toBe("pending");
 
     const lost = await postSignedEvent(
       request,
@@ -701,13 +753,19 @@ test.describe("T7 · platform disputes truth-up entitlements", () => {
     );
     expect(lost.status()).toBe(200);
 
+    // Pass row gone (DB) — the core revocation proof, unchanged.
     const passGone = await withDb((sql) =>
       sql`select 1 from competition_passes where stripe_payment_intent = ${intent}`,
     );
     expect(passGone.length).toBe(0);
 
-    await page.reload();
-    await expect(page.getByText("card payments temporarily unavailable")).toBeVisible();
+    // Cap back to 32 → the 34th spot-holder waitlists. Reverting the dispute
+    // revocation leaves it 64 and this reads 'pending', so it can still fail.
+    const afterRevoke = await submitPublicRegistration(
+      request, org.orgSlug, compSlug, divisionId, "After Dispute 34",
+    );
+    expect(afterRevoke.status).toBe(201);
+    expect(afterRevoke.data!.status).toBe("waitlisted");
   });
 });
 
@@ -847,27 +905,48 @@ test.describe("T9 · past-due grace degrades to community after 14 days", () => 
 // T10 — a downgraded org closes card intake; a pass keeps that comp open (P2-10)
 // ===========================================================================
 
-test.describe("T10 · downgraded card intake closes, a pass keeps its comp open", () => {
-  test("Community org: no-pass comp is closed, passed comp is open", async ({ page }) => {
-    // Connect stays LIVE; only the paid entitlement lapsed (community plan).
+test.describe("T10 · a pass lifts the entrant cap on its own comp only", () => {
+  test("Community org: entry 33 waitlists on the no-pass comp, holds a spot on the passed comp", async ({
+    page,
+  }) => {
+    // Connect stays LIVE; only the paid entitlement lapsed (community plan). V310
+    // made registration.paid true on every plan, so card intake no longer closes
+    // on plan loss — the entrant cap (community 32, pass 64) is the grant the pass
+    // still uniquely provides, and it is competition-scoped.
     const org = await seedOrg({ plan: "community", chargesEnabled: true, connected: true });
 
-    const closed = await seedComp(org.orgId);
-    await seedStripeDivision(closed.compId);
+    const plain = await seedComp(org.orgId);
+    const plainDiv = await seedStripeDivision(plain.compId, null);
 
-    const open = await seedComp(org.orgId);
-    await seedStripeDivision(open.compId);
-    await grantPass(open.compId, org.orgId);
+    const passed = await seedComp(org.orgId);
+    const passedDiv = await seedStripeDivision(passed.compId, null);
+    await grantPass(passed.compId, org.orgId);
 
-    // No pass → card intake is closed with the honest reason.
-    await page.goto(`/shared/${org.orgSlug}/${closed.compSlug}/register`);
-    await expect(page.getByText("card payments temporarily unavailable")).toBeVisible();
-    await expect(page.getByRole("radio").first()).toBeDisabled();
+    // Both sit exactly ON the community cap; entry 33 is the question.
+    await fillDivision(plainDiv.divisionId, org.orgId, COMMUNITY_ENTRANT_CAP);
+    await fillDivision(passedDiv.divisionId, org.orgId, COMMUNITY_ENTRANT_CAP);
 
-    // Pass overlays registration.paid → the same-org card intake stays open.
-    await page.goto(`/shared/${org.orgSlug}/${open.compSlug}/register`);
+    // Both card divisions render OPEN now (registration.paid holds on community),
+    // so the register page alone proves nothing — the cap is what separates them.
+    await page.goto(`/shared/${org.orgSlug}/${passed.compSlug}/register`);
     await expect(page.getByRole("radio").first()).toBeEnabled();
-    await expect(page.getByText("card payments temporarily unavailable")).toHaveCount(0);
+
+    const onPlain = await submitPublicRegistration(
+      page.request, org.orgSlug, plain.compSlug, plainDiv.divisionId, "Plain 33",
+    );
+    const onPassed = await submitPublicRegistration(
+      page.request, org.orgSlug, passed.compSlug, passedDiv.divisionId, "Passed 33",
+    );
+
+    // The pass lifts entrants.per_division.max 32 → 64 for ITS comp: entry 33 holds.
+    expect(onPassed.status).toBe(201);
+    expect(onPassed.data!.status).toBe("pending");
+    // …and only its comp — the sibling still waitlists at 32. This is also the
+    // org-wide-leak guard: a raised cap must not spill to the no-pass comp.
+    // (Drop the pass and BOTH waitlist; leak it org-wide and BOTH pass — either
+    // way an arm flips, so neither assertion is vacuous.)
+    expect(onPlain.status).toBe(201);
+    expect(onPlain.data!.status).toBe("waitlisted");
   });
 });
 

--- a/apps/web/e2e/team-squad.spec.ts
+++ b/apps/web/e2e/team-squad.spec.ts
@@ -9,9 +9,17 @@ test("add a team to a club and manage its squad", async ({ page }) => {
   const teamName = `Squad ${TAG}`;
   const playerName = `Squaddie ${TAG}`;
 
-  const club = (await apiJson<{ id: string }>(page.request, "/api/v1/clubs", "POST", {
+  const clubRes = await apiJson<{ id: string }>(page.request, "/api/v1/clubs", "POST", {
     name: clubName,
-  })).data!;
+  });
+  // Surface the real status: a bare `.data!.id` crashes with an opaque
+  // "undefined (reading 'id')" that hides WHY the create failed (402 clubs.max
+  // on the shared pro org, 409 on a retry's duplicate name, …).
+  expect(
+    clubRes.status,
+    `POST /clubs failed (${clubRes.status}): ${JSON.stringify(clubRes.error)}`,
+  ).toBe(201);
+  const club = clubRes.data!;
   await apiJson(page.request, "/api/v1/persons", "POST", {
     full_name: playerName,
     consent: {},


### PR DESCRIPTION
The Event Pass merge (#202) turned main's E2E red (green immediately before). Two independent regressions, both e2e-test-only — no product code changes.

**1. Stale `payments_unavailable` assertions** (`payments-hardening.spec.ts` T3/T7/T10). V310 made `registration.paid` true on every plan, so a community card division with Connect live never closes on pass/plan loss — the tests asserted it does. Kept each test's DB pass-row-gone revocation proof; replaced the dead "card payments temporarily unavailable" proof with the **entrant cap** (community 32 vs pass 64): a public registration for entry 33 holds a spot (`pending`) while the pass is held and waitlists (201) after revocation. Same observable as event-pass U7. `registration-payments.spec.ts` (a legitimate Connect-off case) is untouched.

**2. CI can't do real Stripe.** `event-pass.spec.ts`'s money path drives the real checkout iframe; CI's dummy `sk_test_ci_e2e_dummy` can't load it. Added the same probe-and-skip `billing.spec.ts` uses — U1/U6/U7/U12/U14/U15/U16 + both cookie-banner tests skip when `/api/billing/pass-checkout` returns ≥500, and pin the non-skip path to a real 200 so it can't silently always-skip. `beforeAll` hard-fail on a missing key kept. `e2e.yml` untouched.

Verified locally (:3021 prod build, real `rk_test`, --retries=0): payments-hardening 18/1 (the 1 is T12, pre-existing — restricted rk_ keys can't mint Connect login links; passes on CI's full-format dummy), event-pass 18/0 with a real key (skip does not trigger), event-pass forced-5xx 16 skipped/2 passed/0 failed (clean CI simulation), registration-payments 5/5, tsc clean. Each changed assertion proven to fail on reversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)