### PR TITLE
chore(i18n): translate on Sonnet + backfill the es/fr/nl backlog

### DIFF
--- a/apps/web/src/lib/__tests__/i18n-translate.test.ts
+++ b/apps/web/src/lib/__tests__/i18n-translate.test.ts
@@ -30,7 +30,7 @@ describe("translateBatch", () => {
       model: string;
       output_config: { format: { type: string } };
     };
-    expect(arg.model).toBe("claude-opus-4-8");
+    expect(arg.model).toBe("claude-sonnet-5");
     expect(arg.output_config.format.type).toBe("json_schema");
   });
 });

--- a/scripts/i18n/translate.ts
+++ b/scripts/i18n/translate.ts
@@ -1,7 +1,7 @@
 // Incremental AI translation (v5 i18n §7). en/*.json is the source of truth.
 // Only keys whose source hash changed since the last run are re-translated
 // (manifest tracks hashes), so re-runs are cheap and self-healing. Translations
-// go through claude-opus-4-8 with structured output, a per-run glossary, and
+// go through claude-sonnet-5 with structured output, a per-run glossary, and
 // explicit {placeholder}/brand preservation. Run: `npm run i18n:translate`.
 import Anthropic from "@anthropic-ai/sdk";
 import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
@@ -14,7 +14,7 @@ const DICT = join(here, "../../apps/web/src/dictionaries");
 const MANIFEST = join(here, "manifest.json");
 const GLOSSARY = join(here, "glossary.json");
 const EN = "en";
-const MODEL = "claude-opus-4-8";
+const MODEL = "claude-sonnet-5";
 
 type StrMap = Record<string, string>;
 type Manifest = Record<string, StrMap>; // locale → key → source-hash


### PR DESCRIPTION
## What

Two commits:

1. **`translate.ts` model → `claude-sonnet-5`** (was `claude-opus-4-8`). You asked to run i18n translation on Sonnet. Pipeline is otherwise unchanged (en/*.json source of truth, hash manifest, `{placeholder}` preservation, structured output).
2. **Backfill es/fr/nl** by running `npm run i18n:translate`.

## Why the backfill

The translation manifest was **~1166 keys behind per locale** (2178/3344 tracked). `i18n:check` parity passed on *presence*, so CI was green — but that many es/fr/nl **values** were never run through the translator (recent billing PRs added English keys without translating), so some still read English. This clears that debt.

## Verified

- `i18n:check`: parity clean — 3344 keys × es/fr/nl.
- Placeholder integrity: **0 mismatches across 10,029 key pairs** (every locale × namespace).
- Spot-checks read idiomatic (e.g. "AI Schedule" → "Planning IA"), brand names preserved.
- Namespaces touched: es/fr/nl `{emails,marketing,public,ui}.json` + `scripts/i18n/manifest.json`.

## Note

The branch name (`board-ai-i18n-keys`) is a leftover: it started as a "board.ai.* keys are missing" investigation, which turned out to be a **false alarm** — those 235 keys were present all along (the dicts are flat dotted-key JSON; a nested lookup mis-reported them). No board changes here; this PR is purely the Sonnet switch + backlog translation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)