### PR TITLE
fix(e2e): event-pass spec wrote the dropped subscriptions.org_id

### DIFF
--- a/apps/web/e2e/event-pass.spec.ts
+++ b/apps/web/e2e/event-pass.spec.ts
@@ -122,9 +122,12 @@ async function seedRig(label: string): Promise<Rig> {
       values (${"EP Org " + tag}, ${orgSlug}, 'active', ${userId}) returning id`;
     await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${userId}, 'owner')`;
     // A raw org insert leaves NO subscriptions row; the resolver's pass arm only
-    // fires while the resolved plan is 'community', so pin it explicitly.
-    await sql`insert into subscriptions (org_id, plan_key, status)
-              values (${orgId}, 'community', 'active')`;
+    // fires while the resolved plan is 'community', so pin it explicitly. V314:
+    // the subscription IS the group and the org points at it.
+    const [{ id: subId }] = await sql<{ id: string }[]>`
+      insert into subscriptions (owner_user_id, plan_key, status)
+      values (${userId}, 'community', 'active') returning id`;
+    await sql`update organizations set subscription_id = ${subId} where id = ${orgId}`;
     await sql`
       insert into sports (key, name, module_version, position_catalog)
       values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
@@ -182,7 +185,9 @@ async function passRows(orgId: string): Promise<{ competition_id: string; stripe
 async function stripeCustomerId(orgId: string): Promise<string | null> {
   return withDb(async (sql) => {
     const [row] = await sql<{ stripe_customer_id: string | null }[]>`
-      select stripe_customer_id from subscriptions where org_id = ${orgId}`;
+      select s.stripe_customer_id from subscriptions s
+      join organizations o on o.subscription_id = s.id
+      where o.id = ${orgId}`;
     return row?.stripe_customer_id ?? null;
   });
 }
@@ -191,7 +196,8 @@ async function stripeCustomerId(orgId: string): Promise<string | null> {
  *  keyed on an org THIS spec created, never a shared account. */
 async function setPlan(orgId: string, planKey: string): Promise<void> {
   await withDb((sql) => sql`
-    update subscriptions set plan_key = ${planKey}, status = 'active' where org_id = ${orgId}`);
+    update subscriptions set plan_key = ${planKey}, status = 'active'
+     where id = (select subscription_id from organizations where id = ${orgId})`);
 }
 
 /** Sign in as a seeded owner. Mints the login token in the DB rather than


### PR DESCRIPTION
## What
The post-merge E2E run on `main` (after #201) failed with `column "org_id" of relation "subscriptions" does not exist` in `e2e/event-pass.spec.ts` (U1 pass money-path + checkout-sheet tests).

## Why it slipped through
#201's `subscriptions.org_id` → group-model sweep covered `src/` tests but not `e2e/` specs, because **`e2e.yml` doesn't run on pull requests** — so this only surfaced on the push to `main`. `event-pass.spec.ts` was the one e2e spec still seeding/reading `subscriptions` by `org_id`.

## Fix
Three sites converted to the group model (V314 dropped `subscriptions.org_id`):
- seed: mint the subscription with `owner_user_id` and point the org at it via `organizations.subscription_id`;
- customer read: join `organizations` → `subscriptions`;
- plan flip: key on `(select subscription_id from organizations where id = …)`.

Typecheck clean; no `subscriptions.org_id` remains in `e2e/`.

## Note
The other two post-merge E2E reds were flakes (an officials-visibility timeout and a club-name 409 from a re-run), not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)