### PR TITLE
fix(billing): show Stripe badge only on registration, not shared org pages

### DIFF
--- a/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
+++ b/apps/web/src/app/(public)/shared/[orgSlug]/layout.tsx
@@ -11,7 +11,6 @@ import { notFound, permanentRedirect } from "next/navigation";
 import Image from "next/image";
 import { Barlow_Condensed } from "next/font/google";
 import { AttributionLink } from "@/components/attribution-link";
-import { PoweredByStripe } from "@/components/powered-by-stripe";
 import { isReservedSlug } from "@/lib/public-site";
 import { publicThemeStyle } from "@/lib/public-theme";
 import { getPublicOrg } from "@/server/public-site/data";
@@ -114,15 +113,6 @@ export default async function PublicOrgLayout({
             <AttributionLink surface="badge" />
           </p>
         )}
-        {/* Trust line only where it's true: the org actually takes card entry
-            fees through Stripe. All tiers — payment trust, not platform chrome.
-            The official "Powered by Stripe" lockup, linked to stripe.com per
-            Stripe's brand policy. */}
-        {org.card_payments ? (
-          <p className="flex justify-center pt-1">
-            <PoweredByStripe variant="blurple" width={110} className="inline-block opacity-80 transition hover:opacity-100" />
-          </p>
-        ) : null}
       </footer>
     </div>
   );

--- a/apps/web/src/components/public-site/register-form.tsx
+++ b/apps/web/src/components/public-site/register-form.tsx
@@ -12,6 +12,7 @@ import Image from "next/image";
 import { apiV1 } from "@/lib/client-v1";
 import { useMsg } from "@/components/i18n/dict-provider";
 import { Tip } from "@/components/ui/tip";
+import { PoweredByStripe } from "@/components/powered-by-stripe";
 
 export interface RegisterCompetition {
   name: string;
@@ -617,6 +618,19 @@ export function RegisterForm({
         </div>
       )}
       {division?.open && <div className="bottom-bar-spacer" aria-hidden />}
+      {/* Official "Powered by Stripe" lockup, centered below the pay button —
+          only for card-paid divisions, where Stripe actually takes the fee.
+          Registration is the one public surface that carries it; the shared
+          layout footer stays badge-free. Light page (bg-canvas) → blurple. */}
+      {division?.open && division.payment_method === "stripe" && (
+        <p className="flex justify-center pt-1">
+          <PoweredByStripe
+            variant="blurple"
+            width={110}
+            className="inline-block opacity-70 transition hover:opacity-100"
+          />
+        </p>
+      )}
     </form>
   );
 }

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -2817,9 +2817,8 @@ async function plgGrowthSuite(admin: Session, proOrgId: string, proOrgSlug: stri
   );
   check(
     // Key off the attribution CTA's own text, not a bare "Powered by" — the
-    // official "Powered by Stripe" trust badge also carries that phrase and
-    // shows on any card-payment org (this Pro one included), so the substring
-    // no longer isolates the Seazn attribution footer that org.branded drops.
+    // community attribution line itself reads "Powered by Seazn Club", so that
+    // substring never isolated the footer that org.branded drops.
     "plg pro page drops the Seazn attribution footer",
     !proShared.body.includes("Run your own free"),
   );


### PR DESCRIPTION
## What

The official **"Powered by Stripe"** lockup was rendered in the shared-org layout footer, so it showed on *every* public `/shared` page (standings, schedule, hub). It should appear only where a card fee is actually charged — the registration page.

- **Restore** the badge on the registration form, centered below the pay button, gated to card-paid divisions (`payment_method === "stripe"`).
- **Remove** the badge from the `/shared/[orgSlug]` layout footer → org public pages carry no Stripe lockup. The "Powered by Seazn Club" attribution line is unchanged.
- Refresh a `smoke.ts` comment that referenced the badge's old presence on shared pages.

Marketing site footer and internal billing page are untouched.

## Verify

- `npm run typecheck` — clean (web + engine)
- `npx vitest run` (apps/web) — 1928 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)