### PR TITLE
fix(e2e): kill the two recurring main-push flakes (networkidle hang + club-name collision)

### DIFF
--- a/apps/web/e2e/billing-groups-journey.spec.ts
+++ b/apps/web/e2e/billing-groups-journey.spec.ts
@@ -106,7 +106,10 @@ test.describe.serial("billing groups — visual workflow", () => {
     await button.click();
     await expect(dialogOf(page)).toHaveCount(0);
     // Every mutation is followed by `load()`, so the panel is briefly stale.
-    await page.waitForLoadState("networkidle");
+    // Settle briefly instead of networkidle: the billing page holds a realtime
+    // socket, so the network is NEVER idle → networkidle hits the 60s test
+    // timeout. Web-first assertions after this auto-wait for the refreshed panel.
+    await page.waitForTimeout(500);
   }
 
   test("01 — a bill with one organisation, and others that could join it", async ({ page }) => {
@@ -394,8 +397,8 @@ test.describe.serial("billing groups — visual workflow", () => {
           select owner_user_id from subscriptions where id = ${groupId}`,
       );
       expect(owner[0].owner_user_id).toBe(heir);
-      await page.goto("/settings/billing");
-      await page.waitForLoadState("networkidle");
+      await page.goto("/settings/billing", { waitUntil: "load" });
+      await page.waitForTimeout(500); // settle, not networkidle (realtime socket never idles → 60s hang)
       await expect(panelOf(page)).toHaveCount(0);
       await shot(page, "handed-over-panel-gone");
     } finally {

--- a/apps/web/e2e/billing-groups.spec.ts
+++ b/apps/web/e2e/billing-groups.spec.ts
@@ -97,8 +97,11 @@ test.describe.serial("billing groups", () => {
       });
       // The panel mounts, then fetches, then decides. `toHaveCount(0)` against
       // a page that has not finished those fetches passes for the wrong reason,
-      // so settle the network before asserting absence.
-      await soloPage.waitForLoadState("networkidle");
+      // so settle before asserting absence. Fixed settle, NOT networkidle: the
+      // billing page's realtime socket keeps the network busy, so networkidle
+      // never fires and hits the 60s test timeout. The heading was already
+      // asserted visible above, so the page has loaded.
+      await soloPage.waitForTimeout(500);
       await expect(panelOf(soloPage)).toHaveCount(0);
     } finally {
       await solo.close();

--- a/apps/web/e2e/team-squad.spec.ts
+++ b/apps/web/e2e/team-squad.spec.ts
@@ -4,8 +4,12 @@ import { TAG, apiJson } from "./helpers";
 // Add a team under a club on its /clubs/[id] hub (Teams tab) and manage the
 // persistent squad — no spreadsheet import. Names are namespaced so this spec
 // never collides with others sharing the per-run org.
-test("add a team to a club and manage its squad", async ({ page }) => {
-  const clubName = `Harbour ${TAG}`;
+test("add a team to a club and manage its squad", async ({ page }, testInfo) => {
+  // Retry-safe + distinct from import.spec's `Harbour ${TAG}`: Playwright retries
+  // reuse the module-level TAG, so a fixed club name 409s ("already exists") on a
+  // retry (and would collide cross-spec in the same worker). The retry index
+  // makes each attempt unique.
+  const clubName = `Harbour ${TAG} ${testInfo.retry}`;
   const teamName = `Squad ${TAG}`;
   const playerName = `Squaddie ${TAG}`;
 


### PR DESCRIPTION
Main's push-triggered e2e has been red on the last two pushes (#273, #274) from **two recurring flakes** — neither caused by those PRs' code. This fixes both.

## 1. `networkidle` 60s hang (the hard failure — the "1 failed")
`billing-groups-journey.spec.ts`'s `confirmDialog` (and two panel-absence checks) waited on `page.waitForLoadState("networkidle")`. The billing page holds a **realtime socket**, so the network is *never* idle → the wait runs to the **60s test timeout**. Replaced all 3 sites with a fixed **500ms settle** — the exact pattern `mobile.spec.ts` already documents ("load + a short settle instead of networkidle — the socket keeps the network permanently busy"). The web-first `expect(...).toHaveCount(0)` after each settle auto-waits for the refreshed panel, so correctness is preserved.

- `billing-groups-journey.spec.ts:109` (confirmDialog), `:398`
- `billing-groups.spec.ts:101`

## 2. Club-name collision on retry (the retry-masked flake)
`team-squad.spec.ts` created `Harbour ${TAG}` with the **module-level** `TAG` (`Date.now().toString(36)`). A Playwright **retry** re-runs the body with the same `TAG`, re-creating the same club → `POST /clubs 409 "already exists"` (and it collides cross-spec with `import.spec.ts`'s identical name in the same worker). Made the club name **retry-index-unique** (`Harbour ${TAG} ${testInfo.retry}`) — distinct per attempt and distinct from import.

## Validation
Compile-checked via `playwright test --list` (33 tests, 4 files, clean). Full functional validation is the **next main-push e2e** (these specs can't fully run without the prod-build-serve harness). No production code touched — e2e specs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)