### PR TITLE
feat(v17): SPEC-4 Event Pass validity — auto-lock on archived/ended competitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,20 @@ jobs:
         env:
           REDIS_URL: redis://localhost:6379
 
+      # Live-Stripe against real test-mode Stripe (sk_test, already in the job env)
+      # on the real Postgres this job runs. Sync prices first, then run ONLY the
+      # CI-safe live suites: billing-tiers (self-contained) + billing-proration
+      # (needs synced prices). Deliberately EXCLUDED: billing-automatic-tax (needs
+      # a Stripe tax registration this account lacks) and schedule-ai-effort-ab
+      # (issues real model calls). These files self-skip in the src/server+src/lib
+      # step above (no BILLING_LIVE); here they run live. Skips cleanly on fork PRs,
+      # where STRIPE_SECRET_KEY is withheld.
+      - name: Live-Stripe integration tests (sk_test, real Postgres)
+        if: env.STRIPE_SECRET_KEY != ''
+        run: |
+          npm run stripe:sync
+          BILLING_LIVE=1 npm test --workspace apps/web -- src/lib/__tests__/billing-tiers.live.test.ts src/lib/__tests__/billing-proration.live.test.ts
+
       # Smoke runs against a PRODUCTION build, not `next dev`. The dev server
       # restarts itself once used heap crosses 80% of its V8 limit (which
       # `next dev` pins to HALF the machine's RAM — ~3.5 GB on the 7 GB

--- a/apps/web/content/help/billing/event-pass.md
+++ b/apps/web/content/help/billing/event-pass.md
@@ -4,7 +4,7 @@ description: A one-time upgrade for a single competition — bigger limits, bran
 order: 3
 ---
 
-An **Event Pass** upgrades one competition for its lifetime — bigger limits, the organiser extras that make an event look the part, and a cheaper platform fee — without a monthly subscription.
+An **Event Pass** upgrades one competition while it runs — bigger limits, the organiser extras that make an event look the part, and a cheaper platform fee — without a monthly subscription.
 
 ## What the pass includes
 
@@ -29,10 +29,21 @@ Charging entry fees, your org logo and plain PDF/XLSX exports need no pass at al
 
 The annual club championship, a one-off fundraiser, a school sports day: events that deserve the full kit for two weekends a year. If you run events most months, Pro costs less.
 
