### PR TITLE
fix(admin): make money-adjacent admin write+audit atomic (extends #272)

### DIFF
--- a/apps/web/src/app/api/admin/size-packs/[key]/route.ts
+++ b/apps/web/src/app/api/admin/size-packs/[key]/route.ts
@@ -1,5 +1,6 @@
-import { requireSuperadmin, logStaffAction } from "@/lib/admin";
+import { requireSuperadmin } from "@/lib/admin";
 import { updateSizePack, setSizePackActive } from "@/lib/size-packs";
+import { sql } from "@/lib/db";
 import { handler } from "@/lib/http";
 import { HttpError } from "@/lib/errors";
 import { z } from "zod";
@@ -23,9 +24,16 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ key: s
     const { key } = await params;
     const staff = await requireSuperadmin();
     const patch = schema.parse(await req.json());
-    const row = await updateSizePack(key, patch);
+    // Catalog edit + its audit row commit together (extend #272); local DB only.
+    const row = await sql.begin(async (tx) => {
+      const r = await updateSizePack(key, patch, tx);
+      if (!r) return null; // 404 below — nothing written, nothing to audit
+      await tx`
+        insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+        values (${staff.id}, 'size_pack_update', 'size_pack', ${key}, ${tx.json(patch as never)})`;
+      return r;
+    });
     if (!row) throw new HttpError(404, "Size pack not found");
-    await logStaffAction(staff.id, "size_pack_update", "size_pack", key, patch);
     return row;
   });
 }
