### PR TITLE
fix(billing): de-duplicate the "Powered by Stripe" badge on payment surfaces

### DIFF
--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -210,11 +210,6 @@ export default async function BillingPage({
           <h1 className="page-title">
             {t(dict, "billing.title")}
           </h1>
-          {/* Quiet trust signal, not a headline: card entry never touches our
-              servers (SAQ A), and saying so belongs above the plan card. */}
-          <p className="mt-1 text-xs text-slate-500">
-            {t(dict, "billing.poweredByStripe")}
-          </p>
         </div>
 
         {justCheckedOut && (

--- a/apps/web/src/components/marketing-footer.tsx
+++ b/apps/web/src/components/marketing-footer.tsx
@@ -76,21 +76,20 @@ export async function MarketingFooter({ lang = "en" }: { lang?: string }) {
             </div>
           ))}
         </div>
-        <div className="mt-10 flex flex-col items-center justify-between gap-2 border-t border-[#2b1d5c] pt-6 text-xs text-[#8d7fc0] sm:flex-row">
+        <div className="mt-10 flex flex-col items-center justify-between gap-3 border-t border-[#2b1d5c] pt-6 text-xs text-[#8d7fc0] sm:flex-row">
           <span>{t(d, "footer.rights", { year: new Date().getFullYear() })}</span>
-          <LocaleSwitcher />
+          {/* Language picker sits alongside the official "Powered by Stripe"
+              lockup (white variant for the night slab, language-neutral image)
+              — trust line and locale share one row. */}
+          <div className="flex items-center gap-4">
+            <LocaleSwitcher />
+            <PoweredByStripe
+              variant="white"
+              width={104}
+              className="inline-block opacity-80 transition hover:opacity-100"
+            />
+          </div>
           <span className="mk-display tracking-[0.2em]">{t(d, "footer.tagline")}</span>
-        </div>
-        {/* Trust line: entry fees run on Stripe (Checkout + Connect) — say so
-            where the whole site signs off. Quiet by design, dead-centered. */}
-        <div className="mt-4 flex w-full justify-center">
-          {/* Official "Powered by Stripe" lockup, white variant for the night
-              slab. A language-neutral image, so no localized lead-in here. */}
-          <PoweredByStripe
-            variant="white"
-            width={112}
-            className="inline-block opacity-80 transition hover:opacity-100"
-          />
         </div>
       </div>
     </footer>

--- a/apps/web/src/components/public-site/register-form.tsx
+++ b/apps/web/src/components/public-site/register-form.tsx
@@ -12,7 +12,6 @@ import Image from "next/image";
 import { apiV1 } from "@/lib/client-v1";
 import { useMsg } from "@/components/i18n/dict-provider";
 import { Tip } from "@/components/ui/tip";
-import { PoweredByStripe } from "@/components/powered-by-stripe";
 
 export interface RegisterCompetition {
   name: string;
@@ -618,18 +617,6 @@ export function RegisterForm({
         </div>
       )}
       {division?.open && <div className="bottom-bar-spacer" aria-hidden />}
-      {/* Official "Powered by Stripe" lockup, centered below the pay button —
-          only for card-paid divisions, where Stripe actually takes the fee.
-          Light page (bg-canvas) → blurple variant. */}
-      {division?.open && division.payment_method === "stripe" && (
-        <p className="flex justify-center pt-1">
-          <PoweredByStripe
-            variant="blurple"
-            width={110}
-            className="inline-block opacity-70 transition hover:opacity-100"
-          />
-        </p>
-      )}
     </form>
   );
 }

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -534,7 +534,6 @@
   "role.viewer": "Viewer",
   "role.scorer": "Scorer",
   "billing.title": "Plan & Billing",
-  "billing.poweredByStripe": "Payments powered by Stripe",
   "billing.checkoutComplete": "Checkout complete — your plan is now",
   "billing.trialSuffix": " (trial)",
   "billing.currentPlan": "Current plan",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -534,7 +534,6 @@
   "role.viewer": "Espectador",
   "role.scorer": "Anotador",
   "billing.title": "Plan y facturación",
-  "billing.poweredByStripe": "Pagos procesados por Stripe",
   "billing.checkoutComplete": "Compra completada — tu plan ahora es",
   "billing.trialSuffix": " (prueba)",
   "billing.currentPlan": "Plan actual",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -534,7 +534,6 @@
   "role.viewer": "Observateur",
   "role.scorer": "Marqueur",
   "billing.title": "Forfait et facturation",
-  "billing.poweredByStripe": "Paiements propulsés par Stripe",
   "billing.checkoutComplete": "Paiement terminé — votre forfait est désormais",
   "billing.trialSuffix": " (essai)",
   "billing.currentPlan": "Forfait actuel",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -534,7 +534,6 @@
   "role.viewer": "Kijker",
   "role.scorer": "Scorer",
   "billing.title": "Abonnement & Facturering",
-  "billing.poweredByStripe": "Betalingen verwerkt door Stripe",
   "billing.checkoutComplete": "Afrekenen voltooid — je abonnement is nu",
   "billing.trialSuffix": " (proefperiode)",
   "billing.currentPlan": "Huidig abonnement",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -192,7 +192,6 @@ export type DictionaryKey =
   | "billing.plus.f4"
   | "billing.plus.f5"
   | "billing.plusSupport"
-  | "billing.poweredByStripe"
   | "billing.pro.f1"
   | "billing.pro.f2"
   | "billing.pro.f3"


### PR DESCRIPTION
## What

Three cosmetic follow-ups to #218 (official Powered-by-Stripe badge):

1. **Registration page — badge shown twice.** The shared-org layout footer already renders the Stripe lockup for card-payment orgs, so the extra form-level lockup under the pay button was a duplicate. Removed the form one; the footer badge stays as the canonical placement across all shared pages.
2. **Billing page — dropped the "Payments powered by Stripe" sentence** above the plan card. The official badge lockup on the card-entry surface already carries the trust signal. Removed the now-dead `billing.poweredByStripe` key from all four locales and the generated key union.
3. **Marketing (night) footer** — the "Powered by Stripe" lockup now sits on the same row as the language picker, instead of a separate centered line below.

## Verify

- `npm run typecheck` — clean (web + engine)
- `npx vitest run` (apps/web) — 1928 pass / 0 fail
- `npm run i18n:check` — parity OK (es/fr/nl vs en, 3271 keys)
- `marketing-shell.test.tsx` — footer still carries the official Powered by Stripe badge (links stripe.com): 4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)