### PR TITLE
feat(v17): earn credits (onboarding + first paid comp) + org-switch & auto-topup UI fixes

### DIFF
--- a/apps/web/src/app/api/onboarding/complete/route.ts
+++ b/apps/web/src/app/api/onboarding/complete/route.ts
@@ -14,11 +14,18 @@ export async function POST() {
   // Grant to the user's active org (a user reaching "onboarding complete" has an
   // org); no side-effecting ensureActiveOrg here — read-only resolution, skip if
   // none.
-  const orgs = await getUserOrgs(user.id);
-  if (orgs.length > 0) {
-    const activeId = await getActiveOrgId();
-    const orgId = orgs.find((o) => o.id === activeId)?.id ?? orgs[0].id;
-    await tryEarnGrant(orgId, "onboarding", ONBOARDING_EARN);
+  // Best-effort covers the ORG RESOLUTION too, not just the grant: getUserOrgs /
+  // getActiveOrgId throwing must not 500 onboarding after markOnboardingDone has
+  // committed (tryEarnGrant alone swallows only its own errors).
+  try {
+    const orgs = await getUserOrgs(user.id);
+    if (orgs.length > 0) {
+      const activeId = await getActiveOrgId();
+      const orgId = orgs.find((o) => o.id === activeId)?.id ?? orgs[0].id;
+      await tryEarnGrant(orgId, "onboarding", ONBOARDING_EARN);
+    }
+  } catch {
+    // earn is a growth-loop nicety; never let it fail onboarding completion.
   }
 
   return NextResponse.json({ ok: true });

--- a/apps/web/src/app/api/onboarding/complete/route.ts
+++ b/apps/web/src/app/api/onboarding/complete/route.ts
@@ -1,10 +1,25 @@
 import { NextResponse } from "next/server";
-import { getCurrentUser } from "@/lib/auth";
+import { getActiveOrgId, getCurrentUser, getUserOrgs } from "@/lib/auth";
 import { markOnboardingDone } from "@/lib/activation";
+import { ONBOARDING_EARN, tryEarnGrant } from "@/lib/credits";
 
 export async function POST() {
   const user = await getCurrentUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   await markOnboardingDone(user.id);
+
+  // Growth loop (SPEC-5 §2 B): completing onboarding earns the org free AI
+  // credits. Best-effort and idempotent per org (tryEarnGrant never throws) — a
+  // grant failure must not fail onboarding, and re-completing never double-grants.
+  // Grant to the user's active org (a user reaching "onboarding complete" has an
+  // org); no side-effecting ensureActiveOrg here — read-only resolution, skip if
+  // none.
+  const orgs = await getUserOrgs(user.id);
+  if (orgs.length > 0) {
+    const activeId = await getActiveOrgId();
+    const orgId = orgs.find((o) => o.id === activeId)?.id ?? orgs[0].id;
+    await tryEarnGrant(orgId, "onboarding", ONBOARDING_EARN);
+  }
+
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/src/components/billing-credits.tsx
+++ b/apps/web/src/components/billing-credits.tsx
@@ -89,22 +89,15 @@ export function BillingCredits({ view, dict, locale, exportHref, packs, currency
           </p>
         )}
 
-        {/* Auto-topup — off-state placeholder (D1 fast-follow, not wired). */}
+        {/* Auto-topup — deferred (SPEC-5 §3, issue #266). Shown as "Coming soon"
+            rather than an actionable "set up", since it isn't wired yet. */}
         <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-purple-100 pt-3">
           <span className="text-sm text-slate-600">
             {t(dict, "billing.credits.autoTopup")}
           </span>
           <span className="badge bg-slate-100 text-slate-600">
-            {t(dict, "billing.credits.autoTopupOff")}
+            {t(dict, "billing.credits.comingSoon")}
           </span>
-          <button
-            type="button"
-            disabled
-            className="btn btn-ghost text-xs"
-            title={t(dict, "billing.credits.comingSoon")}
-          >
-            {t(dict, "billing.credits.autoTopupSetup")}
-          </button>
         </div>
       </div>
 

--- a/apps/web/src/components/org-switcher.tsx
+++ b/apps/web/src/components/org-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { ArrowLeftRight } from "lucide-react";
 import { api } from "@/lib/client";
 import type { OrgMembership } from "@/lib/types";
@@ -26,6 +26,7 @@ export function OrgSwitcher({
   activeId: string;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -47,10 +48,21 @@ export function OrgSwitcher({
     setBusy(id);
     try {
       await api("/api/orgs/active", { method: "POST", json: { org_id: id } });
-      // PROMPT-30: the URL owns which org a page shows — navigate to the
-      // chosen org's settings; a cookie flip alone would change nothing.
-      const slug = orgs.find((o) => o.id === id)?.slug;
-      if (slug) router.push(routes.orgSettings(slug));
+      // PROMPT-30: the URL owns which org a page shows — a cookie flip alone
+      // changes nothing, so navigate. Stay on the SAME page under the new org by
+      // swapping the /o/<slug>/ segment, rather than always dumping the user on
+      // settings. Only org-level settings sub-paths transfer safely; a
+      // competition/entity path (/o/<slug>/c/…) belongs to the OLD org and would
+      // 404 under the new one, so those fall back to the new org's settings.
+      const newSlug = orgs.find((o) => o.id === id)?.slug;
+      const oldSlug = orgs.find((o) => o.id === activeId)?.slug;
+      if (newSlug) {
+        let target = routes.orgSettings(newSlug);
+        if (oldSlug && pathname.startsWith(`/o/${oldSlug}/settings`)) {
+          target = `/o/${newSlug}${pathname.slice(`/o/${oldSlug}`.length)}`;
+        }
+        router.push(target);
+      }
       router.refresh();
     } finally {
       setBusy(null);

--- a/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
+++ b/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
@@ -46,7 +46,7 @@ import {
   revokePassForRefundedCharge,
 } from "@/lib/billing";
 import { processStripeEvent } from "@/server/usecases/billing-events";
-import { FIRST_PAID_EARN, balance, packBalance, reserve, walletIdFor } from "@/lib/credits";
+import { balance, packBalance, reserve, walletIdFor } from "@/lib/credits";
 import { PASS_CREDIT_GRANT } from "@/lib/pricing-cards";
 
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -330,19 +330,17 @@ describe.skipIf(!HAS_DB)("Event Pass grants one-time AI credits", () => {
     });
     stripeMock.retrieve.mockResolvedValue(session);
 
-    // A paid Event Pass through the WEBHOOK is also this org's first paid
-    // competition, so the SPEC-5 §2 first_paid earn (FIRST_PAID_EARN) stacks on
-    // top of the SPEC-2 pass grant — 25 (pass) + 10 (earn). Both are one-time and
-    // idempotent, so the replay below adds nothing. (The direct recordPassPurchase
-    // tests above stay at PASS_CREDIT_GRANT — the earn hook lives in the webhook
-    // handler, not in recordPassPurchase.)
+    // A paid Event Pass grants ONLY the SPEC-2 pass credits (25). The SPEC-5 §2
+    // first_paid earn does NOT stack here: buying a pass is not the org taking a
+    // paid registration, so the earn hook lives in confirmPaidRegistration, not
+    // the pass webhook branch. Both writes are one-time and idempotent, so the
+    // replay below adds nothing.
     await processStripeEvent(passEvent(session));
-    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT + FIRST_PAID_EARN);
+    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT);
     // A second delivery of the same payment is a replay, not a new purchase:
-    // recordPassGrant's per-payment-intent idempotency key makes it a no-op, and
-    // the earn hook's per-org key likewise no-ops.
+    // recordPassGrant's per-payment-intent idempotency key makes it a no-op.
     expect(await reconcilePassCheckout(orgId, "cs_grant_replay")).toBe(true);
-    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT + FIRST_PAID_EARN);
+    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT);
   });
 
   it("a refunded duplicate second charge does NOT grant a second time", async () => {

--- a/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
+++ b/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
@@ -46,7 +46,7 @@ import {
   revokePassForRefundedCharge,
 } from "@/lib/billing";
 import { processStripeEvent } from "@/server/usecases/billing-events";
-import { balance, packBalance, reserve, walletIdFor } from "@/lib/credits";
+import { FIRST_PAID_EARN, balance, packBalance, reserve, walletIdFor } from "@/lib/credits";
 import { PASS_CREDIT_GRANT } from "@/lib/pricing-cards";
 
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -330,12 +330,19 @@ describe.skipIf(!HAS_DB)("Event Pass grants one-time AI credits", () => {
     });
     stripeMock.retrieve.mockResolvedValue(session);
 
+    // A paid Event Pass through the WEBHOOK is also this org's first paid
+    // competition, so the SPEC-5 §2 first_paid earn (FIRST_PAID_EARN) stacks on
+    // top of the SPEC-2 pass grant — 25 (pass) + 10 (earn). Both are one-time and
+    // idempotent, so the replay below adds nothing. (The direct recordPassPurchase
+    // tests above stay at PASS_CREDIT_GRANT — the earn hook lives in the webhook
+    // handler, not in recordPassPurchase.)
     await processStripeEvent(passEvent(session));
-    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT);
+    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT + FIRST_PAID_EARN);
     // A second delivery of the same payment is a replay, not a new purchase:
-    // recordPassGrant's per-payment-intent idempotency key makes it a no-op.
+    // recordPassGrant's per-payment-intent idempotency key makes it a no-op, and
+    // the earn hook's per-org key likewise no-ops.
     expect(await reconcilePassCheckout(orgId, "cs_grant_replay")).toBe(true);
-    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT);
+    expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT + FIRST_PAID_EARN);
   });
 
   it("a refunded duplicate second charge does NOT grant a second time", async () => {

--- a/apps/web/src/lib/__tests__/credits-earn.test.ts
+++ b/apps/web/src/lib/__tests__/credits-earn.test.ts
@@ -1,0 +1,156 @@
+// AI credit wallet — earn grants (v17 SPEC-5 §2, the PLG "earn free credits"
+// loop). recordEarnGrant tops a wallet up with free credits for a growth
+// milestone (onboarding completion / first paid competition) into the
+// never-expire `pack` bucket, idempotent per (reason, ref) and floored by a
+// LIFETIME_EARN_CAP so the loop can never mint unbounded free credits. tryEarnGrant
+// is the best-effort hook wrapper (never throws — a grant failure must not fail
+// onboarding or the checkout webhook). The referral source is DEFERRED (no
+// attribution primitive exists yet), so only onboarding + first_paid are here.
+//
+// Real Postgres required; skipped without DATABASE_URL. Run against the fresh v17
+// schema: DATABASE_URL=$(cat /tmp/v17_base_url) DB_SCHEMA=seazn_club_v17.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import {
+  FIRST_PAID_EARN,
+  LIFETIME_EARN_CAP,
+  ONBOARDING_EARN,
+  balance,
+  grantBalance,
+  packBalance,
+  recordEarnGrant,
+  tryEarnGrant,
+  walletIdFor,
+} from "@/lib/credits";
+import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function seedOrg(): Promise<string> {
+  const [org] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${`Earn ${uniq()}`}, ${`earn-${uniq()}`})
+    returning id`;
+  return org!.id;
+}
+
+/** Seed a raw earn_grant ledger row so a test can put a wallet at/near the
+ *  lifetime cap without replaying every milestone. */
+async function seedEarned(walletId: string, delta: number): Promise<void> {
+  await sql`
+    insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+    values (${walletId}, ${delta}, 'earn_grant', 'pack', ${delta}, ${`seed-${uniq()}`})`;
+}
+
+describe.skipIf(!HAS_DB)("ai credit wallet — earn grants (SPEC-5 §2)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe("recordEarnGrant", () => {
+    it("grants ONBOARDING_EARN once into the never-expire pack bucket, then is idempotent", async () => {
+      const walletId = randomUUID();
+      const orgId = randomUUID();
+
+      const first = await recordEarnGrant(walletId, orgId, "onboarding", orgId, ONBOARDING_EARN);
+      expect(first.granted).toBe(ONBOARDING_EARN);
+      expect(await packBalance(walletId)).toBe(ONBOARDING_EARN);
+      expect(await grantBalance(walletId)).toBe(0); // earned credits are kept, not the resetting bucket
+
+      // Re-completing onboarding (same reason:ref) grants nothing.
+      const replay = await recordEarnGrant(walletId, orgId, "onboarding", orgId, ONBOARDING_EARN);
+      expect(replay.granted).toBe(0);
+      expect(await balance(walletId)).toBe(ONBOARDING_EARN);
+    });
+
+    it("first_paid is once-per-ORG (keyed on org, not competition)", async () => {
+      const walletId = randomUUID();
+      const orgId = randomUUID();
+
+      // ref = orgId → idempotency key earn:first_paid:${orgId}.
+      const first = await recordEarnGrant(walletId, orgId, "first_paid", orgId, FIRST_PAID_EARN);
+      expect(first.granted).toBe(FIRST_PAID_EARN);
+
+      // A SECOND paid competition for the same org — same org-keyed ref — no-ops.
+      const second = await recordEarnGrant(walletId, orgId, "first_paid", orgId, FIRST_PAID_EARN);
+      expect(second.granted).toBe(0);
+      expect(await balance(walletId)).toBe(FIRST_PAID_EARN);
+    });
+
+    it("floors at the lifetime cap — grants only up to the cap, never over", async () => {
+      const walletId = randomUUID();
+      const orgId = randomUUID();
+      // Already earned cap − 5; an earn of 10 grants only the remaining 5.
+      await seedEarned(walletId, LIFETIME_EARN_CAP - 5);
+
+      const partial = await recordEarnGrant(walletId, orgId, "onboarding", orgId, 10);
+      expect(partial.granted).toBe(5);
+      expect(await packBalance(walletId)).toBe(LIFETIME_EARN_CAP); // exactly the cap, not over
+    });
+
+    it("grants 0 once the wallet is already at the lifetime cap", async () => {
+      const walletId = randomUUID();
+      const orgId = randomUUID();
+      await seedEarned(walletId, LIFETIME_EARN_CAP);
+
+      const atCap = await recordEarnGrant(walletId, orgId, "first_paid", orgId, FIRST_PAID_EARN);
+      expect(atCap.granted).toBe(0);
+      expect(await packBalance(walletId)).toBe(LIFETIME_EARN_CAP);
+    });
+
+    it("the cap is pool-wide across earn sources, not per source", async () => {
+      const walletId = randomUUID();
+      const orgId = randomUUID();
+      await seedEarned(walletId, LIFETIME_EARN_CAP - 3); // 97
+
+      // onboarding takes the last 3 of headroom...
+      expect((await recordEarnGrant(walletId, orgId, "onboarding", orgId, 10)).granted).toBe(3);
+      // ...so first_paid (a different source) now has no headroom left.
+      expect((await recordEarnGrant(walletId, orgId, "first_paid", orgId, 10)).granted).toBe(0);
+      expect(await balance(walletId)).toBe(LIFETIME_EARN_CAP);
+    });
+
+    it("records an attributable earn_grant row (source in the ledger/history)", async () => {
+      const walletId = randomUUID();
+      const orgId = randomUUID();
+      await recordEarnGrant(walletId, orgId, "onboarding", orgId, ONBOARDING_EARN);
+
+      const [row] = await sql<{ source: string; bucket: string; ref: string; spent_by_org_id: string }[]>`
+        select source, bucket, ref, spent_by_org_id from ai_credit_ledger
+         where wallet_id = ${walletId}`;
+      expect(row?.source).toBe("earn_grant");
+      expect(row?.bucket).toBe("pack");
+      expect(row?.ref).toBe(orgId);
+      expect(row?.spent_by_org_id).toBe(orgId);
+    });
+  });
+
+  describe("tryEarnGrant (best-effort hook wrapper)", () => {
+    it("resolves the wallet via walletIdFor — a grouped org earns into the group pool", async () => {
+      const orgId = await seedOrg();
+      const subId = await setOrgPlan(orgId, "pro"); // org.subscription_id = subId (the group wallet)
+      expect(await walletIdFor(orgId)).toBe(subId);
+
+      const granted = await tryEarnGrant(orgId, "onboarding", ONBOARDING_EARN);
+      expect(granted).toBe(ONBOARDING_EARN);
+      // Landed on the shared group wallet, not the org's own id.
+      expect(await balance(subId)).toBe(ONBOARDING_EARN);
+    });
+
+    it("is idempotent per org across calls", async () => {
+      const orgId = await seedOrg();
+      await setOrgPlan(orgId, "pro");
+
+      expect(await tryEarnGrant(orgId, "first_paid", FIRST_PAID_EARN)).toBe(FIRST_PAID_EARN);
+      expect(await tryEarnGrant(orgId, "first_paid", FIRST_PAID_EARN)).toBe(0);
+    });
+
+    it("never throws — a grant failure returns 0 (does not fail onboarding/checkout)", async () => {
+      // A bogus org id makes walletIdFor throw; tryEarnGrant must swallow it.
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const granted = await tryEarnGrant(randomUUID(), "onboarding", ONBOARDING_EARN);
+      expect(granted).toBe(0);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -520,6 +520,119 @@ export async function recordPassGrant(
 }
 
 /**
+ * Per-source earn amounts + the lifetime cap (SPEC-5 §2 — the PLG "earn free
+ * credits" loop). All three are tunable knobs that bound COGS: the two grant
+ * amounts are what an org gets for each milestone, and `LIFETIME_EARN_CAP` is
+ * the hard ceiling on how many `earn_grant` credits ANY single wallet can ever
+ * accrue across all earn sources combined — so the loop can never mint unbounded
+ * free credits no matter how many milestones an org hits (or a referral source a
+ * later task adds). Defaults: 10 for onboarding, 10 for the first paid
+ * competition, 100 lifetime — a new org can earn its way to at most 100 free
+ * credits ($25 of COGS at $0.25/credit) before every further earn no-ops.
+ */
+export const ONBOARDING_EARN = 10;
+export const FIRST_PAID_EARN = 10;
+export const LIFETIME_EARN_CAP = 100;
+
+/**
+ * Grant an org free AI credits for a growth milestone (SPEC-5 §2): onboarding
+ * completion or its first paid competition. Mirror of `recordPassGrant` — the
+ * credits land in the never-expire **`pack`** bucket (SPEC-2 §5.4 D2, earned
+ * credits are kept, not the monthly-reset `grant` bucket), `source='earn_grant'`,
+ * under the same wallet advisory lock every credit write takes.
+ *
+ * **Idempotent on `earn:${reason}:${ref}`:** the caller chooses `ref` so each
+ * milestone fires at most once — `ref = orgId` for BOTH sources here. Onboarding
+ * is naturally once-per-org (one org, one onboarding). "First paid competition"
+ * is made once-per-ORG by keying on the org, NOT the competition:
+ * `earn:first_paid:${orgId}` — so the org's first paid competition grants and
+ * every later paid competition conflicts on the unique key and no-ops (simpler
+ * and correct vs a separate "has any prior paid comp" query). A replay of the
+ * same milestone grants nothing.
+ *
+ * **Lifetime earn cap (money-safety):** before granting, sum this wallet's
+ * existing `earn_grant` credits and grant only `min(amount, LIFETIME_EARN_CAP −
+ * alreadyEarned)`, floored at 0 — so the total earned can never exceed the cap
+ * even across sources (a wallet 5 below the cap earning 10 gets exactly 5; a
+ * wallet at the cap gets 0 and writes no row). The read+cap+insert all sit under
+ * the advisory lock so two concurrent earns can't both see the same headroom and
+ * jointly overshoot the cap.
+ *
+ * Returns the credits actually granted this call (`{ granted: 0 }` on a replay
+ * or when the cap leaves no headroom).
+ */
+export async function recordEarnGrant(
+  walletId: string,
+  orgId: string,
+  reason: "onboarding" | "first_paid",
+  ref: string,
+  amount: number,
+): Promise<{ granted: number }> {
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new Error(`recordEarnGrant: amount must be a positive integer, got ${amount}`);
+  }
+  const key = `earn:${reason}:${ref}`;
+  return sql.begin(async (tx) => {
+    await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + walletId}))`;
+
+    // Idempotency pre-check under the lock (same shape as grantMonthly): a
+    // milestone already granted (or a cap-floored partial grant already
+    // recorded) short-circuits to a no-op before we touch the ledger again.
+    const [already] = await tx<{ id: string }[]>`
+      select id from ai_credit_ledger where idempotency_key = ${key}`;
+    if (already) return { granted: 0 };
+
+    // Lifetime earn cap: how much this wallet has earned across ALL earn
+    // sources, so the ceiling is enforced pool-wide, not per source.
+    const [earned] = await tx<{ total: string | null }[]>`
+      select coalesce(sum(delta), 0)::text as total
+        from ai_credit_ledger
+       where wallet_id = ${walletId} and source = 'earn_grant'`;
+    const alreadyEarned = Math.max(0, Number(earned?.total ?? 0));
+    const grantable = Math.max(0, Math.min(amount, LIFETIME_EARN_CAP - alreadyEarned));
+    if (grantable <= 0) return { granted: 0 };
+
+    const inserted = await appendLedgerRow(tx, {
+      walletId,
+      delta: grantable,
+      source: "earn_grant",
+      bucket: "pack",
+      ref,
+      spentByOrgId: orgId,
+      idempotencyKey: key,
+    });
+    return { granted: inserted ? grantable : 0 };
+  });
+}
+
+/**
+ * Best-effort wrapper around `recordEarnGrant` for the growth-loop HOOK sites
+ * (onboarding-complete route + the Event Pass checkout webhook, SPEC-5 §2 B/C).
+ * Resolves the wallet and grants, but NEVER throws — a credit-grant failure must
+ * not fail the onboarding flow or the money-row webhook it rides on (same
+ * discipline as the other post-commit grants in `billing-events.ts` and the
+ * bootstrap grant in `createOrgForUser`). Logs and returns 0 on any error.
+ *
+ * `ref = orgId` for both sources: onboarding is one-per-org, and first_paid is
+ * keyed on the org (not the competition) so ONLY the org's first paid
+ * competition grants (see `recordEarnGrant`'s idempotency note).
+ */
+export async function tryEarnGrant(
+  orgId: string,
+  reason: "onboarding" | "first_paid",
+  amount: number,
+): Promise<number> {
+  try {
+    const walletId = await walletIdFor(orgId);
+    const { granted } = await recordEarnGrant(walletId, orgId, reason, orgId, amount);
+    return granted;
+  } catch (err) {
+    console.error(`[credits] earn grant failed (org ${orgId}, ${reason})`, err);
+    return 0;
+  }
+}
+
+/**
  * Claw back a refunded / disputed Event Pass grant (SPEC-2 §5, money-safety):
  * a `charge.refunded` or a lost dispute on a pass charge revokes the pass, so
  * the one-time `PASS_CREDIT_GRANT` it added must be pulled back — mirror of

--- a/apps/web/src/server/usecases/__tests__/registrations.test.ts
+++ b/apps/web/src/server/usecases/__tests__/registrations.test.ts
@@ -88,6 +88,7 @@ import { LEGAL_VERSION } from "@/lib/legal";
 import { resolveNameDisplay } from "@/lib/name-display";
 
 import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+import { FIRST_PAID_EARN, balance, walletIdFor } from "@/lib/credits";
 const HAS_DB = !!process.env.DATABASE_URL;
 
 // ---------------------------------------------------------------------------
@@ -476,6 +477,61 @@ describe.skipIf(!HAS_DB)("registration flows (doc 16 §1.1, PROMPT-20a)", () => 
     const [{ n }] = await sql<{ n: number }[]>`
       select count(*)::int as n from entrants where division_id = ${division.id}`;
     expect(n).toBe(1);
+  });
+
+  it("SPEC-5 §2: the org's FIRST confirmed paid registration earns the organiser +10, once per org", async () => {
+    // The growth grant lands on the ORGANISER (the competition's org), not the
+    // registrant, and fires only on a genuine first-time paid CONFIRMATION.
+    const { orgId, orgSlug, ownerId } = await seedOrg("pro");
+    const owner = asOwner(orgId, ownerId);
+    const walletId = await walletIdFor(orgId);
+    const before = await balance(walletId);
+
+    const { competition, division } = await rig(owner);
+    await putRegistrationSettings(owner, division.id, {
+      enabled: true,
+      entrant_kind: "individual",
+      fee_cents: 2000,
+      currency: "usd",
+      form_fields: [],
+      opens_at: null,
+      closes_at: null,
+      capacity: null,
+      refund_lock_at: null,
+    });
+    const first = await submitRegistration(
+      orgSlug,
+      competition.slug,
+      { ...SUBMIT_BASE, division_id: division.id },
+      "http://test.local",
+    );
+    await handleRegistrationCheckoutCompleted(fakeSession(first.registration.id, 2000));
+    // The organiser's wallet gained exactly the first_paid earn.
+    expect(await balance(walletId)).toBe(before + FIRST_PAID_EARN);
+
+    // A SECOND competition for the SAME org, also taking a paid registration:
+    // the once-per-ORG key (earn:first_paid:${orgId}) makes it a no-op — no
+    // additional grant.
+    const { competition: comp2, division: div2 } = await rig(owner);
+    await putRegistrationSettings(owner, div2.id, {
+      enabled: true,
+      entrant_kind: "individual",
+      fee_cents: 2000,
+      currency: "usd",
+      form_fields: [],
+      opens_at: null,
+      closes_at: null,
+      capacity: null,
+      refund_lock_at: null,
+    });
+    const second = await submitRegistration(
+      orgSlug,
+      comp2.slug,
+      { ...SUBMIT_BASE, division_id: div2.id },
+      "http://test.local",
+    );
+    await handleRegistrationCheckoutCompleted(fakeSession(second.registration.id, 2000));
+    expect(await balance(walletId)).toBe(before + FIRST_PAID_EARN);
   });
 
   it("capacity: overflow waitlists; withdrawal auto-promotes the oldest; auto-refund pre-lock", async () => {

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -18,7 +18,14 @@ import {
   syncSubscriptionForGroup,
 } from "@/lib/billing";
 import { CREDIT_PACKS } from "@/lib/credit-packs";
-import { recordPackPurchase, recordPackRefund, recordPassRefund, walletIdFor } from "@/lib/credits";
+import {
+  FIRST_PAID_EARN,
+  recordPackPurchase,
+  recordPackRefund,
+  recordPassRefund,
+  tryEarnGrant,
+  walletIdFor,
+} from "@/lib/credits";
 import { SEAT_ADDON, isSeatAddonItem } from "@/lib/seat-addons";
 import { getSizePack } from "@/lib/size-packs";
 import {
@@ -207,6 +214,14 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
         // First purchase of ANY kind fixes the org's billing currency, so a
         // pass buyer is never re-quoted in another currency for Pro later.
         await pinBillingCurrency(orgId, session.currency);
+        // Growth loop (SPEC-5 §2 C): a paid Event Pass IS an org paying to run a
+        // competition — its FIRST one earns free AI credits. Keyed once-per-ORG
+        // (`earn:first_paid:${orgId}`), so only the first paid competition grants
+        // and every later one no-ops via the idempotency key. Best-effort
+        // (tryEarnGrant never throws) so a grant hiccup never blocks the money
+        // row; skipped for the refunded-duplicate above (that payer isn't running
+        // the competition). Idempotency also self-heals a webhook replay.
+        await tryEarnGrant(orgId, "first_paid", FIRST_PAID_EARN);
       }
     }
     return;

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -19,11 +19,9 @@ import {
 } from "@/lib/billing";
 import { CREDIT_PACKS } from "@/lib/credit-packs";
 import {
-  FIRST_PAID_EARN,
   recordPackPurchase,
   recordPackRefund,
   recordPassRefund,
-  tryEarnGrant,
   walletIdFor,
 } from "@/lib/credits";
 import { SEAT_ADDON, isSeatAddonItem } from "@/lib/seat-addons";
@@ -214,14 +212,11 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
         // First purchase of ANY kind fixes the org's billing currency, so a
         // pass buyer is never re-quoted in another currency for Pro later.
         await pinBillingCurrency(orgId, session.currency);
-        // Growth loop (SPEC-5 §2 C): a paid Event Pass IS an org paying to run a
-        // competition — its FIRST one earns free AI credits. Keyed once-per-ORG
-        // (`earn:first_paid:${orgId}`), so only the first paid competition grants
-        // and every later one no-ops via the idempotency key. Best-effort
-        // (tryEarnGrant never throws) so a grant hiccup never blocks the money
-        // row; skipped for the refunded-duplicate above (that payer isn't running
-        // the competition). Idempotency also self-heals a webhook replay.
-        await tryEarnGrant(orgId, "first_paid", FIRST_PAID_EARN);
+        // NB: the SPEC-5 §2 "first paid competition" earn grant is NOT hooked
+        // here. Buying an Event Pass is not the same as an org taking a paid
+        // registration, and stacking +10 onto the pass's +25 credits was wrong.
+        // The earn now fires on the first genuinely-confirmed paid registration
+        // (confirmPaidRegistration in registrations.ts); the pass keeps only +25.
       }
     }
     return;

--- a/apps/web/src/server/usecases/registrations.ts
+++ b/apps/web/src/server/usecases/registrations.ts
@@ -46,6 +46,7 @@ import { fireDivisionRevalidate } from "@/server/public-site/revalidate";
 import { resolveLogoUrl } from "@/server/public-site/data";
 import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { recoverDisputedTransfer as recoverDisputedTransferCore } from "./dispute-recovery";
+import { FIRST_PAID_EARN, tryEarnGrant } from "@/lib/credits";
 
 type Tx = postgres.TransactionSql;
 
@@ -1066,7 +1067,7 @@ export async function handleRegistrationCheckoutCompleted(
 }
 
 type PayOutcome =
-  | { kind: "confirmed"; divisionId: string; competitionId: string }
+  | { kind: "confirmed"; divisionId: string; competitionId: string; orgId: string }
   | { kind: "late" | "duplicate"; reg: RegistrationRow; competitionId: string; intent: string }
   | null;
 
@@ -1140,12 +1141,27 @@ async function confirmPaidRegistration(
       paid: true,
       amount_cents: amountTotal ?? reg.amount_cents,
     }, null);
-    return { kind: "confirmed", divisionId: reg.division_id, competitionId: div.competition_id };
+    return {
+      kind: "confirmed",
+      divisionId: reg.division_id,
+      competitionId: div.competition_id,
+      orgId: reg.org_id,
+    };
   })) as unknown as PayOutcome;
 
   if (!outcome) return;
   if (outcome.kind === "confirmed") {
     fireDivisionRevalidate(outcome.divisionId, outcome.competitionId);
+    // Growth loop (SPEC-5 §2 C): the organiser's FIRST competition to take a paid
+    // registration earns free AI credits. Fires only on a genuine first-time paid
+    // CONFIRMATION (not a replay, a double-pay duplicate, or a late payment to a
+    // withdrawn/expired reg that gets refunded), so the org's once-per-earn grant
+    // is never spent on a payment that bounced back. Keyed once-per-ORG
+    // (`earn:first_paid:${orgId}`) — every later paid registration no-ops on the
+    // idempotency key. Best-effort (tryEarnGrant never throws) so a grant hiccup
+    // never blocks the webhook ACK; orgId is the ORGANISER (reg.org_id mirrors the
+    // division's/competition's org), not the registrant.
+    await tryEarnGrant(outcome.orgId, "first_paid", FIRST_PAID_EARN);
     return;
   }
   // Refunds happen OUTSIDE the tx (network). A failure surfaces on the

--- a/db/migration/deltas/V331__ai_credit_ledger_earn_grant_source.sql
+++ b/db/migration/deltas/V331__ai_credit_ledger_earn_grant_source.sql
@@ -1,0 +1,24 @@
+-- V331 — allow an `earn_grant` source on the AI credit wallet ledger
+-- (design/v17-pricing-entitlements/SPEC-5 §2 — the PLG "earn free credits" loop).
+--
+-- SPEC-5 §2 grows the wallet with free credits for growth milestones: completing
+-- onboarding and running a first paid competition (the referral source is
+-- deferred — no attribution primitive exists yet). recordEarnGrant (lib/credits.ts)
+-- appends a one-time `bucket='pack'` (never-expire) grant to the org's wallet,
+-- idempotent per `(reason, ref)` and floored by a lifetime earn cap, so the loop
+-- can never mint unbounded free credits.
+--
+-- Defensive/idempotent: V330 already enumerated `earn_grant` in this CHECK
+-- (it was added alongside `pass_grant`), so on an up-to-date schema this migration
+-- is a no-op re-assert. It exists to give the earn feature its own migration
+-- record and to guarantee the source is valid on any environment whose V330
+-- predated the `earn_grant` addition. Same drop-if-exists + re-add shape as
+-- V320/V321/V326/V330; Flyway runs -defaultSchema=seazn_club.
+alter table ai_credit_ledger
+  drop constraint if exists ai_credit_ledger_source_check;
+
+alter table ai_credit_ledger
+  add constraint ai_credit_ledger_source_check
+    check (source in ('monthly_grant', 'trial_grant', 'pack_purchase',
+                      'run_spend', 'refund', 'expiry', 'admin_adjust',
+                      'earn_grant', 'pass_grant'));


### PR DESCRIPTION
Three things on one branch (all reviewed MERGE-READY):

## SPEC-5 §2 — Earn credits (the growth loop)
Free AI credits for milestones, `source='earn_grant'`, bucket `pack` (never expire), under the wallet lock:
- **Onboarding completion** → +10, once per org (best-effort — never fails onboarding).
- **First paid competition** → +10 to the *organiser* org, fired at the genuine first paid-registration confirmation (`confirmPaidRegistration`), once per org — not on replays/duplicates/refunds, and **not** stacked on an Event Pass purchase.
- **Lifetime earn cap** 100/wallet (pool-wide) bounds COGS; amounts + cap are tunable consts.
- Referral grant deferred → #267 (no referral-attribution system exists yet). V331 re-asserts the `earn_grant` ledger source.

## UI fixes
- **Org switch stays on the page** — swaps the `/o/<slug>/` segment so a settings sub-page reloads under the new org instead of always bouncing to the settings root (competition paths still fall back).
- **Auto-topup "Coming soon"** — deferred (#266), so the row shows a plain "Coming soon" badge, not an actionable "set up".

## Verify
Whole-branch review MERGE-READY (money-path: no double-grant / cap-bypass / grant-on-refund / best-effort-throw; org-switcher no leak/crash). credits-earn + registrations tests green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)