@@ -37,9 +45,16 @@ export async function DELETE(_req: Request, { params }: { params: Promise<{ key:
   return handler(async () => {
     const { key } = await params;
     const staff = await requireSuperadmin();
-    const row = await setSizePackActive(key, false);
+    // Soft-deactivate + its audit row commit together (extend #272); local DB only.
+    const row = await sql.begin(async (tx) => {
+      const r = await setSizePackActive(key, false, tx);
+      if (!r) return null; // 404 below — nothing written, nothing to audit
+      await tx`
+        insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+        values (${staff.id}, 'size_pack_deactivate', 'size_pack', ${key}, ${tx.json({ label: r.label } as never)})`;
+      return r;
+    });
     if (!row) throw new HttpError(404, "Size pack not found");
-    await logStaffAction(staff.id, "size_pack_deactivate", "size_pack", key, { label: row.label });
     return row;
   });
 }

--- a/apps/web/src/app/api/admin/size-packs/route.ts
+++ b/apps/web/src/app/api/admin/size-packs/route.ts
@@ -1,5 +1,6 @@
-import { requireStaff, requireSuperadmin, logStaffAction } from "@/lib/admin";
+import { requireStaff, requireSuperadmin } from "@/lib/admin";
 import { listSizePacks, createSizePack } from "@/lib/size-packs";
+import { sql } from "@/lib/db";
 import { handler } from "@/lib/http";
 import { z } from "zod";
 
@@ -29,13 +30,21 @@ export async function POST(req: Request) {
   return handler(async () => {
     const staff = await requireSuperadmin();
     const input = schema.parse(await req.json());
-    const row = await createSizePack(input);
-    await logStaffAction(staff.id, "size_pack_create", "size_pack", row.key, {
-      label: row.label,
-      feature_key: row.feature_key,
-      delta_each: row.delta_each,
-      stripe_lookup_key: row.stripe_lookup_key,
+    // The catalog insert and its staff_audit_log row commit TOGETHER (extend
+    // #272): a crash between them can never leave a money-path config change
+    // unaudited. No Stripe call here — the PRICE is Stripe-owned but never
+    // written on this path, so the whole atomic unit is local DB.
+    return sql.begin(async (tx) => {
+      const row = await createSizePack(input, tx);
+      await tx`
+        insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+        values (${staff.id}, 'size_pack_create', 'size_pack', ${row.key}, ${tx.json({
+          label: row.label,
+          feature_key: row.feature_key,
+          delta_each: row.delta_each,
+          stripe_lookup_key: row.stripe_lookup_key,
+        } as never)})`;
+      return row;
     });
-    return row;
   });
 }

--- a/apps/web/src/lib/size-packs.ts
+++ b/apps/web/src/lib/size-packs.ts
@@ -1,8 +1,14 @@
 import "server-only";
 import type Stripe from "stripe";
+import type postgres from "postgres";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
+
+/** A DB executor for the catalog writes: the shared `sql` client, or a
+ *  transaction handle when the caller (an admin route) wants the write and its
+ *  staff_audit_log row to commit atomically (extend #272). */
+type Exec = postgres.TransactionSql | typeof sql;
 import { CHECKOUT_BRANDING, CUSTOMER_UPDATE_FOR_TAX } from "@/lib/billing";
 import { SEAT_ADDON } from "@/lib/seat-addons";
 
@@ -77,16 +83,19 @@ export async function listSizePacks(opts: { activeOnly?: boolean } = {}): Promis
 }
 
 /** Create a catalog row (staff CRUD). */
-export async function createSizePack(input: {
-  key: string;
-  label: string;
-  feature_key: string;
-  delta_each: number;
-  stripe_lookup_key: string;
-  active?: boolean;
-}): Promise<SizePackCatalogRow> {
+export async function createSizePack(
+  input: {
+    key: string;
+    label: string;
+    feature_key: string;
+    delta_each: number;
+    stripe_lookup_key: string;
+    active?: boolean;
+  },
+  exec: Exec = sql,
+): Promise<SizePackCatalogRow> {
   assertNotSeatManaged(input.feature_key);
-  const [row] = await sql<SizePackCatalogRow[]>`
+  const [row] = await exec<SizePackCatalogRow[]>`
     insert into size_pack_catalog (key, label, feature_key, delta_each, stripe_lookup_key, active)
     values (${input.key}, ${input.label}, ${input.feature_key}, ${input.delta_each},
             ${input.stripe_lookup_key}, ${input.active ?? true})
@@ -107,9 +116,10 @@ export async function updateSizePack(
     stripe_lookup_key: string;
     active: boolean;
   }>,
+  exec: Exec = sql,
 ): Promise<SizePackCatalogRow | null> {
   assertNotSeatManaged(patch.feature_key);
-  const [row] = await sql<SizePackCatalogRow[]>`
+  const [row] = await exec<SizePackCatalogRow[]>`
     update size_pack_catalog set
       label             = coalesce(${patch.label ?? null}, label),
       feature_key       = coalesce(${patch.feature_key ?? null}, feature_key),
@@ -125,8 +135,12 @@ export async function updateSizePack(
 /** Soft-deactivate a catalog row (prefer this over DELETE — never orphan a
  *  purchased pack's catalog reference). A deactivated pack cannot be bought,
  *  but already-granted packs are unaffected (frozen org_addons rows). */
-export async function setSizePackActive(key: string, active: boolean): Promise<SizePackCatalogRow | null> {
-  return updateSizePack(key, { active });
+export async function setSizePackActive(
+  key: string,
+  active: boolean,
+  exec: Exec = sql,
+): Promise<SizePackCatalogRow | null> {
+  return updateSizePack(key, { active }, exec);
 }
 
 /**

--- a/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-addons.test.ts
@@ -3,13 +3,15 @@
 // already sums (lib/entitlements.addonBonus), and freezes-not-deletes on revoke.
 //
 // These drive grantAddon/revokeAddon against real Postgres and assert on the
-// real resolver (getLimit). logStaffAction is mocked to a spy so we can assert
-// "audit exactly once on a real state change, never on a replay" without an
-// actor_id FK. The ent cache is disabled so a just-written row is seen at once.
+// real resolver (getLimit). Since #272's sweep, the staff_audit_log row is
+// written INSIDE grantAddon/revokeAddon's own tx (not via a mocked
+// logStaffAction), so audit is asserted by counting REAL rows — and ACTOR must
+// be a real users.id, because staff_audit_log.actor_id is a live FK. The ent
+// cache is disabled so a just-written row is seen at once.
 //
 // Real Postgres required; skipped without DATABASE_URL. Run on the fresh v17
 // schema: DATABASE_URL=$(cat /tmp/v17_base_url) DB_SCHEMA=seazn_club_v17.
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 
 vi.mock("@/lib/cache", () => ({
@@ -20,12 +22,6 @@ vi.mock("@/lib/cache", () => ({
   incrWindow: async () => 1,
 }));
 
-const logStaffActionMock = vi.fn<(...args: unknown[]) => Promise<void>>();
-vi.mock("@/lib/admin", async (orig) => ({
-  ...(await (orig as () => Promise<Record<string, unknown>>)()),
-  logStaffAction: (...args: unknown[]) => logStaffActionMock(...args),
-}));
-
 import { sql } from "@/lib/db";
 import { createOrgForUser } from "@/lib/auth";
 import { walletIdFor } from "@/lib/credits";
@@ -34,7 +30,8 @@ import { grantAddon, revokeAddon } from "../admin-addons";
 
 const HAS_DB = !!process.env.DATABASE_URL;
 const FEATURE = "members.max";
-const ACTOR = "staff-tester";
+// A real staff user — actor_id is an FK, so the audit insert now needs one.
+let ACTOR: string;
 const uniq = () => randomUUID().slice(0, 8);
 
 async function makeUser(): Promise<string> {
@@ -44,8 +41,18 @@ async function makeUser(): Promise<string> {
   return id;
 }
 
-beforeEach(() => {
-  logStaffActionMock.mockClear();
+/** Count real staff_audit_log rows for an org + action (replaces the old
+ *  logStaffAction spy now that the audit commits inside the write's own tx). */
+async function auditCount(orgId: string, action: string): Promise<number> {
+  const [{ n }] = await sql<{ n: number }[]>`
+    select count(*)::int as n from staff_audit_log
+    where target_id = ${orgId} and action = ${action}`;
+  return n;
+}
+
+beforeAll(async () => {
+  if (!HAS_DB) return;
+  ACTOR = await makeUser();
 });
 
 afterAll(async () => {
@@ -78,7 +85,7 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
       select status, stripe_item_id from org_addons where id = ${id}`;
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ status: "granted", stripe_item_id: null });
-    expect(logStaffActionMock).toHaveBeenCalledTimes(1);
+    expect(await auditCount(org.id, "addon_grant")).toBe(1);
   });
 
   it("a target_org_id grant lifts only that org; a sibling on the same wallet is unaffected", async () => {
@@ -128,7 +135,7 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
     const [{ n }] = await sql<{ n: number }[]>`
       select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
     expect(n).toBe(0);
-    expect(logStaffActionMock).not.toHaveBeenCalled();
+    expect(await auditCount(org.id, "addon_grant")).toBe(0);
   });
 
   it("rejects a NONEXISTENT target_org_id with the same typed 422 (not a 500), no row written", async () => {
@@ -153,7 +160,7 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
     const [{ n }] = await sql<{ n: number }[]>`
       select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
     expect(n).toBe(0);
-    expect(logStaffActionMock).not.toHaveBeenCalled();
+    expect(await auditCount(org.id, "addon_grant")).toBe(0);
   });
 
   it("rejects delta_each <= 0 and qty <= 0 with no row written", async () => {
@@ -183,7 +190,7 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
     const [{ n }] = await sql<{ n: number }[]>`
       select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
     expect(n).toBe(0);
-    expect(logStaffActionMock).not.toHaveBeenCalled();
+    expect(await auditCount(org.id, "addon_grant")).toBe(0);
   });
 
   it("is idempotent on the key — a replay makes one row, applied:false, one audit row", async () => {
@@ -206,7 +213,28 @@ describe.skipIf(!HAS_DB)("grantAddon", () => {
     const [{ n }] = await sql<{ n: number }[]>`
       select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
     expect(n).toBe(1);
-    expect(logStaffActionMock).toHaveBeenCalledTimes(1);
+    expect(await auditCount(org.id, "addon_grant")).toBe(1); // logged once, not on replay
+  });
+
+  it("atomicity: a bogus (nonexistent) actor trips the audit FK and rolls the GRANT back too", async () => {
+    // staff_audit_log.actor_id is a real FK to users(id): a grant whose audit
+    // insert fails must roll the org_addons row back with it — both-or-neither.
+    const org = await createOrgForUser(await makeUser(), "Addon Atomic Org");
+    const walletId = await walletIdFor(org.id);
+    const bogusActor = randomUUID(); // names no users row
+
+    await expect(
+      grantAddon(bogusActor, org.id, {
+        featureKey: FEATURE, deltaEach: 3, qty: 1, targetOrgId: null, reason: "promo",
+        idempotencyKey: `atomic-${uniq()}-abcd`,
+      }),
+    ).rejects.toThrow();
+
+    // Neither row survives: the grant and its audit committed together, or not at all.
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from org_addons where wallet_id = ${walletId}`;
+    expect(n).toBe(0);
+    expect(await auditCount(org.id, "addon_grant")).toBe(0);
   });
 });
 
@@ -218,14 +246,13 @@ describe.skipIf(!HAS_DB)("revokeAddon", () => {
       featureKey: FEATURE, deltaEach: 3, qty: 2, targetOrgId: null, reason: "sales_comp", idempotencyKey: `rev-${uniq()}-abcd`,
     });
     expect(await getLimit(org.id, FEATURE)).toBe(base + 6);
-    logStaffActionMock.mockClear();
 
     const res = await revokeAddon(ACTOR, org.id, id, "bug_fix");
     expect(res.revoked).toBe(true);
     expect(await getLimit(org.id, FEATURE)).toBe(base); // fell back to plan base
     const [row] = await sql<{ status: string }[]>`select status from org_addons where id = ${id}`;
     expect(row.status).toBe("canceled"); // freeze-not-delete: still present
-    expect(logStaffActionMock).toHaveBeenCalledTimes(1);
+    expect(await auditCount(org.id, "addon_revoke")).toBe(1);
   });
 
   it("revoking again is a no-op: {revoked:false}, no error, no second audit row", async () => {
@@ -234,11 +261,10 @@ describe.skipIf(!HAS_DB)("revokeAddon", () => {
       featureKey: FEATURE, deltaEach: 3, qty: 1, targetOrgId: null, reason: "promo", idempotencyKey: `rev2-${uniq()}-abcd`,
     });
     await revokeAddon(ACTOR, org.id, id, "promo");
-    logStaffActionMock.mockClear();
 
     const res = await revokeAddon(ACTOR, org.id, id, "promo");
     expect(res.revoked).toBe(false);
-    expect(logStaffActionMock).not.toHaveBeenCalled();
+    expect(await auditCount(org.id, "addon_revoke")).toBe(1); // the replay logged nothing new
   });
 
   it("refuses a Stripe-paid active row and another org's row — both untouched", async () => {

--- a/apps/web/src/server/usecases/__tests__/admin-plan.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-plan.test.ts
@@ -96,6 +96,28 @@ describe.skipIf(!HAS_DB)("admin plan tools", () => {
     expect(audit.detail.reason).toBe("founder friend");
   });
 
+  it("atomicity: a bogus actor trips the audit FK and rolls the comp write back too", async () => {
+    // Since #272's sweep, compToPro writes its staff_audit_log row INSIDE the
+    // same tx as the plan change (staff_audit_log.actor_id is a real FK). A
+    // grant whose audit insert fails must leave the subscription untouched —
+    // the money-adjacent write and its audit commit together or not at all.
+    const { orgId } = await seedOrg();
+    const bogusActor = randomUUID(); // names no users row
+
+    await expect(compToPro(bogusActor, orgId, null, "founder friend")).rejects.toThrow();
+
+    // Plan never moved off community, and no audit row leaked.
+    const [row] = await sql<{ plan_key: string; comped_at: string | null }[]>`
+      select plan_key, comped_at from subscriptions
+      where id = (select subscription_id from organizations where id = ${orgId})`;
+    expect(row.plan_key).toBe("community");
+    expect(row.comped_at).toBeNull();
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from staff_audit_log
+      where target_id = ${orgId} and action = 'comp_to_pro'`;
+    expect(n).toBe(0);
+  });
+
   it("an entitlement override with a lapsed expiry stops resolving", async () => {
     const { orgId } = await seedOrg();
     await sql`

--- a/apps/web/src/server/usecases/__tests__/size-pack-addon.test.ts
+++ b/apps/web/src/server/usecases/__tests__/size-pack-addon.test.ts
@@ -284,8 +284,12 @@ describe.skipIf(!HAS_DB)("size-pack checkout gate (IDOR)", () => {
 describe.skipIf(!HAS_DB)("size-pack catalog admin CRUD", () => {
   it("superadmin can create, edit and soft-deactivate; a non-staff caller is refused", async () => {
     const key = `size_pack_test_${uniq()}`;
-    requireSuperadminMock.mockResolvedValue({ id: "staff", staff_role: "superadmin" });
-    requireStaffMock.mockResolvedValue({ id: "staff" });
+    // Real users.id, not "staff": the admin size-pack routes now write the
+    // staff-audit row INSIDE the route's tx (actor_id → users FK, #275's sweep),
+    // so a non-UUID actor id makes the create 500 instead of 200.
+    const staffId = await makeUser();
+    requireSuperadminMock.mockResolvedValue({ id: staffId, staff_role: "superadmin" });
+    requireStaffMock.mockResolvedValue({ id: staffId });
 
     // Create.
     const created = await adminCreate(

--- a/apps/web/src/server/usecases/admin-addons.ts
+++ b/apps/web/src/server/usecases/admin-addons.ts
@@ -2,7 +2,6 @@ import "server-only";
 import { sql } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { walletIdFor } from "@/lib/credits";
-import { logStaffAction } from "@/lib/admin";
 
 /**
  * Staff GRANT of an add-on (design/v17-pricing-entitlements/SPEC-3 §1 row 3):
@@ -71,31 +70,42 @@ export async function grantAddon(
       throw new HttpError(422, "target_org_id is not part of this organization's billing group.");
     }
   }
-  const [inserted] = await sql<{ id: string }[]>`
-    insert into org_addons
-      (wallet_id, target_org_id, target_competition_id, feature_key, delta_each, qty,
-       stripe_item_id, status, admin_idempotency_key)
-    values (${walletId}, ${targetOrgId}, null, ${featureKey}, ${deltaEach}, ${qty},
-            null, 'granted', ${idempotencyKey})
-    on conflict (admin_idempotency_key) where admin_idempotency_key is not null do nothing
-    returning id`;
+  // The org_addons grant and its staff_audit_log row commit TOGETHER (extend
+  // #272's adminAdjust pattern): a crash between the two can never leave a
+  // cap-lifting grant with no audit trail. The wallet reads above need no
+  // atomicity, only the write + audit — so they stay outside the tx.
+  return sql.begin(async (tx) => {
+    const [inserted] = await tx<{ id: string }[]>`
+      insert into org_addons
+        (wallet_id, target_org_id, target_competition_id, feature_key, delta_each, qty,
+         stripe_item_id, status, admin_idempotency_key)
+      values (${walletId}, ${targetOrgId}, null, ${featureKey}, ${deltaEach}, ${qty},
+              null, 'granted', ${idempotencyKey})
+      on conflict (admin_idempotency_key) where admin_idempotency_key is not null do nothing
+      returning id`;
 
-  // Replay: the key already granted — return the prior row, log nothing.
-  if (!inserted) {
-    const [existing] = await sql<{ id: string }[]>`
-      select id from org_addons where admin_idempotency_key = ${idempotencyKey}`;
-    return { id: existing!.id, applied: false };
-  }
+    // Replay: the key already granted — return the prior row, audit nothing
+    // (the §3 unified log reads staff_audit_log; a second row reads as two grants).
+    if (!inserted) {
+      const [existing] = await tx<{ id: string }[]>`
+        select id from org_addons where admin_idempotency_key = ${idempotencyKey}`;
+      return { id: existing!.id, applied: false };
+    }
 
-  await logStaffAction(actorId, "addon_grant", "org", orgId, {
-    feature_key: featureKey,
-    delta_each: deltaEach,
-    qty,
-    target_org_id: targetOrgId,
-    reason,
-    addon_id: inserted.id,
+    // Mirror logStaffAction's columns (lib/admin.ts) on THIS tx — never call
+    // logStaffAction itself here, it opens its own connection outside the tx.
+    await tx`
+      insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+      values (${actorId}, 'addon_grant', 'org', ${orgId}, ${tx.json({
+        feature_key: featureKey,
+        delta_each: deltaEach,
+        qty,
+        target_org_id: targetOrgId,
+        reason,
+        addon_id: inserted.id,
+      } as never)})`;
+    return { id: inserted.id, applied: true };
   });
-  return { id: inserted.id, applied: true };
 }
 
 /**
@@ -122,30 +132,38 @@ export async function revokeAddon(
 ): Promise<{ revoked: boolean }> {
   const walletId = await walletIdFor(orgId);
 
-  const flipped = await sql<{ id: string }[]>`
-    update org_addons set status = 'canceled'
-     where id = ${addonId}
-       and wallet_id = ${walletId}
-       and status = 'granted'
-       and stripe_item_id is null
-    returning id`;
+  // The status flip and its audit row commit TOGETHER (extend #272). A refusal
+  // throws inside the tx before any write, so it rolls back to a clean no-op.
+  return sql.begin(async (tx) => {
+    const flipped = await tx<{ id: string }[]>`
+      update org_addons set status = 'canceled'
+       where id = ${addonId}
+         and wallet_id = ${walletId}
+         and status = 'granted'
+         and stripe_item_id is null
+      returning id`;
 
-  if (flipped.length === 0) {
-    // Nothing flipped — decide between an idempotent replay (already canceled
-    // admin row) and a genuine refusal (unknown / other-org / Stripe-paid).
-    const [row] = await sql<
-      { wallet_id: string; status: string; stripe_item_id: string | null }[]
-    >`select wallet_id, status, stripe_item_id from org_addons where id = ${addonId}`;
-    if (!row || row.wallet_id !== walletId) {
-      throw new HttpError(404, "No such add-on for this org.");
+    if (flipped.length === 0) {
+      // Nothing flipped — decide between an idempotent replay (already canceled
+      // admin row) and a genuine refusal (unknown / other-org / Stripe-paid).
+      const [row] = await tx<
+        { wallet_id: string; status: string; stripe_item_id: string | null }[]
+      >`select wallet_id, status, stripe_item_id from org_addons where id = ${addonId}`;
+      if (!row || row.wallet_id !== walletId) {
+        throw new HttpError(404, "No such add-on for this org.");
+      }
+      if (row.stripe_item_id !== null) {
+        throw new HttpError(409, "This is a Stripe-paid add-on; cancel it through billing.");
+      }
+      if (row.status === "canceled") return { revoked: false }; // replay — no audit
+      throw new HttpError(409, "This add-on cannot be revoked from the admin adjustment layer.");
     }
-    if (row.stripe_item_id !== null) {
-      throw new HttpError(409, "This is a Stripe-paid add-on; cancel it through billing.");
-    }
-    if (row.status === "canceled") return { revoked: false }; // replay — no audit
-    throw new HttpError(409, "This add-on cannot be revoked from the admin adjustment layer.");
-  }
 
-  await logStaffAction(actorId, "addon_revoke", "org", orgId, { addon_id: addonId, reason });
-  return { revoked: true };
+    // Mirror logStaffAction's columns (lib/admin.ts) on THIS tx — see grantAddon.
+    await tx`
+      insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+      values (${actorId}, 'addon_revoke', 'org', ${orgId},
+              ${tx.json({ addon_id: addonId, reason } as never)})`;
+    return { revoked: true };
+  });
 }

--- a/apps/web/src/server/usecases/admin-plan.ts
+++ b/apps/web/src/server/usecases/admin-plan.ts
@@ -163,38 +163,49 @@ export async function compToPro(
   if (until && until.getTime() <= Date.now()) {
     throw new HttpError(400, "The end date must be in the future.");
   }
-  await sql`
-    update subscriptions set
-      plan_key = 'pro',
-      -- status only moves when there is NO subscription id at all. A departed
-      -- org keeps its dead id, and writing a live-looking status onto that row
-      -- would resurrect liveness: the resolver's comp-expiry branch could never
-      -- fire (the comp would never lapse), checkout would 409 and downgrade
-      -- would 400. So a cancelled status stands. Same shape as extendTrial.
-      status = case when stripe_subscription_id is null then 'active' else status end,
-      comped_until = ${until ? until.toISOString() : null},
-      -- Provenance, not a deadline: this row's paid plan came from staff rather
-      -- than from Stripe. The resolver's cancelled arm keys off THIS, because a
-      -- forever-comp writes comped_until = null and would otherwise be
-      -- indistinguishable from an org that simply left (V313).
-      comped_at = now(),
-      -- A comp IS the free ride: the org has had Pro without paying, so a
-      -- later self-serve upgrade bills from day one. coalesce keeps the first
-      -- comp's date across re-comps. Reversible via Restore trial.
-      trial_used_at = coalesce(trial_used_at, now()),
-      status_changed_at = case when stripe_subscription_id is null
-                                    and status is distinct from 'active'
-                               then now() else status_changed_at end,
-      updated_at = now()
-    where id = ${subscriptionId}`;
-  // A comp moves plan_key on the shared row, so every org in the group is now
-  // on Pro — invalidate all of them, not just the one staff named.
-  await invalidateGroupEntitlements(subscriptionId);
-  await logStaffAction(actorId, "comp_to_pro", "org", orgId, {
-    reason,
-    before: { plan_key: before.plan_key, comped_until: before.comped_until },
-    after: { plan_key: "pro", comped_until: until?.toISOString() ?? "forever" },
+  // The plan write and its staff_audit_log row commit TOGETHER (extend #272):
+  // a crash between them can never leave a comp with no audit trail. No Stripe
+  // call is on this path — compToPro refuses live-Stripe orgs above — so the
+  // whole atomic unit is the local subscriptions write + the audit row.
+  await sql.begin(async (tx) => {
+    await tx`
+      update subscriptions set
+        plan_key = 'pro',
+        -- status only moves when there is NO subscription id at all. A departed
+        -- org keeps its dead id, and writing a live-looking status onto that row
+        -- would resurrect liveness: the resolver's comp-expiry branch could never
+        -- fire (the comp would never lapse), checkout would 409 and downgrade
+        -- would 400. So a cancelled status stands. Same shape as extendTrial.
+        status = case when stripe_subscription_id is null then 'active' else status end,
+        comped_until = ${until ? until.toISOString() : null},
+        -- Provenance, not a deadline: this row's paid plan came from staff rather
+        -- than from Stripe. The resolver's cancelled arm keys off THIS, because a
+        -- forever-comp writes comped_until = null and would otherwise be
+        -- indistinguishable from an org that simply left (V313).
+        comped_at = now(),
+        -- A comp IS the free ride: the org has had Pro without paying, so a
+        -- later self-serve upgrade bills from day one. coalesce keeps the first
+        -- comp's date across re-comps. Reversible via Restore trial.
+        trial_used_at = coalesce(trial_used_at, now()),
+        status_changed_at = case when stripe_subscription_id is null
+                                      and status is distinct from 'active'
+                                 then now() else status_changed_at end,
+        updated_at = now()
+      where id = ${subscriptionId}`;
+    // Mirror logStaffAction's columns (lib/admin.ts) on THIS tx — never call
+    // logStaffAction itself inside the tx, it opens its own connection.
+    await tx`
+      insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+      values (${actorId}, 'comp_to_pro', 'org', ${orgId}, ${tx.json({
+        reason,
+        before: { plan_key: before.plan_key, comped_until: before.comped_until },
+        after: { plan_key: "pro", comped_until: until?.toISOString() ?? "forever" },
+      } as never)})`;
   });
+  // A comp moves plan_key on the shared row, so every org in the group is now
+  // on Pro — invalidate all of them, not just the one staff named. Cache bust
+  // (Redis) stays OUT of the tx and runs after the truth has committed.
+  await invalidateGroupEntitlements(subscriptionId);
 }
 
 export interface FreezePreview {
@@ -428,14 +439,20 @@ export async function restoreTrial(
       "This organization is billed through Stripe — the next sync would re-stamp the trial as used.",
     );
   }
-  await sql`update subscriptions set trial_used_at = null, updated_at = now()
-            where id = ${subscriptionId}`;
-  // The trial burn is a GROUP fact now — restoring it re-opens the 14-day
-  // checkout trial for every org billing through this row.
-  await invalidateGroupEntitlements(subscriptionId);
-  await logStaffAction(actorId, "restore_trial", "org", orgId, {
-    reason,
-    before: { trial_used_at: before.trial_used_at },
-    after: { trial_used_at: null },
+  // The trial-burn clear and its audit row commit TOGETHER (extend #272); this
+  // path refuses live-Stripe orgs above, so it is local DB only.
+  await sql.begin(async (tx) => {
+    await tx`update subscriptions set trial_used_at = null, updated_at = now()
+             where id = ${subscriptionId}`;
+    await tx`
+      insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+      values (${actorId}, 'restore_trial', 'org', ${orgId}, ${tx.json({
+        reason,
+        before: { trial_used_at: before.trial_used_at },
+        after: { trial_used_at: null },
+      } as never)})`;
   });
+  // The trial burn is a GROUP fact now — restoring it re-opens the 14-day
+  // checkout trial for every org billing through this row. Cache bust after commit.
+  await invalidateGroupEntitlements(subscriptionId);
 }


### PR DESCRIPTION
Extends #272's audit-atomicity pattern to the remaining **money-adjacent** admin write paths, so a crash between an admin write and its separate `logStaffAction` can no longer leave an **unaudited** change.

## Converted — write + `staff_audit_log` insert now in ONE `sql.begin`
- `admin-addons.ts` — `grantAddon` / `revokeAddon` (org_addons write + audit atomic; idempotency early-return precedes the audit)
- size-pack routes `POST` / `PATCH` / `DELETE` — via a new `exec` executor threaded from the route into `lib/size-packs.ts` (the transactional path uses `tx`, not the default `sql`)
- `admin-plan.ts` — `compToPro` + `restoreTrial` (UPDATE body byte-identical, just wrapped; neither touches Stripe)

## No Stripe/network inside any tx (the key hazard)
Verified at every site: `walletIdFor` runs before `sql.begin`; the tx holds only the local DB write + audit; `invalidateGroupEntitlements` (Redis) runs **after** commit. Holding a pooled connection across a network round-trip would be worse than the gap being closed — this PR does not do that.

## Deferred (need a Stripe-flow restructure — tracked)
- **coupons** `createCoupon`/`setCouponActive` — pure Stripe promotion codes, no local DB row to pair the audit with
- **admin-plan `extendTrial`** — live Stripe update + a race-guarded pinned write (`localWriteSkipped`); wrapping risks the two-race guard
- **admin-plan `adminDowngrade`** — state split across `downgradeToCommunity()` + a second UPDATE; needs an executor threaded through
- **billing-manage.ts** — N/A (only Stripe param-builders / row-mappers; no write+audit pair)

## Tests
Atomicity via a **real FK trip** (`staff_audit_log.actor_id → users` with a nonexistent actor) asserting **0 state rows AND 0 audit rows** on failure (same as #272). `admin-addons.test.ts` rewritten to drop the `logStaffAction` spy for real `staff_audit_log` row-count asserts. **62 tests** green; typecheck clean. Review: **PASS / APPROVE**, no findings.

Completes the money-adjacent portion of the deferred "audit every admin write" sweep; the non-money admin routes + the 3 Stripe-flow deferrals remain a further follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)