### PR TITLE
fix(org-switch): breadcrumb org dropdown stays on the same page (the REAL cause)

### DIFF
--- a/apps/web/e2e/org-switch.spec.ts
+++ b/apps/web/e2e/org-switch.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { loginUi, apiJson, TAG, setEntitlementOverrideSql } from "./helpers";
+
+// Switching organisations must land on the SAME page under the new org, not
+// bounce to the dashboard (`/o/<slug>`). The user has reported this 3× and it
+// survived #274 — so this reproduces it end to end, against BOTH switch
+// affordances: the settings-header `OrgSwitcher` (the one #274 touched) and
+// the always-visible breadcrumb org dropdown (`OrgCrumb`), which is what a
+// user reaches for on any page.
+//
+// Runs in its own context (own two-org user); no shared storageState.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function seedTwoOrgUser(page: import("@playwright/test").Page) {
+  const email = `e2e-switch-${TAG}-${Math.random().toString(36).slice(2, 7)}@example.com`;
+  await loginUi(page, email, "/dashboard");
+  let orgsA = await apiJson<{ id: string; slug: string; name: string }[]>(page.request, "/api/orgs");
+  if (!orgsA.data?.length) {
+    const a = await apiJson<{ id: string; slug: string }>(page.request, "/api/orgs", "POST", {
+      name: `Switch A ${TAG}`,
+    });
+    if (a.status >= 400) throw new Error(`create org A failed: ${a.status} ${a.error?.message}`);
+    orgsA = await apiJson<{ id: string; slug: string; name: string }[]>(page.request, "/api/orgs");
+  }
+  const orgA = orgsA.data![0]!;
+  // A community org may cap owned orgs below 2 — lift it so the second create
+  // (and thus the two-org switcher) is reachable.
+  await setEntitlementOverrideSql(orgA.id, "orgs.max_owned", 10);
+  // Second org via the product path. Creating it flips the active-org cookie
+  // to B, so we reset back to A afterwards.
+  const created = await apiJson<{ id: string; slug: string; name: string }>(
+    page.request,
+    "/api/orgs",
+    "POST",
+    { name: `Switch B ${TAG}` },
+  );
+  if (created.status >= 400) throw new Error(`create org B failed: ${created.status} ${created.error?.message}`);
+  const orgB = created.data!;
+  // Reset active org to A so the test starts on A's settings.
+  await apiJson(page.request, "/api/orgs/active", "POST", { org_id: orgA.id });
+  return { orgA, orgB };
+}
+
+test("settings OrgSwitcher stays on the settings page under the new org", async ({ page }) => {
+  const { orgA, orgB } = await seedTwoOrgUser(page);
+
+  await page.goto(`/o/${orgA.slug}/settings`);
+  await page.getByRole("button", { name: "Switch organisation" }).click();
+  // The popover lists org B by name — click its row.
+  await page.getByRole("menu").getByText(orgB.slug, { exact: true }).click();
+
+  await page.waitForURL(/\/o\/[^/]+(\/|$)/, { timeout: 20_000 });
+  await page.waitForLoadState("networkidle");
+  expect(page.url(), "settings switch should stay on /settings under org B").toContain(
+    `/o/${orgB.slug}/settings`,
+  );
+});
+
+test("breadcrumb org dropdown stays on the same page under the new org", async ({ page }) => {
+  const { orgA, orgB } = await seedTwoOrgUser(page);
+
+  await page.goto(`/o/${orgA.slug}/settings`);
+  // The breadcrumb org crumb (top dark bar) is the always-visible switcher.
+  // Its trigger shows org A's name with a chevron; open it and click org B.
+  await page.getByRole("button", { name: orgA.name }).click();
+  await page.getByRole("menuitem", { name: orgB.name }).click();
+
+  await page.waitForURL(/\/o\/[^/]+(\/|$)/, { timeout: 20_000 });
+  await page.waitForLoadState("networkidle");
+  expect(page.url(), "breadcrumb switch from settings should stay on settings under org B").toContain(
+    `/o/${orgB.slug}/settings`,
+  );
+});

--- a/apps/web/src/components/breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs.tsx
@@ -9,8 +9,8 @@ import Link from "@/components/ui/console-link";
 import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
