### PR TITLE
fix(org-switch): stay on the same page when switching orgs (no dashboard bounce)

### DIFF
--- a/apps/web/src/components/__tests__/org-switch-target.test.ts
+++ b/apps/web/src/components/__tests__/org-switch-target.test.ts
@@ -1,0 +1,41 @@
+// Org switch lands on the SAME page under the new org (fix for "switching org
+// redirects to dashboard"). orgSwitchTarget is the pure path computation; the
+// component hard-navigates to it (window.location.assign) to avoid the
+// router.push+refresh bounce.
+import { describe, it, expect } from "vitest";
+import { orgSwitchTarget } from "../org-switcher";
+
+describe("orgSwitchTarget", () => {
+  it("stays on the same settings sub-path (Settings → Billing)", () => {
+    expect(orgSwitchTarget("/o/riverside/settings/billing", "riverside", "northside")).toBe(
+      "/o/northside/settings/billing",
+    );
+  });
+
+  it("stays on the settings root", () => {
+    expect(orgSwitchTarget("/o/riverside/settings", "riverside", "northside")).toBe(
+      "/o/northside/settings",
+    );
+  });
+
+  it("stays on the org home", () => {
+    expect(orgSwitchTarget("/o/riverside", "riverside", "northside")).toBe("/o/northside");
+  });
+
+  it("falls back to the new org home from a competition/entity path (can't transfer)", () => {
+    expect(orgSwitchTarget("/o/riverside/c/spring-cup/d/mens", "riverside", "northside")).toBe(
+      "/o/northside",
+    );
+  });
+
+  it("falls back to the new org home when oldSlug is unknown or the path doesn't match", () => {
+    expect(orgSwitchTarget("/somewhere", undefined, "northside")).toBe("/o/northside");
+    expect(orgSwitchTarget("/o/other/settings", "riverside", "northside")).toBe("/o/northside");
+  });
+
+  it("does not treat a slug-prefix collision as a match (/o/riverside-two)", () => {
+    expect(orgSwitchTarget("/o/riverside-two/settings", "riverside", "northside")).toBe(
+      "/o/northside",
+    );
+  });
+});

--- a/apps/web/src/components/__tests__/org-switch-target.test.ts
+++ b/apps/web/src/components/__tests__/org-switch-target.test.ts
@@ -38,4 +38,8 @@ describe("orgSwitchTarget", () => {
       "/o/northside",
     );
   });
+
+  it("does not transfer a non-settings path that merely starts with 'settings' (/settingsX)", () => {
+    expect(orgSwitchTarget("/o/riverside/settingsX", "riverside", "northside")).toBe("/o/northside");
+  });
 });

--- a/apps/web/src/components/org-switcher.tsx
+++ b/apps/web/src/components/org-switcher.tsx
@@ -24,7 +24,9 @@ export function orgSwitchTarget(
     const prefix = `/o/${oldSlug}`;
     if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
       const rest = pathname.slice(prefix.length); // "" | "/settings…" | "/c/…"
-      if (rest === "" || rest.startsWith("/settings")) return `/o/${newSlug}${rest}`;
+      if (rest === "" || rest === "/settings" || rest.startsWith("/settings/")) {
+        return `/o/${newSlug}${rest}`;
+      }
     }
   }
   return routes.orgHome(newSlug);

--- a/apps/web/src/components/org-switcher.tsx
+++ b/apps/web/src/components/org-switcher.tsx
@@ -7,6 +7,29 @@ import { api } from "@/lib/client";
 import type { OrgMembership } from "@/lib/types";
 import { routes } from "@/lib/routes";
 
