### PR TITLE
fix(billing): serialize org-quota + atomic webhook claim (#229 P0-1/P0-2)

### DIFF
--- a/apps/web/src/app/api/webhooks/stripe/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe/route.ts
@@ -1,13 +1,11 @@
 import { NextResponse } from "next/server";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
-import { sql } from "@/lib/db";
 import { runEvent } from "@/server/usecases/billing-events";
 
 // Signed Stripe webhook. The dispatch table lives in
 // server/usecases/billing-events.ts, shared with the staff console's
-// "process now" replay — this route only owns signature verification and
-// the already-processed fast path.
+// "process now" replay — this route only owns signature verification.
 export async function POST(req: Request) {
   const rawBody = await req.text();
   const sig = req.headers.get("stripe-signature");
@@ -24,14 +22,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
   }
 
-  // Idempotency: skip if already recorded (processed or mid-flight).
-  const [existing] = await sql<{ id: string }[]>`
-    select id from billing_events where id = ${event.id}`;
-  if (existing) return NextResponse.json({ received: true });
-
   try {
-    // Records the row first, stamps processed_at only after the handler ran —
-    // a throw leaves it visible as "received" on /admin/billing-events.
+    // runEvent claims the event atomically and processes it exactly once
+    // (#229 P0-2); a duplicate or concurrent delivery is a no-op. It stamps
+    // processed_at only after the handler ran, so a throw leaves the row
+    // visible as "received" on /admin/billing-events for replay.
     await runEvent(event);
   } catch (err) {
     // Return 5xx so Stripe retries

--- a/apps/web/src/lib/__tests__/org-create-concurrency.test.ts
+++ b/apps/web/src/lib/__tests__/org-create-concurrency.test.ts
@@ -1,0 +1,85 @@
+// #229 P0-1: the per-user org cap must hold under concurrency. createOrgForUser
+// used to read the quota (assertMayOwnAnotherOrg) BEFORE opening its
+// transaction, so two concurrent creates both saw spare capacity and each
+// created an organisation plus a Community billing group — busting orgs.max_owned
+// and multiplying per-org free-tier grants. The read, check and inserts are now
+// serialized per user with a transaction-scoped advisory lock.
+//
+// A brand-new user may always create their FIRST org (owned.length === 0 is the
+// free pass), and Community caps a user at one owned org. Two concurrent creates
+// therefore race for that single slot: exactly one must win. Real Postgres
+// required.
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+// A no-op cache: createOrgForUser calls invalidateUserOrgs, which needs no Redis
+// here, and getLimit's entitlement reads must hit the DB, not a stale cache.
+vi.mock("@/lib/cache", () => ({
+  cacheEnabled: () => false,
+  cacheGet: async () => null,
+  cacheSet: async () => {},
+  cacheDelPattern: async () => {},
+  incrWindow: async () => 1,
+}));
+
+import { sql } from "@/lib/db";
+import { createOrgForUser } from "@/lib/auth";
+import { PaymentRequiredError } from "@/lib/errors";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function makeUser(): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`capracer-${uniq()}@test.local`}, 'Cap Racer', true) returning id`;
+  return id;
+}
+
+const ownedCount = async (userId: string) =>
+  Number(
+    (
+      await sql<{ n: string }[]>`
+        select count(*)::text as n from org_members
+        where user_id = ${userId} and role = 'owner'`
+    )[0].n,
+  );
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("two concurrent org creates for one user", () => {
+  it("cannot both take the user past the Community cap of one owned org", async () => {
+    const userId = await makeUser();
+
+    const results = await Promise.allSettled([
+      createOrgForUser(userId, "Race A"),
+      createOrgForUser(userId, "Race B"),
+    ]);
+
+    const ok = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(ok).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(PaymentRequiredError);
+
+    // The cap held: one owned org, and one billing group — never two of either.
+    expect(await ownedCount(userId)).toBe(1);
+    const [{ n: groups }] = await sql<{ n: string }[]>`
+      select count(*)::text as n from subscriptions where owner_user_id = ${userId}`;
+    expect(Number(groups)).toBe(1);
+  });
+
+  it("still lets a user create their legitimate first org", async () => {
+    // Guard against a lock that deadlocks or refuses the happy path.
+    const userId = await makeUser();
+    const org = await createOrgForUser(userId, "Solo");
+    expect(org.id).toBeTruthy();
+    expect(await ownedCount(userId)).toBe(1);
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -255,7 +255,6 @@ export async function createOrgForUser(
   userId: string,
   name: string,
 ): Promise<Organization> {
-  await assertMayOwnAnotherOrg(userId);
   // Readable slugs can collide when two same-named orgs sign up concurrently
   // (check-then-insert race) — retry past the unique index, then salt.
   let org: Organization | undefined;
@@ -264,6 +263,16 @@ export async function createOrgForUser(
     const slug = attempt < 2 ? base : `${base}-${Math.random().toString(36).slice(2, 6)}`;
     try {
       org = await sql.begin(async (tx) => {
+        // #229 P0-1: serialize org creation per user. assertMayOwnAnotherOrg
+        // reads the quota BEFORE any row is written, so two concurrent creates
+        // both saw spare capacity and each minted an org + a Community group —
+        // busting orgs.max_owned and multiplying per-org free-tier grants. The
+        // transaction-scoped advisory lock (released on commit/rollback) makes a
+        // rival wait here until this create commits, so the check below always
+        // counts a just-created org. A failed check throws PaymentRequiredError,
+        // not a 23505 — the catch below rethrows it without retrying.
+        await tx`select pg_advisory_xact_lock(hashtext(${"org-create:" + userId}))`;
+        await assertMayOwnAnotherOrg(userId);
         const [s] = await tx<{ id: string }[]>`
           insert into subscriptions (owner_user_id, plan_key, status, quantity_paid)
           values (${userId}, 'community', 'active', 1)

