### PR TITLE
docs(help): explain the billing-group invoice model + plan-change proration

### DIFF
--- a/apps/web/content/help/billing/downgrade.md
+++ b/apps/web/content/help/billing/downgrade.md
@@ -29,6 +29,10 @@ What changes is the platform fee: back on Community the rate returns to **8%**, 
 
 **Passed competitions keep their own rate.** A competition covered by an [Event Pass](/help/billing/event-pass) stays at **5%** after the downgrade, and keeps everything else the pass grants — bigger limits, branded exports, sponsor tiers and packages — while the rest of the org sits on Community.
 
+## Moving to a cheaper plan gives you credit, not a bill
+
+Stepping down from Pro Plus to Pro (rather than cancelling to Community) is a plan change, so it's prorated: the time you'd already paid for on the pricier plan comes back as **account credit** that pays your next invoices automatically — the confirm step shows "No charge today" and the credit added, never a fresh charge. See the [itemised table you'll see before confirming](/help/billing/plans#changing-plan-or-billing-period-mid-cycle).
+
 ## Common questions
 
 **Do frozen results disappear from public pages?** No — read-only means the record stands; visitors notice nothing.

--- a/apps/web/content/help/billing/groups.md
+++ b/apps/web/content/help/billing/groups.md
@@ -99,7 +99,17 @@ Details worth knowing:
 - **The payer can withdraw an offer** at any time before it's accepted.
 - **Send them the link.** There's no inbox for pending offers yet, so the offer has to reach the recipient the way you'd send anything else. If they lose it, withdraw it and make a new one.
 - **A group with nothing to bill** — Community, or a subscription that has already been cancelled — moves in a single step, because there's no invoice to fail. It can only be handed to someone who already owns an organisation in the group, since there's no acceptance step to serve as their consent.
-- **Nothing about the organisations changes.** Same plan, same limits, same entry-fee rate, same Stripe Connect accounts, same payouts. The only things that move are who is billed and where the invoices and receipts go.
+- **Nothing about the organisations changes.** Same plan, same limits, same entry-fee rate, same Stripe Connect accounts, same payouts. The only things that move are who is billed, and who sees which invoices — see [what happens to your invoices](#what-happens-to-your-invoices-when-the-bill-changes-hands) just below.
+
+### What happens to your invoices when the bill changes hands
+
+A billing group is **one account** at our payment processor, so every invoice the group has ever been sent lives in one place. But each invoice carries the **name and billing address of whoever was paying when it went out** — printed on the PDF. So when the bill changes hands, we split the history by *who paid*, never showing one payer another's details:
+
+- **The new payer sees only their own invoices** — the ones sent from the handover onward. They never see yours, and never see your name or address on an older receipt.
+- **You keep yours.** Your invoices from when *you* paid stay visible to you, read-only, under **Settings → Billing → Your past invoices** on any organisation still in the group — even though you've stopped paying for it. Nothing to download in a rush before you hand over.
+- **If the bill ever comes back to you** later, you see both your earlier stretch and your new one — and still none of the invoices from whoever paid in between.
+
+This is only about who can *see* an invoice. It moves no money and changes no plan.
 
 ## The entry-fee rate locks when sales start
 
@@ -128,5 +138,7 @@ Each organisation keeps its own Stripe account, its own verification, its own ba
 **What currency does the group bill in?** One, fixed at the group's first checkout — organisations that join later are billed in it too, whatever their own entry fees are charged in.
 
 **One organisation was suspended by our team. Do we stop paying for it?** No. Suspension is a moderation action, not a billing one — the slot stays yours and the other organisations in the group are unaffected.
+
+**I handed the group over — where did my old invoices go?** Nowhere. They stay with you: your invoices from when you were the payer remain visible, read-only, under **Settings → Billing** on any organisation still in the group. The new payer can't see them — an invoice carries the billing name and address of whoever paid it, so we only ever show each person their own. See [what happens to your invoices](#what-happens-to-your-invoices-when-the-bill-changes-hands).
 
 **What if the payer deletes their account?** The group passes to the longest-standing owner of an organisation inside it, so nobody is left paying for organisations they can no longer manage — and nobody loses their plan because someone else closed an account. If there's nobody left who could ever manage it, the subscription is cancelled rather than orphaned. If you're deliberately handing over, do it properly with an offer first: that way the incoming payer's own card is on file before you go.

--- a/apps/web/content/help/billing/plans.md
+++ b/apps/web/content/help/billing/plans.md
@@ -37,7 +37,22 @@ Stripe's own processing fee is separate and set by Stripe. The whole money journ
 
 A subscription is a **billing group**: one card and one invoice for up to 5 organisations on Pro, or 10 on Pro Plus. The first is the plan's normal price and each one after that is half — $9/month on Pro, $19/month on Pro Plus. Every organisation in the group runs on the group's plan, so its entry-fee rate follows too. Community holds one organisation. See [one subscription, several organisations](/help/billing/groups).
 
+## Changing plan or billing period mid-cycle
+
+Switch plan — up or down — or flip between monthly and yearly, and we don't wait for your next renewal. The change is priced on the spot, and you see an **itemised table before you confirm**, taken live from our payment processor so the figure is exact:
+
+| Line | What it is |
+| --- | --- |
+| New billing period | the new plan's rate for the time left in this period |
+| Credit for unused time | what you already paid on the old plan, handed back |
+| Tax | on the difference |
+| **Charged today** | the net — usually far less than the sticker price |
+
+**Upgrading mid-cycle** only charges the difference for the days that are left, so it's cheap — not a fresh full period. **Downgrading usually costs nothing today**: the unused time you'd paid for turns into **account credit** that pays your next invoices automatically, shown as "Credit to your balance" instead of a charge. **On a free trial**, any change is still free — the table shows "No charge today" and tells you the date of your first charge. Whatever the case, the number you confirm is the number you're billed.
+
 ## Common questions
+
+**If I change plan mid-month, do I get charged twice?** No. You pay only the prorated difference for the time left in the current period, shown in an itemised table before you confirm — and a downgrade turns your unused time into account credit rather than a charge. See [changing plan mid-cycle](#changing-plan-or-billing-period-mid-cycle).
 
 **Does a passed competition use up an active-competition slot?** No — a competition covered by an [Event Pass](/help/billing/event-pass) doesn't count against your plan's active-competition limit, so a Community org running its annual tournament on a pass still has all 5 free slots.
 


### PR DESCRIPTION
## What

The multi-org billing-group help already covered the model, half-price seats, entry-fee lock, handover and payouts — but not the invoice behaviour shipped in #235, nor the proration table in #234. This closes that gap, in plain end-customer language.

- **`groups.md`** — new "What happens to your invoices when the bill changes hands" subsection + FAQ: a new payer sees only their own tenure's invoices (predecessor's name/address never leak), a former payer keeps a read-only "Your past invoices" view, a returning payer sees the union of their own tenures. Matches the shipped `billing.group.transfer.confirmBody` copy.
- **`plans.md`** — new "Changing plan or billing period mid-cycle" section: itemised new-period − unused-credit + tax = charged-today table, covering upgrade / downgrade-to-credit / trial cases, plus an FAQ.
- **`downgrade.md`** — short credit note + cross-link for the step-down case.

## Notes

- English-only — `content/help` is not localised (the 4-locale rule is app-UI dictionaries only), so no i18n work.
- In-doc `#anchor` links follow the existing shipped convention; heading ids are stripped by `rehypeSanitize` project-wide, so anchors don't scroll — pre-existing, not introduced by this PR.

## Verify

Stale-doc gate green: `help-content.test.ts` 6/6 (renders + sanitizes every article incl. the new table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)