### PR TITLE
fix(admin): adminAdjust self-audits atomically + validate add-on target org in group

### DIFF
--- a/apps/web/src/app/api/admin/orgs/[id]/credits/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/credits/__tests__/route.test.ts
@@ -1,20 +1,20 @@
 // POST /api/admin/orgs/[id]/credits — the SPEC-3 §1/§2 staff credit
-// grant/deduct route. Guard, org-exists, wallet resolution, adminAdjust and
-// logStaffAction are all mocked so this asserts the ROUTE's own contract:
-// the support hard cap (§2 RBAC tiers), the 401 auth boundary, 404, and the
-// strict zod schema. adminAdjust's own ledger/idempotency/below-zero behaviour
-// is covered in lib/__tests__/credits-admin-adjust.test.ts. Mirrors the
-// sibling restore-trial route test idiom.
+// grant/deduct route. Guard, org-exists, wallet resolution, and adminAdjust
+// are all mocked so this asserts the ROUTE's own contract: the support hard
+// cap (§2 RBAC tiers), the 401 auth boundary, 404, and the strict zod schema.
+// adminAdjust's own ledger/idempotency/below-zero/audit behaviour is covered
+// in lib/__tests__/credits-admin-adjust.test.ts — the route itself no longer
+// calls logStaffAction (PR-B follow-up: the audit row moved INSIDE
+// adminAdjust's own transaction), it just passes an `audit` opt through.
+// Mirrors the sibling restore-trial route test idiom.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthError } from "@/lib/errors";
 import type { StaffRole } from "@/lib/admin";
 
 const requireStaffMock =
   vi.fn<() => Promise<{ id: string; staff_role: StaffRole | null }>>();
-const logStaffActionMock = vi.fn<(...args: unknown[]) => Promise<void>>();
 vi.mock("@/lib/admin", () => ({
   requireStaff: () => requireStaffMock(),
-  logStaffAction: (...args: unknown[]) => logStaffActionMock(...args),
 }));
 
 const sqlMock = vi.fn<(...args: unknown[]) => Promise<{ id: string }[]>>();
