### PR TITLE
feat(v17): SPEC-3 Admin Adjustment Layer — audited credit/add-on grants + unified log

### DIFF
--- a/apps/web/src/app/api/admin/orgs/[id]/addons/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/addons/__tests__/route.test.ts
@@ -1,0 +1,172 @@
+// POST/DELETE /api/admin/orgs/[id]/addons — the SPEC-3 §1 row 3 staff add-on
+// grant/revoke route. requireSuperadmin, org-exists, grantAddon and revokeAddon
+// are mocked so this asserts the ROUTE's own contract: the superadmin gate
+// (support cannot comp add-ons), 404 on an unknown org, the strict zod schemas,
+// and the reason (code + note) fold. The grant/revoke DB behaviour (granted
+// row, freeze-not-delete, idempotency) is covered in
+// server/usecases/__tests__/admin-addons.test.ts. Mirrors the sibling credits
+// route test idiom.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { AuthError } from "@/lib/errors";
+import type { StaffRole } from "@/lib/admin";
+
+const requireSuperadminMock =
+  vi.fn<() => Promise<{ id: string; staff_role: StaffRole | null }>>();
+vi.mock("@/lib/admin", () => ({
+  requireSuperadmin: () => requireSuperadminMock(),
+}));
+
+const sqlMock = vi.fn<(...args: unknown[]) => Promise<{ id: string }[]>>();
+vi.mock("@/lib/db", () => ({
+  sql: (...args: unknown[]) => sqlMock(...args),
+}));
+
+const grantAddonMock =
+  vi.fn<(...args: unknown[]) => Promise<{ id: string; applied: boolean }>>();
+const revokeAddonMock = vi.fn<(...args: unknown[]) => Promise<{ revoked: boolean }>>();
+vi.mock("@/server/usecases/admin-addons", () => ({
+  grantAddon: (...args: unknown[]) => grantAddonMock(...args),
+  revokeAddon: (...args: unknown[]) => revokeAddonMock(...args),
+}));
+
+import { POST, DELETE } from "../route";
+
+const ORG = randomUUID();
+const ADDON = randomUUID();
+const KEY = "idem-12345678";
+
+const post = (id: string, body: unknown) =>
+  POST(
+    new Request(`http://test/api/admin/orgs/${id}/addons`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+
+const del = (id: string, body: unknown) =>
+  DELETE(
+    new Request(`http://test/api/admin/orgs/${id}/addons`, {
+      method: "DELETE",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+
+const grantBody = () => ({
+  feature_key: "members.max",
+  delta_each: 2,
+  qty: 3,
+  reason_code: "sales_comp",
+  idempotency_key: KEY,
+});
+
+beforeEach(() => {
+  requireSuperadminMock.mockReset().mockResolvedValue({ id: "root", staff_role: "superadmin" });
+  sqlMock.mockReset().mockResolvedValue([{ id: ORG }]);
+  grantAddonMock.mockReset().mockResolvedValue({ id: ADDON, applied: true });
+  revokeAddonMock.mockReset().mockResolvedValue({ revoked: true });
+});
+
+describe("POST /api/admin/orgs/[id]/addons (grant)", () => {
+  it("grants an add-on and returns the row id + applied", async () => {
+    const res = await post(ORG, grantBody());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      data: { ok: true, addon_id: ADDON, applied: true },
+    });
+    expect(grantAddonMock).toHaveBeenCalledWith(
+      "root",
+      ORG,
+      expect.objectContaining({
+        featureKey: "members.max",
+        deltaEach: 2,
+        qty: 3,
+        targetOrgId: null,
+        idempotencyKey: KEY,
+      }),
+    );
+  });
+
+  it("folds reason_code + note into the stored reason", async () => {
+    await post(ORG, { ...grantBody(), note: "launch deal" });
+    const opts = grantAddonMock.mock.calls[0]![2] as { reason: string };
+    expect(opts.reason).toContain("sales_comp");
+    expect(opts.reason).toContain("launch deal");
+  });
+
+  it("passes a set target_org_id through", async () => {
+    await post(ORG, { ...grantBody(), target_org_id: ADDON });
+    const opts = grantAddonMock.mock.calls[0]![2] as { targetOrgId: string | null };
+    expect(opts.targetOrgId).toBe(ADDON);
+  });
+
+  it("refuses a non-superadmin before touching the DB (support cannot comp add-ons)", async () => {
+    requireSuperadminMock.mockRejectedValueOnce(new AuthError("Superadmin access required"));
+    const res = await post(ORG, grantBody());
+    expect(res.status).toBe(401);
+    expect(sqlMock).not.toHaveBeenCalled();
+    expect(grantAddonMock).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown org before granting", async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await post("nope", grantBody());
+    expect(res.status).toBe(404);
+    expect(grantAddonMock).not.toHaveBeenCalled();
+  });
+
+  describe("schema", () => {
+    it("400s a blank feature_key", async () => {
+      const res = await post(ORG, { ...grantBody(), feature_key: "" });
+      expect(res.status).toBe(400);
+      expect(grantAddonMock).not.toHaveBeenCalled();
+    });
+    it("400s a non-positive qty", async () => {
+      const res = await post(ORG, { ...grantBody(), qty: 0 });
+      expect(res.status).toBe(400);
+    });
+    it("400s a non-positive delta_each", async () => {
+      const res = await post(ORG, { ...grantBody(), delta_each: -1 });
+      expect(res.status).toBe(400);
+    });
+    it("400s a too-short idempotency_key", async () => {
+      const res = await post(ORG, { ...grantBody(), idempotency_key: "short" });
+      expect(res.status).toBe(400);
+    });
+    it("400s an unknown reason_code", async () => {
+      const res = await post(ORG, { ...grantBody(), reason_code: "nope" });
+      expect(res.status).toBe(400);
+    });
+    it("400s an unknown field (strict)", async () => {
+      const res = await post(ORG, { ...grantBody(), extra: "x" });
+      expect(res.status).toBe(400);
+    });
+  });
+});
+
+describe("DELETE /api/admin/orgs/[id]/addons (revoke)", () => {
+  it("revokes an add-on and returns revoked", async () => {
+    const res = await del(ORG, { addon_id: ADDON, reason_code: "bug_fix" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, data: { ok: true, revoked: true } });
+    expect(revokeAddonMock).toHaveBeenCalledWith("root", ORG, ADDON, expect.stringContaining("bug_fix"));
+  });
+
+  it("refuses a non-superadmin", async () => {
+    requireSuperadminMock.mockRejectedValueOnce(new AuthError("Superadmin access required"));
+    const res = await del(ORG, { addon_id: ADDON, reason_code: "bug_fix" });
+    expect(res.status).toBe(401);
+    expect(revokeAddonMock).not.toHaveBeenCalled();
+  });
+
+  it("400s a non-uuid addon_id", async () => {
+    const res = await del(ORG, { addon_id: "not-a-uuid", reason_code: "bug_fix" });
+    expect(res.status).toBe(400);
+    expect(revokeAddonMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/admin/orgs/[id]/addons/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/addons/route.ts
@@ -1,0 +1,87 @@
+import { sql } from "@/lib/db";
+import { requireSuperadmin } from "@/lib/admin";
+import { grantAddon, revokeAddon } from "@/server/usecases/admin-addons";
+import { handler, HttpError } from "@/lib/http";
+import { z } from "zod";
+
+/** SPEC-3 §2 reason taxonomy — the same fixed set the credit-adjust route uses;
+ *  free text lands in `note`, and both fold into the stored `reason`. */
+const REASON_CODE = z.enum([
+  "support_goodwill",
+  "sales_comp",
+  "promo",
+  "bug_fix",
+  "refund_adjust",
+]);
+
+const grantSchema = z
+  .object({
+    feature_key: z.string().min(1).max(80),
+    /** +N per unit; V324 requires > 0. */
+    delta_each: z.number().int().positive(),
+    /** Line quantity; V324 requires > 0. */
+    qty: z.number().int().positive(),
+    /** NULL / omitted = group-wide (lifts every org on the wallet); set = one org. */
+    target_org_id: z.string().uuid().nullable().optional(),
+    reason_code: REASON_CODE,
+    note: z.string().max(500).optional(),
+    /** No double-grant on double-click (SPEC-3 §2). */
+    idempotency_key: z.string().min(8).max(200),
+  })
+  .strict();
+
+const revokeSchema = z
+  .object({
+    addon_id: z.string().uuid(),
+    reason_code: REASON_CODE,
+    note: z.string().max(500).optional(),
+  })
+  .strict();
+
+/** Grant a comped add-on (SPEC-3 §1 row 3). SUPERADMIN ONLY — comping capacity
+ *  is a sales-deal, high-privilege act (matches entitlement-override), so
+ *  support staff cannot. Writes one `status='granted'` org_addons row on the
+ *  org's group wallet; every grant is an attributed, reversible, reason-tagged
+ *  `addon_grant` staff-audit row (SPEC-3 §3). */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  return handler(async () => {
+    const { id } = await params;
+    const staff = await requireSuperadmin();
+    const { feature_key, delta_each, qty, target_org_id, reason_code, note, idempotency_key } =
+      grantSchema.parse(await req.json());
+
+    const [org] = await sql<{ id: string }[]>`select id from organizations where id = ${id}`;
+    if (!org) throw new HttpError(404, "Organization not found");
+
+    // Stored reason = internal code plus any free-text note (as the credit route).
+    const reason = note ? `${reason_code}: ${note}` : reason_code;
+
+    const { id: addonId, applied } = await grantAddon(staff.id, id, {
+      featureKey: feature_key,
+      deltaEach: delta_each,
+      qty,
+      targetOrgId: target_org_id ?? null,
+      reason,
+      idempotencyKey: idempotency_key,
+    });
+    return { ok: true, addon_id: addonId, applied };
+  });
+}
+
+/** Revoke an admin-granted add-on (SPEC-3 §2 reversible = freeze-not-delete).
+ *  SUPERADMIN ONLY. Flips the row to `status='canceled'`; a Stripe-paid or
+ *  other-org row is refused (409/404). */
+export async function DELETE(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  return handler(async () => {
+    const { id } = await params;
+    const staff = await requireSuperadmin();
+    const { addon_id, reason_code, note } = revokeSchema.parse(await req.json());
+
+    const [org] = await sql<{ id: string }[]>`select id from organizations where id = ${id}`;
+    if (!org) throw new HttpError(404, "Organization not found");
+
+    const reason = note ? `${reason_code}: ${note}` : reason_code;
+    const { revoked } = await revokeAddon(staff.id, id, addon_id, reason);
+    return { ok: true, revoked };
+  });
+}

--- a/apps/web/src/app/api/admin/orgs/[id]/adjustments/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/adjustments/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+// GET /api/admin/orgs/[id]/adjustments — the SPEC-3 §3 unified adjustments-log
+// read route. requireStaff, the org-exists check and adjustmentsForOrg are
+// mocked so this asserts the ROUTE's own contract: the entries envelope, the
+// 401 auth boundary, 404 on an unknown org, and the strict query schema. The
+// derivation/filtering/paging is covered by the DB-backed usecase test.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthError } from "@/lib/errors";
+import type { StaffRole } from "@/lib/admin";
+
+const requireStaffMock =
+  vi.fn<() => Promise<{ id: string; staff_role: StaffRole | null }>>();
+vi.mock("@/lib/admin", () => ({
+  requireStaff: () => requireStaffMock(),
+}));
+
+const sqlMock = vi.fn<(...args: unknown[]) => Promise<{ id: string }[]>>();
+vi.mock("@/lib/db", () => ({
+  sql: (...args: unknown[]) => sqlMock(...args),
+}));
+
+const adjustmentsForOrgMock = vi.fn<(...args: unknown[]) => Promise<unknown[]>>();
+vi.mock("@/server/usecases/admin-adjustments-log", () => ({
+  adjustmentsForOrg: (...args: unknown[]) => adjustmentsForOrgMock(...args),
+}));
+
+import { GET } from "../route";
+
+const get = (id: string, qs = "") =>
+  GET(new Request(`http://test/api/admin/orgs/${id}/adjustments${qs}`), {
+    params: Promise.resolve({ id }),
+  });
+
+const ENTRY = {
+  id: "log-1",
+  actorId: "staff-1",
+  actorName: "Casey",
+  action: "credit_adjust",
+  category: "credits",
+  detail: { reason_code: "promo" },
+  reason: "promo",
+  reversible: true,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+beforeEach(() => {
+  requireStaffMock.mockReset().mockResolvedValue({ id: "staff-1", staff_role: "support" });
+  sqlMock.mockReset().mockResolvedValue([{ id: "org-1" }]);
+  adjustmentsForOrgMock.mockReset().mockResolvedValue([ENTRY]);
+});
+
+describe("GET /api/admin/orgs/[id]/adjustments", () => {
+  it("returns the entries envelope for any staff", async () => {
+    const res = await get("org-1");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, data: { ok: true, entries: [ENTRY] } });
+    expect(adjustmentsForOrgMock).toHaveBeenCalledWith("org-1", { limit: undefined, before: undefined });
+  });
+
+  it("passes limit + before through to the usecase", async () => {
+    await get("org-1", "?limit=10&before=2026-01-02T00:00:00.000Z");
+    expect(adjustmentsForOrgMock).toHaveBeenCalledWith("org-1", {
+      limit: 10,
+      before: "2026-01-02T00:00:00.000Z",
+    });
+  });
+
+  it("rejects a non-staff caller before touching the DB", async () => {
+    requireStaffMock.mockRejectedValueOnce(new AuthError("Staff access required"));
+    const res = await get("org-1");
+    expect(res.status).toBe(401);
+    expect(sqlMock).not.toHaveBeenCalled();
+    expect(adjustmentsForOrgMock).not.toHaveBeenCalled();
+  });
+
+  it("404s an unknown org without reading the log", async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await get("org-missing");
+    expect(res.status).toBe(404);
+    expect(adjustmentsForOrgMock).not.toHaveBeenCalled();
+  });
+
+  it("400s a non-numeric limit", async () => {
+    const res = await get("org-1", "?limit=abc");
+    expect(res.status).toBe(400);
+    expect(adjustmentsForOrgMock).not.toHaveBeenCalled();
+  });
+
+  it("400s a non-positive limit", async () => {
+    const res = await get("org-1", "?limit=0");
+    expect(res.status).toBe(400);
+  });
+
+  it("400s a malformed before cursor", async () => {
+    const res = await get("org-1", "?before=not-a-date");
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/admin/orgs/[id]/adjustments/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/adjustments/route.ts
@@ -1,0 +1,37 @@
+import { sql } from "@/lib/db";
+import { requireStaff } from "@/lib/admin";
+import { adjustmentsForOrg } from "@/server/usecases/admin-adjustments-log";
+import { handler, HttpError } from "@/lib/http";
+import { z } from "zod";
+
+const query = z
+  .object({
+    /** Page size; usecase caps at 200. */
+    limit: z.coerce.number().int().positive().optional(),
+    /** created_at ISO cursor (exclusive) for keyset paging. */
+    before: z.string().datetime().optional(),
+  })
+  .strict();
+
+/** Read the SPEC-3 §3 unified adjustments log for one org. Any staff may READ
+ *  (support included); the write-restriction lives on the T1/T2 mutation
+ *  routes. Reads staff_audit_log scoped to this org + the adjustment action
+ *  set — no writes, no migration. */
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  return handler(async () => {
+    const { id } = await params;
+    await requireStaff();
+
+    const { searchParams } = new URL(req.url);
+    const { limit, before } = query.parse({
+      limit: searchParams.get("limit") ?? undefined,
+      before: searchParams.get("before") ?? undefined,
+    });
+
+    const [org] = await sql<{ id: string }[]>`select id from organizations where id = ${id}`;
+    if (!org) throw new HttpError(404, "Organization not found");
+
+    const entries = await adjustmentsForOrg(id, { limit, before });
+    return { ok: true, entries };
+  });
+}

--- a/apps/web/src/app/api/admin/orgs/[id]/credits/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/credits/__tests__/route.test.ts
@@ -82,6 +82,20 @@ describe("POST /api/admin/orgs/[id]/credits", () => {
     );
   });
 
+  it("does NOT write a second audit row when the adjustment is an idempotent replay", async () => {
+    // A replayed idempotency key returns applied:false (adminAdjust wrote no
+    // second ledger row). The route must skip logStaffAction too, else the
+    // SPEC-3 §3 unified log double-counts one adjustment.
+    adminAdjustMock.mockResolvedValueOnce({ applied: false, balanceAfter: 20 });
+    const res = await post("org-1", okBody(20));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      data: { ok: true, balance_after: 20, applied: false },
+    });
+    expect(logStaffActionMock).not.toHaveBeenCalled();
+  });
+
   it("builds the stored reason from reason_code + optional note", async () => {
     await post("org-1", { delta: 5, reason_code: "promo", note: "launch week", idempotency_key: KEY });
     const opts = adminAdjustMock.mock.calls[0]![2] as { reason: string };

--- a/apps/web/src/app/api/admin/orgs/[id]/credits/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/credits/__tests__/route.test.ts
@@ -1,0 +1,166 @@
+// POST /api/admin/orgs/[id]/credits — the SPEC-3 §1/§2 staff credit
+// grant/deduct route. Guard, org-exists, wallet resolution, adminAdjust and
+// logStaffAction are all mocked so this asserts the ROUTE's own contract:
+// the support hard cap (§2 RBAC tiers), the 401 auth boundary, 404, and the
+// strict zod schema. adminAdjust's own ledger/idempotency/below-zero behaviour
+// is covered in lib/__tests__/credits-admin-adjust.test.ts. Mirrors the
+// sibling restore-trial route test idiom.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthError } from "@/lib/errors";
+import type { StaffRole } from "@/lib/admin";
+
+const requireStaffMock =
+  vi.fn<() => Promise<{ id: string; staff_role: StaffRole | null }>>();
+const logStaffActionMock = vi.fn<(...args: unknown[]) => Promise<void>>();
+vi.mock("@/lib/admin", () => ({
+  requireStaff: () => requireStaffMock(),
+  logStaffAction: (...args: unknown[]) => logStaffActionMock(...args),
+}));
+
+const sqlMock = vi.fn<(...args: unknown[]) => Promise<{ id: string }[]>>();
+vi.mock("@/lib/db", () => ({
+  sql: (...args: unknown[]) => sqlMock(...args),
+}));
+
+const adminAdjustMock =
+  vi.fn<(...args: unknown[]) => Promise<{ applied: boolean; balanceAfter: number }>>();
+const walletIdForMock = vi.fn<(...args: unknown[]) => Promise<string>>();
+vi.mock("@/lib/credits", () => ({
+  adminAdjust: (...args: unknown[]) => adminAdjustMock(...args),
+  walletIdFor: (...args: unknown[]) => walletIdForMock(...args),
+  // The route maps this typed error to 422; the mock module must export the
+  // same class the route imports for the `instanceof` check to hold.
+  InsufficientBalanceError: class InsufficientBalanceError extends Error {},
+}));
+
+import { POST } from "../route";
+
+const post = (id: string, body: unknown) =>
+  POST(
+    new Request(`http://test/api/admin/orgs/${id}/credits`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  );
+
+const KEY = "idem-12345678";
+const okBody = (delta: number) => ({
+  delta,
+  reason_code: "support_goodwill",
+  idempotency_key: KEY,
+});
+
+beforeEach(() => {
+  requireStaffMock.mockReset().mockResolvedValue({ id: "staff-1", staff_role: "superadmin" });
+  logStaffActionMock.mockReset().mockResolvedValue(undefined);
+  sqlMock.mockReset().mockResolvedValue([{ id: "org-1" }]);
+  walletIdForMock.mockReset().mockResolvedValue("wallet-1");
+  adminAdjustMock.mockReset().mockResolvedValue({ applied: true, balanceAfter: 20 });
+});
+
+describe("POST /api/admin/orgs/[id]/credits", () => {
+  it("grants credits and returns the new balance", async () => {
+    const res = await post("org-1", okBody(20));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      data: { ok: true, balance_after: 20, applied: true },
+    });
+    expect(adminAdjustMock).toHaveBeenCalledWith(
+      "wallet-1",
+      20,
+      expect.objectContaining({ createdBy: "staff-1", idempotencyKey: KEY }),
+    );
+    expect(logStaffActionMock).toHaveBeenCalledWith(
+      "staff-1",
+      "credit_adjust",
+      "org",
+      "org-1",
+      expect.objectContaining({ delta: 20, reason_code: "support_goodwill", wallet_id: "wallet-1" }),
+    );
+  });
+
+  it("builds the stored reason from reason_code + optional note", async () => {
+    await post("org-1", { delta: 5, reason_code: "promo", note: "launch week", idempotency_key: KEY });
+    const opts = adminAdjustMock.mock.calls[0]![2] as { reason: string };
+    expect(opts.reason).toContain("promo");
+    expect(opts.reason).toContain("launch week");
+  });
+
+  it("rejects a non-staff caller before touching the DB or the wallet", async () => {
+    requireStaffMock.mockRejectedValueOnce(new AuthError("Staff access required"));
+    const res = await post("org-1", okBody(20));
+    expect(res.status).toBe(401);
+    expect(sqlMock).not.toHaveBeenCalled();
+    expect(adminAdjustMock).not.toHaveBeenCalled();
+  });
+
+  it("404s on an unknown org before adjusting", async () => {
+    sqlMock.mockResolvedValueOnce([]);
+    const res = await post("org-missing", okBody(20));
+    expect(res.status).toBe(404);
+    expect(adminAdjustMock).not.toHaveBeenCalled();
+  });
+
+  describe("RBAC threshold (§2)", () => {
+    it("403s a support grant over the 50-credit cap, without adjusting", async () => {
+      requireStaffMock.mockResolvedValue({ id: "sup", staff_role: "support" });
+      const res = await post("org-1", okBody(51));
+      expect(res.status).toBe(403);
+      expect(adminAdjustMock).not.toHaveBeenCalled();
+    });
+
+    it("403s a support deduct beyond the cap by magnitude", async () => {
+      requireStaffMock.mockResolvedValue({ id: "sup", staff_role: "support" });
+      const res = await post("org-1", okBody(-51));
+      expect(res.status).toBe(403);
+      expect(adminAdjustMock).not.toHaveBeenCalled();
+    });
+
+    it("allows a support adjustment at or under the cap", async () => {
+      requireStaffMock.mockResolvedValue({ id: "sup", staff_role: "support" });
+      const res = await post("org-1", okBody(50));
+      expect(res.status).toBe(200);
+      expect(adminAdjustMock).toHaveBeenCalled();
+    });
+
+    it("allows a superadmin a large grant", async () => {
+      requireStaffMock.mockResolvedValue({ id: "root", staff_role: "superadmin" });
+      const res = await post("org-1", okBody(5000));
+      expect(res.status).toBe(200);
+      expect(adminAdjustMock).toHaveBeenCalled();
+    });
+  });
+
+  it("maps an insufficient-balance deduct to 422", async () => {
+    const { InsufficientBalanceError } = await import("@/lib/credits");
+    adminAdjustMock.mockRejectedValueOnce(new InsufficientBalanceError("out of credits"));
+    const res = await post("org-1", okBody(-20));
+    expect(res.status).toBe(422);
+  });
+
+  describe("schema", () => {
+    it("400s a zero delta", async () => {
+      const res = await post("org-1", okBody(0));
+      expect(res.status).toBe(400);
+      expect(adminAdjustMock).not.toHaveBeenCalled();
+    });
+
+    it("400s an unknown reason_code", async () => {
+      const res = await post("org-1", { delta: 5, reason_code: "nope", idempotency_key: KEY });
+      expect(res.status).toBe(400);
+    });
+
+    it("400s a too-short idempotency_key", async () => {
+      const res = await post("org-1", { delta: 5, reason_code: "promo", idempotency_key: "short" });
+      expect(res.status).toBe(400);
+    });
+
+    it("400s an unknown field (strict)", async () => {
+      const res = await post("org-1", { ...okBody(5), extra: "nope" });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/web/src/app/api/admin/orgs/[id]/credits/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/credits/route.ts
@@ -1,0 +1,76 @@
+import { sql } from "@/lib/db";
+import { requireStaff, logStaffAction } from "@/lib/admin";
+import { adminAdjust, walletIdFor, InsufficientBalanceError } from "@/lib/credits";
+import { handler, HttpError } from "@/lib/http";
+import { z } from "zod";
+
+/** RBAC threshold (SPEC-3 §2): support staff may grant/deduct up to this many
+ *  credits per adjustment; anything larger needs a superadmin. Enforced on
+ *  |delta| so a big clawback is gated the same as a big grant. The "confirm
+ *  above threshold" prompt is a SPEC-6 UI concern; the server enforces only the
+ *  support hard cap here. */
+const SUPPORT_CREDIT_CAP = 50;
+
+const schema = z
+  .object({
+    /** ±N credits; non-zero. */
+    delta: z.number().int().refine((n) => n !== 0, "delta must be non-zero"),
+    /** Internal reason (SPEC-3 §2); free text lands in `note`. */
+    reason_code: z.enum(["support_goodwill", "sales_comp", "promo", "bug_fix", "refund_adjust"]),
+    note: z.string().max(500).optional(),
+    /** No double-grant on double-click (SPEC-3 §2). */
+    idempotency_key: z.string().min(8).max(200),
+  })
+  .strict();
+
+/** Grant or deduct AI credits for an org (SPEC-3 §1). Staff (support capped at
+ *  ±50, superadmin unlimited); every adjustment is an attributed, reversible,
+ *  reason-tagged `admin_adjust` ledger row on the group wallet (SPEC-2 §11), so
+ *  it benefits every org in a billing group. Lands in the unified staff audit. */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  return handler(async () => {
+    const { id } = await params;
+    const staff = await requireStaff();
+    const { delta, reason_code, note, idempotency_key } = schema.parse(await req.json());
+
+    // RBAC hard cap: over-threshold for support is refused, never silently
+    // clamped — the operator must escalate to a superadmin.
+    if (staff.staff_role !== "superadmin" && Math.abs(delta) > SUPPORT_CREDIT_CAP) {
+      throw new HttpError(
+        403,
+        `Support staff may adjust at most ${SUPPORT_CREDIT_CAP} credits at a time; ${Math.abs(delta)} needs a superadmin.`,
+      );
+    }
+
+    const [org] = await sql<{ id: string }[]>`select id from organizations where id = ${id}`;
+    if (!org) throw new HttpError(404, "Organization not found");
+
+    const walletId = await walletIdFor(id);
+    // Stored reason = the internal code plus any free-text note; the org-side
+    // friendly line (friendlyAdjustLabel) never surfaces this.
+    const reason = note ? `${reason_code}: ${note}` : reason_code;
+
+    let result: { applied: boolean; balanceAfter: number };
+    try {
+      result = await adminAdjust(walletId, delta, {
+        createdBy: staff.id,
+        reason,
+        idempotencyKey: idempotency_key,
+      });
+    } catch (err) {
+      if (err instanceof InsufficientBalanceError) {
+        throw new HttpError(422, "This deduction would drive the wallet below zero.");
+      }
+      throw err;
+    }
+
+    await logStaffAction(staff.id, "credit_adjust", "org", id, {
+      delta,
+      reason_code,
+      note: note ?? null,
+      wallet_id: walletId,
+      balance_after: result.balanceAfter,
+    });
+    return { ok: true, balance_after: result.balanceAfter, applied: result.applied };
+  });
+}

--- a/apps/web/src/app/api/admin/orgs/[id]/credits/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/credits/route.ts
@@ -64,13 +64,20 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       throw err;
     }
 
-    await logStaffAction(staff.id, "credit_adjust", "org", id, {
-      delta,
-      reason_code,
-      note: note ?? null,
-      wallet_id: walletId,
-      balance_after: result.balanceAfter,
-    });
+    // Only the first application of an idempotency key changes state. A
+    // replayed double-click is a no-op (applied:false) and must NOT write a
+    // second audit row — the SPEC-3 §3 unified adjustments log reads
+    // staff_audit_log, and a duplicate would read as two grants for one
+    // adjustment. The first request already logged it.
+    if (result.applied) {
+      await logStaffAction(staff.id, "credit_adjust", "org", id, {
+        delta,
+        reason_code,
+        note: note ?? null,
+        wallet_id: walletId,
+        balance_after: result.balanceAfter,
+      });
+    }
     return { ok: true, balance_after: result.balanceAfter, applied: result.applied };
   });
 }

--- a/apps/web/src/lib/__tests__/credits-admin-adjust.test.ts
+++ b/apps/web/src/lib/__tests__/credits-admin-adjust.test.ts
@@ -1,0 +1,169 @@
+// Admin AI-credit grant/deduct — the first SPEC-3 adjustment write-path
+// (design/v17-pricing-entitlements/SPEC-3-admin-adjustments.md §1/§2, SPEC-2
+// §5.1). `adminAdjust` appends an attributed `admin_adjust` ledger row (±N,
+// created_by + reason), never mutates a balance, never drives the wallet (or a
+// bucket) below zero, and is idempotent on its key. `friendlyAdjustLabel` is
+// the org-side public phrasing that must never leak the internal reason_code
+// (§5).
+//
+// Real Postgres required; skipped without DATABASE_URL. Run against the fresh
+// v17 schema: DATABASE_URL=$(cat /tmp/v17_base_url) DB_SCHEMA=seazn_club_v17.
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import {
+  adminAdjust,
+  balance,
+  friendlyAdjustLabel,
+  grantBalance,
+  packBalance,
+  InsufficientBalanceError,
+} from "@/lib/credits";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+/** Seed a raw ledger row directly so a test can stand up a starting balance in
+ *  a specific bucket without going through a grant helper. Mirrors
+ *  credits-grant.test.ts's seedLedgerRow. */
+async function seedBalance(
+  walletId: string,
+  delta: number,
+  bucket: "grant" | "pack" = "grant",
+): Promise<void> {
+  await sql`
+    insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+    values (${walletId}, ${delta}, 'monthly_grant', ${bucket}, ${delta}, ${`seed-${uniq()}`})`;
+}
+
+async function adjustRowCount(walletId: string): Promise<number> {
+  const [row] = await sql<{ n: string }[]>`
+    select count(*)::text as n from ai_credit_ledger
+     where wallet_id = ${walletId} and source = 'admin_adjust'`;
+  return Number(row!.n);
+}
+
+describe.skipIf(!HAS_DB)("adminAdjust", () => {
+  it("grant +N writes one attributed admin_adjust row and raises the balance", async () => {
+    const walletId = randomUUID();
+    const res = await adminAdjust(walletId, 20, {
+      createdBy: "staff-1",
+      reason: "sales_comp: POC top-up",
+      idempotencyKey: `adj-${uniq()}`,
+    });
+    expect(res).toEqual({ applied: true, balanceAfter: 20 });
+    expect(await balance(walletId)).toBe(20);
+    expect(await adjustRowCount(walletId)).toBe(1);
+
+    const [row] = await sql<{ delta: number; source: string; bucket: string; created_by: string; reason: string }[]>`
+      select delta, source, bucket, created_by, reason from ai_credit_ledger
+       where wallet_id = ${walletId} and source = 'admin_adjust'`;
+    expect(row).toMatchObject({
+      delta: 20,
+      source: "admin_adjust",
+      bucket: "grant", // SPEC-2 §5.4 / V321: admin_adjust writes the grant bucket
+      created_by: "staff-1",
+      reason: "sales_comp: POC top-up",
+    });
+  });
+
+  it("deduct -N within balance lowers the balance with an append-only negative row", async () => {
+    const walletId = randomUUID();
+    await seedBalance(walletId, 30, "grant");
+    const res = await adminAdjust(walletId, -10, {
+      createdBy: "staff-1",
+      reason: "bug_fix: refunded a botched run",
+      idempotencyKey: `adj-${uniq()}`,
+    });
+    expect(res).toEqual({ applied: true, balanceAfter: 20 });
+    expect(await balance(walletId)).toBe(20);
+    // append-only: the seed row is untouched, a new negative row was added.
+    const [{ n }] = await sql<{ n: string }[]>`
+      select count(*)::text as n from ai_credit_ledger where wallet_id = ${walletId}`;
+    expect(Number(n)).toBe(2);
+    expect(await adjustRowCount(walletId)).toBe(1);
+  });
+
+  it("refuses a deduct beyond balance: throws, balance unchanged, no row written", async () => {
+    const walletId = randomUUID();
+    await seedBalance(walletId, 5, "grant");
+    await expect(
+      adminAdjust(walletId, -10, {
+        createdBy: "staff-1",
+        reason: "bug_fix: too much",
+        idempotencyKey: `adj-${uniq()}`,
+      }),
+    ).rejects.toBeInstanceOf(InsufficientBalanceError);
+    expect(await balance(walletId)).toBe(5);
+    expect(await adjustRowCount(walletId)).toBe(0);
+  });
+
+  it("is idempotent on its key: a replay is a no-op returning the current balance", async () => {
+    const walletId = randomUUID();
+    const key = `adj-${uniq()}`;
+    const first = await adminAdjust(walletId, 15, {
+      createdBy: "staff-1",
+      reason: "promo: launch credits",
+      idempotencyKey: key,
+    });
+    expect(first).toEqual({ applied: true, balanceAfter: 15 });
+
+    const replay = await adminAdjust(walletId, 15, {
+      createdBy: "staff-1",
+      reason: "promo: launch credits",
+      idempotencyKey: key,
+    });
+    expect(replay).toEqual({ applied: false, balanceAfter: 15 });
+    expect(await balance(walletId)).toBe(15);
+    expect(await adjustRowCount(walletId)).toBe(1);
+  });
+
+  it("deducts grant-first when the wallet straddles both buckets, never below zero per bucket", async () => {
+    const walletId = randomUUID();
+    await seedBalance(walletId, 8, "grant");
+    await seedBalance(walletId, 8, "pack");
+    // Deduct 12 → 8 from grant (emptied), 4 from pack.
+    const res = await adminAdjust(walletId, -12, {
+      createdBy: "staff-1",
+      reason: "refund_adjust: correction",
+      idempotencyKey: `adj-${uniq()}`,
+    });
+    expect(res).toEqual({ applied: true, balanceAfter: 4 });
+    expect(await grantBalance(walletId)).toBe(0);
+    expect(await packBalance(walletId)).toBe(4);
+  });
+
+  it("two concurrent grants both apply with no lost update", async () => {
+    const walletId = randomUUID();
+    const [a, b] = await Promise.all([
+      adminAdjust(walletId, 10, { createdBy: "s", reason: "promo: a", idempotencyKey: `adj-${uniq()}` }),
+      adminAdjust(walletId, 10, { createdBy: "s", reason: "promo: b", idempotencyKey: `adj-${uniq()}` }),
+    ]);
+    expect(a.applied).toBe(true);
+    expect(b.applied).toBe(true);
+    expect(await balance(walletId)).toBe(20);
+    expect(await adjustRowCount(walletId)).toBe(2);
+  });
+});
+
+describe("friendlyAdjustLabel", () => {
+  const codes = ["support_goodwill", "sales_comp", "promo", "bug_fix", "refund_adjust", "anything_else"];
+
+  it("never echoes the internal reason_code for any code or sign", () => {
+    for (const code of codes) {
+      for (const sign of [1, -1] as const) {
+        const label = friendlyAdjustLabel(sign, code);
+        expect(label).not.toContain(code);
+        expect(label.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("maps goodwill-family codes to a warm public phrase for a grant", () => {
+    expect(friendlyAdjustLabel(1, "support_goodwill")).toBe("Seazn goodwill");
+    expect(friendlyAdjustLabel(1, "promo")).toBe("Seazn goodwill");
+    expect(friendlyAdjustLabel(1, "bug_fix")).toBe("Seazn goodwill");
+    expect(friendlyAdjustLabel(1, "sales_comp")).toBe("Account credit");
+    expect(friendlyAdjustLabel(1, "refund_adjust")).toBe("Refund adjustment");
+  });
+});

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -75,7 +75,14 @@ export async function walletIdFor(orgId: string): Promise<string> {
  * no rows is 0.
  */
 export async function balance(walletId: string): Promise<number> {
-  const [row] = await sql<{ bal: string | null }[]>`
+  return walletBalance(sql, walletId);
+}
+
+/** `sum(delta)` over the whole wallet, against any executor — the shared read
+ *  behind `balance()` (plain client) and the in-transaction balance readbacks
+ *  `adminAdjust` returns after a locked grant/deduct. */
+async function walletBalance(exec: Executor, walletId: string): Promise<number> {
+  const [row] = await exec<{ bal: string | null }[]>`
     select coalesce(sum(delta), 0)::text as bal
       from ai_credit_ledger where wallet_id = ${walletId}`;
   return Number(row?.bal ?? 0);
@@ -152,6 +159,10 @@ async function appendLedgerRow(
     ref?: string | null;
     spentByOrgId?: string | null;
     idempotencyKey: string | null;
+    // Attribution for staff-written rows (admin_adjust, SPEC-3 §1/§2): who and
+    // why. Null on every machine-written row (grant/spend/refund/expiry).
+    createdBy?: string | null;
+    reason?: string | null;
   },
 ): Promise<{ id: string } | null> {
   const [prior] = await tx<{ bal: string | null }[]>`
@@ -160,9 +171,11 @@ async function appendLedgerRow(
   const balanceAfter = Number(prior?.bal ?? 0) + row.delta;
   const [inserted] = await tx<{ id: string }[]>`
     insert into ai_credit_ledger
-      (wallet_id, delta, source, bucket, ref, spent_by_org_id, balance_after, idempotency_key)
+      (wallet_id, delta, source, bucket, ref, spent_by_org_id, balance_after,
+       idempotency_key, created_by, reason)
     values (${row.walletId}, ${row.delta}, ${row.source}, ${row.bucket}, ${row.ref ?? null},
-            ${row.spentByOrgId ?? null}, ${balanceAfter}, ${row.idempotencyKey})
+            ${row.spentByOrgId ?? null}, ${balanceAfter}, ${row.idempotencyKey},
+            ${row.createdBy ?? null}, ${row.reason ?? null})
     on conflict (idempotency_key) do nothing
     returning id`;
   return inserted ?? null;
@@ -706,4 +719,134 @@ export async function spendCredit<T>(
     throw err;
   }
   return ran.result;
+}
+
+/**
+ * A staff credit DEDUCT that would drive the wallet (or a bucket) below zero
+ * (SPEC-3 §2 "no adjustment can push a balance below 0"). Thrown by
+ * `adminAdjust`; the admin credits route maps it to HTTP 422. A distinct typed
+ * error (not the spend path's `PaymentRequiredError`/402) because this is a
+ * staff mis-click on an over-large clawback, not an org running out of credit
+ * mid-run.
+ */
+export class InsufficientBalanceError extends Error {
+  constructor(message = "This deduction would drive the wallet below zero.") {
+    super(message);
+    this.name = "InsufficientBalanceError";
+  }
+}
+
+/**
+ * The staff grant/deduct primitive (SPEC-3 §1, the first adjustment
+ * write-path; reuses SPEC-2 §5.1's `admin_adjust` source + `created_by` +
+ * `reason` — no new store). Appends attributed `admin_adjust` ledger row(s)
+ * to a wallet the caller has already resolved via `walletIdFor(orgId)` (SPEC-2
+ * §11), so the adjustment benefits every org in a billing group.
+ *
+ * **Bucket (SPEC-2 §5.4 / V321):** a POSITIVE grant lands in the resetting
+ * `grant` bucket — the bucket `admin_adjust` writes per V321's own column
+ * comment — unless `opts.bucket` pins it (e.g. a comped pack into `pack`). A
+ * DEDUCT burns grant-first then pack (the same spend order `reserve()` uses),
+ * so a clawback never wastes a paid pack credit while free grant remains, and
+ * writes one row per bucket it touches.
+ *
+ * **Never below zero (§2):** the whole read→compute→insert runs inside one
+ * transaction serialized per wallet by the same
+ * `pg_advisory_xact_lock(hashtext('ai-credit-wallet:' || walletId))` idiom
+ * `reserve()`/`grantMonthly()` take, so a deduct racing a spend can't
+ * lost-update the balance. A deduct larger than the wallet's total balance is
+ * refused with `InsufficientBalanceError` before any row is written — the
+ * ledger stays append-only (a deduct is a negative row, never an edit/delete).
+ *
+ * **Idempotent (§2 "no double-grant on double-click"):** a replay of the same
+ * `idempotencyKey` finds the prior row (checked under the lock) and no-ops,
+ * returning `{ applied: false, balanceAfter: <current> }`. A straddling deduct
+ * writes its second (pack) row under a derived key so both rows satisfy the
+ * unique constraint while a replay still conflicts on the base key.
+ */
+export async function adminAdjust(
+  walletId: string,
+  delta: number,
+  opts: { createdBy: string; reason: string; idempotencyKey: string; bucket?: Bucket },
+): Promise<{ applied: boolean; balanceAfter: number }> {
+  if (!Number.isInteger(delta) || delta === 0) {
+    throw new Error(`adminAdjust: delta must be a non-zero integer, got ${delta}`);
+  }
+  const { createdBy, reason, idempotencyKey } = opts;
+  return sql.begin(async (tx) => {
+    await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + walletId}))`;
+
+    const [already] = await tx<{ id: string }[]>`
+      select id from ai_credit_ledger where idempotency_key = ${idempotencyKey}`;
+    if (already) {
+      return { applied: false, balanceAfter: await walletBalance(tx, walletId) };
+    }
+
+    if (delta > 0) {
+      await appendLedgerRow(tx, {
+        walletId,
+        delta,
+        source: "admin_adjust",
+        bucket: opts.bucket ?? "grant",
+        createdBy,
+        reason,
+        idempotencyKey,
+      });
+      return { applied: true, balanceAfter: await walletBalance(tx, walletId) };
+    }
+
+    const need = -delta;
+    const grantAvail = Math.max(0, await bucketBalance(tx, walletId, "grant"));
+    const packAvail = Math.max(0, await bucketBalance(tx, walletId, "pack"));
+    if (grantAvail + packAvail < need) {
+      throw new InsufficientBalanceError(
+        `adminAdjust: deduct of ${need} exceeds wallet ${walletId} balance ${grantAvail + packAvail}`,
+      );
+    }
+    const grantCut = Math.min(need, grantAvail);
+    const packCut = need - grantCut;
+    let usedKey = false;
+    for (const [bucket, cut] of [
+      ["grant", grantCut],
+      ["pack", packCut],
+    ] as const) {
+      if (cut <= 0) continue;
+      await appendLedgerRow(tx, {
+        walletId,
+        delta: -cut,
+        source: "admin_adjust",
+        bucket,
+        createdBy,
+        reason,
+        idempotencyKey: usedKey ? `${idempotencyKey}#${bucket}` : idempotencyKey,
+      });
+      usedKey = true;
+    }
+    return { applied: true, balanceAfter: await walletBalance(tx, walletId) };
+  });
+}
+
+/**
+ * The org-facing label for a staff credit adjustment in the org's OWN history
+ * (SPEC-3 §5) — "+20 credits — Seazn goodwill". The internal `reason_code`
+ * (`sales_comp`, etc.) is operational and stays internal; this maps it to warm
+ * public phrasing and must NEVER echo the raw code. A deduct reads as a
+ * neutral "Account adjustment" regardless of code (a removal isn't goodwill),
+ * and any unrecognised code falls back to the same neutral phrase rather than
+ * leaking. The org-history VIEW that renders this is SPEC-6; this is data only.
+ */
+export function friendlyAdjustLabel(deltaSign: 1 | -1, reason_code: string): string {
+  if (deltaSign < 0) return "Account adjustment";
+  switch (reason_code) {
+    case "support_goodwill":
+    case "promo":
+    case "bug_fix":
+      return "Seazn goodwill";
+    case "sales_comp":
+      return "Account credit";
+    case "refund_adjust":
+      return "Refund adjustment";
+    default:
+      return "Account adjustment";
+  }
 }

--- a/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
@@ -1,0 +1,215 @@
+// v17 SPEC-3 §1 row 3 — the staff GRANT / REVOKE add-on adjustment. Writes
+// org_addons rows (status='granted', stripe_item_id=null) that the resolver
+// already sums (lib/entitlements.addonBonus), and freezes-not-deletes on revoke.
+//
+// These drive grantAddon/revokeAddon against real Postgres and assert on the
+// real resolver (getLimit). logStaffAction is mocked to a spy so we can assert
+// "audit exactly once on a real state change, never on a replay" without an
+// actor_id FK. The ent cache is disabled so a just-written row is seen at once.
+//
+// Real Postgres required; skipped without DATABASE_URL. Run on the fresh v17
+// schema: DATABASE_URL=$(cat /tmp/v17_base_url) DB_SCHEMA=seazn_club_v17.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+vi.mock("@/lib/cache", () => ({
+  cacheEnabled: () => false,
+  cacheGet: async () => null,
+  cacheSet: async () => {},
+  cacheDelPattern: async () => {},
+  incrWindow: async () => 1,
+}));
+
+const logStaffActionMock = vi.fn<(...args: unknown[]) => Promise<void>>();
+vi.mock("@/lib/admin", async (orig) => ({
+  ...(await (orig as () => Promise<Record<string, unknown>>)()),
+  logStaffAction: (...args: unknown[]) => logStaffActionMock(...args),
+}));
+
+import { sql } from "@/lib/db";
+import { createOrgForUser } from "@/lib/auth";
+import { walletIdFor } from "@/lib/credits";
+import { getLimit } from "@/lib/entitlements";
+import { grantAddon, revokeAddon } from "../admin-addons";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const FEATURE = "members.max";
+const ACTOR = "staff-tester";
+const uniq = () => randomUUID().slice(0, 8);
+
+async function makeUser(): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`addon-${uniq()}@test.local`}, 'Addon Admin', true) returning id`;
+  return id;
+}
+
+beforeEach(() => {
+  logStaffActionMock.mockClear();
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("grantAddon", () => {
+  it("writes one granted row (stripe_item_id null) and lifts the cap by delta_each*qty", async () => {
+    const org = await createOrgForUser(await makeUser(), "Addon Grant Org");
+    const walletId = await walletIdFor(org.id);
+    const base = await getLimit(org.id, FEATURE);
+    expect(base).not.toBeNull();
+
+    const { id, applied } = await grantAddon(ACTOR, org.id, {
+      featureKey: FEATURE,
+      deltaEach: 2,
+      qty: 3,
+      targetOrgId: null,
+      reason: "sales_comp: launch deal",
+      idempotencyKey: `grant-${uniq()}-abcd`,
+    });
+    expect(applied).toBe(true);
+
+    expect(await getLimit(org.id, FEATURE)).toBe((base as number) + 6);
+    const rows = await sql<{ status: string; stripe_item_id: string | null }[]>`
+      select status, stripe_item_id from org_addons where id = ${id}`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ status: "granted", stripe_item_id: null });
+    expect(logStaffActionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("a target_org_id grant lifts only that org; a sibling on the same wallet is unaffected", async () => {
+    // Two orgs sharing ONE wallet (a billing group): org B is re-pointed at
+    // org A's subscription, so walletIdFor(A) === walletIdFor(B).
+    const orgA = await createOrgForUser(await makeUser(), "Addon Target A");
+    const orgB = await createOrgForUser(await makeUser(), "Addon Target B");
+    const walletA = await walletIdFor(orgA.id);
+    await sql`update organizations set subscription_id = ${walletA} where id = ${orgB.id}`;
+    expect(await walletIdFor(orgB.id)).toBe(walletA);
+
+    const baseA = (await getLimit(orgA.id, FEATURE)) as number;
+    const baseB = (await getLimit(orgB.id, FEATURE)) as number;
+
+    await grantAddon(ACTOR, orgA.id, {
+      featureKey: FEATURE,
+      deltaEach: 4,
+      qty: 1,
+      targetOrgId: orgA.id,
+      reason: "sales_comp",
+      idempotencyKey: `target-${uniq()}-abcd`,
+    });
+
+    expect(await getLimit(orgA.id, FEATURE)).toBe(baseA + 4);
+    expect(await getLimit(orgB.id, FEATURE)).toBe(baseB); // sibling untouched
+  });
+
+  it("rejects delta_each <= 0 and qty <= 0 with no row written", async () => {
+    const org = await createOrgForUser(await makeUser(), "Addon Bad Input");
+    const walletId = await walletIdFor(org.id);
+    await expect(
+      grantAddon(ACTOR, org.id, {
+        featureKey: FEATURE,
+        deltaEach: 0,
+        qty: 1,
+        targetOrgId: null,
+        reason: "promo",
+        idempotencyKey: `bad-${uniq()}-abcd`,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+    await expect(
+      grantAddon(ACTOR, org.id, {
+        featureKey: FEATURE,
+        deltaEach: 2,
+        qty: 0,
+        targetOrgId: null,
+        reason: "promo",
+        idempotencyKey: `bad2-${uniq()}-abcd`,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
+    expect(n).toBe(0);
+    expect(logStaffActionMock).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent on the key — a replay makes one row, applied:false, one audit row", async () => {
+    const org = await createOrgForUser(await makeUser(), "Addon Idem Org");
+    const walletId = await walletIdFor(org.id);
+    const key = `idem-${uniq()}-abcd`;
+    const base = (await getLimit(org.id, FEATURE)) as number;
+
+    const first = await grantAddon(ACTOR, org.id, {
+      featureKey: FEATURE, deltaEach: 5, qty: 1, targetOrgId: null, reason: "promo", idempotencyKey: key,
+    });
+    const second = await grantAddon(ACTOR, org.id, {
+      featureKey: FEATURE, deltaEach: 5, qty: 1, targetOrgId: null, reason: "promo", idempotencyKey: key,
+    });
+
+    expect(first.applied).toBe(true);
+    expect(second.applied).toBe(false);
+    expect(second.id).toBe(first.id);
+    expect(await getLimit(org.id, FEATURE)).toBe(base + 5); // lifted once, not twice
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
+    expect(n).toBe(1);
+    expect(logStaffActionMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe.skipIf(!HAS_DB)("revokeAddon", () => {
+  it("flips a granted row to canceled — cap falls back, the row survives", async () => {
+    const org = await createOrgForUser(await makeUser(), "Addon Revoke Org");
+    const base = (await getLimit(org.id, FEATURE)) as number;
+    const { id } = await grantAddon(ACTOR, org.id, {
+      featureKey: FEATURE, deltaEach: 3, qty: 2, targetOrgId: null, reason: "sales_comp", idempotencyKey: `rev-${uniq()}-abcd`,
+    });
+    expect(await getLimit(org.id, FEATURE)).toBe(base + 6);
+    logStaffActionMock.mockClear();
+
+    const res = await revokeAddon(ACTOR, org.id, id, "bug_fix");
+    expect(res.revoked).toBe(true);
+    expect(await getLimit(org.id, FEATURE)).toBe(base); // fell back to plan base
+    const [row] = await sql<{ status: string }[]>`select status from org_addons where id = ${id}`;
+    expect(row.status).toBe("canceled"); // freeze-not-delete: still present
+    expect(logStaffActionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("revoking again is a no-op: {revoked:false}, no error, no second audit row", async () => {
+    const org = await createOrgForUser(await makeUser(), "Addon Revoke Twice");
+    const { id } = await grantAddon(ACTOR, org.id, {
+      featureKey: FEATURE, deltaEach: 3, qty: 1, targetOrgId: null, reason: "promo", idempotencyKey: `rev2-${uniq()}-abcd`,
+    });
+    await revokeAddon(ACTOR, org.id, id, "promo");
+    logStaffActionMock.mockClear();
+
+    const res = await revokeAddon(ACTOR, org.id, id, "promo");
+    expect(res.revoked).toBe(false);
+    expect(logStaffActionMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a Stripe-paid active row and another org's row — both untouched", async () => {
+    const org = await createOrgForUser(await makeUser(), "Addon Refuse Org");
+    const walletId = await walletIdFor(org.id);
+
+    // A Stripe-paid 'active' row on this org's wallet — billing-events' to cancel.
+    const [{ id: paidId }] = await sql<{ id: string }[]>`
+      insert into org_addons (wallet_id, target_org_id, feature_key, delta_each, qty, stripe_item_id, status)
+      values (${walletId}, ${org.id}, ${FEATURE}, 1, 1, ${`pi_${uniq()}`}, 'active') returning id`;
+    await expect(revokeAddon(ACTOR, org.id, paidId, "bug_fix")).rejects.toMatchObject({ status: 409 });
+    const [paid] = await sql<{ status: string }[]>`select status from org_addons where id = ${paidId}`;
+    expect(paid.status).toBe("active"); // untouched
+
+    // Another org's granted row (different wallet).
+    const other = await createOrgForUser(await makeUser(), "Addon Other Org");
+    const { id: otherId } = await grantAddon(ACTOR, other.id, {
+      featureKey: FEATURE, deltaEach: 2, qty: 1, targetOrgId: null, reason: "promo", idempotencyKey: `other-${uniq()}-abcd`,
+    });
+    await expect(revokeAddon(ACTOR, org.id, otherId, "bug_fix")).rejects.toMatchObject({ status: 404 });
+    const [otherRow] = await sql<{ status: string }[]>`select status from org_addons where id = ${otherId}`;
+    expect(otherRow.status).toBe("granted"); // untouched
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/admin-adjustments-log.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-adjustments-log.test.ts
@@ -76,7 +76,10 @@ describe.skipIf(!HAS_DB)("adjustmentsForOrg (SPEC-3 §3)", () => {
 
     const credit = await log(staff.id, "credit_adjust", "org", orgId, { reason_code: "promo" }, t(1));
     const addon = await log(staff.id, "addon_grant", "org", orgId, { reason: "sales comp" }, t(2));
-    const override = await log(staff.id, "entitlement_override", "org", orgId, {}, t(3));
+    // The real writer (entitlement-override route) logs target_type='entitlement'
+    // with target_id=org id — seed that true shape so the log's type filter is
+    // exercised, not a fiction. Fails if adjustmentsForOrg only reads 'org'.
+    const override = await log(staff.id, "entitlement_override", "entitlement", orgId, {}, t(3));
     const comp = await log(staff.id, "comp_to_pro", "org", orgId, {}, t(4));
 
     // Noise that must NOT surface:
@@ -93,7 +96,7 @@ describe.skipIf(!HAS_DB)("adjustmentsForOrg (SPEC-3 §3)", () => {
     const orgId = await makeOrg();
     await log(staff.id, "credit_adjust", "org", orgId, { reason_code: "bug_fix" }, t(1));
     await log(staff.id, "addon_revoke", "org", orgId, { reason: "downgrade" }, t(2));
-    await log(staff.id, "entitlement_override_removed", "org", orgId, {}, t(3));
+    await log(staff.id, "entitlement_override_removed", "entitlement", orgId, {}, t(3));
     await log(staff.id, "admin_downgrade", "org", orgId, {}, t(4));
 
     const byAction = Object.fromEntries(

--- a/apps/web/src/server/usecases/__tests__/admin-adjustments-log.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-adjustments-log.test.ts
@@ -1,0 +1,159 @@
+// SPEC-3 §3 — the unified per-org adjustments log. DB-backed: seed
+// staff_audit_log rows across several actions for one org (+ noise) and assert
+// the scope filter, the category/reversible/reason derivation, keyset paging,
+// and the actor-name join. Real Postgres required.
+import { describe, expect, it, afterAll } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { adjustmentsForOrg, ADJUSTMENT_ACTIONS } from "../admin-adjustments-log";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+async function makeUser(name: string): Promise<{ id: string; email: string }> {
+  const email = `${name}-${randomUUID().slice(0, 8)}@test.local`;
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${email}, ${name}, true) returning id`;
+  return { id, email };
+}
+
+async function makeOrg(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Adj " + suffix}, ${"adj-" + suffix})
+    returning id`;
+  return id;
+}
+
+/** Insert a staff_audit_log row with an explicit created_at so ordering is
+ *  deterministic. detail lands as real jsonb (sql.json) so detail->> reads work. */
+async function seedLog(
+  actorId: string,
+  action: string,
+  targetType: string,
+  targetId: string,
+  detail: Record<string, unknown> | null,
+  createdAt: string,
+): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into staff_audit_log (actor_id, action, target_type, target_id, detail, created_at)
+    values (${actorId}, ${action}, ${targetType}, ${targetId},
+            ${detail ? sql.json(detail as never) : null}, ${createdAt})
+    returning id`;
+  return id;
+}
+
+const created: string[] = [];
+async function log(
+  actorId: string,
+  action: string,
+  targetType: string,
+  targetId: string,
+  detail: Record<string, unknown> | null,
+  createdAt: string,
+): Promise<string> {
+  const id = await seedLog(actorId, action, targetType, targetId, detail, createdAt);
+  created.push(id);
+  return id;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  if (created.length) await sql`delete from staff_audit_log where id = any(${created})`;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+const t = (n: number) => new Date(Date.UTC(2026, 0, 1, 0, n, 0)).toISOString();
+
+describe.skipIf(!HAS_DB)("adjustmentsForOrg (SPEC-3 §3)", () => {
+  it("returns only this org's adjustment rows, newest first, excluding noise", async () => {
+    const staff = await makeUser("staffer");
+    const orgId = await makeOrg();
+    const otherOrgId = await makeOrg();
+
+    const credit = await log(staff.id, "credit_adjust", "org", orgId, { reason_code: "promo" }, t(1));
+    const addon = await log(staff.id, "addon_grant", "org", orgId, { reason: "sales comp" }, t(2));
+    const override = await log(staff.id, "entitlement_override", "org", orgId, {}, t(3));
+    const comp = await log(staff.id, "comp_to_pro", "org", orgId, {}, t(4));
+
+    // Noise that must NOT surface:
+    await log(staff.id, "credit_adjust", "org", otherOrgId, {}, t(5)); // different org
+    await log(staff.id, "impersonate_start", "org", orgId, {}, t(6)); // non-adjustment action
+    await log(staff.id, "remove_payment_method", "user", staff.id, {}, t(7)); // target_type=user
+
+    const entries = await adjustmentsForOrg(orgId);
+    expect(entries.map((e) => e.id)).toEqual([comp, override, addon, credit]);
+  });
+
+  it("derives category, reversible and reason per action", async () => {
+    const staff = await makeUser("staffer");
+    const orgId = await makeOrg();
+    await log(staff.id, "credit_adjust", "org", orgId, { reason_code: "bug_fix" }, t(1));
+    await log(staff.id, "addon_revoke", "org", orgId, { reason: "downgrade" }, t(2));
+    await log(staff.id, "entitlement_override_removed", "org", orgId, {}, t(3));
+    await log(staff.id, "admin_downgrade", "org", orgId, {}, t(4));
+
+    const byAction = Object.fromEntries(
+      (await adjustmentsForOrg(orgId)).map((e) => [e.action, e]),
+    );
+    expect(byAction.credit_adjust).toMatchObject({
+      category: "credits",
+      reversible: true,
+      reason: "bug_fix",
+    });
+    expect(byAction.addon_revoke).toMatchObject({
+      category: "addon",
+      reversible: false,
+      reason: "downgrade",
+    });
+    expect(byAction.entitlement_override_removed).toMatchObject({
+      category: "cap",
+      reversible: false,
+      reason: null,
+    });
+    expect(byAction.admin_downgrade).toMatchObject({ category: "plan", reversible: false });
+  });
+
+  it("prefers detail.reason over detail.reason_code", async () => {
+    const staff = await makeUser("staffer");
+    const orgId = await makeOrg();
+    await log(staff.id, "credit_adjust", "org", orgId, { reason: "note wins", reason_code: "promo" }, t(1));
+    const [e] = await adjustmentsForOrg(orgId);
+    expect(e!.reason).toBe("note wins");
+  });
+
+  it("pages with limit + before cursor", async () => {
+    const staff = await makeUser("staffer");
+    const orgId = await makeOrg();
+    // 5 rows at minutes 1..5
+    for (let i = 1; i <= 5; i++) {
+      await log(staff.id, "credit_adjust", "org", orgId, { reason_code: `r${i}` }, t(i));
+    }
+    const page1 = await adjustmentsForOrg(orgId, { limit: 2 });
+    expect(page1.map((e) => e.createdAt)).toEqual([t(5), t(4)]);
+
+    const page2 = await adjustmentsForOrg(orgId, { limit: 2, before: page1[1]!.createdAt });
+    expect(page2.map((e) => e.createdAt)).toEqual([t(3), t(2)]);
+
+    const page3 = await adjustmentsForOrg(orgId, { limit: 2, before: page2[1]!.createdAt });
+    expect(page3.map((e) => e.createdAt)).toEqual([t(1)]);
+  });
+
+  it("joins the actor name from users (display_name/email)", async () => {
+    const staff = await makeUser("Casey Staff");
+    const orgId = await makeOrg();
+    await log(staff.id, "credit_adjust", "org", orgId, {}, t(1));
+    const [e] = await adjustmentsForOrg(orgId);
+    expect(e!.actorId).toBe(staff.id);
+    expect(e!.actorName).toBe("Casey Staff");
+  });
+
+  it("ADJUSTMENT_ACTIONS excludes non-per-org catalog/view actions", () => {
+    expect(ADJUSTMENT_ACTIONS).toContain("credit_adjust");
+    expect(ADJUSTMENT_ACTIONS).not.toContain("impersonate_start");
+    expect(ADJUSTMENT_ACTIONS).not.toContain("size_pack_upsert");
+  });
+});

--- a/apps/web/src/server/usecases/admin-addons.ts
+++ b/apps/web/src/server/usecases/admin-addons.ts
@@ -1,0 +1,128 @@
+import "server-only";
+import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { walletIdFor } from "@/lib/credits";
+import { logStaffAction } from "@/lib/admin";
+
+/**
+ * Staff GRANT of an add-on (design/v17-pricing-entitlements/SPEC-3 §1 row 3):
+ * comp extra seats / a size pack / extra orgs for a sales deal. Writes ONE
+ * `org_addons` row with `status='granted'` and `stripe_item_id=null` — the
+ * additive-cap axis the resolver already sums (`lib/entitlements.addonBonus`,
+ * `status in ('active','granted')`), so the cap rises on the very next check.
+ * This is the admin WRITE path only; no Stripe object exists behind it.
+ *
+ * Keyed on the org's WALLET (`coalesce(group_subscription_id, org_id)`, SPEC-2
+ * §11) so a group-wide grant (`targetOrgId=null`) lifts every org on the wallet;
+ * a set `targetOrgId` narrows it to one. `delta_each>0`/`qty>0` are pinned by
+ * V324's CHECKs, but we reject ≤0 up front with a typed 422 so the route never
+ * surfaces a raw constraint error.
+ *
+ * **Idempotent (SPEC-3 §2, no double-grant on double-click):** V324's
+ * stripe_item_id unique index is PARTIAL and does not cover null-item admin
+ * rows, so grants dedupe on `admin_idempotency_key` (V327) instead —
+ * ON CONFLICT DO NOTHING. A replayed key returns the existing row id with
+ * `applied:false` and writes NO second audit row (the SPEC-3 §3 unified log
+ * reads staff_audit_log; a duplicate there reads as two grants for one action).
+ *
+ * @returns the row id and whether this call actually created it.
+ */
+export async function grantAddon(
+  actorId: string,
+  orgId: string,
+  input: {
+    featureKey: string;
+    deltaEach: number;
+    qty: number;
+    targetOrgId: string | null;
+    reason: string;
+    idempotencyKey: string;
+  },
+): Promise<{ id: string; applied: boolean }> {
+  const { featureKey, deltaEach, qty, targetOrgId, reason, idempotencyKey } = input;
+  if (!Number.isInteger(deltaEach) || deltaEach <= 0) {
+    throw new HttpError(422, "delta_each must be a positive integer.");
+  }
+  if (!Number.isInteger(qty) || qty <= 0) {
+    throw new HttpError(422, "qty must be a positive integer.");
+  }
+
+  const walletId = await walletIdFor(orgId);
+  const [inserted] = await sql<{ id: string }[]>`
+    insert into org_addons
+      (wallet_id, target_org_id, target_competition_id, feature_key, delta_each, qty,
+       stripe_item_id, status, admin_idempotency_key)
+    values (${walletId}, ${targetOrgId}, null, ${featureKey}, ${deltaEach}, ${qty},
+            null, 'granted', ${idempotencyKey})
+    on conflict (admin_idempotency_key) where admin_idempotency_key is not null do nothing
+    returning id`;
+
+  // Replay: the key already granted — return the prior row, log nothing.
+  if (!inserted) {
+    const [existing] = await sql<{ id: string }[]>`
+      select id from org_addons where admin_idempotency_key = ${idempotencyKey}`;
+    return { id: existing!.id, applied: false };
+  }
+
+  await logStaffAction(actorId, "addon_grant", "org", orgId, {
+    feature_key: featureKey,
+    delta_each: deltaEach,
+    qty,
+    target_org_id: targetOrgId,
+    reason,
+    addon_id: inserted.id,
+  });
+  return { id: inserted.id, applied: true };
+}
+
+/**
+ * Staff REVOKE of an admin-granted add-on (SPEC-3 §2 reversible =
+ * freeze-not-delete, §7 "no history deletion"): flip `status` to `'canceled'`
+ * so the resolver stops counting it and the cap drops back to base. The row is
+ * NEVER deleted — the qty>0 CHECK (V324) stays satisfied and the audit trail
+ * survives.
+ *
+ * Only a row that is (a) on THIS org's wallet, (b) `status='granted'`, and
+ * (c) admin-written (`stripe_item_id is null`) can be revoked here. A
+ * Stripe-paid `active` row is billing-events' to cancel (409); another org's
+ * row or an unknown id is a 404 — neither is touched.
+ *
+ * **Idempotent:** revoking an already-`canceled` admin row on this wallet
+ * returns `{revoked:false}` without error and writes NO second audit row
+ * (mirrors grantAddon's applied-guard — only a real state change is logged).
+ */
+export async function revokeAddon(
+  actorId: string,
+  orgId: string,
+  addonId: string,
+  reason: string,
+): Promise<{ revoked: boolean }> {
+  const walletId = await walletIdFor(orgId);
+
+  const flipped = await sql<{ id: string }[]>`
+    update org_addons set status = 'canceled'
+     where id = ${addonId}
+       and wallet_id = ${walletId}
+       and status = 'granted'
+       and stripe_item_id is null
+    returning id`;
+
+  if (flipped.length === 0) {
+    // Nothing flipped — decide between an idempotent replay (already canceled
+    // admin row) and a genuine refusal (unknown / other-org / Stripe-paid).
+    const [row] = await sql<
+      { wallet_id: string; status: string; stripe_item_id: string | null }[]
+    >`select wallet_id, status, stripe_item_id from org_addons where id = ${addonId}`;
+    if (!row || row.wallet_id !== walletId) {
+      throw new HttpError(404, "No such add-on for this org.");
+    }
+    if (row.stripe_item_id !== null) {
+      throw new HttpError(409, "This is a Stripe-paid add-on; cancel it through billing.");
+    }
+    if (row.status === "canceled") return { revoked: false }; // replay — no audit
+    throw new HttpError(409, "This add-on cannot be revoked from the admin adjustment layer.");
+  }
+
+  await logStaffAction(actorId, "addon_revoke", "org", orgId, { addon_id: addonId, reason });
+  return { revoked: true };
+}

--- a/apps/web/src/server/usecases/admin-adjustments-log.ts
+++ b/apps/web/src/server/usecases/admin-adjustments-log.ts
@@ -1,0 +1,129 @@
+// SPEC-3 §3 — the unified per-org "Adjustments log". Every staff adjustment
+// already writes ONE row to staff_audit_log (V103: actor_id, action,
+// target_type, target_id, detail jsonb, created_at; indexed on
+// (target_id, created_at desc)). So this is a READ + derive over that one
+// table, scoped to one org and the org-adjustment action subset — NOT a
+// multi-store union. Callers must have passed requireStaff (any staff READS;
+// the write-restriction lives in the T1/T2 mutation routes). The rendered UI
+// is SPEC-6.
+import { sql } from "@/lib/db";
+
+/** The org-adjustment action subset that surfaces in the log. Excludes
+ *  view/impersonate and the non-per-org catalog actions (coupon, fee,
+ *  size_pack). Exported so the routes and tests share the one source. */
+export const ADJUSTMENT_ACTIONS = [
+  "credit_adjust",
+  "addon_grant",
+  "addon_revoke",
+  "comp_to_pro",
+  "admin_downgrade",
+  "extend_trial",
+  "restore_trial",
+  "entitlement_override",
+  "entitlement_override_removed",
+  "remove_payment_method",
+] as const;
+
+export type AdjustmentAction = (typeof ADJUSTMENT_ACTIONS)[number];
+export type AdjustmentCategory = "credits" | "cap" | "addon" | "plan" | "pass";
+
+/** action → display category. */
+const CATEGORY: Record<AdjustmentAction, AdjustmentCategory> = {
+  credit_adjust: "credits",
+  addon_grant: "addon",
+  addon_revoke: "addon",
+  entitlement_override: "cap",
+  entitlement_override_removed: "cap",
+  comp_to_pro: "plan",
+  admin_downgrade: "plan",
+  extend_trial: "plan",
+  restore_trial: "plan",
+  remove_payment_method: "plan",
+};
+
+/** action → has a compensating action a staffer can apply to undo it. The
+ *  already-compensating/terminal actions are false. */
+const REVERSIBLE: Record<AdjustmentAction, boolean> = {
+  credit_adjust: true,
+  addon_grant: true,
+  entitlement_override: true,
+  comp_to_pro: true,
+  extend_trial: true,
+  addon_revoke: false,
+  entitlement_override_removed: false,
+  admin_downgrade: false,
+  restore_trial: false,
+  remove_payment_method: false,
+};
+
+export interface AdjustmentEntry {
+  id: string;
+  actorId: string;
+  actorName: string | null;
+  action: string;
+  category: AdjustmentCategory;
+  detail: Record<string, unknown>;
+  reason: string | null;
+  reversible: boolean;
+  createdAt: string;
+}
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+interface Row {
+  id: string;
+  actor_id: string;
+  actor_name: string | null;
+  action: AdjustmentAction;
+  detail: Record<string, unknown> | null;
+  created_at: string | Date;
+}
+
+/** Newest-first adjustments for one org. `before` is a created_at ISO cursor
+ *  (exclusive) for keyset paging; `limit` defaults to 50, capped at 200. */
+export async function adjustmentsForOrg(
+  orgId: string,
+  opts?: { limit?: number; before?: string },
+): Promise<AdjustmentEntry[]> {
+  const limit = Math.min(Math.max(1, Math.trunc(opts?.limit ?? DEFAULT_LIMIT)), MAX_LIMIT);
+  const before = opts?.before ?? null;
+
+  const rows = await sql<Row[]>`
+    select s.id,
+           s.actor_id,
+           coalesce(u.display_name, u.email) as actor_name,
+           s.action,
+           s.detail,
+           s.created_at
+    from staff_audit_log s
+    left join users u on u.id = s.actor_id
+    where s.target_type = 'org'
+      and s.target_id = ${orgId}
+      and s.action = any(${ADJUSTMENT_ACTIONS as unknown as string[]})
+      ${before ? sql`and s.created_at < ${before}` : sql``}
+    order by s.created_at desc
+    limit ${limit}`;
+
+  return rows.map(toEntry);
+}
+
+function toEntry(row: Row): AdjustmentEntry {
+  const detail = (row.detail ?? {}) as Record<string, unknown>;
+  const reason =
+    (typeof detail.reason === "string" && detail.reason) ||
+    (typeof detail.reason_code === "string" && detail.reason_code) ||
+    null;
+  return {
+    id: row.id,
+    actorId: row.actor_id,
+    actorName: row.actor_name,
+    action: row.action,
+    category: CATEGORY[row.action],
+    detail,
+    reason,
+    reversible: REVERSIBLE[row.action],
+    createdAt:
+      row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+  };
+}

--- a/apps/web/src/server/usecases/admin-adjustments-log.ts
+++ b/apps/web/src/server/usecases/admin-adjustments-log.ts
@@ -98,7 +98,11 @@ export async function adjustmentsForOrg(
            s.created_at
     from staff_audit_log s
     left join users u on u.id = s.actor_id
-    where s.target_type = 'org'
+    -- entitlement_override(_removed) log with target_type='entitlement' (the
+    -- feature they touch), target_id still the org id — include that type so
+    -- cap overrides surface in the org's log. The action-set filter below is
+    -- what scopes the rows; these two are the only 'entitlement'-typed actions.
+    where s.target_type in ('org', 'entitlement')
       and s.target_id = ${orgId}
       and s.action = any(${ADJUSTMENT_ACTIONS as unknown as string[]})
       ${before ? sql`and s.created_at < ${before}` : sql``}

--- a/db/migration/deltas/V326__ai_credit_ledger_reason.sql
+++ b/db/migration/deltas/V326__ai_credit_ledger_reason.sql
@@ -1,0 +1,21 @@
+-- V326 — attributed reason on the AI credit ledger (design/v17-pricing-
+-- entitlements/SPEC-3-admin-adjustments.md §1, §2 "Reason mandatory").
+--
+-- SPEC-3's admin adjustment layer requires every money-adjacent row to carry
+-- WHO (created_by, already on V320) and WHY. `admin_adjust` rows (staff
+-- grant/deduct of AI credits) store a reason built from a fixed reason_code
+-- (support_goodwill · sales_comp · promo · bug_fix · refund_adjust) plus
+-- optional free text — the Adjustments log (§3) and the org-side friendly line
+-- (§5) both read it. The column is nullable: the machine-written rows
+-- (monthly_grant, trial_grant, pack_purchase, run_spend, refund, expiry) carry
+-- no reason and never did.
+--
+-- Same upsert-safe shape as V320/V321; Flyway runs -defaultSchema=seazn_club.
+alter table ai_credit_ledger
+  add column if not exists reason text;
+
+comment on column ai_credit_ledger.reason is
+  'admin_adjust only (SPEC-3 §1/§2): staff-supplied reason (reason_code + '
+  'optional note) for a manual credit grant/deduct. Null for machine-written '
+  'grant/spend/refund/expiry rows. Paired with created_by (V320) for the '
+  'attributed, auditable adjustment trail.';

--- a/db/migration/deltas/V327__org_addons_admin_idempotency.sql
+++ b/db/migration/deltas/V327__org_addons_admin_idempotency.sql
@@ -1,0 +1,32 @@
+-- V327 — an idempotency key for ADMIN-granted add-ons (design/v17-pricing-
+-- entitlements/SPEC-3-admin-adjustments.md §1 row 3, §2 "no double-grant on
+-- double-click").
+--
+-- SPEC-3 lets staff comp capacity (extra seats / a size pack / extra orgs for a
+-- sales deal) by writing an org_addons row with status='granted' and a NULL
+-- stripe_item_id. The Stripe-paid writer dedupes redeliveries on
+-- org_addons_stripe_item_id_uk (V324) — but that index is PARTIAL
+-- (where stripe_item_id is not null), so it does NOT cover admin grants, whose
+-- stripe_item_id is always NULL. A double-clicked grant would therefore land
+-- twice and double-lift the cap.
+--
+-- Give the admin grant path its OWN idempotency arbiter: a nullable key column
+-- plus a partial unique index (where the key is not null), mirroring V324's
+-- shape. grantAddon (server/usecases/admin-addons.ts) writes the key and
+-- ON CONFLICT DO NOTHING; a replayed key returns the existing row and writes no
+-- second audit row.
+--
+-- Forward-only + upsert-safe: V323's existing rows (and every Stripe-paid row)
+-- carry a NULL key, so the partial index sees none of them and there is no
+-- collision on backfill. Unqualified DDL only — Flyway runs
+-- -defaultSchema=seazn_club; same text+index style as V324.
+
+alter table org_addons add column if not exists admin_idempotency_key text;
+
+create unique index if not exists org_addons_admin_idem_uk
+  on org_addons (admin_idempotency_key) where admin_idempotency_key is not null;
+
+comment on column org_addons.admin_idempotency_key is
+  'Idempotency arbiter for admin-granted rows (SPEC-3 §2). NULL on Stripe-paid '
+  'rows (those dedupe on stripe_item_id, V324) and on pre-V327 rows. A replayed '
+  'grantAddon key conflicts on org_addons_admin_idem_uk and no-ops.';


### PR DESCRIPTION
v17 **SPEC-3 (Admin Adjustment Layer)** — backend. One audited, reversible, attributed surface for staff to adjust money/entitlement state. Plan/trial + cap-override write-paths already existed; this adds the two missing write-paths + the unified read.

## What's here (3 tasks, each reviewed opus+max)
- **Credit grant/deduct** — `credits.adminAdjust` (one append-only `admin_adjust` ledger row, `created_by`+`reason`, group wallet, no-below-zero under the wallet lock, idempotent) + `POST /api/admin/orgs/[id]/credits` (RBAC: support ≤50 credits / superadmin unlimited) + `friendlyAdjustLabel` (org-side line never leaks the internal reason). V326 adds `ai_credit_ledger.reason`.
- **Add-on grant/revoke** — `admin-addons.ts` (grant `org_addons status='granted' stripe_item_id=null`; revoke = freeze-not-delete, guarded to own-wallet + granted + null-item) + `/api/admin/orgs/[id]/addons` (superadmin). V327 adds `admin_idempotency_key` (V324's unique index excludes null-item admin grants). Resolver already counts `granted` — unchanged.
- **Unified adjustments log** — `adjustmentsForOrg` reads `staff_audit_log` (`target_type in ('org','entitlement')`, the adjustment-action set), derives category/reversible/reason, keyset-paged + `GET /api/admin/orgs/[id]/adjustments` (any staff reads). No migration.

## Reviews & tests
- Per-task reviews all reached spec-PASS + quality-APPROVE. Two real defects caught + fixed: T1 audited an idempotent replay twice (`b6a8cc45`); T3 dropped entitlement cap-overrides from the log (`36dff5fc`).
- Whole-branch final review: **MERGE-READY YES**, all 10 audit actions traced to real writers, §7 acceptance satisfied as a system.
- **91 tests green on the v17 schema** (56 P4 core + 35 P2 credit-wallet regression); typecheck clean. No live-Stripe surface (adjustments are internal comps/grants, no charges).

## Tracked follow-ups (reviewer-accepted, non-blocking)
- Wrap each adjustment's write + `logStaffAction` in one tx (crash-between = unaudited row; mirrors existing billing-events pattern).
- Validate `target_org_id` belongs to the wallet's group (a typo currently writes an inert-but-200 grant).
- Move the credit audit into `adminAdjust` so a future non-route caller can't skip it; add a real-shape `remove_payment_method` case to the log test.
- Admin size-pack comp is org-wide (no per-comp param) — product decision if per-comp is wanted.
- UI surfaces for all of the above = SPEC-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)