### PR TITLE
feat(v17): SPEC-5 §1 Operator Allocation — per-org credit caps on the shared pool

### DIFF
--- a/apps/web/src/app/api/billing/group/allocation/__tests__/route.test.ts
+++ b/apps/web/src/app/api/billing/group/allocation/__tests__/route.test.ts
@@ -1,0 +1,95 @@
+// GET/PUT /api/billing/group/allocation — the operator allocation console API
+// (v17 SPEC-5 §1). The use case owns the DB gating (tested against real Postgres
+// in server/usecases/__tests__/operator-allocation.test.ts); here the use case
+// and auth are mocked, so what is asserted is purely the ROUTE contract: it
+// passes the authenticated caller through, validates the PUT body strictly, and
+// surfaces the use case's HttpError with the right status via the shared handler.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { randomUUID } from "node:crypto";
+
+const caller = vi.hoisted(() => ({ id: "user-1" }));
+vi.mock("@/lib/auth", () => ({ requireUser: async () => ({ id: caller.id }) }));
+
+const usecase = vi.hoisted(() => ({
+  allocationConsole: vi.fn(),
+  setOrgAllocation: vi.fn(),
+}));
+vi.mock("@/server/usecases/operator-allocation", () => ({
+  allocationConsole: (...a: unknown[]) => usecase.allocationConsole(...a),
+  setOrgAllocation: (...a: unknown[]) => usecase.setOrgAllocation(...a),
+}));
+
+import { HttpError } from "@/lib/errors";
+import { GET, PUT } from "../route";
+
+const putReq = (body: unknown) =>
+  new Request("http://x/api/billing/group/allocation", {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+
+beforeEach(() => {
+  caller.id = "user-1";
+  usecase.allocationConsole.mockReset();
+  usecase.setOrgAllocation.mockReset();
+});
+
+describe("GET /api/billing/group/allocation", () => {
+  it("returns the console for the authenticated caller", async () => {
+    const data = { walletId: "sub_1", poolBalance: 40, members: [] };
+    usecase.allocationConsole.mockResolvedValue(data);
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, data });
+    expect(usecase.allocationConsole).toHaveBeenCalledWith("user-1");
+  });
+
+  it("surfaces the payer-gate 403 from the use case", async () => {
+    usecase.allocationConsole.mockRejectedValue(new HttpError(403, "not a payer"));
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect((await res.json()).ok).toBe(false);
+  });
+});
+
+describe("PUT /api/billing/group/allocation", () => {
+  it("sets a member's cap and returns ok", async () => {
+    usecase.setOrgAllocation.mockResolvedValue(undefined);
+    const org = randomUUID();
+
+    const res = await PUT(putReq({ org_id: org, monthly_cap: 25 }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+    expect(usecase.setOrgAllocation).toHaveBeenCalledWith("user-1", org, 25);
+  });
+
+  it("accepts monthly_cap: null (clear to unlimited)", async () => {
+    usecase.setOrgAllocation.mockResolvedValue(undefined);
+    const org = randomUUID();
+
+    const res = await PUT(putReq({ org_id: org, monthly_cap: null }));
+    expect(res.status).toBe(200);
+    expect(usecase.setOrgAllocation).toHaveBeenCalledWith("user-1", org, null);
+  });
+
+  it("rejects a non-uuid org_id with 400, never calling the use case", async () => {
+    const res = await PUT(putReq({ org_id: "not-a-uuid", monthly_cap: 5 }));
+    expect(res.status).toBe(400);
+    expect(usecase.setOrgAllocation).not.toHaveBeenCalled();
+  });
+
+  it("rejects a negative or fractional cap with 400", async () => {
+    const org = randomUUID();
+    expect((await PUT(putReq({ org_id: org, monthly_cap: -1 }))).status).toBe(400);
+    expect((await PUT(putReq({ org_id: org, monthly_cap: 2.5 }))).status).toBe(400);
+    expect(usecase.setOrgAllocation).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a use-case 403 (org not in the caller's group)", async () => {
+    usecase.setOrgAllocation.mockRejectedValue(new HttpError(403, "not the payer"));
+    const org = randomUUID();
+    const res = await PUT(putReq({ org_id: org, monthly_cap: 5 }));
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/web/src/app/api/billing/group/allocation/route.ts
+++ b/apps/web/src/app/api/billing/group/allocation/route.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { requireUser } from "@/lib/auth";
+import { handler } from "@/lib/http";
+import { allocationConsole, setOrgAllocation } from "@/server/usecases/operator-allocation";
+
+const schema = z.object({
+  org_id: z.string().uuid(),
+  monthly_cap: z.number().int().nonnegative().nullable(),
+});
+
+/**
+ * GET /api/billing/group/allocation — the operator allocation console
+ * (design/v17-pricing-entitlements/SPEC-5 §1): every member org's cap, its burn
+ * this period, and the shared pool balance for the caller's group wallet.
+ *
+ * Payer-gated exactly like the sibling group routes (attach/detach/transfer):
+ * `requireUser` establishes who is asking, and `allocationConsole` gates on
+ * `subscriptions.owner_user_id` — a non-payer resolves to no owned group and
+ * gets a 403.
+ */
+export async function GET() {
+  return handler(async () => {
+    const user = await requireUser();
+    return allocationConsole(user.id);
+  });
+}
+
+/**
+ * PUT /api/billing/group/allocation — set (or clear) a member org's monthly
+ * credit cap on the shared wallet. `monthly_cap: null` clears to an unlimited
+ * share. Payer-only; an org outside the caller's group is refused (403/404) by
+ * the use case's `subscriptionIsOwnedBy` gate.
+ */
+export async function PUT(req: Request) {
+  return handler(async () => {
+    const user = await requireUser();
+    const body = schema.parse(await req.json());
+    return setOrgAllocation(user.id, body.org_id, body.monthly_cap);
+  });
+}

--- a/apps/web/src/lib/__tests__/credits-allocation.test.ts
+++ b/apps/web/src/lib/__tests__/credits-allocation.test.ts
@@ -1,0 +1,174 @@
+// AI credit wallet — operator per-org monthly allocation cap (v17 SPEC-5 §1).
+//
+// A Pro Plus operator runs ONE shared group wallet (SPEC-2 §11); every member
+// org spends from the same pool. org_credit_allocation (V329) lets the operator
+// set a per-member HARD monthly cap, enforced at spend time INSIDE reserve()'s
+// advisory-lock transaction (derive-then-check-then-write, so it's tight under
+// concurrency). The org's spend-this-period is DERIVED from the ledger (no
+// counter): the sum of its run_spend holds since date_trunc('month', now()),
+// each netted by its refund row (refund.ref = hold.id) so a failed/released run
+// gives its allowance back. A cap hit emits a DISTINCT 402
+// `ai.credits.allocation` (vs the pool-empty `ai.credits`).
+//
+// Real Postgres required; skipped without DATABASE_URL. Run against the fresh
+// v17 schema: DATABASE_URL=$(cat /tmp/v17_base_url) DB_SCHEMA=seazn_club_v17.
+import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { balance, release, reserve } from "@/lib/credits";
+import { PaymentRequiredError } from "@/lib/errors";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+/** Seed a wallet balance directly (bypassing grant helpers). */
+async function seedWalletBalance(
+  walletId: string,
+  delta: number,
+  bucket: "grant" | "pack" = "grant",
+): Promise<void> {
+  await sql`
+    insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+    values (${walletId}, ${delta}, 'monthly_grant', ${bucket}, ${delta}, ${`seed-${uniq()}`})`;
+}
+
+/** A real org row — org_credit_allocation.org_id FKs organizations(id). */
+async function seedOrg(): Promise<string> {
+  const [org] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${`Alloc ${uniq()}`}, ${`alloc-${uniq()}`})
+    returning id`;
+  return org!.id;
+}
+
+/** Set (or clear) a per-(wallet, org) monthly cap. cap === null → unlimited. */
+async function seedAllocation(
+  walletId: string,
+  orgId: string,
+  cap: number | null,
+): Promise<void> {
+  await sql`
+    insert into org_credit_allocation (wallet_id, org_id, monthly_cap)
+    values (${walletId}, ${orgId}, ${cap})`;
+}
+
+describe.skipIf(!HAS_DB)("ai credit wallet — operator allocation cap", () => {
+  it("1. no allocation row → free-for-all: org spends up to the whole pool", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    await seedWalletBalance(walletId, 10);
+
+    await reserve(walletId, orgId, 10); // no cap row → allowed to drain the pool
+    expect(await balance(walletId)).toBe(0);
+  });
+
+  it("2. NULL cap → unlimited: org is pool-bounded only", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    await seedWalletBalance(walletId, 10);
+    await seedAllocation(walletId, orgId, null);
+
+    await reserve(walletId, orgId, 10);
+    expect(await balance(walletId)).toBe(0);
+  });
+
+  it("3. under cap → allowed: cap 5, spent 3, a 1-credit run succeeds", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    await seedWalletBalance(walletId, 100);
+    await seedAllocation(walletId, orgId, 5);
+
+    await reserve(walletId, orgId, 3); // spent = 3
+    await reserve(walletId, orgId, 1); // 3 + 1 = 4 <= 5 → allowed
+    expect(await balance(walletId)).toBe(96);
+  });
+
+  it("4. at/over cap → 402 ai.credits.allocation, and writes NO hold", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    await seedWalletBalance(walletId, 100);
+    await seedAllocation(walletId, orgId, 5);
+
+    await reserve(walletId, orgId, 5); // spent = 5, exactly at cap
+    expect(await balance(walletId)).toBe(95);
+
+    let thrown: unknown;
+    try {
+      await reserve(walletId, orgId, 1); // 5 + 1 = 6 > 5 → blocked
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(PaymentRequiredError);
+    expect((thrown as PaymentRequiredError).featureKey).toBe("ai.credits.allocation");
+    // No hold written — the gate fires before the bucket cut.
+    expect(await balance(walletId)).toBe(95);
+  });
+
+  it("5. a failed run refunds the allocation (ref-join derive nets it out)", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    await seedWalletBalance(walletId, 100);
+    await seedAllocation(walletId, orgId, 2);
+
+    const holdId = await reserve(walletId, orgId, 2); // spent = 2, at cap
+    await release(holdId); // failed run → refund nets spent-this-period back to 0
+
+    // Without the ref-join net the original hold would still count (2 + 2 > 2)
+    // and this would 402. It must be allowed.
+    await reserve(walletId, orgId, 2);
+    expect(await balance(walletId)).toBe(98);
+  });
+
+  it("6. pool-empty still wins with its own code (ai.credits, not allocation)", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    // Generous cap, but the pool is empty.
+    await seedAllocation(walletId, orgId, 100);
+
+    let thrown: unknown;
+    try {
+      await reserve(walletId, orgId, 1);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(PaymentRequiredError);
+    expect((thrown as PaymentRequiredError).featureKey).toBe("ai.credits");
+  });
+
+  it("7. per-org isolation: org A at its cap is blocked, org B still runs", async () => {
+    const walletId = randomUUID();
+    const orgA = await seedOrg();
+    const orgB = await seedOrg();
+    await seedWalletBalance(walletId, 100);
+    await seedAllocation(walletId, orgA, 2); // A is capped; B has no row
+
+    await reserve(walletId, orgA, 2); // A at cap
+    await expect(reserve(walletId, orgA, 1)).rejects.toMatchObject({
+      featureKey: "ai.credits.allocation",
+    });
+
+    // B shares the wallet but has no cap → pool-bounded only, still runs.
+    await reserve(walletId, orgB, 5);
+    expect(await balance(walletId)).toBe(93); // 100 - 2 (A) - 5 (B)
+  });
+
+  it("8. period-scoped: a hold stamped last month does not count toward the cap", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    await seedWalletBalance(walletId, 100);
+    await seedAllocation(walletId, orgId, 1);
+
+    // A big spend by this org, but backdated to a prior calendar month — it
+    // must be excluded from this period's derive (else 5 > cap 1 would block).
+    await sql`
+      insert into ai_credit_ledger
+        (wallet_id, delta, source, bucket, spent_by_org_id, balance_after,
+         idempotency_key, created_at)
+      values (${walletId}, -5, 'run_spend', 'grant', ${orgId}, 95,
+              ${`old-${uniq()}`}, now() - interval '2 months')`;
+
+    // This-period spend is 0, so a 1-credit run is under the cap.
+    await reserve(walletId, orgId, 1);
+    expect(await balance(walletId)).toBe(94); // 100 - 5 (last month) - 1 (now)
+  });
+});

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -529,6 +529,48 @@ export async function recordPackRefund(
 }
 
 /**
+ * Net credits `orgId` has spent on `walletId` THIS calendar month (SPEC-5 §1) —
+ * the derived quantity the operator allocation cap is checked against. There is
+ * deliberately NO `spent_this_period` counter: the ledger is the single source
+ * of truth (no reset job, no drift, no reserve/settle race), and the spend is
+ * already recorded as the `run_spend` hold tagged `spent_by_org_id = orgId`.
+ *
+ * **Nets refunds via the ref link, not a tag.** A failed run's `release()`
+ * writes a `source='refund'` row with `ref = hold.id` and NO `spent_by_org_id`
+ * (it doesn't re-tag the org), so the derive nets each hold by summing the
+ * refund rows that reference it — a released/failed run correctly gives its
+ * allowance back without touching `release()`. Pack refunds also use
+ * `source='refund'` but `ref` = a payment-intent id, never a `run_spend` row
+ * id, so they can't match a hold here.
+ *
+ * **Period bound** = `date_trunc('month', now())`, the same calendar-month
+ * anchor `grantMonthly` resets on — so the cap resets implicitly with the grant
+ * cycle. A hold from a prior month is excluded (its refund, if any, is moot —
+ * only holds inside the period are summed). Runs inside the caller's executor
+ * (`reserve`'s advisory-locked tx) so the check sees this reserve's own prior
+ * writes. Returns a non-negative integer.
+ */
+async function spentThisPeriodByOrg(
+  exec: Executor,
+  walletId: string,
+  orgId: string,
+): Promise<number> {
+  const [row] = await exec<{ spent: string | null }[]>`
+    select coalesce(sum(
+      -h.delta - coalesce((
+        select sum(r.delta) from ai_credit_ledger r
+         where r.source = 'refund' and r.ref = h.id::text
+      ), 0)
+    ), 0)::text as spent
+      from ai_credit_ledger h
+     where h.wallet_id = ${walletId}
+       and h.spent_by_org_id = ${orgId}
+       and h.source = 'run_spend'
+       and h.created_at >= date_trunc('month', now())`;
+  return Math.max(0, Number(row?.spent ?? 0));
+}
+
+/**
  * Reserve `cost` credits against `walletId` for an AI run started by `orgId`
  * (SPEC-2 §5.2 step 2, §5.4 spend order). The ledger's `source` CHECK has no
  * distinct "hold" value, so the hold IS the debit from the moment it's
@@ -566,6 +608,24 @@ export async function reserve(walletId: string, orgId: string, cost: number): Pr
   try {
     return await sql.begin(async (tx) => {
       await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + walletId}))`;
+
+      // Operator allocation cap (SPEC-5 §1): a member org on a shared group
+      // wallet can be capped to a per-month credit share. NO row = free-for-all
+      // (spend up to the pool); NULL cap = unlimited share; a number = a HARD
+      // cap. Checked HERE, inside the advisory lock and BEFORE the bucket cuts,
+      // so the derive sees this reserve's own prior holds and the cap stays
+      // tight under concurrency (no over-spend race). A cap hit emits a DISTINCT
+      // 402 `ai.credits.allocation` (UI: "ask your operator to raise your cap")
+      // vs the pool-empty `ai.credits` ("buy credits") thrown by the CHECK below.
+      const [alloc] = await tx<{ monthly_cap: number | null }[]>`
+        select monthly_cap from org_credit_allocation
+         where wallet_id = ${walletId} and org_id = ${orgId}`;
+      if (alloc && alloc.monthly_cap != null) {
+        const spent = await spentThisPeriodByOrg(tx, walletId, orgId);
+        if (spent + cost > alloc.monthly_cap) {
+          throw new PaymentRequiredError("ai.credits.allocation");
+        }
+      }
 
       const grantAvailable = Math.max(0, await bucketBalance(tx, walletId, "grant"));
       const grantCut = Math.min(cost, grantAvailable);

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -549,8 +549,14 @@ export async function recordPackRefund(
  * only holds inside the period are summed). Runs inside the caller's executor
  * (`reserve`'s advisory-locked tx) so the check sees this reserve's own prior
  * writes. Returns a non-negative integer.
+ *
+ * Exported (Phase 6 Task 2, SPEC-5 §1) so the operator allocation console
+ * (`server/usecases/operator-allocation.ts`) reports each member org's burn
+ * from the SAME derive the `reserve()` cap gate checks against — one source of
+ * truth for the period-spend rule. The console passes the plain `sql` client
+ * (a read, no transaction); `reserve` passes its advisory-locked `tx`.
  */
-async function spentThisPeriodByOrg(
+export async function spentThisPeriodByOrg(
   exec: Executor,
   walletId: string,
   orgId: string,

--- a/apps/web/src/server/usecases/__tests__/operator-allocation.test.ts
+++ b/apps/web/src/server/usecases/__tests__/operator-allocation.test.ts
@@ -1,0 +1,211 @@
+// Operator allocation console — set member caps + read burn (v17 SPEC-5 §1).
+//
+// The WRITE (setOrgAllocation) and READ (allocationConsole) API a Pro Plus
+// operator uses to cap each member org's share of the ONE shared group wallet
+// (SPEC-2 §11) and to see each member's burn against the pool. The cap is
+// enforced at spend time in reserve() (Task 1); this proves the write path
+// actually drives that enforcement (the money proof below) and that the console
+// reports the same period-spend derive the gate checks.
+//
+// Payer-only: gating reuses subscriptionIsOwnedBy (the exact helper attach/
+// detach/transfer gate on) — a member org's owner is NOT its group's payer.
+//
+// Real Postgres required; skipped without DATABASE_URL. Fresh v17 schema:
+// DATABASE_URL=$(cat /tmp/v17_base_url) DB_SCHEMA=seazn_club_v17.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { balance, release, reserve } from "@/lib/credits";
+import { HttpError } from "@/lib/errors";
+import { PaymentRequiredError } from "@/lib/errors";
+import { allocationConsole, setOrgAllocation } from "../operator-allocation";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function makeUser(tag: string): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`${tag}-${uniq()}@test.local`}, ${`User ${tag}`}, true) returning id`;
+  return id;
+}
+
+/** A group (subscription) owned by `ownerId`. Its id IS the wallet id. */
+async function makeGroup(ownerId: string, plan = "pro_plus"): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into subscriptions (owner_user_id, plan_key, status, quantity_paid)
+    values (${ownerId}, ${plan}, 'active', 1) returning id`;
+  return id;
+}
+
+/** A member org in group `subId`. */
+async function makeOrg(subId: string, ownerId: string, name?: string): Promise<string> {
+  const s = uniq();
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by, subscription_id)
+    values (${name ?? `Alloc ${s}`}, ${`alloc-${s}`}, ${ownerId}, ${subId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${id}, ${ownerId}, 'owner')`;
+  return id;
+}
+
+/** Fund the shared wallet directly (bypassing grant helpers). */
+async function fundWallet(walletId: string, credits: number): Promise<void> {
+  await sql`
+    insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+    values (${walletId}, ${credits}, 'monthly_grant', 'grant', ${credits}, ${`seed-${uniq()}`})`;
+}
+
+const capRow = async (walletId: string, orgId: string) =>
+  (
+    await sql<{ monthly_cap: number | null; updated_by: string | null }[]>`
+      select monthly_cap, updated_by from org_credit_allocation
+       where wallet_id = ${walletId} and org_id = ${orgId}`
+  )[0];
+
+afterAll(async () => {
+  await sql.end({ timeout: 5 });
+});
+
+describe.skipIf(!HAS_DB)("operator allocation — setOrgAllocation", () => {
+  it("1. payer sets a cap, then updates it (idempotent on the PK, audited)", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer);
+    const org = await makeOrg(group, payer);
+
+    await setOrgAllocation(payer, org, 5);
+    let row = await capRow(group, org);
+    expect(row?.monthly_cap).toBe(5);
+    expect(row?.updated_by).toBe(payer);
+
+    await setOrgAllocation(payer, org, 10); // second call updates, no PK conflict
+    row = await capRow(group, org);
+    expect(row?.monthly_cap).toBe(10);
+
+    // Still exactly one row for (wallet, org).
+    const [{ n }] = await sql<{ n: string }[]>`
+      select count(*)::text as n from org_credit_allocation
+       where wallet_id = ${group} and org_id = ${org}`;
+    expect(n).toBe("1");
+  });
+
+  it("2. an org NOT in the payer's group is refused, and no row is written", async () => {
+    const payer = await makeUser("payer");
+    await makeGroup(payer); // the payer has a group, but the target is elsewhere
+
+    const stranger = await makeUser("stranger");
+    const otherGroup = await makeGroup(stranger);
+    const foreignOrg = await makeOrg(otherGroup, stranger);
+
+    await expect(setOrgAllocation(payer, foreignOrg, 5)).rejects.toMatchObject({ status: 403 });
+    expect(await capRow(otherGroup, foreignOrg)).toBeUndefined();
+  });
+
+  it("3. a non-payer caller (a member org owner) is refused by the payer gate", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer);
+    const org = await makeOrg(group, payer);
+
+    const nonPayer = await makeUser("nonpayer");
+    await sql`insert into org_members (org_id, user_id, role) values (${org}, ${nonPayer}, 'owner')`;
+
+    await expect(setOrgAllocation(nonPayer, org, 5)).rejects.toBeInstanceOf(HttpError);
+    await expect(setOrgAllocation(nonPayer, org, 5)).rejects.toMatchObject({ status: 403 });
+    expect(await capRow(group, org)).toBeUndefined();
+  });
+
+  it("rejects a negative or non-integer cap with a 400", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer);
+    const org = await makeOrg(group, payer);
+
+    await expect(setOrgAllocation(payer, org, -1)).rejects.toMatchObject({ status: 400 });
+    await expect(setOrgAllocation(payer, org, 2.5)).rejects.toMatchObject({ status: 400 });
+    expect(await capRow(group, org)).toBeUndefined();
+  });
+});
+
+describe.skipIf(!HAS_DB)("operator allocation — allocationConsole", () => {
+  it("4. returns every member with its cap, burn this period, and the pool balance", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer);
+    const orgA = await makeOrg(group, payer, "Alpha");
+    const orgB = await makeOrg(group, payer, "Bravo");
+    await fundWallet(group, 100);
+
+    // Cap Alpha at 5; leave Bravo uncapped. Alpha has prior burn of 3.
+    await setOrgAllocation(payer, orgA, 5);
+    await reserve(group, orgA, 3);
+
+    const console = await allocationConsole(payer);
+    expect(console.walletId).toBe(group);
+    expect(console.poolBalance).toBe(97); // 100 - 3
+
+    const members = new Map(console.members.map((m) => [m.orgId, m]));
+    expect(members.get(orgA)).toMatchObject({
+      orgName: "Alpha",
+      monthlyCap: 5,
+      spentThisPeriod: 3,
+    });
+    expect(members.get(orgB)).toMatchObject({
+      orgName: "Bravo",
+      monthlyCap: null, // no row → unlimited share
+      spentThisPeriod: 0,
+    });
+    // Ordered by name.
+    expect(console.members.map((m) => m.orgName)).toEqual(["Alpha", "Bravo"]);
+  });
+
+  it("refuses a caller who is not a payer of any group", async () => {
+    const nobody = await makeUser("nobody");
+    await expect(allocationConsole(nobody)).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe.skipIf(!HAS_DB)("operator allocation — the money proof", () => {
+  it("5. set cap 2 → member's 3rd reserve 402s allocation → raise cap → succeeds", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer);
+    const org = await makeOrg(group, payer);
+    await fundWallet(group, 100); // pool is deep — the cap, not the pool, is the limit
+
+    await setOrgAllocation(payer, org, 2);
+
+    await reserve(group, org, 1); // spent 1
+    await reserve(group, org, 1); // spent 2, exactly at cap
+
+    let thrown: unknown;
+    try {
+      await reserve(group, org, 1); // 2 + 1 > 2 → blocked by the Task 1 gate
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(PaymentRequiredError);
+    expect((thrown as PaymentRequiredError).featureKey).toBe("ai.credits.allocation");
+
+    // Operator raises the cap via the write path — the very thing this proves.
+    await setOrgAllocation(payer, org, 10);
+    await reserve(group, org, 1); // now allowed
+    expect(await balance(group)).toBe(97); // 100 - 3 spent
+  });
+
+  it("6. cap=null clears to unlimited: an at-limit member runs again", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer);
+    const org = await makeOrg(group, payer);
+    await fundWallet(group, 100);
+
+    await setOrgAllocation(payer, org, 2);
+    await reserve(group, org, 2); // at cap
+    await expect(reserve(group, org, 1)).rejects.toMatchObject({
+      featureKey: "ai.credits.allocation",
+    });
+
+    await setOrgAllocation(payer, org, null); // clear to unlimited share
+    const row = await capRow(group, org);
+    expect(row?.monthly_cap).toBeNull(); // NULL row, not a delete — audit trail kept
+    expect(row?.updated_by).toBe(payer);
+
+    await reserve(group, org, 1); // unlimited share → pool-bounded only, runs
+    expect(await balance(group)).toBe(97); // 100 - 3
+  });
+});

--- a/apps/web/src/server/usecases/operator-allocation.ts
+++ b/apps/web/src/server/usecases/operator-allocation.ts
@@ -1,0 +1,141 @@
+import "server-only";
+// Operator allocation console (design/v17-pricing-entitlements/SPEC-5 §1).
+//
+// A Pro Plus operator (federation/academy/county) runs ONE shared group wallet
+// (SPEC-2 §11): every member org spends from the same credit pool. Without a
+// control, one member can burn the whole month. `org_credit_allocation` (V329)
+// lets the operator set a per-member HARD monthly cap; the cap is ENFORCED at
+// spend time inside `reserve()`'s advisory-lock transaction (`lib/credits.ts`).
+//
+// This module is the WRITE (set/clear a member's cap) + READ (the console data:
+// each member's cap, its burn this period, the pool balance) API. The console
+// UI itself is SPEC-6 — this is data + gating only.
+//
+// Gating is PAYER-only, matching every sibling group route (attach/detach/
+// transfer): billing belongs to whoever pays for the group
+// (`subscriptions.owner_user_id`), never to a member org's owner. The write
+// reuses `subscriptionIsOwnedBy` (the exact helper those routes gate on) —
+// deriving the group from the target org and asserting the actor is its payer
+// checks membership AND authorisation in one, and refuses an org in someone
+// else's group with the same 403 the siblings return.
+import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import { balance, spentThisPeriodByOrg } from "@/lib/credits";
+import { subscriptionIsOwnedBy } from "@/server/usecases/billing-groups";
+
+export interface MemberAllocation {
+  orgId: string;
+  orgName: string;
+  /** null = unlimited share (an explicit NULL row, or no row at all). */
+  monthlyCap: number | null;
+  /** Net credits this org has spent from the shared wallet this calendar month
+   *  (derived from the ledger — the SAME quantity `reserve()`'s cap checks). */
+  spentThisPeriod: number;
+}
+
+export interface AllocationConsole {
+  /** The group's wallet id (`coalesce(group_subscription_id, org_id)` = the
+   *  group subscription id). */
+  walletId: string;
+  /** Credits in the shared pool right now (`credits.balance`). */
+  poolBalance: number;
+  members: MemberAllocation[];
+}
+
+/**
+ * Set (or clear) a member org's monthly credit cap on the shared group wallet.
+ * Payer-only.
+ *
+ * `monthlyCap`:
+ *   * a non-negative integer → the hard monthly cap for that member;
+ *   * `null` → clear to an unlimited share (an explicit NULL row, NOT a delete —
+ *     it keeps the `updated_by`/`updated_at` audit trail, and both NULL and
+ *     no-row skip the `reserve()` gate identically, so the auditable form is
+ *     strictly better).
+ *
+ * The group is derived from the target org's own `subscription_id`, then the
+ * actor is asserted to be that group's payer via `subscriptionIsOwnedBy` — so
+ * an org in a DIFFERENT group (or one the actor doesn't pay for) is refused with
+ * the sibling routes' 403, and an org that belongs to no billing group is 404.
+ * Upserts on the `(wallet_id, org_id)` PK, so a re-set is idempotent.
+ */
+export async function setOrgAllocation(
+  actorUserId: string,
+  targetOrgId: string,
+  monthlyCap: number | null,
+): Promise<void> {
+  if (monthlyCap !== null && (!Number.isInteger(monthlyCap) || monthlyCap < 0)) {
+    throw new HttpError(400, "A credit cap must be a non-negative whole number, or null to clear it.");
+  }
+
+  const [org] = await sql<{ subscription_id: string | null; deleted_at: Date | null }[]>`
+    select subscription_id, deleted_at from organizations where id = ${targetOrgId}`;
+  if (!org || org.deleted_at) throw new HttpError(404, "Organisation not found.");
+  const walletId = org.subscription_id;
+  if (!walletId) throw new HttpError(404, "That organisation is not in a billing group.");
+
+  // The payer gate — the exact helper attach/detach/transfer use. Also proves
+  // the org is a member of the actor's group (the wallet was derived from it).
+  await subscriptionIsOwnedBy(walletId, actorUserId);
+
+  await sql`
+    insert into org_credit_allocation (wallet_id, org_id, monthly_cap, updated_by, updated_at)
+    values (${walletId}, ${targetOrgId}, ${monthlyCap}, ${actorUserId}, now())
+    on conflict (wallet_id, org_id)
+    do update set monthly_cap = ${monthlyCap}, updated_by = ${actorUserId}, updated_at = now()`;
+}
+
+/**
+ * The operator console for the actor's own group wallet. Payer-only.
+ *
+ * Lists every member org (`organizations.subscription_id = wallet`, not
+ * soft-deleted) with its cap (left-joined from `org_credit_allocation`) and its
+ * burn this period (reusing `spentThisPeriodByOrg`, the SAME derive the spend
+ * gate checks), plus the shared pool balance. Members are ordered by name.
+ *
+ * Group resolution: the actor is a payer (`subscriptions.owner_user_id`). A
+ * payer may own SEVERAL groups (a real operator group plus group-of-one
+ * Community subscriptions — see the `/api/billing/groups` "several groups"
+ * case), so this resolves DETERMINISTICALLY to the group with the most live
+ * member orgs (id tiebreak) — i.e. the actual operator group. A payer who owns
+ * no group with a live org at all gets a 403. (When a payer runs more than one
+ * multi-member group, SPEC-6's UI will pass an explicit group; the API's
+ * single-group resolution is the sensible default until then.)
+ */
+export async function allocationConsole(actorUserId: string): Promise<AllocationConsole> {
+  const [group] = await sql<{ id: string }[]>`
+    select s.id from subscriptions s
+     where s.owner_user_id = ${actorUserId}
+       and exists (
+             select 1 from organizations o
+              where o.subscription_id = s.id and o.deleted_at is null)
+     order by (
+       select count(*) from organizations o
+        where o.subscription_id = s.id and o.deleted_at is null
+     ) desc, s.id
+     limit 1`;
+  if (!group) {
+    throw new HttpError(403, "Only a billing-group payer can view the allocation console.");
+  }
+  const walletId = group.id;
+
+  const memberRows = await sql<{ id: string; name: string; monthly_cap: number | null }[]>`
+    select o.id, o.name, a.monthly_cap
+      from organizations o
+      left join org_credit_allocation a
+        on a.wallet_id = ${walletId} and a.org_id = o.id
+     where o.subscription_id = ${walletId} and o.deleted_at is null
+     order by o.name, o.id`;
+
+  const members: MemberAllocation[] = [];
+  for (const m of memberRows) {
+    members.push({
+      orgId: m.id,
+      orgName: m.name,
+      monthlyCap: m.monthly_cap,
+      spentThisPeriod: await spentThisPeriodByOrg(sql, walletId, m.id),
+    });
+  }
+
+  return { walletId, poolBalance: await balance(walletId), members };
+}

--- a/db/migration/deltas/V329__org_credit_allocation.sql
+++ b/db/migration/deltas/V329__org_credit_allocation.sql
@@ -1,0 +1,48 @@
+-- V329 — operator per-org monthly credit allocation cap (design/v17-pricing-
+-- entitlements/SPEC-5 §1).
+--
+-- A Pro Plus operator (federation/academy/county) runs ONE shared group wallet
+-- (SPEC-2 §11): every member org spends from the same pool. Without a control,
+-- one member can burn the whole month's credits. This table lets the operator
+-- set a per-member HARD monthly cap, enforced at SPEND time inside reserve()'s
+-- advisory-lock transaction (lib/credits.ts) — derive-then-check-then-write, so
+-- the cap is tight under concurrency (no over-spend race).
+--
+-- Cap semantics (SPEC-5 §1, Q8 hard-cap):
+--   * NO ROW for (wallet, org) = free-for-all — the member can spend up to the
+--     whole pool (backward-compatible with SPEC-2 §11 before this task).
+--   * a row with monthly_cap = NULL = unlimited share (an explicit "no cap").
+--   * a row with a number = the hard monthly credit cap for that member org.
+-- The cap resets implicitly with the grant cycle: the spend check derives the
+-- org's spend from the ledger since date_trunc('month', now()), the same
+-- calendar-month anchor grantMonthly() uses — no counter column, no reset job.
+--
+-- org_id is uuid (references organizations) — every org-scoped table in the
+-- schema types it so (V005/V023/V025). wallet_id stays TEXT with no FK, exactly
+-- like ai_credit_ledger.wallet_id / org_addons.wallet_id: it is
+-- coalesce(group_subscription_id, org_id) (§11.1) and cannot reference one
+-- table. The cap is keyed per (wallet, org) so the operator caps each member
+-- independently on the shared wallet.
+--
+-- Same text/CHECK style as ai_credit_ledger (V320) / org_addons (V323), no pg
+-- enum type; Flyway runs -defaultSchema=seazn_club.
+
+create table if not exists org_credit_allocation (
+  wallet_id    text not null,
+  org_id       uuid not null references organizations(id) on delete cascade,
+  -- NULL = unlimited share of the pool; a number = the hard monthly cap.
+  monthly_cap  int,
+  -- Staff/operator user id who set the cap (attribution; no FK, like
+  -- ai_credit_ledger.created_by).
+  updated_by   uuid,
+  updated_at   timestamptz not null default now(),
+  primary key (wallet_id, org_id),
+  check (monthly_cap is null or monthly_cap >= 0)
+);
+
+comment on table org_credit_allocation is
+  'Operator per-org monthly AI-credit cap on a shared group wallet (SPEC-5 §1). '
+  'NO ROW = free-for-all (spend up to the pool); NULL cap = unlimited share; a '
+  'number = hard monthly cap, enforced at spend time in reserve() and reset '
+  'implicitly with the calendar-month grant cycle. wallet_id = '
+  'coalesce(group_subscription_id, org_id), keyed per (wallet, org).';


### PR DESCRIPTION
v17 **SPEC-5 §1 (Operator Allocation)** — backend. Turns a Pro Plus group's shared credit wallet into a mini-reseller console: the operator (payer) hands each member org a monthly credit cap, enforced as a hard cap so one org can't burn the whole pool. (§2 earn-credits + §3 auto-topup are fast-follow, not built here.)

## What's here
- **Allocation cap in the spend path** (`credits.ts` + `V329 org_credit_allocation`) — inside `reserve()`'s advisory-locked tx, before the pool check: if the org has a non-NULL `monthly_cap`, derive its spend-this-period from the ledger (netting failed-run refunds via the `ref` link, scoped to the calendar month) and refuse over-cap with a **distinct** `PaymentRequiredError("ai.credits.allocation")` (vs pool-empty `ai.credits`). No row = free-for-all; NULL cap = unlimited share. Tight under concurrency (serialized on the wallet lock); no counter (single source of truth = the ledger).
- **Operator console API** (`operator-allocation.ts` + `GET/PUT /api/billing/group/allocation`) — payer-only (reuses `subscriptionIsOwnedBy`, the exact attach/detach/transfer gate): set/clear a member's cap; read each member's cap + burn (reusing the same derive) + pool balance. Console UI = SPEC-6.

## Reviews & tests
- Both tasks + the whole-branch review all **MERGE-READY**. Money path traced (no over-spend race, no double-count, no stale read); authz traced (no non-payer write, no cross-group leak). The money-proof test drives the full loop: set cap 2 → 3rd run 402s → raise cap → next run succeeds.
- **39 tests green** on the v17 schema (allocation + operator + route + credit-wallet regression); typecheck clean. No live-Stripe surface.

## Deferred (recorded, reviewer-accepted)
- §2 earn-credits + §3 auto-topup (fast-follow).
- Console UI + multi-group picker + N+1→grouped-derive → SPEC-6.
- Accepted Minor: derive month-basis (`date_trunc` session-TZ vs grant UTC) — agree on UTC prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)