@@ -54,14 +54,13 @@ const okBody = (delta: number) => ({
 
 beforeEach(() => {
   requireStaffMock.mockReset().mockResolvedValue({ id: "staff-1", staff_role: "superadmin" });
-  logStaffActionMock.mockReset().mockResolvedValue(undefined);
   sqlMock.mockReset().mockResolvedValue([{ id: "org-1" }]);
   walletIdForMock.mockReset().mockResolvedValue("wallet-1");
   adminAdjustMock.mockReset().mockResolvedValue({ applied: true, balanceAfter: 20 });
 });
 
 describe("POST /api/admin/orgs/[id]/credits", () => {
-  it("grants credits and returns the new balance", async () => {
+  it("grants credits, returns the new balance, and passes an audit target through to adminAdjust", async () => {
     const res = await post("org-1", okBody(20));
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
@@ -71,21 +70,26 @@ describe("POST /api/admin/orgs/[id]/credits", () => {
     expect(adminAdjustMock).toHaveBeenCalledWith(
       "wallet-1",
       20,
-      expect.objectContaining({ createdBy: "staff-1", idempotencyKey: KEY }),
-    );
-    expect(logStaffActionMock).toHaveBeenCalledWith(
-      "staff-1",
-      "credit_adjust",
-      "org",
-      "org-1",
-      expect.objectContaining({ delta: 20, reason_code: "support_goodwill", wallet_id: "wallet-1" }),
+      expect.objectContaining({
+        createdBy: "staff-1",
+        idempotencyKey: KEY,
+        audit: expect.objectContaining({
+          orgId: "org-1",
+          action: "credit_adjust",
+          details: expect.objectContaining({
+            delta: 20,
+            reason_code: "support_goodwill",
+            wallet_id: "wallet-1",
+          }),
+        }),
+      }),
     );
   });
 
-  it("does NOT write a second audit row when the adjustment is an idempotent replay", async () => {
-    // A replayed idempotency key returns applied:false (adminAdjust wrote no
-    // second ledger row). The route must skip logStaffAction too, else the
-    // SPEC-3 §3 unified log double-counts one adjustment.
+  it("an idempotent replay (applied:false) still returns 200 — adminAdjust itself skips the audit row", async () => {
+    // The route no longer decides whether to audit — adminAdjust does, inside
+    // its own transaction, and skips it entirely on a replay. The route just
+    // relays whatever `applied` it gets back.
     adminAdjustMock.mockResolvedValueOnce({ applied: false, balanceAfter: 20 });
     const res = await post("org-1", okBody(20));
     expect(res.status).toBe(200);
@@ -93,7 +97,6 @@ describe("POST /api/admin/orgs/[id]/credits", () => {
       ok: true,
       data: { ok: true, balance_after: 20, applied: false },
     });
-    expect(logStaffActionMock).not.toHaveBeenCalled();
   });
 
   it("builds the stored reason from reason_code + optional note", async () => {

--- a/apps/web/src/app/api/admin/orgs/[id]/credits/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/credits/route.ts
@@ -1,5 +1,5 @@
 import { sql } from "@/lib/db";
-import { requireStaff, logStaffAction } from "@/lib/admin";
+import { requireStaff } from "@/lib/admin";
 import { adminAdjust, walletIdFor, InsufficientBalanceError } from "@/lib/credits";
 import { handler, HttpError } from "@/lib/http";
 import { z } from "zod";
@@ -52,10 +52,19 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
 
     let result: { applied: boolean; balanceAfter: number };
     try {
+      // The staff-audit row is written INSIDE adminAdjust's own transaction
+      // (PR-B follow-up) — the ledger delta and the audit row commit or roll
+      // back together, and a replayed idempotency_key (applied:false) writes
+      // no second audit row. See adminAdjust's docblock in lib/credits.ts.
       result = await adminAdjust(walletId, delta, {
         createdBy: staff.id,
         reason,
         idempotencyKey: idempotency_key,
+        audit: {
+          orgId: id,
+          action: "credit_adjust",
+          details: { delta, reason_code, note: note ?? null, wallet_id: walletId },
+        },
       });
     } catch (err) {
       if (err instanceof InsufficientBalanceError) {
@@ -64,20 +73,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
       throw err;
     }
 
-    // Only the first application of an idempotency key changes state. A
-    // replayed double-click is a no-op (applied:false) and must NOT write a
-    // second audit row — the SPEC-3 §3 unified adjustments log reads
-    // staff_audit_log, and a duplicate would read as two grants for one
-    // adjustment. The first request already logged it.
-    if (result.applied) {
-      await logStaffAction(staff.id, "credit_adjust", "org", id, {
-        delta,
-        reason_code,
-        note: note ?? null,
-        wallet_id: walletId,
-        balance_after: result.balanceAfter,
-      });
-    }
     return { ok: true, balance_after: result.balanceAfter, applied: result.applied };
   });
 }

--- a/apps/web/src/lib/__tests__/credits-admin-adjust.test.ts
+++ b/apps/web/src/lib/__tests__/credits-admin-adjust.test.ts
@@ -43,6 +43,23 @@ async function adjustRowCount(walletId: string): Promise<number> {
   return Number(row!.n);
 }
 
+/** A real `users` row — `staff_audit_log.actor_id` is a real FK, so the
+ *  audit-writing tests need an actor that exists (a stub string like
+ *  "staff-1" would fail the FK the moment `adminAdjust` tries to audit). */
+async function makeStaffUser(): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`adjust-staff-${uniq()}@test.local`}, 'Adjust Staff', true) returning id`;
+  return id;
+}
+
+async function auditRowCount(orgId: string): Promise<number> {
+  const [row] = await sql<{ n: string }[]>`
+    select count(*)::text as n from staff_audit_log
+     where target_type = 'org' and target_id = ${orgId} and action = 'credit_adjust'`;
+  return Number(row!.n);
+}
+
 describe.skipIf(!HAS_DB)("adminAdjust", () => {
   it("grant +N writes one attributed admin_adjust row and raises the balance", async () => {
     const walletId = randomUUID();
@@ -131,6 +148,72 @@ describe.skipIf(!HAS_DB)("adminAdjust", () => {
     expect(res).toEqual({ applied: true, balanceAfter: 4 });
     expect(await grantBalance(walletId)).toBe(0);
     expect(await packBalance(walletId)).toBe(4);
+  });
+
+  it("self-audits atomically: a real applied adjustment writes BOTH the ledger row and one staff_audit_log row", async () => {
+    const walletId = randomUUID();
+    const orgId = randomUUID();
+    const staffId = await makeStaffUser();
+    const res = await adminAdjust(walletId, 25, {
+      createdBy: staffId,
+      reason: "sales_comp: audited grant",
+      idempotencyKey: `adj-${uniq()}`,
+      audit: { orgId, action: "credit_adjust", details: { delta: 25, reason_code: "sales_comp" } },
+    });
+    expect(res).toEqual({ applied: true, balanceAfter: 25 });
+    expect(await adjustRowCount(walletId)).toBe(1);
+    expect(await auditRowCount(orgId)).toBe(1);
+    const [row] = await sql<{ actor_id: string; detail: { delta: number; balance_after: number } }[]>`
+      select actor_id, detail from staff_audit_log
+       where target_type = 'org' and target_id = ${orgId} and action = 'credit_adjust'`;
+    expect(row).toMatchObject({ actor_id: staffId });
+    expect(row!.detail).toMatchObject({ delta: 25, balance_after: 25 });
+  });
+
+  it("atomicity: an audit write that fails rolls back the ledger row too (both or neither)", async () => {
+    // `staff_audit_log.actor_id` is a real FK to `users` — a `createdBy` that
+    // names no user makes the audit INSERT (inside adminAdjust's own tx) fail
+    // with an FK violation AFTER the ledger row would have been written. The
+    // whole transaction must roll back: no ledger row, no audit row.
+    const walletId = randomUUID();
+    const orgId = randomUUID();
+    const noSuchStaffId = randomUUID();
+    await expect(
+      adminAdjust(walletId, 25, {
+        createdBy: noSuchStaffId,
+        reason: "sales_comp: should roll back",
+        idempotencyKey: `adj-${uniq()}`,
+        audit: { orgId, action: "credit_adjust", details: { delta: 25 } },
+      }),
+    ).rejects.toThrow();
+    expect(await adjustRowCount(walletId)).toBe(0);
+    expect(await auditRowCount(orgId)).toBe(0);
+  });
+
+  it("idempotent replay writes no second ledger row AND no second audit row", async () => {
+    const walletId = randomUUID();
+    const orgId = randomUUID();
+    const staffId = await makeStaffUser();
+    const key = `adj-${uniq()}`;
+    const audit = { orgId, action: "credit_adjust", details: { delta: 25 } };
+
+    const first = await adminAdjust(walletId, 25, {
+      createdBy: staffId,
+      reason: "promo: launch",
+      idempotencyKey: key,
+      audit,
+    });
+    expect(first).toEqual({ applied: true, balanceAfter: 25 });
+
+    const replay = await adminAdjust(walletId, 25, {
+      createdBy: staffId,
+      reason: "promo: launch",
+      idempotencyKey: key,
+      audit,
+    });
+    expect(replay).toEqual({ applied: false, balanceAfter: 25 });
+    expect(await adjustRowCount(walletId)).toBe(1);
+    expect(await auditRowCount(orgId)).toBe(1);
   });
 
   it("two concurrent grants both apply with no lost update", async () => {

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -1073,16 +1073,34 @@ export class InsufficientBalanceError extends Error {
  * returning `{ applied: false, balanceAfter: <current> }`. A straddling deduct
  * writes its second (pack) row under a derived key so both rows satisfy the
  * unique constraint while a replay still conflicts on the base key.
+ *
+ * **Self-audits atomically (PR-B follow-up):** when `opts.audit` is given, the
+ * `staff_audit_log` row for this adjustment is written INSIDE this same
+ * `sql.begin` transaction, right after the ledger delta — so the money move
+ * and its audit trail commit or roll back together (a crash between the
+ * ledger write and a separate post-commit `logStaffAction` call used to be
+ * able to leave an adjustment with no audit row). Only written on a real
+ * applied adjustment: the idempotent-replay early-return above skips it, so a
+ * double-click never writes a second audit row either.
  */
 export async function adminAdjust(
   walletId: string,
   delta: number,
-  opts: { createdBy: string; reason: string; idempotencyKey: string; bucket?: Bucket },
+  opts: {
+    createdBy: string;
+    reason: string;
+    idempotencyKey: string;
+    bucket?: Bucket;
+    /** Staff-audit target for this adjustment. Omit only for a caller that
+     *  audits itself some other way; every current caller (the admin credits
+     *  route) passes this. `target_type` is always `"org"` here. */
+    audit?: { orgId: string; action: string; details?: Record<string, unknown> };
+  },
 ): Promise<{ applied: boolean; balanceAfter: number }> {
   if (!Number.isInteger(delta) || delta === 0) {
     throw new Error(`adminAdjust: delta must be a non-zero integer, got ${delta}`);
   }
-  const { createdBy, reason, idempotencyKey } = opts;
+  const { createdBy, reason, idempotencyKey, audit } = opts;
   return sql.begin(async (tx) => {
     await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + walletId}))`;
 
@@ -1090,6 +1108,14 @@ export async function adminAdjust(
       select id from ai_credit_ledger where idempotency_key = ${idempotencyKey}`;
     if (already) {
       return { applied: false, balanceAfter: await walletBalance(tx, walletId) };
+    }
+
+    async function auditApplied(balanceAfter: number): Promise<void> {
+      if (!audit) return;
+      await tx`
+        insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+        values (${createdBy}, ${audit.action}, 'org', ${audit.orgId},
+                ${tx.json({ ...audit.details, balance_after: balanceAfter } as never)})`;
     }
 
     if (delta > 0) {
@@ -1102,7 +1128,9 @@ export async function adminAdjust(
         reason,
         idempotencyKey,
       });
-      return { applied: true, balanceAfter: await walletBalance(tx, walletId) };
+      const balanceAfter = await walletBalance(tx, walletId);
+      await auditApplied(balanceAfter);
+      return { applied: true, balanceAfter };
     }
 
     const need = -delta;
@@ -1132,7 +1160,9 @@ export async function adminAdjust(
       });
       usedKey = true;
     }
-    return { applied: true, balanceAfter: await walletBalance(tx, walletId) };
+    const balanceAfter = await walletBalance(tx, walletId);
+    await auditApplied(balanceAfter);
+    return { applied: true, balanceAfter };
   });
 }
 

--- a/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
@@ -131,6 +131,31 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
     expect(logStaffActionMock).not.toHaveBeenCalled();
   });
 
+  it("rejects a NONEXISTENT target_org_id with the same typed 422 (not a 500), no row written", async () => {
+    // A mistyped/nonexistent target_org_id must reject the same way as a real
+    // foreign org — walletIdFor would THROW a plain Error on a missing org,
+    // which would otherwise fall through handler()'s catch-all to a 500.
+    const org = await createOrgForUser(await makeUser(), "Addon Nonexistent Target Org");
+    const walletId = await walletIdFor(org.id);
+    const bogusOrgId = randomUUID();
+
+    await expect(
+      grantAddon(ACTOR, org.id, {
+        featureKey: FEATURE,
+        deltaEach: 2,
+        qty: 1,
+        targetOrgId: bogusOrgId,
+        reason: "sales_comp",
+        idempotencyKey: `bogus-${uniq()}-abcd`,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
+    expect(n).toBe(0);
+    expect(logStaffActionMock).not.toHaveBeenCalled();
+  });
+
   it("rejects delta_each <= 0 and qty <= 0 with no row written", async () => {
     const org = await createOrgForUser(await makeUser(), "Addon Bad Input");
     const walletId = await walletIdFor(org.id);

--- a/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
@@ -106,6 +106,31 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
     expect(await getLimit(orgB.id, FEATURE)).toBe(baseB); // sibling untouched
   });
 
+  it("rejects a target_org_id that is not in the granting org's wallet/group, with no row written", async () => {
+    // org and foreignOrg are on two DIFFERENT (standalone) wallets — a typo'd
+    // or foreign target_org_id must not resolve as an inert, misleading grant.
+    const org = await createOrgForUser(await makeUser(), "Addon Group Guard Org");
+    const foreignOrg = await createOrgForUser(await makeUser(), "Addon Group Guard Foreign");
+    const walletId = await walletIdFor(org.id);
+    expect(await walletIdFor(foreignOrg.id)).not.toBe(walletId);
+
+    await expect(
+      grantAddon(ACTOR, org.id, {
+        featureKey: FEATURE,
+        deltaEach: 2,
+        qty: 1,
+        targetOrgId: foreignOrg.id,
+        reason: "sales_comp",
+        idempotencyKey: `foreign-${uniq()}-abcd`,
+      }),
+    ).rejects.toMatchObject({ status: 422 });
+
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
+    expect(n).toBe(0);
+    expect(logStaffActionMock).not.toHaveBeenCalled();
+  });
+
   it("rejects delta_each <= 0 and qty <= 0 with no row written", async () => {
     const org = await createOrgForUser(await makeUser(), "Addon Bad Input");
     const walletId = await walletIdFor(org.id);

--- a/apps/web/src/server/usecases/admin-addons.ts
+++ b/apps/web/src/server/usecases/admin-addons.ts
@@ -25,6 +25,15 @@ import { logStaffAction } from "@/lib/admin";
  * `applied:false` and writes NO second audit row (the SPEC-3 §3 unified log
  * reads staff_audit_log; a duplicate there reads as two grants for one action).
  *
+ * **Target org must be in the granting org's group (PR-B follow-up):** a set
+ * `targetOrgId` that isn't actually a member of this wallet's billing group
+ * (a typo, or a foreign org id) would still write a `granted` row that
+ * resolves for nobody — an inert "success" that misleads the operator. So a
+ * set `targetOrgId` is checked against the wallet BEFORE the insert
+ * (`walletIdFor(targetOrgId) === walletId`, the same wallet-equality the
+ * sibling test in `admin-addons.test.ts` sets up); a mismatch throws a 422
+ * and writes no row. `targetOrgId: null` (group-wide) skips the check.
+ *
  * @returns the row id and whether this call actually created it.
  */
 export async function grantAddon(
@@ -48,6 +57,9 @@ export async function grantAddon(
   }
 
   const walletId = await walletIdFor(orgId);
+  if (targetOrgId !== null && (await walletIdFor(targetOrgId)) !== walletId) {
+    throw new HttpError(422, "target_org_id is not part of this organization's billing group.");
+  }
   const [inserted] = await sql<{ id: string }[]>`
     insert into org_addons
       (wallet_id, target_org_id, target_competition_id, feature_key, delta_each, qty,

--- a/apps/web/src/server/usecases/admin-addons.ts
+++ b/apps/web/src/server/usecases/admin-addons.ts
@@ -27,12 +27,15 @@ import { logStaffAction } from "@/lib/admin";
  *
  * **Target org must be in the granting org's group (PR-B follow-up):** a set
  * `targetOrgId` that isn't actually a member of this wallet's billing group
- * (a typo, or a foreign org id) would still write a `granted` row that
- * resolves for nobody — an inert "success" that misleads the operator. So a
- * set `targetOrgId` is checked against the wallet BEFORE the insert
- * (`walletIdFor(targetOrgId) === walletId`, the same wallet-equality the
- * sibling test in `admin-addons.test.ts` sets up); a mismatch throws a 422
- * and writes no row. `targetOrgId: null` (group-wide) skips the check.
+ * (a typo, a nonexistent org id, or a foreign org id) would still write a
+ * `granted` row that resolves for nobody — an inert "success" that misleads
+ * the operator. So a set `targetOrgId` is checked against the wallet BEFORE
+ * the insert, resolving the target's wallet with a plain (non-throwing)
+ * query — matching `walletIdFor`'s `coalesce(subscription_id, id)` but
+ * returning no row instead of throwing when the org doesn't exist — so a
+ * nonexistent org and a foreign org both throw the SAME typed 422 (the route
+ * maps this to a client error, not a 500 + Sentry noise on an operator typo).
+ * `targetOrgId: null` (group-wide) skips the check.
  *
  * @returns the row id and whether this call actually created it.
  */
@@ -57,8 +60,16 @@ export async function grantAddon(
   }
 
   const walletId = await walletIdFor(orgId);
-  if (targetOrgId !== null && (await walletIdFor(targetOrgId)) !== walletId) {
-    throw new HttpError(422, "target_org_id is not part of this organization's billing group.");
+  if (targetOrgId !== null) {
+    // Resolve targetOrgId's wallet WITHOUT throwing on a missing org (unlike
+    // walletIdFor) — a nonexistent org and an existing-but-foreign org must
+    // both be rejected with the SAME typed 422 the route maps, not a 500.
+    const [targetRow] = await sql<{ wallet_id: string }[]>`
+      select coalesce(subscription_id, id)::text as wallet_id
+        from organizations where id = ${targetOrgId}`;
+    if (!targetRow || targetRow.wallet_id !== walletId) {
+      throw new HttpError(422, "target_org_id is not part of this organization's billing group.");
+    }
   }
   const [inserted] = await sql<{ id: string }[]>`
     insert into org_addons


### PR DESCRIPTION
Two v17 accepted follow-ups hardening the admin credit/add-on write paths (money-adjacent).

## 1. `adminAdjust` self-audits inside its own transaction
Before: the admin credits route wrote the ledger delta via `adminAdjust` (own tx), then called `logStaffAction` **separately** — a crash between them left an **unaudited credit adjustment**.
After: `adminAdjust` writes the `staff_audit_log` row on the **same `tx` handle**, so the ledger delta and its audit commit or roll back together. The idempotency early-return precedes the audit insert (a replay writes **no** second ledger row and **no** second audit row), and the route's separate `logStaffAction` call is removed (no double-audit). Rejected adjusts (InsufficientBalance) still write nothing.

Proven by a **real FK-rollback test** (nonexistent `createdBy` → `ai_credit_ledger.created_by` is untyped text so the ledger insert succeeds, then `staff_audit_log.actor_id`'s FK fails → both rows roll back), not a stub.

## 2. Add-on grant validates the target org is in the granting wallet's group
`grantAddon` now rejects a `target_org_id` outside the payer's group with a typed **422** and writes **no** `org_addons` row — closing the "typo → inert success row" gap. Covers both an existing-but-foreign org **and** a nonexistent org id (the latter previously 500'd + spammed Sentry; review-caught, fixed in 542da559 via a non-throwing wallet lookup).

## Review + tests
Whole-diff reviewer: **PASS / APPROVE** (the one Important finding — nonexistent-org 500 — fixed + re-verified). typecheck clean; **34/34** across admin-addons, credits route, and credits-admin-adjust tests on the fresh schema. `staff_audit_log` insert shape cross-checked against `logStaffAction` (V103 columns).

## Deferred (separate PR)
The broader "wrap **every** admin write + audit in one tx" sweep (admin-plan.ts, suspend, etc.) is tracked as a follow-up — this PR does the credits + add-on paths only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)