### PR TITLE
fix(billing): entitlement null-bool pass parity + honest pass-reconcile return

### DIFF
--- a/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
+++ b/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
@@ -166,6 +166,35 @@ describe.skipIf(!HAS_DB)("Event Pass leaves a financial trace (reconcile-on-retu
     expect(sub.currency).toBeNull();
   });
 
+  it("still reports success when the money-trace write hiccups on an already-recorded pass", async () => {
+    // The pass is recorded and live the moment recordPassPurchase returns; the
+    // trace writes (linkStripeCustomer / pinBillingCurrency) run AFTER it and
+    // are best-effort. A DB hiccup on the trace must not flip the return to
+    // false for a pass that already exists (issue #210). Force a real hiccup:
+    // another subscription already owns this customer id, so linkStripeCustomer's
+    // UPDATE trips V314's partial unique index on stripe_customer_id and throws.
+    const { orgId, compId } = await seedPassBuyer();
+    const cid = "cus_pass_hiccup_" + uniq();
+    await sql`
+      with _owner as (
+        insert into users (email, display_name, email_verified)
+        values ('conflict-' || gen_random_uuid() || '@test.local', 'Conflict Owner', true)
+        returning id
+      )
+      insert into subscriptions (owner_user_id, plan_key, status, stripe_customer_id)
+      select id, 'community', 'active', ${cid} from _owner`;
+    stripeMock.retrieve.mockResolvedValue(passSession(orgId, compId, { customer: cid }));
+
+    // Before the fix the trace fault propagated to the function-wide catch and
+    // returned false — a lie, since the pass is already recorded below.
+    expect(await reconcilePassCheckout(orgId, "cs_pass_hiccup")).toBe(true);
+
+    const [pass] = await sql<{ competition_id: string }[]>`
+      select competition_id from competition_passes
+      where competition_id = ${compId} and org_id = ${orgId}`;
+    expect(pass?.competition_id).toBe(compId);
+  });
+
   it("does not link the customer of a session that is not paid", async () => {
     const { orgId, compId } = await seedPassBuyer();
     stripeMock.retrieve.mockResolvedValue({

--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -153,6 +153,29 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     expect(await sqlHasFeature(orgId, "realtime", otherId)).toBe(false);
   });
 
+  it("coalesces a null-bool Event Pass row THROUGH to the plan, not into a deny", async () => {
+    // A pass row whose bool_value is null is NO answer, not a deny: it must fall
+    // through to the plan row, exactly as org_has_feature's coalesce does.
+    // Latent today — no shipped pass key is null-bool where community is true —
+    // so a run-unique key builds precisely that shape. Before the fix the TS
+    // resolver took the pass row as authoritative and denied while SQL allowed.
+    // See issue #209.
+    const key = `passnull-${uniq()}`;
+    await sql`
+      insert into plan_entitlements (plan_key, feature_key, bool_value, int_value)
+      values ('community',  ${key}, true, null),
+             ('event_pass', ${key}, null, 7)`;
+    const passedId = await seedCompetition(orgId, "passnull");
+    await sql`
+      insert into competition_passes (competition_id, org_id) values (${passedId}, ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+
+    expect(await sqlHasFeature(orgId, key, passedId)).toBe(true);
+    expect(await hasFeature(orgId, key, passedId)).toBe(true);
+
+    await sql`delete from plan_entitlements where feature_key = ${key}`;
+  });
+
   it("treats a null-bool override as no answer, not as a deny", async () => {
     await sql`
       insert into org_entitlement_overrides (org_id, feature_key, bool_value, int_value)

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -869,12 +869,22 @@ export async function reconcilePassCheckout(
     // are idempotent — linkStripeCustomer touches nothing on a same-customer
     // link, and the currency pin never overwrites — and re-running is what
     // heals a first attempt that died between the insert and these writes.
-    if (session.customer) {
-      // Not a bare UPDATE: a re-buy lands on a NEW customer and the
-      // has_payment_method mirror describes the OLD one. See linkStripeCustomer.
-      await linkStripeCustomer(orgId, session.customer as string);
+    //
+    // Best-effort, like the refund above: the pass is ALREADY recorded and live
+    // once recordPassPurchase returned, so a DB hiccup on either trace write
+    // must NOT flip this reconcile to a failure — the return value would then
+    // lie about a pass that exists. Logged, not rethrown; the webhook re-runs
+    // both idempotently and heals the trace. (issue #210)
+    try {
+      if (session.customer) {
+        // Not a bare UPDATE: a re-buy lands on a NEW customer and the
+        // has_payment_method mirror describes the OLD one. See linkStripeCustomer.
+        await linkStripeCustomer(orgId, session.customer as string);
+      }
+      await pinBillingCurrency(orgId, session.currency);
+    } catch (err) {
+      logReconcileFailure("reconcilePassCheckout", orgId, sessionId, err);
     }
-    await pinBillingCurrency(orgId, session.currency);
     return true;
   } catch (err) {
     logReconcileFailure("reconcilePassCheckout", orgId, sessionId, err);

--- a/apps/web/src/lib/entitlements.ts
+++ b/apps/web/src/lib/entitlements.ts
@@ -203,6 +203,17 @@ async function resolveFromDb(
   // must be resolved exactly once.
   const planKey = await orgPlanKey(orgId);
 
+  // Plan row first: it is the base whenever no pass applies AND the fall-through
+  // the pass overlay below coalesces into — a pass that answers null on a bool
+  // is no answer, not a deny, and must resolve to the plan's bool (org_has_feature
+  // does exactly this in SQL). Fetching it unconditionally is behaviour-neutral:
+  // the old code reached the same query on every path a pass did not fully own.
+  const [planRow] = await sql<Resolved[]>`
+    select bool_value, int_value
+    from plan_entitlements
+    where plan_key = ${planKey} and feature_key = ${featureKey}`;
+  let base: Resolved | null = planRow ?? null;
+
   // Event Pass (v3/07 §3): lifts a single competition for community orgs
   // only — under any paid plan the pass is deliberately moot (Pro's matrix is
   // a strict superset), which is also what lets it survive a later downgrade.
@@ -212,7 +223,6 @@ async function resolveFromDb(
   // `isPaidPlan` is the same predicate the competition layout uses to decide
   // whether to OFFER a pass, on purpose: "the pass does nothing here" and
   // "stop selling the pass here" must never be able to disagree.
-  let base: Resolved | null = null;
   if (!isPaidPlan(planKey) && competitionId) {
     const [pass] = await sql<Resolved[]>`
       select pe.bool_value, pe.int_value
@@ -220,14 +230,18 @@ async function resolveFromDb(
       join plan_entitlements pe
         on pe.plan_key = cp.pass_key and pe.feature_key = ${featureKey}
       where cp.competition_id = ${competitionId} and cp.org_id = ${orgId}`;
-    base = pass ?? null;
-  }
-  if (!base) {
-    const [pe] = await sql<Resolved[]>`
-      select bool_value, int_value
-      from plan_entitlements
-      where plan_key = ${planKey} and feature_key = ${featureKey}`;
-    base = pe ?? null;
+    if (pass) {
+      // Overlay field by field, EXACTLY as the override arm below and as the SQL
+      // resolver's coalesce (org_has_feature, V306): a null pass bool_value is no
+      // answer and falls THROUGH to the plan bool, never a deny. int_value stays
+      // wholesale — a null pass int is UNLIMITED, a load-bearing answer on that
+      // column, not "unset". Skipping the coalesce is what let TS deny a feature
+      // the plan grants while SQL allowed it (issue #209).
+      base = {
+        bool_value: pass.bool_value ?? base?.bool_value ?? null,
+        int_value: pass.int_value,
+      };
+    }
   }
 
   // A live override wins — but a null `bool_value` is NO ANSWER, not a deny, so

--- a/apps/web/src/server/usecases/__tests__/billing-manage-plan.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-manage-plan.test.ts
@@ -249,4 +249,38 @@ describe("applyPlanChange", () => {
     expect(entitlementsMock.invalidateEntitlementsForOrgGroup).toHaveBeenCalledWith(ORG_ID);
     expect(result).toEqual({ requires_action: false });
   });
+
+  it("hands the client secret back when the change needs SCA/3DS (requires_action)", async () => {
+    // SCA makes 3DS the normal path for European cards and Indian card mandates
+    // require it. When Stripe leaves the plan-change invoice OPEN pending
+    // confirmation, applyPlanChange must return the confirmation client_secret so
+    // the client can complete 3DS — a silent { requires_action: false } would
+    // look to the buyer like "I clicked upgrade and nothing happened" while
+    // Stripe holds an unconfirmed PaymentIntent. Only the false branch was
+    // covered before (the test above). (issue #205)
+    db.sub = sub({ plan_key: "pro" });
+    stripeMock.retrieveSubscription.mockResolvedValue({
+      status: "active",
+      currency: "usd",
+      items: { data: [{ id: "si_1", price: { id: "price_pro_m" } }] },
+    });
+    const updated = {
+      status: "active",
+      currency: "usd",
+      items: { data: [{ id: "si_1", price: { id: "price_plus_m" } }] },
+      latest_invoice: {
+        status: "open",
+        confirmation_secret: { client_secret: "pi_3ds_secret_abc" },
+      },
+    };
+    stripeMock.updateSubscription.mockResolvedValue(updated);
+
+    const result = await applyPlanChange(ORG_ID, "pro_plus", "monthly", 1_770_000_000);
+
+    expect(result).toEqual({ requires_action: true, client_secret: "pi_3ds_secret_abc" });
+    // The plan is still synced and the group cache still dropped BEFORE 3DS is
+    // handed back — the confirmation completes an already-applied change.
+    expect(billingMock.syncSubscription).toHaveBeenCalledWith(ORG_ID, updated);
+    expect(entitlementsMock.invalidateEntitlementsForOrgGroup).toHaveBeenCalledWith(ORG_ID);
+  });
 });


### PR DESCRIPTION
Three latent billing/entitlement bugs from the open issue backlog, each with a regression test that fails without the fix.

## #209 — entitlements TS/SQL divergence on a null-bool pass row
`lib/entitlements.ts:resolveFromDb` took a `competition_passes` row as authoritative even when its `plan_entitlements.bool_value` was null — so TS denied while the SQL resolver `org_has_feature` (V306) coalesced the null **through** to the plan row. Latent today (no shipped pass key is null-bool where community is true); fires the moment one is.

Fix: fetch the plan row first as the base, then overlay the pass **field by field** — bool coalesces through (`pass.bool_value ?? base?.bool_value ?? null`), int stays wholesale (a null pass int is UNLIMITED). Exactly the asymmetry the override arm below it already uses, and exactly what SQL does.

## #210 — `reconcilePassCheckout` reports failure for an already-recorded pass
The money-trace writes (`linkStripeCustomer`, `pinBillingCurrency`) sat inside the function-wide `catch { return false }`, so a DB hiccup on the trace flipped the return to `false` for a pass that is already recorded and live. Fix: wrap the two trace writes in their own try/catch (logged, not rethrown) and `return true` once the pass is recorded — the same courtesy the refund path already extends. The webhook re-runs both idempotently and heals the trace.

## #205 — 3DS `requires_action` had no coverage
Producer code was correct; only the `requires_action: false` branch was tested. Added the true-branch counterpart for `applyPlanChange` (SCA is the normal path for European cards / Indian mandates; a silent no-op looks like "nothing happened"). Interval + retry-invoice route producers remain uncovered — noted in #223.

## Verification
- `tsc --noEmit` clean
- Regression tests RED→GREEN, verified against a fresh V316 Postgres:
  - `entitlements-sql-parity.test.ts` — null-bool pass coalesces through (synthetic key)
  - `billing-pass-financial-trace.test.ts` — trace hiccup via V314's unique index, pass still recorded, return true
  - `billing-manage-plan.test.ts` — `requires_action: true` hands the client secret back
- 76 entitlement tests green (no regression from the `resolveFromDb` restructure)

## Not in this PR
Remaining billing bugs #214 (durable group-invoice ledger stamp — needs a migration) and #206 (decline-at-checkout / grace — needs live Stripe test mode) are root-caused and tracked in #223.

Closes #209
Closes #210
Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