-import { routes } from "@/lib/routes";
 import { buildCrumbs, type BreadcrumbNameMap } from "@/lib/breadcrumb-chain";
+import { orgSwitchTarget } from "@/components/org-switcher";
 import { useMsg } from "@/components/i18n/dict-provider";
 
 export type { BreadcrumbNameMap };
@@ -21,9 +21,19 @@ interface BreadcrumbsProps {
   names: BreadcrumbNameMap;
 }
 
-function OrgCrumb({ orgName, orgs }: Pick<BreadcrumbsProps, "orgName" | "orgs">) {
+function OrgCrumb({
+  orgName,
+  orgs,
+  pathname,
+}: Pick<BreadcrumbsProps, "orgName" | "orgs"> & { pathname: string }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  // The org segment doubles as the switcher. Land on the SAME page under the
+  // target org (Settings → Settings) instead of always bouncing to the org
+  // home — the "switching org redirects to the dashboard" bug. orgSwitchTarget
+  // transfers org-level paths (/o/<slug>, /settings…) and falls back to the new
+  // org home for entity paths (/c, /d) that can't exist under another org.
+  const oldSlug = pathname.match(/^\/o\/([^/]+)/)?.[1];
   useEffect(() => {
     if (!open) return;
     const close = (e: MouseEvent) => {
@@ -57,7 +67,7 @@ function OrgCrumb({ orgName, orgs }: Pick<BreadcrumbsProps, "orgName" | "orgs">)
             <Link
               key={o.slug}
               role="menuitem"
-              href={routes.orgHome(o.slug)}
+              href={orgSwitchTarget(pathname, oldSlug, o.slug)}
               onClick={() => setOpen(false)}
               className={`block truncate px-3 py-2 text-sm transition hover:bg-cream/10 hover:text-cream ${
                 o.name === orgName ? "font-medium text-lime-400" : "text-cream/80"
@@ -107,13 +117,13 @@ export function Breadcrumbs({ orgName, orgs, names }: BreadcrumbsProps) {
           </Link>
         ) : (
           <div className="flex min-w-0 items-center py-2 sm:hidden">
-            <OrgCrumb orgName={orgName} orgs={orgs} />
+            <OrgCrumb orgName={orgName} orgs={orgs} pathname={pathname} />
           </div>
         )}
 
         {/* Desktop trail: every level links; the current page is plain text. */}
         <nav aria-label="Breadcrumb" className="hidden min-w-0 items-center gap-1 py-2 sm:flex">
-          <OrgCrumb orgName={orgName} orgs={orgs} />
+          <OrgCrumb orgName={orgName} orgs={orgs} pathname={pathname} />
           {crumbs.slice(1).map((crumb, i) => {
             const isLast = i === crumbs.length - 2;
             return (


### PR DESCRIPTION
The actual fix for the repeatedly-reported "switching organisations jumps to the dashboard" bug.

## Root cause (found by reproducing, not guessing)
The app has **two** org switchers:
1. the settings-header `OrgSwitcher` (fixed in #274), and
2. the **always-visible breadcrumb org dropdown** (`OrgCrumb` in `breadcrumbs.tsx`) — the one users actually click, on every page.

The breadcrumb hard-linked every org to `routes.orgHome(slug)` = `/o/<slug>` (the **dashboard**). So #274 fixed the wrong switcher, and the bug persisted. This makes the breadcrumb reuse the same `orgSwitchTarget` helper as the settings switcher, so it transfers the current page (org-home + any `/settings…` path) to the same page under the new org, falling back to the org home only for entity paths (`/c`, `/d`) that can't exist under the other org.

## Verified by e2e (the missing evidence)
New `apps/web/e2e/org-switch.spec.ts` drives **both** switchers from `/o/<A>/settings`:
- **Before:** the breadcrumb landed on `/o/<B>` (dashboard) — reproduced the bug.
- **After:** both land on `/o/<B>/settings`. **2/2 pass**, typecheck clean, `orgSwitchTarget` units unchanged/green.

No cookie desync: the breadcrumb navigates with a plain `NextLink`; the org layout authorises from the URL slug and `ActiveOrgSync` reconciles the active-org cookie on arrival.

## Scope
`breadcrumbs.tsx` (the real cause) + the new e2e spec. 88 insertions / 5 deletions. Reviewed **PASS / APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)