### PR TITLE
fix(billing): don't record paid seats during a trial + clear trial copy on the group panel

### DIFF
--- a/apps/web/src/components/billing-group-panel.tsx
+++ b/apps/web/src/components/billing-group-panel.tsx
@@ -145,6 +145,12 @@ export function BillingGroupPanel({
   if (!view || view.hidden) return null;
 
   const group = groups.find((g) => g.id === subscriptionId)!;
+  // During a trial nothing is billed and quantity_paid is frozen at its baseline
+  // (see syncGroupQuantity), so `freeSlots` is 0 and the "paid slots free" line
+  // never fires — but the truth a payer needs is different, not absent: adding an
+  // organisation is free because it rides the trial, not because a seat was paid
+  // for and freed. Drive the copy off the group's own status.
+  const trialing = group.status === "trialing";
   const {
     onBill,
     seatsPaid,
@@ -332,11 +338,17 @@ export function BillingGroupPanel({
         )}
       </p>
 
-      {freeSlots > 0 && (
+      {trialing ? (
         <p className="mb-4 rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
-          {msg("billing.group.freedSlot", { count: String(freeSlots) })}
-          <Tip id="billing.freed-slot" className="ml-1 align-middle" />
+          {msg("billing.group.trialFree")}
         </p>
+      ) : (
+        freeSlots > 0 && (
+          <p className="mb-4 rounded-xl bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+            {msg("billing.group.freedSlot", { count: String(freeSlots) })}
+            <Tip id="billing.freed-slot" className="ml-1 align-middle" />
+          </p>
+        )
       )}
 
       <ul className="divide-y divide-slate-100 border-y border-slate-100">

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -547,6 +547,7 @@
   "billing.group.counts": "On this bill: {orgs} · Seats paid for: {seats}",
   "billing.group.capacity": "Room for {max}",
   "billing.group.freedSlot": "Paid slots free until renewal: {count}. Moving an organisation into one costs nothing.",
+  "billing.group.trialFree": "You're on a trial, so adding an organisation is free until it ends — you're first billed for it then.",
   "billing.group.suspended": "suspended",
   "billing.group.remove": "Remove from this bill",
   "billing.group.add": "Add an organisation",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -547,6 +547,7 @@
   "billing.group.counts": "En esta factura: {orgs} · Plazas pagadas: {seats}",
   "billing.group.capacity": "Cabida para {max}",
   "billing.group.freedSlot": "Plazas pagadas libres hasta la renovación: {count}. Mover una organización a una de ellas no cuesta nada.",
+  "billing.group.trialFree": "Estás en una prueba, así que añadir una organización es gratis hasta que termine: se te cobra por primera vez entonces.",
   "billing.group.suspended": "suspendida",
   "billing.group.remove": "Quitar de esta factura",
   "billing.group.add": "Añadir una organización",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -547,6 +547,7 @@
   "billing.group.counts": "Sur cette facture : {orgs} · Places payées : {seats}",
   "billing.group.capacity": "Capacité de {max}",
   "billing.group.freedSlot": "Places payées libres jusqu’au renouvellement : {count}. Y déplacer une organisation ne coûte rien.",
+  "billing.group.trialFree": "Vous êtes en période d’essai : ajouter une organisation est gratuit jusqu’à sa fin — elle vous est facturée à ce moment-là.",
   "billing.group.suspended": "suspendue",
   "billing.group.remove": "Retirer de cette facture",
   "billing.group.add": "Ajouter une organisation",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -547,6 +547,7 @@
   "billing.group.counts": "Op deze factuur: {orgs} · Betaalde plekken: {seats}",
   "billing.group.capacity": "Ruimte voor {max}",
   "billing.group.freedSlot": "Betaalde plekken vrij tot de verlenging: {count}. Een organisatie daarheen verplaatsen kost niets.",
+  "billing.group.trialFree": "Je hebt een proefperiode, dus een organisatie toevoegen is gratis tot die afloopt — je wordt er dan voor het eerst voor gefactureerd.",
   "billing.group.suspended": "geschorst",
   "billing.group.remove": "Van deze factuur halen",
   "billing.group.add": "Een organisatie toevoegen",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -240,6 +240,7 @@ export type DictionaryKey =
   | "billing.group.transfer.summary.takingOver"
   | "billing.group.transfer.title"
   | "billing.group.transfer.withdraw"
+  | "billing.group.trialFree"
   | "billing.intervalChange.confirm"
   | "billing.intervalChange.keep"
   | "billing.intervalChange.toMonthly"

--- a/apps/web/src/server/usecases/__tests__/billing-group-trial-seat.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-trial-seat.test.ts
@@ -1,0 +1,199 @@
+// The TRIAL seat-accounting rule, end to end through the REAL Stripe SDK.
+//
+// Like billing-group-charged-attach.test.ts, this does NOT mock @/lib/stripe: it
+// points the real client at e2e/stripe-fixture-server so syncGroupQuantity does
+// its retrieve→update round trip for real. What it pins is the trial branch: a
+// trial defers every charge to its end invoice, so attaching/detaching an org
+// mid-trial must NOT move `quantity_paid` (doing so minted a phantom "paid seat
+// free" line on a group that had paid nothing — reproduced live as quantity_paid
+// going {1, 2, 2, 1} across attach/detach/trial-end). The Stripe ITEM still syncs
+// to the active count so the trial-end invoice bills the right number, and the
+// renewal path is what finally sets `quantity_paid`. An ACTIVE (non-trial) group
+// is asserted to still inflate quantity_paid, so the fix is scoped to trials.
+
+// BEFORE any import pulls in @/lib/stripe: a fake key (the fixture ignores it)
+// and the host override, so getStripe() builds a client aimed at the fixture.
+process.env.STRIPE_SECRET_KEY ??= "sk_test_fixture_never_real";
+process.env.STRIPE_MOCK_HOST = "127.0.0.1";
+process.env.STRIPE_MOCK_PORT = "12118";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import {
+  attachOrgToGroup,
+  detachOrgFromGroup,
+  previewAttachCharge,
+  syncGroupQuantity,
+} from "@/server/usecases/billing-groups";
+import {
+  startStripeFixtureServer,
+  type StripeFixtureServer,
+} from "../../../../e2e/stripe-fixture-server";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+let fixture: StripeFixtureServer;
+
+async function makeUser(): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`trial-${uniq()}@test.local`}, 'Trial', true) returning id`;
+  return id;
+}
+
+/** A live group + one org in it, owned by `ownerId`. `status` lets a test build
+ *  a trialing group as easily as an active one. */
+async function makeGroupWithOrg(
+  ownerId: string,
+  opts: {
+    stripeSubId: string;
+    stripeCustomerId?: string;
+    quantityPaid?: number;
+    status?: "trialing" | "active";
+  },
+): Promise<{ groupId: string; orgId: string }> {
+  const [{ id: groupId }] = await sql<{ id: string }[]>`
+    insert into subscriptions
+      (owner_user_id, plan_key, status, quantity_paid, stripe_subscription_id,
+       stripe_customer_id, current_period_end, status_changed_at)
+    values (${ownerId}, 'pro', ${opts.status ?? "trialing"}, ${opts.quantityPaid ?? 1},
+            ${opts.stripeSubId}, ${opts.stripeCustomerId ?? "cus_" + uniq()},
+            now() + interval '20 days', now())
+    returning id`;
+  const s = uniq();
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by, subscription_id)
+    values (${`Trial ${s}`}, ${`trial-${s}`}, ${ownerId}, ${groupId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  return { groupId, orgId };
+}
+
+/** A community group of its own for the org that will be attached. */
+async function makeCommunityOrg(ownerId: string): Promise<string> {
+  const [{ id: subId }] = await sql<{ id: string }[]>`
+    insert into subscriptions (owner_user_id, plan_key, status, quantity_paid)
+    values (${ownerId}, 'community', 'active', 1) returning id`;
+  const s = uniq();
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by, subscription_id)
+    values (${`Joiner ${s}`}, ${`joiner-${s}`}, ${ownerId}, ${subId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  return orgId;
+}
+
+async function quantityPaid(groupId: string): Promise<number> {
+  const [{ quantity_paid }] = await sql<{ quantity_paid: number }[]>`
+    select quantity_paid from subscriptions where id = ${groupId}`;
+  return quantity_paid;
+}
+
+beforeAll(async () => {
+  if (!HAS_DB) return;
+  fixture = await startStripeFixtureServer(12118);
+});
+beforeEach(() => fixture?.reset());
+afterAll(async () => {
+  await fixture?.close();
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("trial seat accounting against the real SDK + Stripe fixture", () => {
+  it("freezes quantity_paid through a trial attach and detach", async () => {
+    const payer = await makeUser();
+    const subId = "sub_" + uniq();
+    const { groupId } = await makeGroupWithOrg(payer, {
+      stripeSubId: subId,
+      quantityPaid: 1,
+      status: "trialing",
+    });
+    fixture.seedSubscription({ id: subId, customer: "cus_seed", quantity: 1, scheme: "tiered" });
+    const joiner = await makeCommunityOrg(payer);
+
+    // Attach DURING the trial: the item syncs to 2 so the trial-end invoice bills
+    // two, but nothing is charged now and quantity_paid must not move off 1.
+    const attach = await attachOrgToGroup({ actorUserId: payer, orgId: joiner, subscriptionId: groupId });
+    expect(attach.quantity).toBe(2);
+    expect(attach.charged).toBe(false);
+    expect(await quantityPaid(groupId)).toBe(1);
+
+    // The item reached Stripe at quantity 2 but with NO proration (deferred to
+    // trial end), not create_prorations.
+    const up = fixture.calls.find(
+      (c) => c.method === "POST" && c.path === `/v1/subscriptions/${subId}`,
+    );
+    expect(up).toBeDefined();
+    expect(up!.body["items[0][quantity]"]).toBe("2");
+    expect(up!.body["proration_behavior"]).toBe("none");
+
+    // Detach it again: still mid-trial, quantity_paid stays 1 (no phantom freed
+    // paid seat left behind).
+    await detachOrgFromGroup({ actorUserId: payer, orgId: joiner });
+    expect(await quantityPaid(groupId)).toBe(1);
+  });
+
+  it("previews a trial attach as free", async () => {
+    const payer = await makeUser();
+    const subId = "sub_" + uniq();
+    const { groupId } = await makeGroupWithOrg(payer, {
+      stripeSubId: subId,
+      quantityPaid: 1,
+      status: "trialing",
+    });
+    fixture.seedSubscription({ id: subId, customer: "cus_seed", quantity: 1, scheme: "tiered" });
+    // Even with a proration seeded, a trialing group previews free — the trial
+    // defers it, so the confirm dialog must not promise "charged now".
+    fixture.setUpcomingProration(900, "gbp");
+    expect(await previewAttachCharge(groupId)).toBeNull();
+  });
+
+  it("lets the trial-end renewal set quantity_paid to the active count", async () => {
+    const payer = await makeUser();
+    const subId = "sub_" + uniq();
+    const { groupId } = await makeGroupWithOrg(payer, {
+      stripeSubId: subId,
+      quantityPaid: 1,
+      status: "trialing",
+    });
+    fixture.seedSubscription({ id: subId, customer: "cus_seed", quantity: 2, scheme: "tiered" });
+    // A second org rode the trial (item already at 2, quantity_paid frozen at 1).
+    const s = uniq();
+    await sql`
+      insert into organizations (name, slug, created_by, subscription_id)
+      values (${`Rider ${s}`}, ${`rider-${s}`}, ${payer}, ${groupId})`;
+    expect(await quantityPaid(groupId)).toBe(1);
+
+    // The trial converts: the renewal invoice is the authoritative setter, and it
+    // records the two seats it actually billed.
+    await syncGroupQuantity(groupId, { renewal: true, invoicedQuantity: 2 });
+    expect(await quantityPaid(groupId)).toBe(2);
+  });
+
+  it("still inflates quantity_paid on an ACTIVE (non-trial) group", async () => {
+    const payer = await makeUser();
+    const subId = "sub_" + uniq();
+    const { groupId } = await makeGroupWithOrg(payer, {
+      stripeSubId: subId,
+      quantityPaid: 1,
+      status: "active",
+    });
+    fixture.seedSubscription({ id: subId, customer: "cus_seed", quantity: 1, scheme: "tiered" });
+    const joiner = await makeCommunityOrg(payer);
+
+    // The non-trial path is unchanged: the second seat is a real charge and
+    // quantity_paid rises to match.
+    const attach = await attachOrgToGroup({ actorUserId: payer, orgId: joiner, subscriptionId: groupId });
+    expect(attach.charged).toBe(true);
+    expect(attach.quantity).toBe(2);
+    expect(await quantityPaid(groupId)).toBe(2);
+
+    const up = fixture.calls.find(
+      (c) => c.method === "POST" && c.path === `/v1/subscriptions/${subId}`,
+    );
+    expect(up!.body["proration_behavior"]).toBe("create_prorations");
+  });
+});

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -114,6 +114,11 @@ export async function previewAttachCharge(
 ): Promise<{ amount_minor: number; currency: string } | null> {
   const group = await groupRow(subscriptionId);
   if (!group || !group.stripe_subscription_id || !hasLiveSubscription(group)) return null;
+  // A trial defers every charge to its end invoice, so attaching DURING a trial
+  // costs nothing now — the seat rides the trial and is first billed when it
+  // converts. Preview free rather than asking Stripe to price a proration the
+  // trial will defer (and which would otherwise read back as a phantom charge).
+  if (group.status === "trialing") return null;
   const active = await activeOrgCount(subscriptionId);
   const raised = active + 1;
   // A re-add into a paid-and-freed slot raises no proration.
@@ -268,6 +273,14 @@ export async function syncGroupQuantity(
     // after the update made the renewal path record the quantity it had just
     // SET rather than the one the invoice was cut from.
     const heldBefore = item.quantity ?? 0;
+    // A trial bills NOTHING until it converts: every quantity change rides the
+    // trial and is first invoiced at trial end (the renewal path below is the
+    // authoritative setter then). So while trialing we still sync the Stripe
+    // ITEM to the active count — the trial-end invoice must bill the right
+    // number — but never prorate, never report a charge, and (further down)
+    // never move quantity_paid, which would fabricate a paid seat nothing paid
+    // for and light up a phantom "freed slot" mid-trial.
+    const trialing = group.status === "trialing";
     let charged = false;
     let synced = false;
 
@@ -287,7 +300,7 @@ export async function syncGroupQuantity(
       // create_prorations and hand out a credit, which is the refund path this
       // design exists to have none of; without the second, re-adding into a slot
       // already paid for would charge twice for it.
-      const raising = active > heldBefore && active > group.quantity_paid;
+      const raising = active > heldBefore && active > group.quantity_paid && !trialing;
       await getStripe().subscriptions.update(group.stripe_subscription_id, {
         items: [{ id: item.id, quantity: active }],
         proration_behavior: raising ? "create_prorations" : "none",
@@ -318,9 +331,15 @@ export async function syncGroupQuantity(
     // the seat has been converted into the departing org's comp, not refunded.
     const paid = opts.renewal
       ? Math.max(opts.invoicedQuantity ?? heldBefore, raised)
-      : opts.spendFreedSeat
-        ? Math.max(active, group.quantity_paid - 1)
-        : Math.max(group.quantity_paid, heldBefore, raised);
+      : trialing
+        ? // Nothing has been billed yet: quantity_paid stays at its pre-trial
+          // baseline until the trial-end invoice (the renewal branch above) sets
+          // it. Freezing it here is what keeps a mid-trial attach from minting a
+          // phantom paid seat, and it self-heals when the trial converts.
+          group.quantity_paid
+        : opts.spendFreedSeat
+          ? Math.max(active, group.quantity_paid - 1)
+          : Math.max(group.quantity_paid, heldBefore, raised);
     if (paid !== group.quantity_paid) {
       await tx`
         update subscriptions set quantity_paid = ${paid}, updated_at = now()


### PR DESCRIPTION
You asked to reproduce this and fix it clearly — done. During a Pro **trial**, attaching an org into the billing group was recording a phantom "paid seat", so the panel showed **"1 paid seat free · move-in costs nothing"** when the payer had paid nothing.

## Reproduced
`quantity_paid` across a trial lifecycle was `{start:1, afterAttachB:2, afterDetachB:2, afterTrialEndSync:1}` — it inflated on attach (no real charge — a trial defers billing) and stayed inflated after detach. It self-healed at the trial-end invoice, so no money leak, but the mid-trial display was wrong.

## Fix (money-path, narrowly scoped)
`syncGroupQuantity` guarded `quantity_paid` against moving only for non-live subs — but `trialing` is a "live" status, so it slipped through. Added a `trialing` arm (ordered `renewal → trialing → spendFreedSeat → default`): while trialing, **`quantity_paid` is frozen** (nothing is billed during a trial). The Stripe **item quantity still syncs** to the active count (so the trial-end invoice bills the right number), the trial add previews **free** (`charged:false`, no phantom proration), and the existing **renewal** path still sets `quantity_paid` from the trial-end invoice at conversion. **Active/non-trial accounting is byte-identical.**

Now: `{1, 1, 1, 1}` through the trial.

## Show it clearly
The group panel (`billing-group-panel.tsx`) now shows **"adding organisations is free during your trial"** while trialing, instead of the "paid seats free" line. New `billing.group.trialFree` key in all 4 locales.

## Tests
New `billing-group-trial-seat.test.ts` (real-SDK fixture) — 4 cases: freeze through attach+detach (item→2, proration `none`), preview-free, renewal sets active count, **active group still inflates** (no regression). +66 existing billing-group tests green. Typecheck + i18n:check clean. Review: **PASS / APPROVE**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)