+## When a pass stops applying
+
+A pass lifts the plan **while its competition is running**. It stops once that competition is over:
+
+- You mark the competition **completed or archived**, or
+- Its **end date passed more than 7 days ago** (a grace window, so the pass doesn't switch off mid-finals).
+
+When that happens the event stays fully **readable** — nothing you built is deleted — but the paid-for-running lifts switch off: the entrant and division headroom drops back to your plan's limits, branded exports return to plain tables, the realtime board and sponsor tools stop, and the platform fee returns to your plan's rate. It's the same fallback as a downgrade, scoped to that one finished event.
+
+**Renaming a competition does not create a new pass requirement** — the pass is bound to the competition itself, not its name, so you can rename this year's event freely and its pass rides along. But a **brand-new competition needs its own pass, even if it has the same name**: completing this year's championship and creating next year's is a new event, so it's a new purchase (or the moment Pro starts making sense).
+
 ## The fine print
 
-- The pass covers **that competition only**, for as long as it runs.
-- It does **not** carry to next season's edition — a new edition is a new pass (or the moment Pro starts making sense).
+- The pass covers **that competition only**, while it runs.
+- It does **not** carry to next season's edition — a new edition is a new competition, so a new pass (or the moment Pro starts making sense).
 - A passed competition **doesn't count against your active-competition limit** — the pass is self-contained, so a Community org keeps all 10 free slots while its passed event runs.
 - Refunding a pass — or losing a chargeback on one — **revokes it**: the competition drops back to your plan's normal limits and the owner gets an email. Nothing you've built is deleted; the extra divisions, the entrant headroom, branded exports and the sponsor tools simply switch off and the platform fee returns to your plan's rate, exactly like a downgrade.
 - Buy the same pass twice (a double-tap, or two people checking out at once) and only the first charge sticks — the **duplicate is refunded automatically**, so a competition is never billed twice.

--- a/apps/web/src/lib/__tests__/entitlements-pass-lock.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-pass-lock.test.ts
@@ -1,0 +1,198 @@
+// v17 SPEC-4 §7 — an Event Pass stops applying once its competition is over.
+//
+// Two layers are proven here:
+//   1. isPassLocked (pure) — the lock predicate, no DB.
+//   2. The TS resolver (DB-backed) — a community org's pass lifts a LIVE
+//      competition and falls back to Community caps once that competition is
+//      archived or long-ended. Asserted through the real hasFeature/getLimit,
+//      not a raw row read.
+//
+// The SQL side of the same lock is proven in entitlements-sql-parity.test.ts.
+// Real Postgres required for layer 2; skipped without DATABASE_URL.
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import {
+  getLimit,
+  hasFeature,
+  invalidateOrgEntitlements,
+  isPassLocked,
+  PASS_END_GRACE_DAYS,
+} from "@/lib/entitlements";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+const daysFromToday = (n: number) => {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + n);
+  return d;
+};
+
+// ---------------------------------------------------------------------------
+// 1. isPassLocked — pure predicate (SPEC-4 §7, mapped to reality)
+// ---------------------------------------------------------------------------
+describe("isPassLocked", () => {
+  it("locks a terminal competition (archived or completed)", () => {
+    expect(isPassLocked("archived", null)).toBe(true);
+    expect(isPassLocked("archived", daysFromToday(30))).toBe(true);
+    // A FINISHED competition (usecases/competitions.ts sets 'completed') is the
+    // primary terminal case SPEC-4 §7 targets.
+    expect(isPassLocked("completed", null)).toBe(true);
+    expect(isPassLocked("completed", daysFromToday(30))).toBe(true);
+  });
+
+  it("does NOT lock an active competition (draft/published/live)", () => {
+    for (const status of ["draft", "published", "live"]) {
+      expect(isPassLocked(status, null)).toBe(false);
+      expect(isPassLocked(status, daysFromToday(30))).toBe(false);
+    }
+  });
+
+  it("locks a competition ended beyond the grace window", () => {
+    expect(isPassLocked("live", daysFromToday(-(PASS_END_GRACE_DAYS + 1)))).toBe(true);
+  });
+
+  it("keeps a competition inside the grace window unlocked", () => {
+    expect(isPassLocked("live", daysFromToday(-3))).toBe(false);
+    // Exactly grace days ago: ends_on + 7 == today, not < today, so NOT locked.
+    expect(isPassLocked("live", daysFromToday(-PASS_END_GRACE_DAYS))).toBe(false);
+  });
+
+  it("does not lock a future or null ends_on on an active competition", () => {
+    expect(isPassLocked("live", daysFromToday(30))).toBe(false);
+    expect(isPassLocked("live", null)).toBe(false);
+  });
+
+  it("accepts a YYYY-MM-DD string for ends_on", () => {
+    const past = daysFromToday(-(PASS_END_GRACE_DAYS + 1)).toISOString().slice(0, 10);
+    expect(isPassLocked("live", past)).toBe(true);
+    const future = daysFromToday(30).toISOString().slice(0, 10);
+    expect(isPassLocked("live", future)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. TS resolver — the lock through hasFeature/getLimit
+// ---------------------------------------------------------------------------
+// `realtime` is the probe key the parity suite uses: community false, event_pass
+// true — so a pass LIFT and its removal are both visible.
+async function seedCommunityOrg(): Promise<string> {
+  const s = uniq();
+  const [{ id: ownerId }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`passlock-${s}@test.local`}, 'Pass Lock Owner', true) returning id`;
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"PassLock " + s}, ${"passlock-" + s}, ${ownerId}) returning id`;
+  await sql`
+    with _seed_sub as (
+      insert into subscriptions (owner_user_id, plan_key, status)
+      select o.created_by, 'community', 'active' from organizations o where o.id = ${orgId}
+      returning id
+    )
+    update organizations set subscription_id = (select id from _seed_sub) where id = ${orgId}`;
+  return orgId;
+}
+
+/** A competition with an explicit lifecycle. ends_on may be null. */
+async function seedCompetition(
+  orgId: string,
+  label: string,
+  status: string,
+  endsInDays: number | null,
+): Promise<string> {
+  const endsOn = endsInDays === null ? null : daysFromToday(endsInDays).toISOString().slice(0, 10);
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug, status, ends_on)
+    values (${orgId}, ${label + " " + uniq()}, ${label + "-" + uniq()}, ${status}, ${endsOn})
+    returning id`;
+  return id;
+}
+
+async function addPass(orgId: string, competitionId: string): Promise<void> {
+  await sql`
+    insert into competition_passes (competition_id, org_id)
+    values (${competitionId}, ${orgId})`;
+  await invalidateOrgEntitlements(orgId);
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("Event Pass lifecycle lock (TS resolver)", () => {
+  let orgId: string;
+  beforeEach(async () => {
+    orgId = await seedCommunityOrg();
+    await invalidateOrgEntitlements(orgId);
+  });
+
+  it("applies the pass on a LIVE competition", async () => {
+    const compId = await seedCompetition(orgId, "live", "live", 30);
+    await addPass(orgId, compId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+  });
+
+  it("stops applying once the competition is ARCHIVED", async () => {
+    const compId = await seedCompetition(orgId, "arch", "live", 30);
+    await addPass(orgId, compId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+
+    // Pass lifts the entrants cap 64 -> 128 while live.
+    expect(await getLimit(orgId, "entrants.per_division.max", compId)).toBe(128);
+
+    await sql`update competitions set status = 'archived' where id = ${compId}`;
+    await invalidateOrgEntitlements(orgId);
+    // Falls back to Community caps — the pass no longer lifts anything.
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(false);
+    // Community entrants cap (64), not the pass's raised cap (128).
+    expect(await getLimit(orgId, "entrants.per_division.max", compId)).toBe(64);
+  });
+
+  it("stops applying once the competition is COMPLETED (finished)", async () => {
+    const compId = await seedCompetition(orgId, "done", "live", 30);
+    await addPass(orgId, compId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+
+    await sql`update competitions set status = 'completed' where id = ${compId}`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(false);
+    expect(await getLimit(orgId, "entrants.per_division.max", compId)).toBe(64);
+  });
+
+  it("stops applying once the competition ended beyond the grace window", async () => {
+    const compId = await seedCompetition(orgId, "ended", "live", -(PASS_END_GRACE_DAYS + 1));
+    await addPass(orgId, compId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(false);
+  });
+
+  it("still applies while inside the ended-grace window", async () => {
+    const compId = await seedCompetition(orgId, "grace", "live", -3);
+    await addPass(orgId, compId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+  });
+
+  // Acceptance §14: the pass is bound to the competition ID, never the name. A
+  // rename cannot relock/unlock, and a brand-new competition (new id) with the
+  // same name has NO pass row of its own.
+  it("does not follow a rename onto a fresh competition of the same name", async () => {
+    const compId = await seedCompetition(orgId, "year1", "live", 30);
+    await addPass(orgId, compId);
+    const [{ name }] = await sql<{ name: string }[]>`
+      select name from competitions where id = ${compId}`;
+    // Rename does not touch eligibility.
+    await sql`update competitions set name = ${name + " (Year 2)"} where id = ${compId}`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+
+    // A genuinely new competition reusing the same display name has no pass.
+    const [{ id: freshId }] = await sql<{ id: string }[]>`
+      insert into competitions (org_id, name, slug, status)
+      values (${orgId}, ${name}, ${"fresh-" + uniq()}, 'live') returning id`;
+    expect(await hasFeature(orgId, "realtime", freshId)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -153,6 +153,49 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     expect(await sqlHasFeature(orgId, "realtime", otherId)).toBe(false);
   });
 
+  // v17 SPEC-4 §7: an Event Pass stops applying once its competition is over.
+  // Both resolvers must agree the pass is LOCKED, not just that it is honoured on
+  // a live competition — so an archived comp and a long-ended comp are proven in
+  // lockstep here, next to the honoured case above.
+  it("both resolvers drop a pass on an ARCHIVED competition", async () => {
+    const compId = await seedCompetition(orgId, "archived");
+    await sql`
+      insert into competition_passes (competition_id, org_id) values (${compId}, ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    // Honoured while live…
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+    expect(await sqlHasFeature(orgId, "realtime", compId)).toBe(true);
+    // …dropped once archived, in BOTH resolvers.
+    await sql`update competitions set status = 'archived' where id = ${compId}`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(false);
+    expect(await sqlHasFeature(orgId, "realtime", compId)).toBe(false);
+  });
+
+  it("both resolvers drop a pass on a COMPLETED (finished) competition", async () => {
+    const compId = await seedCompetition(orgId, "completed");
+    await sql`
+      insert into competition_passes (competition_id, org_id) values (${compId}, ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(true);
+    expect(await sqlHasFeature(orgId, "realtime", compId)).toBe(true);
+    await sql`update competitions set status = 'completed' where id = ${compId}`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(false);
+    expect(await sqlHasFeature(orgId, "realtime", compId)).toBe(false);
+  });
+
+  it("both resolvers drop a pass on a competition ended beyond the grace window", async () => {
+    const compId = await seedCompetition(orgId, "ended");
+    await sql`
+      update competitions set ends_on = (current_date - 8)::date where id = ${compId}`;
+    await sql`
+      insert into competition_passes (competition_id, org_id) values (${compId}, ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(false);
+    expect(await sqlHasFeature(orgId, "realtime", compId)).toBe(false);
+  });
+
   it("coalesces a null-bool Event Pass row THROUGH to the plan, not into a deny", async () => {
     // A pass row whose bool_value is null is NO answer, not a deny: it must fall
     // through to the plan row, exactly as org_has_feature's coalesce does.

--- a/apps/web/src/lib/entitlements.ts
+++ b/apps/web/src/lib/entitlements.ts
@@ -100,6 +100,48 @@ export function isPaidPlan(planKey: string): boolean {
   return planKey !== "community";
 }
 
+/** Grace period (days) an Event Pass keeps applying AFTER its competition's
+ *  ends_on date, before the ended-competition lock (arm B) fires. SPEC-4 §7.2. */
+export const PASS_END_GRACE_DAYS = 7;
+
+/**
+ * Is an Event Pass no longer eligible to apply because its competition is over?
+ * (v17 SPEC-4 §7, the "hybrid" lifecycle rule, mapped to the real competition
+ * status vocabulary.)
+ *
+ * Compute-at-read (SPEC §13.1): NO column on competition_passes, no status
+ * write-back, no auto-archiving — the answer is derived from the competition's
+ * live `status` and `ends_on` every time. The pass ROW is never deleted; this is
+ * runtime eligibility only.
+ *
+ *   A (terminal):  status in {completed, archived} — SPEC §7's terminal set, and
+ *                  both are reachable: a finished competition is set to
+ *                  'completed' (usecases/competitions.ts) and archived to
+ *                  'archived'. The active set is {draft, published, live} (V270).
+ *   B (long-ended): ends_on is set AND ends_on + PASS_END_GRACE_DAYS < today.
+ *                   A date-only comparison (ends_on is a DATE), grace 7 days.
+ *
+ * Kept exactly in step with the SQL resolver's pass arm (org_has_feature, V328):
+ * `not (c.status in ('archived','completed') or (c.ends_on is not null and
+ * c.ends_on + interval '7 days' < current_date))`. The entitlements-sql-parity
+ * suite is the tie. Exported so the OFFER side can reuse it later; this task
+ * wires no other call site.
+ */
+export function isPassLocked(status: string, endsOn: Date | string | null): boolean {
+  if (status === "archived" || status === "completed") return true;
+  if (endsOn == null) return false;
+  // ends_on is a DATE; the postgres driver hands it back as a Date at UTC
+  // midnight, and `new Date('YYYY-MM-DD')` also parses to UTC midnight, so UTC
+  // getters give a stable day-number for either shape.
+  const end = endsOn instanceof Date ? endsOn : new Date(endsOn);
+  const endMs = end.getTime();
+  if (Number.isNaN(endMs)) return false;
+  const graceEndMs = endMs + PASS_END_GRACE_DAYS * 86_400_000;
+  const now = new Date();
+  const todayMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return graceEndMs < todayMs;
+}
+
 /**
  * The org's plan AS THE RESOLVER SEES IT — after the read-time degradations,
  * which is the only version that predicts what an entitlement read will do.
@@ -232,13 +274,20 @@ async function resolveFromDb(
   // whether to OFFER a pass, on purpose: "the pass does nothing here" and
   // "stop selling the pass here" must never be able to disagree.
   if (!isPaidPlan(planKey) && competitionId) {
-    const [pass] = await sql<Resolved[]>`
-      select pe.bool_value, pe.int_value
+    // Also load the competition's lifecycle so a pass on an ARCHIVED or
+    // long-ended competition stops applying (v17 SPEC-4 §7). Compute-at-read:
+    // the competitions row is joined live, never a stored flag. The lock mirrors
+    // org_has_feature (V328); entitlements-sql-parity is the tie.
+    const [pass] = await sql<
+      (Resolved & { status: string; ends_on: Date | string | null })[]
+    >`
+      select pe.bool_value, pe.int_value, c.status, c.ends_on
       from competition_passes cp
+      join competitions c on c.id = cp.competition_id
       join plan_entitlements pe
         on pe.plan_key = cp.pass_key and pe.feature_key = ${featureKey}
       where cp.competition_id = ${competitionId} and cp.org_id = ${orgId}`;
-    if (pass) {
+    if (pass && !isPassLocked(pass.status, pass.ends_on)) {
       // Overlay field by field, EXACTLY as the override arm below and as the SQL
       // resolver's coalesce (org_has_feature, V306): a null pass bool_value is no
       // answer and falls THROUGH to the plan bool, never a deny. int_value stays

--- a/apps/web/src/server/usecases/__tests__/billing-overview-passes.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-overview-passes.test.ts
@@ -64,6 +64,15 @@ async function grantPass(
     values (${compId}, ${orgId}, ${intent}, ${purchasedAt})`;
 }
 
+/** SPEC-4 §9: set the competition's lifecycle so `ended` can be exercised. */
+async function setCompLifecycle(
+  compId: string,
+  status: string,
+  endsOn: string | null,
+): Promise<void> {
+  await sql`update competitions set status = ${status}, ends_on = ${endsOn} where id = ${compId}`;
+}
+
 /** One paid invoice for the intent, as invoicePayments.list returns it. */
 function invoiceFor(total: number, currency = "gbp", url = "https://invoice.stripe.test/i/x") {
   return { data: [{ invoice: { total, currency, hosted_invoice_url: url } }] };
@@ -205,5 +214,34 @@ describe.skipIf(!HAS_DB)("getPassPurchases", () => {
   it("returns an empty list for an org that holds no pass", async () => {
     const orgId = await seedOrg();
     expect(await getPassPurchases(orgId)).toEqual([]);
+  });
+
+  // SPEC-4 §9: `ended` mirrors the resolver lock (isPassLocked) — the badge the
+  // billing page will render (SPEC-6 UI). A running competition's pass is
+  // active; a completed/archived one, or one whose end date passed the 7-day
+  // grace, is ended.
+  it("marks the pass ended exactly when its competition is locked", async () => {
+    const orgId = await seedOrg();
+    const live = await seedComp(orgId, "live-cup");
+    const done = await seedComp(orgId, "done-cup");
+    const shelved = await seedComp(orgId, "shelved-cup");
+    const lapsed = await seedComp(orgId, "lapsed-cup");
+    await grantPass(live.id, orgId, null, "2026-01-01T09:00:00Z");
+    await grantPass(done.id, orgId, null, "2026-01-02T09:00:00Z");
+    await grantPass(shelved.id, orgId, null, "2026-01-03T09:00:00Z");
+    await grantPass(lapsed.id, orgId, null, "2026-01-04T09:00:00Z");
+    await setCompLifecycle(live.id, "live", null);
+    await setCompLifecycle(done.id, "completed", null);
+    await setCompLifecycle(shelved.id, "archived", null);
+    // A live competition whose end date passed more than 7 days ago (grace).
+    const eightDaysAgo = new Date(Date.now() - 8 * 86_400_000).toISOString().slice(0, 10);
+    await setCompLifecycle(lapsed.id, "live", eightDaysAgo);
+
+    const byId = Object.fromEntries((await getPassPurchases(orgId)).map((r) => [r.competitionId, r]));
+
+    expect(byId[live.id].ended).toBe(false);
+    expect(byId[done.id].ended).toBe(true);
+    expect(byId[shelved.id].ended).toBe(true);
+    expect(byId[lapsed.id].ended).toBe(true);
   });
 });

--- a/apps/web/src/server/usecases/billing-manage.ts
+++ b/apps/web/src/server/usecases/billing-manage.ts
@@ -9,7 +9,7 @@ import {
   syncPaymentMethodFlagFromCards,
   syncSubscription,
 } from "@/lib/billing";
-import { invalidateEntitlementsForOrgGroup } from "@/lib/entitlements";
+import { invalidateEntitlementsForOrgGroup, isPassLocked } from "@/lib/entitlements";
 import { subscriptionIdForOrg } from "@/lib/billing-group";
 import { logStaffAction } from "@/lib/admin";
 import {
@@ -316,6 +316,15 @@ export interface PassPurchaseRow {
   amountMinor: number | null;
   currency: string | null;
   hostedInvoiceUrl: string | null;
+  /**
+   * SPEC-4 §9: the pass has stopped lifting the plan (its competition is
+   * completed/archived, or its end date passed the 7-day grace). Computed from
+   * `isPassLocked` — the ONE place the lock rule lives (entitlements.ts, T1) —
+   * so the Active/Ended badge the billing page renders can never disagree with
+   * what the resolver actually enforces. Finished events stay readable; the
+   * paid-for-running lifts are what switch off.
+   */
+  ended: boolean;
 }
 
 interface PassInvoice {
@@ -376,9 +385,12 @@ export async function getPassPurchases(orgId: string): Promise<PassPurchaseRow[]
       slug: string;
       purchased_at: Date | string;
       stripe_payment_intent: string | null;
+      status: string;
+      ends_on: Date | string | null;
     }[]
   >`
-    select cp.competition_id, c.name, c.slug, cp.purchased_at, cp.stripe_payment_intent
+    select cp.competition_id, c.name, c.slug, cp.purchased_at, cp.stripe_payment_intent,
+           c.status, c.ends_on
     from competition_passes cp
     join competitions c on c.id = cp.competition_id
     where cp.org_id = ${orgId}
@@ -396,6 +408,7 @@ export async function getPassPurchases(orgId: string): Promise<PassPurchaseRow[]
     amountMinor: invoices[i]?.amountMinor ?? null,
     currency: invoices[i]?.currency ?? null,
     hostedInvoiceUrl: invoices[i]?.hostedInvoiceUrl ?? null,
+    ended: isPassLocked(r.status, r.ends_on),
   }));
 }
 

--- a/db/migration/deltas/V328__event_pass_lifecycle_lock.sql
+++ b/db/migration/deltas/V328__event_pass_lifecycle_lock.sql
@@ -1,0 +1,95 @@
+-- V328 — an Event Pass stops applying once its competition is over
+-- (v17 SPEC-4 §7, #249).
+--
+-- Until now the resolver's Pass arm granted a community org the pass matrix on a
+-- competition forever, regardless of that competition's lifecycle. So a
+-- completed/archived (or long-ended) competition kept its Pass entitlements —
+-- the abuse in SPEC-4 §2: buy one pass, rename Year-1 -> Year-2, stay entitled.
+--
+-- The lock is COMPUTE-AT-READ (SPEC §13.1): no column on competition_passes, no
+-- status write-back, no auto-archiving, and the pass ROW is never deleted. The
+-- pass sub-select simply joins the competition and drops out when the
+-- competition is over. This mirrors lib/entitlements.ts's isPassLocked, and
+-- apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts holds the two in
+-- step — change one and that suite fails.
+--
+--   lock(status, ends_on) =
+--        status in ('archived', 'completed')                       -- A terminal
+--     OR (ends_on is not null and ends_on + interval '7 days' < current_date) -- B
+--
+-- Terminal is SPEC §7's {completed, archived}, and both are reachable: a finished
+-- competition is set to 'completed' (usecases/competitions.ts) and an archived one
+-- to 'archived'; the active set is {draft, published, live} (V270). The optional
+-- 12-month purchased_at cap (§7.3 / #252) is DEFERRED — not built here.
+--
+-- The body is copied FORWARD from V314 (the current definition of
+-- org_has_feature — V306 introduced it, V313 added the cancelled-subscription
+-- arm, V314 reached the subscription through organizations.subscription_id and
+-- added the suspended-org arm). The ONLY change is the two extra lines on the
+-- Event Pass sub-select: a join to competitions and the `not (...)` lifecycle
+-- guard. Every other arm — override, plan CASE, coalesce order, false default —
+-- is byte-for-byte V314.
+--
+-- Signature, security-definer and the pinned `search_path = <defaultSchema>,
+-- pg_temp` (pg_temp LAST so no session can shadow a table inside this definer
+-- function) are unchanged from V314. Replacing the function body carries
+-- public_competitions_v / public_entrants_v / public_discovery_v unchanged —
+-- they call the FUNCTION, so no view is reissued here.
+
+create or replace function org_has_feature(
+  p_org_id uuid,
+  p_feature_key text,
+  p_competition_id uuid
+) returns boolean
+  language sql stable security definer
+  set search_path = ${flyway:defaultSchema}, pg_temp as $$
+    with plan as (
+      select case
+        -- MODERATION, not billing (mirrors entitlements.ts): a suspended ORG
+        -- resolves community whatever its group pays for, scoped to that one org
+        -- so a moderator cannot degrade siblings that merely share a payer.
+        when o.status = 'suspended' then 'community'
+        when s.comped_until is not null and s.comped_until <= now()
+             and (s.stripe_subscription_id is null
+                  or coalesce(s.status, '') not in
+                     ('trialing', 'active', 'past_due'))
+             then 'community'
+        when s.status = 'past_due'
+             and coalesce(s.status_changed_at, s.updated_at) <= now() - interval '14 days'
+             then 'community'
+        -- A CANCELLED subscription does not convey its plan (V313). The
+        -- comped_at guard keeps an INDEFINITE staff comp alive; a lapsed comp is
+        -- already community via the comped_until arm above.
+        when s.status = 'canceled' and s.comped_at is null
+             then 'community'
+        else coalesce(s.plan_key, 'community')
+      end as plan_key
+      from organizations o
+      left join subscriptions s on s.id = o.subscription_id
+      where o.id = p_org_id
+    )
+    select coalesce(
+      (select bool_value from org_entitlement_overrides
+        where org_id = p_org_id and feature_key = p_feature_key
+          and (expires_at is null or expires_at > now())),
+      -- Event Pass: community orgs only, competition in scope. A key absent from
+      -- the pass matrix falls through to the plan row rather than denying. v17
+      -- SPEC-4 §7: the pass stops applying once its competition is archived or
+      -- long-ended (mirrors isPassLocked in lib/entitlements.ts).
+      (select pe.bool_value
+         from competition_passes cp
+         join competitions c on c.id = cp.competition_id
+         join plan_entitlements pe
+           on pe.plan_key = cp.pass_key and pe.feature_key = p_feature_key
+        where p_competition_id is not null
+          and cp.competition_id = p_competition_id
+          and cp.org_id = p_org_id
+          and (select plan_key from plan) = 'community'
+          and not (c.status in ('archived', 'completed')
+                   or (c.ends_on is not null
+                       and c.ends_on + interval '7 days' < current_date))),
+      (select pe.bool_value from plan_entitlements pe
+        where pe.feature_key = p_feature_key
+          and pe.plan_key = (select plan_key from plan)),
+      false)
+  $$;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1831,6 +1831,23 @@ async function passGrantsSuite(): Promise<void> {
       ent.entitlements["ai.credits.monthly"]?.limit === 10 &&
       ent.entitlements["registration.fee_percent"]?.limit === 8,
   );
+
+  // === lock — a pass stops lifting once its competition is terminal (SPEC-4
+  // §7/§13.5, isPassLocked). Every grant above held while `passComp` ran; retire
+  // it to `archived` and the SAME create that a moment ago succeeded under the
+  // pass — a tiered sponsor (sponsors.tiers, 201 as passTier) — must now 402.
+  // sponsors.tiers is boolean and state-free, so it flips cleanly, where the
+  // entrant cap (already at 128) would 402 either way. The status write does NOT
+  // invalidate the resolver's (org, competition, feature) cache, so bust it the
+  // way the suite does after any raw entitlement write — no sleep on the 300s TTL.
+  const retire = await v1(s, `/api/v1/competitions/${passComp.id}`, "PATCH", { status: "archived" });
+  check("pass grants/lock: the passed competition retires to archived (200)", retire.status === 200);
+  await bustOrgEntitlements(s, orgId);
+  const lockedTier = await tierOn(passComp.id, "locked");
+  check(
+    "pass grants/lock: once archived the pass no longer lifts sponsors.tiers — the create that held under the pass now 402s",
+    lockedTier.status === 402 && featureKey(lockedTier) === "sponsors.tiers",
+  );
 }
 
 /** clubs-w1 (W1 §5): parent clubs group teams across divisions. The Pro path


### PR DESCRIPTION
v17 **SPEC-4 (Event Pass Validity)** — backend. Closes the abuse where a completed/archived competition keeps its Event Pass forever (rename Year-1 → Year-2, stay entitled). Makes the help copy true in code.

## What's here
- **Resolver lifecycle lock** (`entitlements.ts` + `V328`) — a Pass stops applying when its competition is `archived`/`completed`, or its `ends_on` is >7 days past. Enforced in **both** the TS resolver and the parity-tested SQL `org_has_feature` (V328 is a faithful forward-port of V314 + only the pass-arm lock). Compute-at-read — the `competition_passes` row is never mutated; refund still deletes it. `isPassLocked` is one exported rule.
- **Active/Ended surface** — `getPassPurchases` gains an `ended` field (calls `isPassLocked`); the billing "Event Pass purchases" list can badge Active vs Ended. (The pill rendering is SPEC-6 UI.)
- **Honest help copy** — `content/help/billing/event-pass.md`: states the lock triggers, that renaming ≠ a new Pass but a new competition needs its own, drops "lifetime forever".
- **Smoke lock path** — `passGrantsSuite` archives a passed comp, busts the cache, asserts the pass-granted capability is now refused.
- **CI: live-Stripe on real Postgres** — a curated Smoke-job step runs `stripe:sync` + `BILLING_LIVE=1` for `billing-tiers.live` + `billing-proration.live` (excludes tax-registration / real-AI live suites); fork-safe. Verified locally against test-mode Stripe.

## Reviews & tests
- T1 + T2 per-task reviews + whole-branch review all **MERGE-READY**. One real gap caught + fixed mid-review: the lock initially missed `completed` (only `archived`) — corrected to both, in TS + SQL, with parity proof.
- Entitlements + parity + pass-lock + billing-passes suites green on the v17 schema; typecheck clean; the two live-Stripe suites pass locally.

## Deferred (recorded)
- 12-month `purchased_at` safety cap (#252) — DEFERRED per §7.3.
- Next-edition UX / Active-Ended pill rendering (#250, §9) — SPEC-6 (needs visual sign-off).
- Accepted Minor: TS uses UTC-midnight, SQL `current_date` — agree on UTC prod Postgres; parity guards it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)