### PR TITLE
fix(v17): post-merge CI — Stripe test-mode wiring + e2e reconcile + out-of-credits board copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,15 @@ jobs:
           git diff --exit-code openapi/v1.json || {
             echo "openapi/v1.json is stale — run 'npm run openapi:gen' and commit."; exit 1; }
       - run: npm test --workspace apps/web
+      # Live-Stripe tier probe (sk_test, test-mode): confirms our plan/tier
+      # amounts still round-trip real Stripe. Self-contained (no stripe:sync /
+      # DATABASE_URL needed). The secret is withheld from fork PRs, so it just
+      # skips there; runs on the owner's branch PRs.
+      - name: Live-Stripe tier probe (sk_test)
+        run: npm test --workspace apps/web -- --run src/lib/__tests__/billing-tiers.live.test.ts
+        env:
+          BILLING_LIVE: "1"
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
       # Engine suite includes the PROMPT-14 simulation harness (SIM_RUNS
       # defaults to 200 divisions per sport×format when CI=true) and the
       # coverage gate (≥90% lines; 100% on core/ and tiebreakers.ts).
@@ -159,6 +168,10 @@ jobs:
       SCHEDULING_AI_BASE_URL: "http://127.0.0.1:4319"
       AI_FIXTURE_PORT: "4319"
       ANTHROPIC_API_KEY: sk-ant-ci-smoke-fixture
+      # Stripe test-mode key (sk_test) so the smoke card-attach / billing paths
+      # exercise real test-mode Stripe instead of skipping (`pm: skipped …`).
+      # Withheld from fork PRs (they skip); present on the owner's branch PRs.
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
 
     steps:
       - uses: actions/checkout@v5

--- a/apps/web/e2e/ai-architect.spec.ts
+++ b/apps/web/e2e/ai-architect.spec.ts
@@ -6,7 +6,7 @@ import {
   apiJson,
   activeOrg,
   setOrgPlanBySql,
-  seedAiGeneratedRuns,
+  drainAiCredits,
   getAiScheduleApply,
   getFixtureScheduleSources,
 } from "./helpers";
@@ -286,31 +286,35 @@ test("blackout injected over a scheduled fixture surfaces the repair nudge", asy
   await shot(page, "06-repair-scoped");
 });
 