--- a/apps/web/src/server/usecases/__tests__/billing-events-concurrency.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-events-concurrency.test.ts
@@ -1,0 +1,119 @@
+// #229 P0-2: two concurrent deliveries of the SAME Stripe event must run the
+// handler — and therefore its side effects — exactly once. The webhook used to
+// SELECT-then-INSERT and always process, so a duplicate delivery double-fired
+// the handler (a second dunning analytics event, a second email) while only one
+// ledger row was written. runEvent now claims the event atomically under a
+// lease and only the claimant processes.
+//
+// The side effect counted here is the PAYMENT_FAILED analytics capture that
+// handleInvoicePaymentFailed fires once per run: with the bug it is called
+// twice, with the fix once. Real Postgres required.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
+
+const captureServer = vi.hoisted(() => vi.fn(async () => {}));
+vi.mock("@/lib/posthog-server", () => ({ captureServer }));
+// A no-op cache so invalidateGroupEntitlements does not need Redis.
+vi.mock("@/lib/cache", () => ({
+  cacheEnabled: () => false,
+  cacheGet: async () => null,
+  cacheSet: async () => {},
+  cacheDelPattern: async () => {},
+  incrWindow: async () => 1,
+}));
+
+import { sql } from "@/lib/db";
+import { runEvent, ledgerByIds, eventStatus } from "../billing-events";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function makeUser(): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`racer-${uniq()}@test.local`}, 'Racer', true) returning id`;
+  return id;
+}
+
+/** A live group with a Stripe subscription id and one org, so a payment-failed
+ *  event resolves to a primary org and the analytics capture actually fires. */
+async function makeGroupWithOrg(stripeSubId: string): Promise<void> {
+  const owner = await makeUser();
+  const [{ id: subId }] = await sql<{ id: string }[]>`
+    insert into subscriptions (owner_user_id, plan_key, status, quantity_paid, stripe_subscription_id)
+    values (${owner}, 'pro', 'active', 1, ${stripeSubId}) returning id`;
+  const s = uniq();
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by, subscription_id)
+    values (${`Race ${s}`}, ${`race-${s}`}, ${owner}, ${subId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${owner}, 'owner')`;
+}
+
+function paymentFailedEvent(stripeSubId: string): Stripe.Event {
+  return {
+    id: `evt_${uniq()}`,
+    type: "invoice.payment_failed",
+    data: {
+      object: {
+        id: `in_${uniq()}`,
+        parent: { subscription_details: { subscription: stripeSubId } },
+        metadata: {},
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+beforeEach(() => {
+  captureServer.mockClear();
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("concurrent webhook delivery of one event", () => {
+  it("runs the handler and its side effects exactly once", async () => {
+    const stripeSubId = "sub_race_" + uniq();
+    await makeGroupWithOrg(stripeSubId);
+    const event = paymentFailedEvent(stripeSubId);
+
+    // Both deliveries land at the same instant. Without an atomic claim both
+    // pass the "already recorded?" check and both process.
+    await Promise.all([runEvent(event), runEvent(event)]);
+
+    // The side effect fired once, not once per delivery.
+    expect(captureServer).toHaveBeenCalledTimes(1);
+
+    // Exactly one ledger row, and it is processed.
+    const [{ n }] = await sql<{ n: string }[]>`
+      select count(*)::text as n from billing_events where id = ${event.id}`;
+    expect(Number(n)).toBe(1);
+    const rows = await ledgerByIds([event.id]);
+    expect(eventStatus(rows.get(event.id))).toBe("processed");
+  });
+
+  it("still heals a stuck row: a redelivery of an unprocessed, unleased event reprocesses it", async () => {
+    // Recovery must survive the atomic claim. A row recorded but never processed
+    // (crash mid-handler) has a null/expired lease; the next delivery — or the
+    // stuck-event sweep — takes it over and runs the handler.
+    const stripeSubId = "sub_stuck_" + uniq();
+    await makeGroupWithOrg(stripeSubId);
+    const event = paymentFailedEvent(stripeSubId);
+    // Seed a stuck row: recorded, unprocessed, no lease (as a legacy/crashed row).
+    await sql`
+      insert into billing_events (id, type, org_id, payload, processing_started_at)
+      values (${event.id}, ${event.type}, null, ${JSON.stringify(event.data.object)}, null)`;
+
+    const ran = await runEvent(event);
+
+    expect(ran).toBe(true);
+    expect(captureServer).toHaveBeenCalledTimes(1);
+    const rows = await ledgerByIds([event.id]);
+    expect(eventStatus(rows.get(event.id))).toBe("processed");
+  });
+});

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -828,32 +828,52 @@ async function resolveEventGroup(event: Stripe.Event): Promise<string | null> {
 }
 
 /**
- * Record + process one event, stamping processed_at only after the handler
- * ran (a throw leaves the row in the "received" state for the console).
+ * Record + process one event exactly once, stamping processed_at only after the
+ * handler ran (a throw leaves the row in the "received" state for the console).
  * Shared by the signed webhook and the staff replay.
+ *
+ * #229 P0-2: the claim is atomic. The webhook used to SELECT then INSERT ON
+ * CONFLICT DO NOTHING but process unconditionally, so two concurrent deliveries
+ * of the same event both ran the handler (a second dunning email/analytics
+ * event) while only one wrote the ledger row. Now a single statement either
+ * inserts a fresh row (leased now) or takes over a row that is still unprocessed
+ * AND whose lease has expired (a crashed attempt); a row already processed, or
+ * being processed under a live lease, matches nothing and returns no id. Only
+ * the caller that gets an id back runs the handler. Returns whether it did.
  */
-export async function runEvent(event: Stripe.Event): Promise<void> {
+export async function runEvent(event: Stripe.Event): Promise<boolean> {
   const orgId =
     (event.data.object as { metadata?: { org_id?: string } }).metadata?.org_id ?? null;
   const groupId = await resolveEventGroup(event);
-  await sql`
-    insert into billing_events (id, type, org_id, subscription_id, payload)
-    values (${event.id}, ${event.type}, ${orgId}, ${groupId}, ${JSON.stringify(event.data.object)})
-    on conflict (id) do nothing`;
+  const claimed = await sql<{ id: string }[]>`
+    insert into billing_events
+      (id, type, org_id, subscription_id, payload, processing_started_at)
+    values (${event.id}, ${event.type}, ${orgId}, ${groupId},
+            ${JSON.stringify(event.data.object)}, now())
+    on conflict (id) do update
+      set processing_started_at = now()
+      where billing_events.processed_at is null
+        -- Lease is shorter than the hourly stuck-event sweep, so a crash
+        -- mid-handler is recovered, but long enough to cover a slow handler.
+        and (billing_events.processing_started_at is null
+             or billing_events.processing_started_at < now() - interval '10 minutes')
+    returning id`;
+  if (claimed.length === 0) return false;
   await processStripeEvent(event);
   await sql`
     update billing_events set processed_at = now() where id = ${event.id}`;
+  return true;
 }
 
-/** Staff replay: skip events the ledger already saw through. */
+/** Staff replay: skip events the ledger already saw through; heal a stuck one. */
 export async function replayEvent(
   event: Stripe.Event,
 ): Promise<"processed" | "already_processed"> {
   const [existing] = await sql<{ processed_at: string | null }[]>`
     select processed_at from billing_events where id = ${event.id}`;
   if (existing?.processed_at) return "already_processed";
-  await runEvent(event);
-  return "processed";
+  // runEvent claims atomically; a live delivery may have taken the lease first.
+  return (await runEvent(event)) ? "processed" : "already_processed";
 }
 
 /** Ledger rows for a set of live Stripe event ids (the diff read). */

--- a/db/migration/deltas/V318__billing_events_processing_lease.sql
+++ b/db/migration/deltas/V318__billing_events_processing_lease.sql
@@ -1,0 +1,16 @@
+-- #229 P0-2: make webhook event claiming atomic.
+--
+-- The webhook used to SELECT billing_events, then INSERT ... ON CONFLICT DO
+-- NOTHING but always run the handler. Two concurrent deliveries of the same
+-- event both saw no row and both ran the side effects (a second dunning
+-- analytics event, a second email), even though only one inserted the ledger
+-- row. runEvent now claims an event atomically with a lease: it inserts a fresh
+-- row (leased now) or takes over a row that is still unprocessed AND whose lease
+-- has expired (a crashed attempt), and only the claimant runs the handler.
+--
+-- processing_started_at is that lease. Null on a legacy row means "no live
+-- lease" so the stuck-event sweeper (hourly, > 10 minutes old) can always take
+-- it over; once claimed it holds the lease for the lease window, which is
+-- shorter than the sweep interval so a genuine crash is still recovered.
+alter table billing_events
+  add column if not exists processing_started_at timestamptz;


### PR DESCRIPTION
Closes the two **P0 correctness gaps** from the #229 multi-org review. Both ship a DB-backed concurrent test that fails without the fix (TDD: verified RED → GREEN).

## P0-1 — serialize organisation quota enforcement
`assertMayOwnAnotherOrg()` read the per-user quota **before** `createOrgForUser()` opened its transaction, so two concurrent create requests both observed spare capacity and each created an org **plus** a Community billing group — exceeding `orgs.max_owned` and multiplying per-org free-tier grants.

**Fix:** the quota read, check and org/group/member inserts now run inside the transaction behind a per-user **transaction-scoped advisory lock** (`pg_advisory_xact_lock(hashtext('org-create:'||userId))`, the codebase's existing convention). A rival waits until the first create commits, so its check counts the just-created org. A failed check throws `PaymentRequiredError` (not a `23505`), so the slug-collision retry does **not** re-run a failed quota check.

- Test: `apps/web/src/lib/__tests__/org-create-concurrency.test.ts` — two concurrent creates for a fresh user race for the single Community slot; exactly one wins, one `PaymentRequiredError`, one org, one group.

## P0-2 — make webhook event claiming atomic
The webhook `SELECT`ed `billing_events`, then `runEvent()` did `INSERT ... ON CONFLICT DO NOTHING` but **always** processed. Two concurrent deliveries of the same event both saw no row and both ran the handler (a second dunning email / analytics event), though only one wrote the ledger row.

**Fix:** `runEvent` now claims atomically under a **lease** (V318 `billing_events.processing_started_at`). One statement inserts a fresh row *or* takes over a row that is still unprocessed **and** whose lease has expired; a processed row, or one under a live lease, matches nothing. Only the caller that gets an id back runs the handler. The webhook route drops its `SELECT`-then-`INSERT` and lets `runEvent` be the sole gate.

Recovery is preserved: the lease (10 min) is shorter than the hourly stuck-event sweep, so a crash mid-handler is still re-processed by `replayEvent`/`sweepStuckEvents` — covered by a "heals a stuck row" test.

- Test: `apps/web/src/server/usecases/__tests__/billing-events-concurrency.test.ts` — two concurrent `runEvent` of one event fire the handler side effect exactly once; a redelivery of an unprocessed/unleased row reprocesses it.

## Not in scope (remaining #229 items → follow-up)
Tracked in #232:
- **P1** operationalize the repair crons (confirm prod scheduler + monitoring) — ops, no code change.
- **P2** `organizations.subscription_id` `NOT NULL` — needs a prod null-check first, then a migration.

No user-facing behavior changed (both are concurrency guards), so no help-page or smoke-script edits.

Verify: `DATABASE_URL=... npx vitest run` the two new specs + `billing-events*`, `billing-group-move`, `orgs/route`; `tsc --noEmit`; `eslint`. All green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Closes #229