### PR TITLE
fix(a11y): 2 axe serious violations on the Credits section (#262 follow-up)

### DIFF
--- a/apps/web/src/components/billing-credits.tsx
+++ b/apps/web/src/components/billing-credits.tsx
@@ -94,7 +94,7 @@ export function BillingCredits({ view, dict, locale, exportHref, packs, currency
           <span className="text-sm text-slate-600">
             {t(dict, "billing.credits.autoTopup")}
           </span>
-          <span className="badge bg-slate-100 text-slate-500">
+          <span className="badge bg-slate-100 text-slate-600">
             {t(dict, "billing.credits.autoTopupOff")}
           </span>
           <button
@@ -126,7 +126,12 @@ export function BillingCredits({ view, dict, locale, exportHref, packs, currency
             {t(dict, "billing.credits.empty")}
           </p>
         ) : (
-          <div className="scroll-x scroll-x-fade -mx-1 px-1">
+          <div
+            className="scroll-x scroll-x-fade -mx-1 px-1"
+            tabIndex={0}
+            role="region"
+            aria-label={t(dict, "billing.credits.history")}
+          >
             <table className="w-full min-w-[34rem] text-left text-sm">
               <thead>
                 <tr className="border-b border-purple-100 text-xs uppercase tracking-wide text-slate-400">


### PR DESCRIPTION
Post-#262 main e2e caught 2 axe serious issues on /settings/billing (the new A3 Credits card): the auto-topup 'Off' badge failed color-contrast (slate-500/slate-100), and the run-history scroll container wasn't keyboard-focusable. Fixes: text-slate-600; tabIndex=0 + role=region + aria-label. Greens main's e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)