### PR TITLE
fix(ui): plan-cap errors read as a sentence, not a feature key

### DIFF
--- a/apps/web/src/lib/__tests__/client-api-reason.test.ts
+++ b/apps/web/src/lib/__tests__/client-api-reason.test.ts
@@ -1,0 +1,45 @@
+// A 402 upgrade error carries a human `reason` (feature-copy) next to the raw
+// `error`, which is the developer string leaking the internal feature key. The
+// client `api()` helper must surface the reason, so a form shows the sentence
+// ("Your current plan covers the most organisations it allows…"), not
+// "Plan upgrade required: orgs.max_owned".
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { api } from "@/lib/client";
+
+const origFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = origFetch;
+  vi.restoreAllMocks();
+});
+
+function mockResponse(status: number, body: unknown) {
+  globalThis.fetch = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe("api() error message", () => {
+  it("throws the human reason on a 402, not the raw feature-key message", async () => {
+    mockResponse(402, {
+      ok: false,
+      error: "Plan upgrade required: orgs.max_owned",
+      feature_key: "orgs.max_owned",
+      reason: "Your current plan covers the most organisations it allows.",
+    });
+    await expect(api("/api/orgs", { method: "POST", json: { name: "X" } })).rejects.toThrow(
+      "Your current plan covers the most organisations it allows.",
+    );
+  });
+
+  it("falls back to `error` when there is no reason", async () => {
+    mockResponse(409, { ok: false, error: "already exists" });
+    await expect(api("/x", { method: "POST" })).rejects.toThrow("already exists");
+  });
+
+  it("returns data on success", async () => {
+    mockResponse(200, { ok: true, data: { id: "org_1" } });
+    await expect(api<{ id: string }>("/x")).resolves.toEqual({ id: "org_1" });
+  });
+});

--- a/apps/web/src/lib/client.ts
+++ b/apps/web/src/lib/client.ts
@@ -16,7 +16,11 @@ export async function api<T = unknown>(
   });
   const payload = await res.json().catch(() => ({}));
   if (!res.ok || payload?.ok === false) {
-    throw new Error(payload?.error || `Request failed (${res.status})`);
+    // A 402 upgrade error carries a human `reason` (feature-copy) alongside the
+    // raw `error`, which leaks the internal feature key ("Plan upgrade required:
+    // orgs.max_owned"). Prefer the reason so a form shows the sentence, not the
+    // key. Everything else keeps its `error` message.
+    throw new Error(payload?.reason || payload?.error || `Request failed (${res.status})`);
   }
   return payload.data as T;
 }

--- a/apps/web/src/lib/feature-copy.ts
+++ b/apps/web/src/lib/feature-copy.ts
@@ -8,8 +8,12 @@ const FEATURE_REASONS: Record<string, string> = {
   // Billing groups (spec 2026-07-21): the cap belongs to the billing GROUP, so
   // the way forward is the group's plan — not a per-org purchase. Never says
   // "clubs", which is a separate in-org entity with its own clubs.max cap.
+  // Fires for BOTH caps: the per-USER limit (creating one org too many for your
+  // plan — Community allows 1) and the per-GROUP limit (a shared bill that is
+  // full). Worded to make sense for either, and to name the upgrade path and the
+  // half-price extra-org rule rather than the raw key.
   "orgs.max_owned":
-    "Your billing group already holds the most organisations its plan allows. Upgrade the group's plan in Settings → Billing to raise the cap — each extra organisation is half your plan's rate.",
+    "Your current plan covers the most organisations it allows (Community 1, Pro 5, Pro Plus 10). Upgrade in Settings → Billing to create more — each extra organisation is half your plan's rate, on one shared bill.",
   "members.max": "You've reached your plan's team-member seats.",
   "scorers.max": "You've reached your plan's scorer seats.",
   "competitions.max_active": "Your plan's active-competition limit is reached.",


### PR DESCRIPTION
"Plan upgrade required: orgs.max_owned" leaked the internal key and gave no guidance. The 402 already carries a human `reason` (feature-copy); the client `api()` helper now prefers it, so every upgrade error reads as a sentence. The `orgs.max_owned` copy is reworded to fit both the per-user (Community=1) and per-group caps. Regression test on `api()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)