-test.describe("community quota", () => {
+test.describe("community credit gate", () => {
   test.use({ storageState: "e2e/.auth/community.json" });
 
-  test("a community org at its 5-runs/division cap is refused before any model call", async ({
+  test("a community org with an empty AI-credit wallet is refused before any model call", async ({
     page,
     request,
   }) => {
     fixture.reset();
     const org = await activeOrg(page);
-    // No settings PUT / officials — the quota gate fires before the pack builds.
+    // No settings PUT / officials — the credit reserve refuses before the pack builds.
     const { competitionId, divisionId } = await seedAiDivision(request, { settings: false });
     try {
-      // Sit exactly at the free tier's cap: five prior generations for this division.
-      await seedAiGeneratedRuns(competitionId, org.id, divisionId, 5);
+      // v17: AI is credit-metered (1 credit/run). Drain the community wallet to 0
+      // so the next run's reserve refuses (V322 credit wallet replaced the retired
+      // V302 per-division run cap).
+      await drainAiCredits(org.id);
 
       await page.goto(`/divisions/${divisionId}/schedule?tab=board`);
       await openConsole(page);
-      // The community org CAN open the wizard (V302 grants scheduling.ai) …
+      // The community org CAN open the wizard (scheduling.ai is granted) …
       await page.locator("#ai-instruction").fill("Spread the matches across the day.");
       await page.getByRole("button", { name: "Generate schedule" }).click();
 
-      // … but the sixth run is refused with the quota copy, and no model call fires.
-      await expect(page.getByText("AI scheduling needs a Pro plan.")).toBeVisible({ timeout: 20_000 });
+      // … but the run is refused with the out-of-credits copy, and no model call fires.
+      await expect(
+        page.getByText("You're out of AI credits for this billing period.", { exact: false }),
+      ).toBeVisible({ timeout: 20_000 });
       expect(fixture.calls.length).toBe(0);
-      await shot(page, "07-community-quota");
+      await shot(page, "07-community-out-of-credits");
     } finally {
       // Free the community org's single active-competition slot for the serial specs.
       await apiJson(request, `/api/v1/competitions/${competitionId}`, "PATCH", { status: "archived" });

--- a/apps/web/e2e/billing-states.spec.ts
+++ b/apps/web/e2e/billing-states.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { TAG, apiJson, setOrgSubscriptionSql, setOwnerStaffSql } from "./helpers";
+import { TAG, apiJson, communityLimit, setOrgSubscriptionSql, setOwnerStaffSql } from "./helpers";
 
 // Subscription lifecycle states Stripe normally owns (trialing, past_due) —
 // forced via SQL so the app-wide billing banner and CTAs can be asserted
@@ -89,10 +89,12 @@ test.describe.serial("billing lifecycle states", () => {
       });
 
     // Fill Community's active-competition quota until it BITES — the ceiling
-    // is plan data (1 today) so it is discovered, not hardcoded. Observing the
-    // 402 is what stops the post-grant 201 from proving nothing.
+    // is plan data (V319 took competitions.max_active to 10) so it is read
+    // from the matrix, not hardcoded. Observing the 402 is what stops the
+    // post-grant 201 from proving nothing.
+    const maxActive = await communityLimit("competitions.max_active");
     let blockedAt = 0;
-    for (let i = 1; i <= 6 && blockedAt === 0; i++) {
+    for (let i = 1; i <= maxActive + 1 && blockedAt === 0; i++) {
       const res = await newCompetition(`Grant ${i}`);
       if (res.status === 402) {
         expect(res.error?.code).toBe("PAYMENT_REQUIRED");
@@ -165,11 +167,13 @@ test.describe.serial("billing lifecycle states", () => {
       });
 
     // Discover Community's real ceiling by filling it until a create 402s
-    // (plan data, not a constant — see the sibling "staff trial grant" test
+    // (plan data, not a constant — V319 took competitions.max_active to 10;
+    // read it from the matrix, see the sibling "staff trial grant" test
     // above). The oldest one created ("FreezeOldest") is what must show up
     // frozen later, since selectFrozen keeps the most-recently-active N.
+    const maxActive = await communityLimit("competitions.max_active");
     let blockedAt = 0;
-    for (let i = 1; i <= 6 && blockedAt === 0; i++) {
+    for (let i = 1; i <= maxActive + 1 && blockedAt === 0; i++) {
       const res = await newCompetition(i === 1 ? "FreezeOldest" : `FreezeFiller ${i}`);
       if (res.status === 402) {
         expect(res.error?.code).toBe("PAYMENT_REQUIRED");

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -288,6 +288,16 @@ export async function seedAiGeneratedRuns(
   });
 }
 
+/** Zero an org's AI-credit wallet (v17): delete its ledger rows so the next
+ *  run's reserve refuses with 402 ai.credits. Wallet id = coalesce(
+ *  subscription_id, id) per SPEC-2 §11.1. Superuser (RLS-bypassing). */
+export async function drainAiCredits(orgId: string): Promise<void> {
+  await withDb(async (sql) => {
+    await sql`delete from ai_credit_ledger where wallet_id =
+      (select coalesce(subscription_id, id)::text from organizations where id = ${orgId})`;
+  });
+}
+
 /** The most recent AI-sourced schedule apply audit for a division (v4 Task 17):
  *  the division_events 'schedule_applied' row with payload.source = 'ai'. */
 export async function getAiScheduleApply(

--- a/apps/web/e2e/pro-plus-tier.spec.ts
+++ b/apps/web/e2e/pro-plus-tier.spec.ts
@@ -249,7 +249,7 @@ test.describe("Pro Plus · billing surface", () => {
 // ===========================================================================
 
 test.describe("Pro Plus · officials-per-fixture quota", () => {
-  test("Community: one official per fixture is fine, a second 402s", async ({ page }) => {
+  test("Community: officials-per-fixture is ungated (#253, unlimited)", async ({ page }) => {
     const org = await seedOrg({ plan: "community" });
     await loginAsOwner(page, org.ownerEmail);
     const orgId = (await activeOrg(page)).id;
@@ -260,10 +260,9 @@ test.describe("Pro Plus · officials-per-fixture quota", () => {
     const one = await setFixtureOfficials(page.request, fixtureId, [o1!]);
     expect(one.status).toBe(200);
 
-    // A second official on the same fixture is over the community quota.
+    // A second official on the same fixture is allowed — officials ungated (#253).
     const two = await setFixtureOfficials(page.request, fixtureId, [o1!, o2!]);
-    expect(two.status).toBe(402);
-    expect(two.featureKey).toBe("officials.per_fixture.max");
+    expect(two.status).toBe(200);
   });
 
   test("Pro: officials-per-fixture is unlimited", async ({ page }) => {
@@ -420,11 +419,11 @@ test.describe("Pro Plus · disclosure + admin matrix", () => {
     // per-division count, so the comparison table has nothing left to show
     // there — no row to assert on.
 
-    // V290 quota: officials-per-fixture community 1 / pro ∞ / pro_plus ∞.
+    // Officials-per-fixture is ungated on every tier now (#253): community ∞ / pro ∞ / pro_plus ∞.
     const ofpRow = page
       .locator("tbody tr")
       .filter({ has: page.getByRole("cell", { name: "officials.per_fixture.max", exact: true }) });
-    await expect(ofpRow.locator("td").nth(2)).toHaveText("1"); // Community
+    await expect(ofpRow.locator("td").nth(2)).toHaveText("∞"); // Community
     await expect(ofpRow.locator("td").nth(4)).toHaveText("∞"); // Pro
     await expect(ofpRow.locator("td").nth(5)).toHaveText("∞"); // Pro Plus
 

--- a/apps/web/src/components/v2/board/__tests__/ai-console-state.test.ts
+++ b/apps/web/src/components/v2/board/__tests__/ai-console-state.test.ts
@@ -217,6 +217,15 @@ describe("aiErrorKey (status → localized copy key)", () => {
     expect(aiErrorKey(400)).toBe("board.ai.error.invalid");
   });
 
+  it("splits 402 on the feature key: an empty AI wallet tops up, a plan gate upgrades", () => {
+    // AI is credit-metered on every tier now, so an out-of-credits 402 (feature_key
+    // ai.credits) must offer a top-up, not "upgrade to Pro". A plain (non-credit)
+    // paywall 402 still routes to the upgrade line.
+    expect(aiErrorKey(402, "ai.credits")).toBe("board.ai.error.outOfCredits");
+    expect(aiErrorKey(402)).toBe("board.ai.error.upgrade");
+    expect(aiErrorKey(402, "scheduling.ai")).toBe("board.ai.error.upgrade");
+  });
+
   it("splits 422 on the server code: TOO_LARGE vs everything else", () => {
     expect(aiErrorKey(422, "AI_PLAN_TOO_LARGE")).toBe("board.ai.error.tooLarge");
     expect(aiErrorKey(422, "AI_PLAN_FAILED")).toBe("board.ai.error.invalid");
@@ -248,6 +257,12 @@ describe("applyErrorKey (apply outcome → localized copy key)", () => {
     expect(applyErrorKey(outcome({ errorCode: "schedule.checkpoints.max", errorStatus: 402 }))).toBe(
       "board.ai.apply.checkpointQuota",
     );
+  });
+
+  it("routes an out-of-credits 402 at apply to the top-up line", () => {
+    // ai-apply forwards the 402's feature_key as errorCode; an empty AI wallet
+    // (ai.credits) must reach the top-up copy, not the checkpoint-quota or upgrade line.
+    expect(applyErrorKey(outcome({ errorCode: "ai.credits", errorStatus: 402 }))).toBe("board.ai.error.outOfCredits");
   });
 
   it("sharpens an actionable failure through the outcome's status + code", () => {

--- a/apps/web/src/components/v2/board/ai-console-state.ts
+++ b/apps/web/src/components/v2/board/ai-console-state.ts
@@ -179,6 +179,7 @@ export function aiConsoleReducer(s: AiConsoleState, a: AiConsoleAction): AiConso
 /** ui-catalog copy keys for a failed run. */
 export type AiErrorKey =
   | "board.ai.error.upgrade"
+  | "board.ai.error.outOfCredits"
   | "board.ai.error.unavailable"
   | "board.ai.error.rateLimited"
   | "board.ai.error.conflict"
@@ -192,11 +193,14 @@ export type AiErrorKey =
  * the returned key through the ui catalog so a raw, untranslated server string
  * never reaches the UI. 422 splits on the code: AI_PLAN_TOO_LARGE asks the user
  * to narrow the scope; anything else is a plain "couldn't use that instruction".
+ * 402 splits on the feature key: an empty AI credit wallet (feature_key
+ * "ai.credits") asks the organiser to top up — AI is metered on every tier now,
+ * so "upgrade to Pro" is only right for the plain (non-credit) paywall.
  */
 export function aiErrorKey(status: number, code?: string): AiErrorKey {
   switch (status) {
     case 402:
-      return "board.ai.error.upgrade";
+      return code === "ai.credits" ? "board.ai.error.outOfCredits" : "board.ai.error.upgrade";
     case 503:
       // AI isn't configured on this server (no key / disabled) — a distinct line
       // from the run failures so the organiser isn't told to just try again.

--- a/apps/web/src/components/v2/board/ai-console.tsx
+++ b/apps/web/src/components/v2/board/ai-console.tsx
@@ -126,6 +126,17 @@ function stepDone(state: AiConsoleState, step: AiStep): boolean {
   }
 }
 
+// The server code aiErrorKey sharpens on. A 402 paywall's envelope `code` is the
+// generic "PAYMENT_REQUIRED" — the specific key rides in `extra.feature_key` (an
+// empty AI wallet → "ai.credits", a save-point cap → "schedule.checkpoints.max"),
+// so prefer the feature key and fall back to the typed code (a 422's
+// AI_PLAN_TOO_LARGE). This mirrors ai-apply.ts's `featureKeyOf(err) ?? codeOf(err)`
+// precedence; they don't collide (a 402 carries feature_key, a 422 does not).
+function aiErrorCodeOf(err: unknown): string | undefined {
+  if (!(err instanceof ApiV1Error)) return undefined;
+  return typeof err.extra.feature_key === "string" ? err.extra.feature_key : err.code;
+}
+
 // Re-export so the board imports the ghost/diff fixture shape from one place.
 export type { AiConsoleFixture } from "./ai-diff";
 
@@ -369,8 +380,7 @@ export function AiConsole({
       if (ac.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
       // Map the status (+ code) to a localized line; never render raw server text.
       const status = err instanceof ApiV1Error ? err.status : 0;
-      const code = err instanceof ApiV1Error ? err.code : undefined;
-      dispatch({ type: "RUN_ERROR", error: { status, message: msg(aiErrorKey(status, code)) } });
+      dispatch({ type: "RUN_ERROR", error: { status, message: msg(aiErrorKey(status, aiErrorCodeOf(err))) } });
     }
   }, [busy, divisionId, msg, officialsPolicy, state.instruction, state.mode, state.scope, state.schedulePlan]);
 
@@ -413,8 +423,7 @@ export function AiConsole({
       } catch (err) {
         if (ac.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
         const status = err instanceof ApiV1Error ? err.status : 0;
-        const code = err instanceof ApiV1Error ? err.code : undefined;
-        dispatch({ type: "RUN_ERROR", error: { status, message: msg(aiErrorKey(status, code)) } });
+        dispatch({ type: "RUN_ERROR", error: { status, message: msg(aiErrorKey(status, aiErrorCodeOf(err))) } });
       }
     },
     [busy, divisionId, msg, officialsPolicy, state.schedulePlan],
@@ -556,8 +565,7 @@ export function AiConsole({
       onApplied?.();
     } catch (err) {
       const status = err instanceof ApiV1Error ? err.status : 0;
-      const code = err instanceof ApiV1Error ? err.code : undefined;
-      dispatch({ type: "APPLY_ERROR", error: { status, message: msg(aiErrorKey(status, code)) } });
+      dispatch({ type: "APPLY_ERROR", error: { status, message: msg(aiErrorKey(status, aiErrorCodeOf(err))) } });
     } finally {
       setUndoing(false);
     }

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -46,6 +46,7 @@
   "board.ai.errorLabel": "Couldn't finish.",
   "board.ai.errorGeneric": "Something went wrong. Try again.",
   "board.ai.error.upgrade": "AI scheduling needs a Pro plan.",
+  "board.ai.error.outOfCredits": "You're out of AI credits for this billing period. Top up a credit pack or upgrade your plan to keep using AI Schedule.",
   "board.ai.error.unavailable": "AI scheduling isn't available on this server.",
   "board.ai.error.rateLimited": "Too many runs just now — wait a moment and try again.",
   "board.ai.error.conflict": "The schedule changed while planning — reopen and try again.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -46,6 +46,7 @@
   "board.ai.errorLabel": "No se pudo completar.",
   "board.ai.errorGeneric": "Algo salió mal. Inténtalo de nuevo.",
   "board.ai.error.upgrade": "La programación con IA necesita un plan Pro.",
+  "board.ai.error.outOfCredits": "Se han agotado tus créditos de IA para este periodo de facturación. Compra un paquete de créditos o mejora tu plan para seguir usando el Horario con IA.",
   "board.ai.error.unavailable": "La programación con IA no está disponible en este servidor.",
   "board.ai.error.rateLimited": "Demasiadas ejecuciones ahora mismo: espera un momento e inténtalo de nuevo.",
   "board.ai.error.conflict": "El calendario cambió durante la planificación: vuelve a abrir e inténtalo de nuevo.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -46,6 +46,7 @@
   "board.ai.errorLabel": "Impossible de terminer.",
   "board.ai.errorGeneric": "Une erreur s'est produite. Réessayez.",
   "board.ai.error.upgrade": "La planification IA nécessite un forfait Pro.",
+  "board.ai.error.outOfCredits": "Vous n'avez plus de crédits IA pour cette période de facturation. Achetez un pack de crédits ou passez à un forfait supérieur pour continuer à utiliser l'IA Planning.",
   "board.ai.error.unavailable": "La planification IA n'est pas disponible sur ce serveur.",
   "board.ai.error.rateLimited": "Trop d'exécutions à la fois — patientez un instant et réessayez.",
   "board.ai.error.conflict": "Le calendrier a changé pendant la planification — rouvrez et réessayez.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -46,6 +46,7 @@
   "board.ai.errorLabel": "Kon niet voltooien.",
   "board.ai.errorGeneric": "Er ging iets mis. Probeer opnieuw.",
   "board.ai.error.upgrade": "AI-planning vereist een Pro-abonnement.",
+  "board.ai.error.outOfCredits": "Je AI-credits voor deze factureringsperiode zijn op. Koop een creditpakket of upgrade je abonnement om AI Planning te blijven gebruiken.",
   "board.ai.error.unavailable": "AI-planning is niet beschikbaar op deze server.",
   "board.ai.error.rateLimited": "Te veel runs zojuist — wacht even en probeer opnieuw.",
   "board.ai.error.conflict": "Het schema is gewijzigd tijdens het plannen — heropen en probeer opnieuw.",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -318,6 +318,7 @@ export type DictionaryKey =
   | "board.ai.elapsed"
   | "board.ai.error.conflict"
   | "board.ai.error.invalid"
+  | "board.ai.error.outOfCredits"
   | "board.ai.error.rateLimited"
   | "board.ai.error.tooLarge"
   | "board.ai.error.unavailable"


### PR DESCRIPTION
Post-merge follow-up to #257. The main-push E2E after that merge failed 3/200 on stale-vs-v17 assertions; wiring those up surfaced one **real** v17 client gap (out-of-credits shown as "upgrade to Pro"). This branch closes all three plus adds Stripe test-mode coverage to CI.

## Commits
1. **`cec47f63` ci: Stripe test-mode checks** — adds a live-Stripe tier probe (`BILLING_LIVE=1`, `billing-tiers.live.test.ts`) to the test job and `STRIPE_SECRET_KEY` (sk_test) to the smoke job env, so the card path runs in CI. Fork PRs skip it (secret withheld).
2. **`dda88340` test(e2e): reconcile AI-quota + officials-cap specs to v17** — retires the V302 5-run/division cap assertion (AI is credit-metered now) via a new `drainAiCredits` helper; flips community `officials.per_fixture` from 402→200 and the matrix cell `1`→`∞` (#253 officials ungated).
3. **`322ff235` fix(board): show 'out of AI credits' not 'upgrade' when the wallet is empty** — the board mapped **every** 402 → "AI scheduling needs a Pro plan." A community org (credit-metered, 10/mo) that runs dry got the wrong copy. Now `aiErrorKey` splits the 402 on the `ai.credits` feature_key → new `board.ai.error.outOfCredits` (×4 locales), and the client forwards `feature_key` (not the always-`PAYMENT_REQUIRED` envelope `code`) at all three run sites.

## Verification
- Unit: `ai-console-state` 32/32; typecheck clean; i18n parity (3373 keys).
- **Full local e2e green: ai-architect 7/7** (credit-gate + generate CLEAN + refusal 422-path) **+ pro-plus-tier 13/13** (officials #253 + matrix + save-points). No regression on any error path.
- Two opus+max reviews: e2e-reconcile + Stripe-CI **APPROVED**; board fix **APPROVED** (credit-402 wired end-to-end, all other status paths byte-unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)