+/**
+ * Where to land after switching from `oldSlug` to `newSlug`, given the current
+ * path. Org-level paths — the org home (`/o/<slug>`) and any `/settings…`
+ * sub-path — transfer to the SAME page under the new org, so switching from
+ * Settings → Billing stays on Settings → Billing. A competition/entity path
+ * (`/o/<slug>/c/…`, `/d/…`) belongs to the OLD org and can't exist under the
+ * new one, so it falls back to the new org's home. Pure + exported for tests.
+ */
+export function orgSwitchTarget(
+  pathname: string,
+  oldSlug: string | undefined,
+  newSlug: string,
+): string {
+  if (oldSlug) {
+    const prefix = `/o/${oldSlug}`;
+    if (pathname === prefix || pathname.startsWith(`${prefix}/`)) {
+      const rest = pathname.slice(prefix.length); // "" | "/settings…" | "/c/…"
+      if (rest === "" || rest.startsWith("/settings")) return `/o/${newSlug}${rest}`;
+    }
+  }
+  return routes.orgHome(newSlug);
+}
+
 const ROLE_BADGE: Record<string, string> = {
   owner: "bg-amber-100 text-amber-700",
   admin: "bg-purple-100 text-purple-700",
@@ -49,21 +72,19 @@ export function OrgSwitcher({
     try {
       await api("/api/orgs/active", { method: "POST", json: { org_id: id } });
       // PROMPT-30: the URL owns which org a page shows — a cookie flip alone
-      // changes nothing, so navigate. Stay on the SAME page under the new org by
-      // swapping the /o/<slug>/ segment, rather than always dumping the user on
-      // settings. Only org-level settings sub-paths transfer safely; a
-      // competition/entity path (/o/<slug>/c/…) belongs to the OLD org and would
-      // 404 under the new one, so those fall back to the new org's settings.
+      // changes nothing, so navigate. Stay on the SAME page under the new org
+      // (orgSwitchTarget swaps the /o/<slug> segment).
       const newSlug = orgs.find((o) => o.id === id)?.slug;
       const oldSlug = orgs.find((o) => o.id === activeId)?.slug;
       if (newSlug) {
-        let target = routes.orgSettings(newSlug);
-        if (oldSlug && pathname.startsWith(`/o/${oldSlug}/settings`)) {
-          target = `/o/${newSlug}${pathname.slice(`/o/${oldSlug}`.length)}`;
-        }
-        router.push(target);
+        // HARD navigation, not router.push + router.refresh: the active-org
+        // cookie was just flipped, and a client push while refresh() re-renders
+        // the OLD path against the NEW cookie can bounce the user to the org
+        // home ("redirects to dashboard"). A full load to the computed target
+        // applies the new org server-side and lands cleanly on the same page.
+        window.location.assign(orgSwitchTarget(pathname, oldSlug, newSlug));
+        return;
       }
-      router.refresh();
     } finally {
       setBusy(null);
       setOpen(false);


### PR DESCRIPTION
Addresses the repeated report: **switching organizations "redirects to dashboard"** instead of staying put.

## What I found
The org switcher (`org-switcher.tsx`, in the Settings header) already swapped `/settings` sub-paths, but used `router.push(target)` **followed by `router.refresh()`**. The `refresh()` re-renders the **old** URL slug against the just-flipped active-org cookie — and a layout that reconciles slug≠cookie can bounce the user to the org home. I **could not reproduce the exact bounce from code alone** (the switcher only renders on Settings, and the push-target was already a settings path), so this is a **robustness fix** — please verify on staging once it deploys.

## The fix
1. **Pure `orgSwitchTarget(pathname, oldSlug, newSlug)`** (extracted + unit-tested): the org home (`/o/<slug>`) and any `/settings…` sub-path transfer to the **same page** under the new org; a competition/entity path (`/o/<slug>/c/…`, `/d/…`) can't exist under the new org, so it falls back to the new org's home. Slug-prefix collisions (`/o/riverside-two` vs `riverside`) and `/settingsX` are handled.
2. **Hard navigation** — `window.location.assign(target)` instead of `router.push + router.refresh`. A full load applies the new active org **server-side** and lands exactly on the target, eliminating any client-router/refresh race.

## Tests
`org-switch-target.test.ts` — **7/7** (settings sub-path stays · settings root stays · org home stays · entity path → home · unknown/mismatch → home · sibling-slug collision · `/settingsX`). typecheck clean. Reviewed **PASS / APPROVE**.

⚠️ **Verify on staging:** switch orgs from Settings → Billing and confirm you land on the new org's Settings → Billing (not the dashboard). If it still bounces, the root cause is server-side and I'll dig further with a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)