### PR TITLE
fix(referral): tighten 3 review-Minors from #267 (label i18n, funnel consume, doc)

### DIFF
--- a/apps/web/src/app/api/orgs/route.ts
+++ b/apps/web/src/app/api/orgs/route.ts
@@ -18,6 +18,11 @@ export async function POST(req: Request) {
   return handler(async () => {
     const user = await requireUser();
     const { name, attachToGroupId } = createOrgSchema.parse(await req.json());
+    // Consume before create because the referrer must be stamped IN the insert.
+    // If createOrgForUser throws the cookie is already spent — accepted: a
+    // first-org create (the only real referral case) can't hit the org-quota
+    // throw, and an Nth-org failure means the user already has orgs and so was
+    // never a fresh referral. No attribution is lost in a case that mattered.
     const referredByOrgId = await consumeReferralCookie(user.id);
     const org = await createOrgForUser(user.id, name, { referredByOrgId });
     await setActiveOrgId(org.id);

--- a/apps/web/src/components/__tests__/copy-link-mobile-width.test.tsx
+++ b/apps/web/src/components/__tests__/copy-link-mobile-width.test.tsx
@@ -9,7 +9,7 @@ import { CopyLink } from "@/components/copy-link";
 // The input must take the full row width on mobile.
 describe("CopyLink — mobile width", () => {
   it("gives the readonly URL input the full row width, with buttons on their own row", () => {
-    const html = renderToStaticMarkup(<CopyLink path="/shared/org/comp/register" qrFileName="q.png" />);
+    const html = renderToStaticMarkup(<CopyLink path="/shared/org/comp/register" qrFileName="q.png" label="Shareable link" />);
     const inputMatch = html.match(/<input[^>]*class="([^"]+)"/);
     expect(inputMatch).not.toBeNull();
     expect(inputMatch![1]).toContain("w-full");

--- a/apps/web/src/components/copy-link.tsx
+++ b/apps/web/src/components/copy-link.tsx
@@ -7,15 +7,17 @@ import QRCode from "qrcode";
  *  Pass `qrFileName` to add a QR reveal — a printable code for noticeboards
  *  (generated client-side from the same URL, downloadable as a PNG). `label`
  *  names the link for screen readers (axe `label` rule — a bare readonly
- *  input has no accessible name otherwise); defaults to a generic caption. */
+ *  input has no accessible name otherwise). REQUIRED (no default) so every
+ *  caller supplies a translated string — a hardcoded English default would
+ *  silently ship untranslated to es/fr/nl. */
 export function CopyLink({
   path,
   qrFileName,
-  label = "Shareable link",
+  label,
 }: {
   path: string;
   qrFileName?: string;
-  label?: string;
+  label: string;
 }) {
   const [origin, setOrigin] = useState("");
   const [copied, setCopied] = useState(false);

--- a/apps/web/src/lib/funnel.ts
+++ b/apps/web/src/lib/funnel.ts
@@ -103,10 +103,14 @@ export async function createFromDraft(
   draft: FunnelDraft,
 ): Promise<{ redirect: string; orgId: string }> {
   const orgs = await getUserOrgs(userId);
-  const referredByOrgId = await consumeReferralCookie(userId);
+  // Consume the referral cookie ONLY when actually creating a new org — an
+  // existing user (orgs[0]) can't be a fresh referral, so don't burn their
+  // cookie for nothing (it stays for a genuine new-org create later).
   const org =
     orgs[0] ??
-    (await createOrgForUser(userId, `${draft.payload.name} organisers`, { referredByOrgId }));
+    (await createOrgForUser(userId, `${draft.payload.name} organisers`, {
+      referredByOrgId: await consumeReferralCookie(userId),
+    }));
 
   const auth: AuthCtx = { orgId: org.id, via: "session", userId, role: "owner", keyId: null };
   const competition = await createCompetition(auth, {

--- a/apps/web/src/lib/funnel.ts
+++ b/apps/web/src/lib/funnel.ts
@@ -95,8 +95,9 @@ async function resolveSport(
  * Turn a claimed draft into real structure for `userId` and return where to
  * land: inside the new competition on the division's entrants tab. Uses the
  * standard use-cases, so quotas/slugs/audit all apply as if typed by hand.
- * Reads the referral cookie (`consumeReferralCookie`) to attribute the new org,
- * so this needs request scope — its only caller is the funnel claim route.
+ * Reads the referral cookie (`consumeReferralCookie`) ONLY when creating a new
+ * org, to attribute it — so this needs request scope; its only caller is the
+ * funnel claim route.
  */
 export async function createFromDraft(
   userId: string,


### PR DESCRIPTION
Non-blocking follow-ups from #267's whole-branch review (all reviewer-triaged as fast-follow).

## Changes
1. **`CopyLink` `label` now required** — dropped the hardcoded English `"Shareable link"` default so every caller supplies a translated string (a default would silently ship untranslated to es/fr/nl). Both real call sites already pass `t(dict, …)`; only the mobile-width test needed updating.
2. **`funnel.createFromDraft` consumes the referral cookie only on the create path** — moved inside the `createOrgForUser` branch (via the `??` short-circuit), so an existing-org user no longer burns their `ref` cookie for nothing.
3. **`POST /api/orgs`** — comment documenting why consume-before-create is benign (a first-org create can't hit the org-quota throw; an Nth-org failure means the user already has orgs and was never a fresh referral).

## Review
Whole-branch reviewer: **APPROVE / APPROVE** — clean, minimal, correctly scoped. typecheck clean; 13/13 affected tests (referral-attribution, copy-link, orgs-route). `funnel.test.ts`'s "badminton" red is a pre-existing, unrelated local sports-catalog gap (CI runs `sync:sports`).

Deferred (still open, benign): the 4th #267 Minor (`resolveReferralCode` deleted-org filter) already shipped in the #267 PR; the two remaining v17 follow-up clusters (admin write+audit tx; resolver TS/SQL TZ basis) come as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)