### PR TITLE
fix(billing): never-paid subscription no longer grants 14 days of Pro (#206)

### DIFF
--- a/apps/web/src/lib/__tests__/billing-checkout.test.ts
+++ b/apps/web/src/lib/__tests__/billing-checkout.test.ts
@@ -418,13 +418,22 @@ describe("hasLiveSubscription", () => {
   });
 
   // Pins the `?? ""` fallback: a null status (row written before the column was
-  // populated) is not live, and neither is a raw Stripe status — STATUS_MAP has
-  // already folded `incomplete` into past_due before anything reaches here, so
-  // seeing the raw value means an unmapped write, not a live subscription.
-  it("is false for a null status or a raw unmapped Stripe status", () => {
+  // populated) is not live, and neither is an unmapped Stripe status.
+  it("is false for a null status or an unmapped Stripe status", () => {
     expect(hasLiveSubscription({ stripe_subscription_id: "sub_1", status: null })).toBe(false);
+    // incomplete_expired maps to canceled (terminal); a bare unknown is not live.
+    expect(
+      hasLiveSubscription({ stripe_subscription_id: "sub_1", status: "incomplete_expired" }),
+    ).toBe(false);
+    expect(hasLiveSubscription({ stripe_subscription_id: "sub_1", status: "wat" })).toBe(false);
+  });
+
+  // #206: `incomplete` is now a distinct, live status (it owns a real
+  // subscription, so a second checkout is blocked) — even though it is entitled
+  // to nothing until the first payment lands.
+  it("is true for incomplete — a never-paid subscription still owns billing", () => {
     expect(hasLiveSubscription({ stripe_subscription_id: "sub_1", status: "incomplete" })).toBe(
-      false,
+      true,
     );
   });
 });
@@ -449,12 +458,21 @@ describe("assertCheckoutAllowed past_due", () => {
     expect(status).toBe(409);
   });
 
-  // STATUS_MAP folds Stripe's `incomplete` into past_due, so this message is
-  // the whole recovery path for an org whose first payment never confirmed.
-  it("names the recovery path so the block is not a dead end", () => {
-    expect(() =>
-      assertCheckoutAllowed({ stripe_subscription_id: "sub_1", status: "past_due" }),
-    ).toThrow(/payment method|retry/i);
+  // #206: an org whose FIRST payment never confirmed now carries `incomplete`,
+  // not past_due. It still owns a subscription (block a second checkout), and the
+  // message names the recovery path so the block is not a dead end.
+  it("409s an incomplete org and names the recovery path", () => {
+    const call = () =>
+      assertCheckoutAllowed({ stripe_subscription_id: "sub_1", status: "incomplete" });
+    expect(call).toThrow(HttpError);
+    expect(call).toThrow(/hasn't finished|complete it|retry/i);
+    let status: unknown;
+    try {
+      call();
+    } catch (e) {
+      status = (e as HttpError).status;
+    }
+    expect(status).toBe(409);
   });
 
   it("still lets a departed customer buy again", () => {

--- a/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
+++ b/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
@@ -10,6 +10,7 @@ import type Stripe from "stripe";
 import { sql } from "@/lib/db";
 import { syncSubscription } from "@/lib/billing";
 import { processStripeEvent } from "@/server/usecases/billing-events";
+import { orgPlanKey } from "@/lib/entitlements";
 
 import { setOrgPlan } from "./_billing-group";
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -120,5 +121,49 @@ describe.skipIf(!HAS_DB)("status_changed_at transition stamping", () => {
     const held = await readAnchor(orgId);
     expect(held.status).toBe("past_due");
     expect(new Date(held.status_changed_at!).getTime()).toBeLessThan(Date.now() - 9 * 86_400_000);
+  });
+});
+
+// The bug this closes (#206 / #223-B): a checkout whose FIRST payment never
+// confirmed (abandoned 3DS, declined card at the sheet) lands `incomplete`.
+// STATUS_MAP used to fold that into past_due, and the 14-day past_due grace
+// then handed the org full Pro, paid for nothing, until Stripe expired the
+// subscription ~23h later. `incomplete` is now a distinct status the resolver
+// grants nothing — while genuine dunning (a renewal that failed after the sub
+// was active) still gets its grace.
+describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
+  async function setSub(
+    orgId: string,
+    over: { status: string; plan_key?: string; ageDays?: number },
+  ) {
+    await sql`
+      update subscriptions
+         set plan_key = ${over.plan_key ?? "pro"},
+             status = ${over.status},
+             stripe_subscription_id = ${`sub_${randomUUID().slice(0, 8)}`},
+             status_changed_at = now() - (${over.ageDays ?? 0} * interval '1 day')
+       where id = (select subscription_id from organizations where id = ${orgId})`;
+  }
+
+  it("an incomplete subscription conveys NO plan, even fresh inside the 14-day window", async () => {
+    const orgId = await seedOrg();
+    await setSub(orgId, { status: "incomplete", plan_key: "pro", ageDays: 0 });
+    // Before the fix this returned 'pro' (incomplete → past_due → grace).
+    expect(await orgPlanKey(orgId)).toBe("community");
+  });
+
+  it("a genuine past_due keeps Pro through the grace, then degrades — unchanged", async () => {
+    const orgId = await seedOrg();
+    await setSub(orgId, { status: "past_due", plan_key: "pro", ageDays: 3 });
+    expect(await orgPlanKey(orgId)).toBe("pro"); // within 14-day grace
+    await setSub(orgId, { status: "past_due", plan_key: "pro", ageDays: 15 });
+    expect(await orgPlanKey(orgId)).toBe("community"); // past the grace
+  });
+
+  it("syncSubscription writes Stripe `incomplete` as our incomplete, not past_due", async () => {
+    const orgId = await seedOrg();
+    const subId = `sub_inc_${randomUUID().slice(0, 8)}`;
+    await syncSubscription(orgId, stripeSub({ id: subId, status: "incomplete" }));
+    expect((await readAnchor(orgId)).status).toBe("incomplete");
   });
 });

--- a/apps/web/src/lib/__tests__/entitlements-comp-liveness.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-comp-liveness.test.ts
@@ -62,8 +62,20 @@ afterAll(async () => {
 });
 
 describe.skipIf(!HAS_DB)("comp-expiry arm derives its status list from billing", () => {
-  // The tie-proof: parameterised over the array itself.
+  // The tie-proof: parameterised over the array itself. Every live status keeps
+  // the plan despite a lapsed comp — EXCEPT `incomplete`, the one live status
+  // that conveys no plan (a never-paid first invoice; #206). It is in the list
+  // because it still owns a subscription slot (blocks a second checkout), but a
+  // dedicated resolver arm degrades it to community regardless of a comp.
   for (const status of LIVE_SUBSCRIPTION_STATUSES) {
+    if (status === "incomplete") {
+      it(`a never-paid '${status}' subscription degrades despite a lapsed comped_until`, async () => {
+        const orgId = await seedLapsedComp({ status });
+        expect(await hasFeature(orgId, "exports.branded")).toBe(false);
+        expect(await getLimit(orgId, "competitions.max_active")).toBe(COMMUNITY_MAX_ACTIVE);
+      });
+      continue;
+    }
     it(`a live '${status}' subscription still owns the plan despite a lapsed comped_until`, async () => {
       const orgId = await seedLapsedComp({ status });
       expect(await hasFeature(orgId, "exports.branded")).toBe(true);

--- a/apps/web/src/lib/billing-manage.ts
+++ b/apps/web/src/lib/billing-manage.ts
@@ -400,6 +400,10 @@ export function needsRenewalResync(
 ): boolean {
   if (!sub?.stripe_subscription_id) return false;
   if (sub.status === "past_due") return true;
+  // `incomplete` grants nothing (#206), so a first payment that DID confirm but
+  // whose `active` webhook was missed would otherwise strand the org on
+  // community. Re-sync any incomplete row so the billing page self-heals it.
+  if (sub.status === "incomplete") return true;
   if (sub.status !== "active" && sub.status !== "trialing") return false;
   if (!sub.current_period_end) return false;
   return new Date(sub.current_period_end).getTime() < Date.now();

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -240,6 +240,15 @@ export function assertCheckoutAllowed(
       "This organization's subscription needs a working payment method — update your card or retry the invoice from the billing page instead of starting a new subscription.",
     );
   }
+  if (sub.status === "incomplete") {
+    // First payment never confirmed (e.g. a 3DS challenge left unfinished). The
+    // subscription already exists, so a fresh checkout would mint a second one —
+    // point them at completing the pending payment instead.
+    throw new HttpError(
+      409,
+      "This organization has a payment that hasn't finished — complete it, or retry the invoice from the billing page, instead of starting a new subscription.",
+    );
+  }
   throw new HttpError(
     409,
     "This organization already has a subscription — manage your plan from the billing page instead.",
@@ -390,7 +399,13 @@ const STATUS_MAP: Record<string, string> = {
   active: "active",
   past_due: "past_due",
   canceled: "canceled",
-  incomplete: "past_due",
+  // `incomplete` is kept DISTINCT, not folded into past_due (#206/#223-B): it
+  // means the FIRST invoice never succeeded, so the org has paid nothing and
+  // must NOT get the 14-day past_due grace (which is for a subscription that WAS
+  // active and then a renewal failed). It is still a LIVE status (it owns a real
+  // subscription — see LIVE_SUBSCRIPTION_STATUSES), so a second checkout is
+  // blocked; the entitlement resolver degrades it to community until it pays.
+  incomplete: "incomplete",
   incomplete_expired: "canceled",
   unpaid: "past_due",
   paused: "past_due",

--- a/apps/web/src/lib/entitlements.ts
+++ b/apps/web/src/lib/entitlements.ts
@@ -157,6 +157,13 @@ export async function orgPlanKey(orgId: string): Promise<string> {
       when s.status = 'past_due'
            and coalesce(s.status_changed_at, s.updated_at) <= now() - interval '14 days'
            then 'community'
+      -- A never-paid subscription conveys NO plan. 'incomplete' means the FIRST
+      -- invoice never succeeded (an abandoned 3DS challenge, a declined card at
+      -- the sheet). It used to fold into past_due and so inherited the 14-day
+      -- grace: full Pro, paid for nothing, until Stripe expired it ~23h later
+      -- (#206/#223-B). The past_due grace is for a subscription that WAS active
+      -- and then a renewal failed; a first payment that never landed gets none.
+      when s.status = 'incomplete' then 'community'
       -- A CANCELLED subscription does not convey its plan. Without this arm the
       -- only thing standing between a departed org and permanent Pro is the
       -- customer.subscription.deleted handler having run and written

--- a/apps/web/src/lib/subscription-status.ts
+++ b/apps/web/src/lib/subscription-status.ts
@@ -1,7 +1,8 @@
 /** Statuses in which a Stripe subscription still owns the org's billing. Our
- *  STATUS_MAP collapses incomplete/unpaid/paused into past_due, so this list
- *  is the whole non-terminal set of STRIPE-SOURCED statuses. `canceled` is
- *  terminal — a departed customer must be able to come back.
+ *  STATUS_MAP collapses unpaid/paused into past_due and keeps `incomplete`
+ *  distinct (a never-paid first invoice — live, but entitled to nothing until it
+ *  pays), so this list is the whole non-terminal set of STRIPE-SOURCED statuses.
+ *  `canceled` is terminal — a departed customer must be able to come back.
  *
  *  STATUS_MAP is NOT the whole vocabulary of subscriptions.status: 'suspended'
  *  is written in-app by the staff suspend route (api/admin/orgs/[id]/suspend)
@@ -22,6 +23,9 @@ export const LIVE_SUBSCRIPTION_STATUSES: readonly string[] = [
   "trialing",
   "active",
   "past_due",
+  // A never-paid first invoice still owns a real subscription (blocks a second
+  // checkout); the entitlement resolver grants it nothing until it pays (#206).
+  "incomplete",
 ];
 
 /**


### PR DESCRIPTION
Closes the highest-value item in the `sk_test` cluster — and it's **headless** (no live Stripe needed to fix or prove).

## The bug (#206.2 / #223-B.2)
A checkout whose **first payment never confirmed** (abandoned 3DS, card declined at the sheet) lands the subscription in Stripe **`incomplete`**. `STATUS_MAP` folded `incomplete` → `past_due`, and the **14-day `past_due` grace** (`entitlements.ts`) then handed the org **full Pro, paid for nothing**, until Stripe expired the subscription ~23h later.

## The fix — `incomplete` becomes a first-class status
- **`STATUS_MAP`**: `incomplete → "incomplete"` (not `past_due`).
- **`LIVE_SUBSCRIPTION_STATUSES`**: keeps `incomplete` (it still owns a subscription slot → a second checkout is blocked). `assertCheckoutAllowed` gives it a distinct *"complete the pending payment"* message.
- **`orgPlanKey`**: a new arm degrades `incomplete` → **community**, regardless of the grace window. The `past_due` grace is only for a subscription that **was active** and then a renewal failed.
- **`needsRenewalResync`**: re-syncs an `incomplete` row, so a first payment that *did* confirm but whose `active` webhook was missed self-heals via the billing page (no false community).

**Robust by construction:** the leak is closed at the **entitlement layer**, so it holds even if Stripe's `customer.subscription.deleted` on `incomplete_expired` is ever missed — that status maps to `canceled`, also community. This resolves the issue's open worry about that webhook.

## Design tension surfaced (and handled)
`LIVE_SUBSCRIPTION_STATUSES` means two things: *owns a subscription slot* (checkout gating — incomplete **yes**) vs *conveys the plan* (comp-exemption — incomplete **no**). The comp-liveness sync-guard test caught this; it now special-cases `incomplete` as the one live status that still degrades under a lapsed comp.

## Tests (all green, DB-backed where needed)
- `incomplete` → community even **fresh inside the 14-day window** (the regression).
- A genuine `past_due` keeps Pro through the grace, then degrades — **unchanged**.
- `syncSubscription` writes `incomplete` (not `past_due`) end to end.
- `hasLiveSubscription` / `assertCheckoutAllowed` for `incomplete`.
- comp-liveness sync-guard updated.
- `tsc` + `eslint` clean; adjacent billing/entitlements suites (200+) green.

## Not in this PR (rest of the cluster)
- **#206.1** — decline-card **e2e** at the embedded checkout (does the sheet recover, is the buyer told, any stranded row).
- **#213** — graduated-tier billing verified against real test-mode Stripe.

Both next, using the `sk_test` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)