### PR TITLE
fix(entitlements): align Event-Pass end-grace on UTC in the SQL resolver (V334)

### DIFF
--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -196,6 +196,72 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     expect(await sqlHasFeature(orgId, "realtime", compId)).toBe(false);
   });
 
+  // V334: the pass-lock grace boundary must be the UTC calendar date on BOTH
+  // sides, not the DB session's TimeZone GUC. Before the fix, the SQL arm
+  // compared against bare `current_date` (the session's TimeZone GUC —
+  // Europe/London in production) while the TS resolver (isPassLocked) always
+  // computes on the UTC calendar date, so around the moment the session's
+  // date rolls over the two can disagree on whether a pass is locked.
+  //
+  // Etc/GMT-14 (UTC+14) only rolls the session date FORWARD a day once the
+  // real UTC hour has reached 10 (10 + 14 = 24 wraps); Etc/GMT+12 (UTC-12) is
+  // the mirror — it rolls the date BACKWARD a day whenever the UTC hour is
+  // under 12. Between the two, every possible real-clock UTC hour gets a
+  // guaranteed one-day divergence from the UTC date, so this test can't
+  // spuriously pass by running during a UTC hour where a fixed tz offset
+  // happens not to cross midnight. `set local time zone` is scoped to a
+  // transaction (a single pinned connection via sql.begin) so it reverts
+  // automatically at commit — no other test or connection in the pool
+  // inherits it.
+  it("agrees with the TS resolver at the grace boundary under a non-UTC session TZ", async () => {
+    const compId = await seedCompetition(orgId, "tz-boundary");
+    const [{ h }] = await sql<{ h: number }[]>`
+      select extract(hour from now() at time zone 'utc')::int as h`;
+    const forward = h >= 10;
+
+    if (forward) {
+      // Session date lands one day AHEAD of the UTC date — production's
+      // Europe/London BST bug shape. `ends_on + 7 days` sits exactly ON the
+      // UTC boundary (not locked under UTC), so the buggy SQL (comparing
+      // against a date one day further on) wrongly locks it.
+      await sql`
+        update competitions
+        set ends_on = ((now() at time zone 'utc')::date - interval '7 days')::date
+        where id = ${compId}`;
+    } else {
+      // Mirror divergence: session date lands one day BEHIND the UTC date.
+      // `ends_on + 7 days` sits exactly on the SESSION date (not locked under
+      // the buggy session-TZ basis), one day short of the UTC boundary, so
+      // the buggy SQL wrongly leaves it unlocked while UTC says locked.
+      await sql`
+        update competitions
+        set ends_on = ((now() at time zone 'utc')::date - interval '8 days')::date
+        where id = ${compId}`;
+    }
+    await sql`
+      insert into competition_passes (competition_id, org_id) values (${compId}, ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+
+    // TS resolver: always UTC-based, unaffected by the DB session's TZ.
+    // Forward case is just inside the grace window (pass lifts); the mirror
+    // case is one day past it (pass is locked).
+    const expected = forward;
+    expect(await hasFeature(orgId, "realtime", compId)).toBe(expected);
+
+    // SQL resolver, forced onto a session TZ a calendar day off from UTC.
+    const sqlAnswer = await sql.begin(async (tx) => {
+      if (forward) {
+        await tx`set local time zone 'Etc/GMT-14'`;
+      } else {
+        await tx`set local time zone 'Etc/GMT+12'`;
+      }
+      const [row] = await tx<{ v: boolean }[]>`
+        select org_has_feature(${orgId}, 'realtime', ${compId}) as v`;
+      return row.v;
+    });
+    expect(sqlAnswer).toBe(expected);
+  });
+
   it("coalesces a null-bool Event Pass row THROUGH to the plan, not into a deny", async () => {
     // A pass row whose bool_value is null is NO answer, not a deny: it must fall
     // through to the plan row, exactly as org_has_feature's coalesce does.

--- a/apps/web/src/lib/entitlements.ts
+++ b/apps/web/src/lib/entitlements.ts
@@ -121,11 +121,17 @@ export const PASS_END_GRACE_DAYS = 7;
  *   B (long-ended): ends_on is set AND ends_on + PASS_END_GRACE_DAYS < today.
  *                   A date-only comparison (ends_on is a DATE), grace 7 days.
  *
- * Kept exactly in step with the SQL resolver's pass arm (org_has_feature, V328):
+ * Kept exactly in step with the SQL resolver's pass arm (org_has_feature, V328,
+ * grace boundary moved to UTC in V334):
  * `not (c.status in ('archived','completed') or (c.ends_on is not null and
- * c.ends_on + interval '7 days' < current_date))`. The entitlements-sql-parity
- * suite is the tie. Exported so the OFFER side can reuse it later; this task
- * wires no other call site.
+ * c.ends_on + interval '7 days' < (now() at time zone 'utc')::date))`. Both
+ * sides now compare against the UTC calendar date — the SQL used to compare
+ * against bare `current_date` (the DB session's TimeZone GUC, Europe/London in
+ * production), which could disagree with this function's UTC computation for
+ * an up-to-1h window around UTC midnight; V334 aligned SQL to this function's
+ * basis rather than the other way round. The entitlements-sql-parity suite is
+ * the tie. Exported so the OFFER side can reuse it later; this task wires no
+ * other call site.
  */
 export function isPassLocked(status: string, endsOn: Date | string | null): boolean {
   if (status === "archived" || status === "completed") return true;

--- a/db/migration/deltas/V334__org_has_feature_utc_pass_grace.sql
+++ b/db/migration/deltas/V334__org_has_feature_utc_pass_grace.sql
@@ -1,0 +1,101 @@
+-- V334 — the Event Pass end-grace comparison switches from `current_date`
+-- (session-TZ calendar date) to the UTC calendar date, matching the TS
+-- resolver.
+--
+-- lib/entitlements.ts's isPassLocked computes the grace boundary as
+-- `Date.UTC(now.getUTCFullYear(), getUTCMonth(), getUTCDate())` — i.e. UTC
+-- calendar-midnight today. `org_has_feature`'s pass arm instead compared
+-- against bare `current_date`, which Postgres evaluates in the SESSION's
+-- TimeZone GUC. Production's session TZ is Europe/London, not UTC — during
+-- BST (UTC+1) the ~1h window from 23:00 to 00:00 UTC has `current_date` one
+-- day AHEAD of the UTC calendar date, so around the grace boundary the two
+-- resolvers can disagree on whether a pass is locked (public/embed views via
+-- SQL vs the app via TS). UTC is the chosen basis — TS already computes on it
+-- — so SQL moves to match, not the other way round.
+--
+-- The body is copied FORWARD from V332 (the current definition of
+-- org_has_feature, incl. the trialing/trial_end backstop arm). The ONLY
+-- change is that one `current_date` becomes
+-- `(now() at time zone 'utc')::date` (today's UTC calendar date). Every other
+-- arm — override, plan CASE, coalesce order, Event Pass lifecycle lock's
+-- terminal-status check, false default — is byte-for-byte V332.
+--
+-- Signature, security-definer and the pinned `search_path = <defaultSchema>,
+-- pg_temp` (pg_temp LAST so no session can shadow a table inside this definer
+-- function) are unchanged. Replacing the function body carries
+-- public_competitions_v / public_entrants_v / public_discovery_v unchanged —
+-- they call the FUNCTION, so no view is reissued here.
+--
+-- apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts holds the two
+-- resolvers in step; its TZ-divergence case forces a non-UTC session TZ (via
+-- a transaction-scoped `set local time zone`) to prove the two agree
+-- regardless of the DB session's TimeZone GUC.
+
+create or replace function org_has_feature(
+  p_org_id uuid,
+  p_feature_key text,
+  p_competition_id uuid
+) returns boolean
+  language sql stable security definer
+  set search_path = ${flyway:defaultSchema}, pg_temp as $$
+    with plan as (
+      select case
+        -- MODERATION, not billing (mirrors entitlements.ts): a suspended ORG
+        -- resolves community whatever its group pays for, scoped to that one org
+        -- so a moderator cannot degrade siblings that merely share a payer.
+        when o.status = 'suspended' then 'community'
+        when s.comped_until is not null and s.comped_until <= now()
+             and (s.stripe_subscription_id is null
+                  or coalesce(s.status, '') not in
+                     ('trialing', 'active', 'past_due'))
+             then 'community'
+        when s.status = 'past_due'
+             and coalesce(s.status_changed_at, s.updated_at) <= now() - interval '14 days'
+             then 'community'
+        -- Trial-end backstop: a trialing sub whose trial ended over a day ago is a
+        -- MISSED transition webhook (Stripe moves trialing→active/past_due/canceled at
+        -- trial_end). The resolver stops trusting the stale status, cron-free, the same
+        -- way the past_due arm above does. 1-day grace absorbs Stripe's transition lag.
+        -- trial_end IS null on a never-trialed sub → guard it so those stay on plan.
+        when s.status = 'trialing'
+             and s.trial_end is not null
+             and s.trial_end <= now() - interval '1 day'
+             then 'community'
+        -- A CANCELLED subscription does not convey its plan (V313). The
+        -- comped_at guard keeps an INDEFINITE staff comp alive; a lapsed comp is
+        -- already community via the comped_until arm above.
+        when s.status = 'canceled' and s.comped_at is null
+             then 'community'
+        else coalesce(s.plan_key, 'community')
+      end as plan_key
+      from organizations o
+      left join subscriptions s on s.id = o.subscription_id
+      where o.id = p_org_id
+    )
+    select coalesce(
+      (select bool_value from org_entitlement_overrides
+        where org_id = p_org_id and feature_key = p_feature_key
+          and (expires_at is null or expires_at > now())),
+      -- Event Pass: community orgs only, competition in scope. A key absent from
+      -- the pass matrix falls through to the plan row rather than denying. v17
+      -- SPEC-4 §7: the pass stops applying once its competition is archived or
+      -- long-ended (mirrors isPassLocked in lib/entitlements.ts). The grace
+      -- boundary is the UTC calendar date (V334), matching isPassLocked's
+      -- Date.UTC(getUTC*) — NOT the session-TZ `current_date`.
+      (select pe.bool_value
+         from competition_passes cp
+         join competitions c on c.id = cp.competition_id
+         join plan_entitlements pe
+           on pe.plan_key = cp.pass_key and pe.feature_key = p_feature_key
+        where p_competition_id is not null
+          and cp.competition_id = p_competition_id
+          and cp.org_id = p_org_id
+          and (select plan_key from plan) = 'community'
+          and not (c.status in ('archived', 'completed')
+                   or (c.ends_on is not null
+                       and c.ends_on + interval '7 days' < (now() at time zone 'utc')::date))),
+      (select pe.bool_value from plan_entitlements pe
+        where pe.feature_key = p_feature_key
+          and pe.plan_key = (select plan_key from plan)),
+      false)
+  $$;


### PR DESCRIPTION
Last v17 accepted follow-up — a **real** entitlement-resolver parity bug.

## The divergence
The Event-Pass end-grace was computed on two different date bases:
- **TS resolver** (`entitlements.ts:141`, `isPassLocked`): `ends_on + 7d < Date.UTC(getUTCFullYear/Month/Date)` — a **UTC** calendar date.
- **SQL resolver** (`org_has_feature`): `ends_on + 7 days < current_date` — the **session-TZ** date.

The DB session TZ is **Europe/London** (UTC+1 in summer), so for the ~1h window each night around UTC midnight, `current_date` is a day ahead of the UTC date the TS side uses. The app resolver and the public/embed SQL resolver then **disagree** on whether a pass is locked at the grace boundary.

## Fix (SQL → UTC; TS unchanged, it's canonical)
**`V334`** does `create or replace function org_has_feature` copying V332's current definition **verbatim**, changing **only**:

```
c.ends_on + interval '7 days' < current_date
→
c.ends_on + interval '7 days' < (now() at time zone 'utc')::date
```

Every other arm (suspended / comped / past_due / trialing / canceled, the plan + pass-overlay CTEs, signature, `security definer`, `search_path`) is byte-identical to V332. `entitlements.ts` is comment-only (the TS math already uses UTC). Confirmed `current_date` appears nowhere else in the resolver.

## Testing
`entitlements-sql-parity.test.ts` gains a **TZ-divergence case**: it SETs a far-from-UTC session TZ and an `ends_on` on the UTC boundary, then asserts the TS and SQL resolvers agree — it **fails without V334, passes with it** (verified both directions by flipping the live function). **17/17** parity green; typecheck clean; V334 Flyway-applied.

Review: **PASS / APPROVE**, no findings.

---
Completes the v17 non-blocking follow-up cluster: **#271** (referral Minors) + **#272** (admin hardening) merged; this is the third.

🤖 Generated with [Claude Code](https://claude.com/claude-code)