### PR TITLE
fix(e2e): truly anonymous context for the invite-claim specs

### DIFF
--- a/apps/web/e2e/invite-claim.spec.ts
+++ b/apps/web/e2e/invite-claim.spec.ts
@@ -19,12 +19,20 @@ test.describe("email invite auto-login (claim)", () => {
     return invite.data!.token;
   }
 
+  // A genuinely anonymous visitor. `browser.newContext()` on its own inherits the
+  // project storageState — the authed owner's session (playwright.config.ts) — so
+  // a "fresh" context would silently carry seazn_session, and every assertion here
+  // (session minted / refused, the anonymous one-tap UI) would pass vacuously
+  // against the very behaviour it guards. Spell out empty storage.
+  const anon = (b: import("@playwright/test").Browser) =>
+    b.newContext({ storageState: { cookies: [], origins: [] } });
+
   test("a brand-new invitee is signed in and joined in one POST", async ({ page, browser }) => {
     const org = await activeOrg(page);
     const email = `e2e-claim-${Date.now()}@example.com`;
     const token = await emailInvite(page, org.id, "viewer", email);
 
-    const ctx = await browser.newContext();
+    const ctx = await anon(browser);
     try {
       const res = await ctx.request.post(`/api/invites/${token}/claim`, { data: {} });
       expect(res.ok()).toBe(true);
@@ -48,7 +56,7 @@ test.describe("email invite auto-login (claim)", () => {
 
     // First claim creates the account and verifies the address.
     const first = await emailInvite(page, org.id, "viewer", email);
-    const ctx1 = await browser.newContext();
+    const ctx1 = await anon(browser);
     try {
       const r1 = await ctx1.request.post(`/api/invites/${first}/claim`, { data: {} });
       const b1 = ((await r1.json()) as { data: { needs_signin: boolean } }).data;
@@ -60,7 +68,7 @@ test.describe("email invite auto-login (claim)", () => {
     // Re-issue to the same (now verified) address; a fresh visitor holding the
     // link must NOT be handed a session — this is the forwarded-invite guard.
     const second = await emailInvite(page, org.id, "admin", email);
-    const ctx2 = await browser.newContext();
+    const ctx2 = await anon(browser);
     try {
       const r2 = await ctx2.request.post(`/api/invites/${second}/claim`, { data: {} });
       expect(r2.ok()).toBe(true);
@@ -78,7 +86,7 @@ test.describe("email invite auto-login (claim)", () => {
     const email = `e2e-claim-ui-${Date.now()}@example.com`;
     const token = await emailInvite(page, org.id, "viewer", email);
 
-    const ctx = await browser.newContext();
+    const ctx = await anon(browser);
     try {
       const p = await ctx.newPage();
       await p.goto(`/join/${token}`);


### PR DESCRIPTION
Post-merge E2E on main (run 29965316792, after #228 merged) failed 2 of the 3 `invite-claim.spec.ts` tests. Root cause is test-only: `browser.newContext()` inherits the project `storageState` (the authed owner's session, `playwright.config.ts`), so the "fresh visitor" contexts silently carried `seazn_session`.

- brand-new-claim test → passed **vacuously** (cookie present regardless of the claim);
- now-VERIFIED-account guard → saw the inherited owner cookie, read it as "session minted" (Expected false, Received true) though the claim correctly returned `needs_signin`;
- join-page one-tap → loaded `/join` already authenticated, so the anonymous `ClaimInvite` button never rendered → click timed out.

Fix: a local `anon()` helper that spells out empty storage (`{ cookies: [], origins: [] }`), matching `routing.spec.ts` and `event-pass.spec.ts`. **Test-only; the shipped feature is unaffected** (deploy-staging for the same tip was green).

Verification: e2e does not auto-run on PRs, so I dispatched the E2E workflow against this PR (`target=local`) to confirm all 3 tests pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)