### PR TITLE
fix(billing): W1 money-leaks — wallet stranding on attach + refund cap leak (#285, #286)

### DIFF
--- a/apps/web/content/help/billing/credits.md
+++ b/apps/web/content/help/billing/credits.md
@@ -28,6 +28,8 @@ To buy one, use **Buy credits** on the Credits tab. Pick a pack from the ladder 
 
 Billing is group-level: one subscription can pay for several organisations. When it does, those organisations **share one credit wallet** — buy once, and any organisation in the group can spend from the pool. The monthly grant scales with the number of paid seats. The Credits tab shows a "shared across N organisations" note when your organisation is part of a group, and the run history records which organisation spent each credit.
 
+Any credits your organisation already holds **move with it**: joining a group merges your unspent balance straight into the shared pool — monthly-grant credits stay monthly-grant credits, purchased and earned credits stay in their own never-expiring pool, exactly as before. Leaving a group works the other way: you take **no share** of the pool with you. Your new bill starts a fresh, empty wallet, and the credits you were sharing stay with the group.
+
 ## Run history and export
 
 The run history lists each grant, purchase and AI run, newest first, with the credit change for each. Use **Export** to download the full history as a CSV.

--- a/apps/web/content/help/billing/credits.md
+++ b/apps/web/content/help/billing/credits.md
@@ -28,7 +28,9 @@ To buy one, use **Buy credits** on the Credits tab. Pick a pack from the ladder 
 
 Billing is group-level: one subscription can pay for several organisations. When it does, those organisations **share one credit wallet** — buy once, and any organisation in the group can spend from the pool. The monthly grant scales with the number of paid seats. The Credits tab shows a "shared across N organisations" note when your organisation is part of a group, and the run history records which organisation spent each credit.
 
-Any credits your organisation already holds **move with it**: joining a group merges your unspent balance straight into the shared pool — monthly-grant credits stay monthly-grant credits, purchased and earned credits stay in their own never-expiring pool, exactly as before. Leaving a group works the other way: you take **no share** of the pool with you. Your new bill starts a fresh, empty wallet, and the credits you were sharing stay with the group.
+What happens to the credits you already hold depends on whether they are yours alone. If your organisation is **billed on its own**, they **move with you**: joining a group merges your unspent balance straight into the shared pool — monthly-grant credits stay monthly-grant credits, purchased and earned credits stay in their own never-expiring pool, exactly as before. If you are **already sharing a wallet** with other organisations, that balance **stays with them** — it is the whole group's pool, not your share of it — and you join the new group with a fresh wallet.
+
+Leaving a group works the same way: you take **no share** of the pool with you. Your organisation goes back to its own bill and starts with a fresh, empty wallet, and the credits you were sharing stay with the group.
 
 ## Run history and export
 

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -686,6 +686,7 @@
   "billing.credits.action.earn": "Earned credits",
   "billing.credits.action.refund": "Refund",
   "billing.credits.action.expiry": "Grant reset",
+  "billing.credits.action.groupMerge": "Moved onto this bill",
   "billing.credits.action.adminGoodwill": "Seazn goodwill",
   "billing.credits.action.adminCredit": "Account credit",
   "billing.credits.action.adminRefund": "Refund adjustment",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -686,6 +686,7 @@
   "billing.credits.action.earn": "Créditos ganados",
   "billing.credits.action.refund": "Reembolso",
   "billing.credits.action.expiry": "Reinicio de asignación",
+  "billing.credits.action.groupMerge": "Movidos a esta factura",
   "billing.credits.action.adminGoodwill": "Cortesía de Seazn",
   "billing.credits.action.adminCredit": "Crédito de cuenta",
   "billing.credits.action.adminRefund": "Ajuste de reembolso",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -686,6 +686,7 @@
   "billing.credits.action.earn": "Crédits gagnés",
   "billing.credits.action.refund": "Remboursement",
   "billing.credits.action.expiry": "Réinitialisation de la dotation",
+  "billing.credits.action.groupMerge": "Déplacés sur cette facture",
   "billing.credits.action.adminGoodwill": "Geste commercial Seazn",
   "billing.credits.action.adminCredit": "Crédit de compte",
   "billing.credits.action.adminRefund": "Ajustement de remboursement",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -686,6 +686,7 @@
   "billing.credits.action.earn": "Verdiende credits",
   "billing.credits.action.refund": "Terugbetaling",
   "billing.credits.action.expiry": "Toewijzing gereset",
+  "billing.credits.action.groupMerge": "Naar deze factuur verplaatst",
   "billing.credits.action.adminGoodwill": "Seazn-tegemoetkoming",
   "billing.credits.action.adminCredit": "Accountkrediet",
   "billing.credits.action.adminRefund": "Terugbetalingscorrectie",

--- a/apps/web/src/lib/__tests__/credits-wallet-merge.test.ts
+++ b/apps/web/src/lib/__tests__/credits-wallet-merge.test.ts
@@ -1,0 +1,99 @@
+// AI credit wallet — merging a departing wallet into the group it joins
+// (v17 gap #285, docs/superpowers/specs/2026-07-26-v17-gap-remediation-design.md
+// §W1). attachOrgToGroup (server/usecases/billing-groups.ts) rewrites
+// organizations.subscription_id with NO wallet merge: the org's own AI
+// credit balance sat on ai_credit_ledger keyed to its OLD subscription id,
+// and once that row is gone (dropEmptyGroup) nothing can ever resolve to it
+// again — walletIdFor only ever returns coalesce(subscription_id, id), and
+// the org's subscription_id now points at the group. mergeWalletOnAttach is
+// the fix: two compensating ledger rows per non-zero bucket, written inside
+// the SAME transaction that moves the org (Task 2), so the balance and the
+// move commit or roll back together.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+import { describe, expect, it } from "vitest";
+import fc from "fast-check";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { balance, grantBalance, mergeWalletOnAttach, packBalance } from "@/lib/credits";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+/** Seed a wallet with a grant-bucket and/or pack-bucket balance via raw
+ *  ledger rows, cumulative balance_after — mirrors credits-earn.test.ts's
+ *  seedEarned (apps/web/src/lib/__tests__/credits-earn.test.ts:41). */
+async function seedWallet(walletId: string, opts: { grant?: number; pack?: number }): Promise<void> {
+  let running = 0;
+  if (opts.grant) {
+    running += opts.grant;
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${walletId}, ${opts.grant}, 'monthly_grant', 'grant', ${running}, ${`seed-${randomUUID()}`})`;
+  }
+  if (opts.pack) {
+    running += opts.pack;
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${walletId}, ${opts.pack}, 'pack_purchase', 'pack', ${running}, ${`seed-${randomUUID()}`})`;
+  }
+}
+
+describe.skipIf(!HAS_DB)("mergeWalletOnAttach (#285)", () => {
+  it("moves BOTH buckets from the old wallet to the new one, bucket-preserving", async () => {
+    const oldWallet = randomUUID();
+    const newWallet = randomUUID();
+    await seedWallet(oldWallet, { grant: 15, pack: 30 });
+    await seedWallet(newWallet, { grant: 5 });
+
+    const moved = await sql.begin((tx) => mergeWalletOnAttach(tx, oldWallet, newWallet));
+
+    expect(moved).toEqual({ grant: 15, pack: 30 });
+    // The old wallet is fully drained — nothing left stranded.
+    expect(await balance(oldWallet)).toBe(0);
+    // Landed in the SAME bucket it came from — never pooled into one row.
+    expect(await grantBalance(newWallet)).toBe(20); // 5 (already there) + 15 (merged)
+    expect(await packBalance(newWallet)).toBe(30); // the new wallet had no pack credits yet
+  });
+
+  it("is a no-op when the old wallet is empty", async () => {
+    const oldWallet = randomUUID();
+    const newWallet = randomUUID();
+    await seedWallet(newWallet, { grant: 10 });
+
+    const moved = await sql.begin((tx) => mergeWalletOnAttach(tx, oldWallet, newWallet));
+
+    expect(moved).toEqual({ grant: 0, pack: 0 });
+    expect(await balance(newWallet)).toBe(10); // untouched
+    const rows = await sql`select 1 from ai_credit_ledger where wallet_id = ${oldWallet}`;
+    expect(rows).toHaveLength(0); // no rows written for an empty wallet
+  });
+
+  it("compensating rows net to ZERO per bucket, for any starting balances (property)", async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.record({ grant: fc.integer({ min: 0, max: 500 }), pack: fc.integer({ min: 0, max: 500 }) }),
+        fc.record({ grant: fc.integer({ min: 0, max: 500 }), pack: fc.integer({ min: 0, max: 500 }) }),
+        async (oldBal, newBal) => {
+          const oldWallet = randomUUID();
+          const newWallet = randomUUID();
+          await seedWallet(oldWallet, oldBal);
+          await seedWallet(newWallet, newBal);
+
+          await sql.begin((tx) => mergeWalletOnAttach(tx, oldWallet, newWallet));
+
+          expect(await balance(oldWallet)).toBe(0);
+          expect(await grantBalance(newWallet)).toBe(oldBal.grant + newBal.grant);
+          expect(await packBalance(newWallet)).toBe(oldBal.pack + newBal.pack);
+
+          // The actual property: every group_merge row this call wrote nets
+          // to zero PER BUCKET across the (old, new) pair — money moved,
+          // none created or destroyed.
+          const rows = await sql<{ bucket: string; net: string }[]>`
+            select bucket, sum(delta)::text as net from ai_credit_ledger
+             where source = 'group_merge' and wallet_id in (${oldWallet}, ${newWallet})
+             group by bucket`;
+          for (const row of rows) expect(Number(row.net)).toBe(0);
+        },
+      ),
+      { numRuns: 15 },
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/pass-credit-reversal-alert-email.test.ts
+++ b/apps/web/src/lib/__tests__/pass-credit-reversal-alert-email.test.ts
@@ -1,0 +1,97 @@
+// Body copy for the staff alert sent when a refunded Event Pass credit could
+// NOT be safely reversed (`reason: "undetermined"`, pass-credit.ts §5).
+//
+// The alert used to end at "nothing was automatically reversed", which reads
+// like the only outstanding item is a number to check in Stripe. It isn't: the
+// undetermined row goes on holding `pass_credit_redemptions_group_cap` (V337 /
+// #286), so the billing group's ONE lifetime Event Pass credit is blocked for
+// every org in it, and settling the customer's balance in Stripe does not
+// release it — there is no self-serve release this wave. A staff member acting
+// on the old wording would close the ticket with a customer silently unable to
+// ever earn another pass credit.
+//
+// Internal staff alert: NOT localised (unlike the customer-facing builders in
+// email-templates/, this one takes no `locale`/`Dict` and is composed inline in
+// lib/email.ts), so English is the only copy to assert.
+//
+// Asserted through the real send path with `fetch` stubbed, because the body
+// string is built inside the send function and there is no separate template
+// export to call.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendPassCreditReversalIncompleteAlertEmail } from "../email";
+
+interface SentPayload {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+let sent: SentPayload[] = [];
+const OLD_KEY = process.env.RESEND_API_KEY;
+
+beforeEach(() => {
+  sent = [];
+  process.env.RESEND_API_KEY = "re_test_key";
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init: { body: string }) => {
+      sent.push(JSON.parse(init.body) as SentPayload);
+      return { ok: true, status: 200, text: async () => "" } as unknown as Response;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (OLD_KEY === undefined) delete process.env.RESEND_API_KEY;
+  else process.env.RESEND_API_KEY = OLD_KEY;
+});
+
+const base = {
+  to: "ops@seazn.test",
+  orgId: "org-123",
+  orgName: "Riverside Racquets",
+  competitionName: "Spring Open 2026",
+  grantedMinor: 2500,
+  currency: "gbp",
+};
+
+describe("pass credit reversal alert — undetermined", () => {
+  it("says the group's lifetime credit is BLOCKED and cannot be released in Stripe", async () => {
+    await sendPassCreditReversalIncompleteAlertEmail({
+      ...base,
+      reversedMinor: 0,
+      reason: "undetermined",
+    });
+
+    expect(sent).toHaveLength(1);
+    const { text, html } = sent[0]!;
+    // The existing "nothing was reversed" line is not enough on its own — the
+    // consequence has to be spelled out.
+    expect(text).toContain("nothing was automatically reversed");
+    expect(text.toLowerCase()).toContain("blocked");
+    expect(text).toContain("lifetime Event Pass credit");
+    // Settling the balance in Stripe is the obvious-but-wrong next step.
+    expect(text).toContain("does NOT release it");
+    // And there is no button anywhere that clears it today.
+    expect(text).toContain("no self-serve way");
+    // Same copy reaches the HTML part, not just the plain-text fallback.
+    expect(html.toLowerCase()).toContain("blocked");
+    expect(html).not.toMatch(/\{\{[A-Z_]+\}\}/);
+  });
+
+  it("does NOT claim a block on the ordinary consumed-remainder alert", async () => {
+    // "consumed" reversals did claw back what they could and cleared the cap;
+    // telling staff that group is blocked would be a lie.
+    await sendPassCreditReversalIncompleteAlertEmail({
+      ...base,
+      reversedMinor: 1000,
+      reason: "consumed",
+    });
+
+    expect(sent).toHaveLength(1);
+    const { text } = sent[0]!;
+    expect(text.toLowerCase()).not.toContain("blocked");
+    expect(text).toContain("written off");
+  });
+});

--- a/apps/web/src/lib/__tests__/reconcile-stranded-wallets-select-target.test.ts
+++ b/apps/web/src/lib/__tests__/reconcile-stranded-wallets-select-target.test.ts
@@ -1,0 +1,32 @@
+// Pure-function coverage for `chooseReconcileTarget`
+// (scripts/reconcile-stranded-wallets.ts, #285 one-off staging cleanup).
+//
+// The script must never GUESS which org a stranded wallet belongs to — a
+// wallet with no spend attribution at all is reported for manual review,
+// not merged on a hunch. This pins that decision directly, the same way
+// `isBalanceHistoryTruncated` is pinned in pass-credit-backfill-truncation.
+// test.ts without touching Postgres.
+import { describe, expect, it } from "vitest";
+import { chooseReconcileTarget } from "../../../../../scripts/reconcile-stranded-wallets";
+
+describe("chooseReconcileTarget", () => {
+  it("returns null when nothing carries a spend attribution", () => {
+    expect(chooseReconcileTarget([])).toBeNull();
+    expect(chooseReconcileTarget([{ spent_by_org_id: null }, { spent_by_org_id: null }])).toBeNull();
+  });
+
+  it("returns the first (most recent, given created_at desc ordering) attributed org", () => {
+    expect(
+      chooseReconcileTarget([
+        { spent_by_org_id: "org-newest" },
+        { spent_by_org_id: "org-older" },
+      ]),
+    ).toBe("org-newest");
+  });
+
+  it("skips leading nulls to find the first real attribution", () => {
+    expect(
+      chooseReconcileTarget([{ spent_by_org_id: null }, { spent_by_org_id: "org-x" }]),
+    ).toBe("org-x");
+  });
+});

--- a/apps/web/src/lib/__tests__/reconcile-stranded-wallets-select-target.test.ts
+++ b/apps/web/src/lib/__tests__/reconcile-stranded-wallets-select-target.test.ts
@@ -7,7 +7,11 @@
 // `isBalanceHistoryTruncated` is pinned in pass-credit-backfill-truncation.
 // test.ts without touching Postgres.
 import { describe, expect, it } from "vitest";
-import { chooseReconcileTarget } from "../../../../../scripts/reconcile-stranded-wallets";
+import {
+  chooseReconcileTarget,
+  classifyBucketAmounts,
+  writeGateBlocked,
+} from "../../../../../scripts/reconcile-stranded-wallets";
 
 describe("chooseReconcileTarget", () => {
   it("returns null when nothing carries a spend attribution", () => {
@@ -28,5 +32,54 @@ describe("chooseReconcileTarget", () => {
     expect(
       chooseReconcileTarget([{ spent_by_org_id: null }, { spent_by_org_id: "org-x" }]),
     ).toBe("org-x");
+  });
+});
+
+// The stranded-wallet SELECT filters on the wallet's NET balance (`<> 0`), so
+// it deliberately surfaces wallets whose net is NEGATIVE — a real data
+// integrity signal worth reporting. But there is nothing to move out of such a
+// wallet: every insert is capped at `Math.max(0, bucketBalance)`, and the
+// ledger's own `balance_after >= 0` CHECK would reject the attempt anyway.
+// This decides that case BEFORE a transaction is opened and two advisory
+// locks are taken for a merge that would move nothing.
+describe("classifyBucketAmounts", () => {
+  it("merges when either bucket carries a positive balance", () => {
+    expect(classifyBucketAmounts({ grant: 10, pack: 5 })).toBe("merge");
+    expect(classifyBucketAmounts({ grant: 10, pack: 0 })).toBe("merge");
+    expect(classifyBucketAmounts({ grant: 0, pack: 1 })).toBe("merge");
+  });
+
+  it("still merges when one bucket is negative but the other is positive", () => {
+    // Only the positive bucket moves; the negative one is floored to 0.
+    expect(classifyBucketAmounts({ grant: -5, pack: 10 })).toBe("merge");
+  });
+
+  it("refuses when no bucket is positive, even for a non-zero net", () => {
+    expect(classifyBucketAmounts({ grant: 0, pack: 0 })).toBe("no_positive_balance");
+    expect(classifyBucketAmounts({ grant: 0, pack: -5 })).toBe("no_positive_balance");
+    expect(classifyBucketAmounts({ grant: -3, pack: -5 })).toBe("no_positive_balance");
+  });
+});
+
+// STAGING ONLY is a load-bearing claim, not a comment: #284 means production
+// starts at V336 with no pre-existing stranded data, so a --write run against
+// prod could only ever be unreviewed ledger surgery. A dry run is always safe
+// and must never be gated.
+describe("writeGateBlocked", () => {
+  it("never blocks a dry run, whatever the env says", () => {
+    expect(writeGateBlocked(false, undefined)).toBe(false);
+    expect(writeGateBlocked(false, "1")).toBe(false);
+    expect(writeGateBlocked(false, "nonsense")).toBe(false);
+  });
+
+  it("blocks --write unless the operator opted in", () => {
+    expect(writeGateBlocked(true, undefined)).toBe(true);
+    expect(writeGateBlocked(true, "1")).toBe(false);
+  });
+
+  it("requires exactly \"1\" — no truthy-looking near misses", () => {
+    for (const v of ["", "0", "true", "yes", "TRUE", " 1"]) {
+      expect(writeGateBlocked(true, v)).toBe(true);
+    }
   });
 });

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -842,6 +842,45 @@ export async function mergeWalletOnAttach(
 }
 
 /**
+ * Record, for accountability, that `orgId` left a shared wallet holding
+ * `oldWalletId`'s balance behind (#285, "leaver takes no wallet share" —
+ * a decided default, not a bug: a shared group wallet has no notion of a
+ * per-org share to carry out, so `detachOrgFromGroup` mints the departing
+ * org a brand-new, empty wallet at `newWalletId` rather than attempting to
+ * split anything off `oldWalletId`).
+ *
+ * Writes to `staff_audit_log` (V103), not the money ledger: no credits
+ * actually move, so there is nothing for `ai_credit_ledger` — append-only
+ * TRUTH about money, SPEC-2 §5.1 — to record. `staff_audit_log` is the only
+ * generic actor+target+detail audit sink the schema has (`db/migration/
+ * deltas/V103__admin.sql`); `actor_id` carries no `is_staff` constraint at
+ * the database level, and every detach (staff-initiated or self-service) is
+ * exactly the kind of money-adjacent event that table exists to leave a
+ * trail for.
+ *
+ * Called INSIDE detachOrgFromGroup's own transaction, right after the fresh
+ * subscription row is minted, so the snapshot and the move commit together.
+ */
+export async function auditWalletForfeitedOnDetach(
+  tx: Tx,
+  actorUserId: string,
+  orgId: string,
+  oldWalletId: string,
+  newWalletId: string,
+): Promise<void> {
+  const grant = Math.max(0, await bucketBalance(tx, oldWalletId, "grant"));
+  const pack = Math.max(0, await bucketBalance(tx, oldWalletId, "pack"));
+  await tx`
+    insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+    values (${actorUserId}, 'billing_group.detach_wallet_not_carried', 'org', ${orgId},
+            ${tx.json({
+              old_wallet_id: oldWalletId,
+              new_wallet_id: newWalletId,
+              old_wallet_balance_left_behind: { grant, pack },
+            } as never)})`;
+}
+
+/**
  * Net credits `orgId` has spent on `walletId` THIS calendar month (SPEC-5 §1) —
  * the derived quantity the operator allocation cap is checked against. There is
  * deliberately NO `spent_this_period` counter: the ledger is the single source

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -773,6 +773,75 @@ export async function recordPackRefund(
 }
 
 /**
+ * Merge one wallet's balance into another (#285): called INSIDE
+ * attachOrgToGroup's own transaction, immediately after
+ * `organizations.subscription_id` is rewritten, so the credit balance the
+ * departing wallet held moves atomically with the org — otherwise it is
+ * stranded on a subscription id nothing points at any more (and
+ * dropEmptyGroup can delete the row outright).
+ *
+ * Bucket-preserving (SPEC-2 §5.4 / V321): each non-zero bucket gets its OWN
+ * pair of compensating rows — a debit on `oldWalletId`, a credit on
+ * `newWalletId` — so a grant-bucket balance lands back in `grant` and a
+ * pack-bucket balance lands back in `pack`, never pooled into one row.
+ * `recordEarnGrant`'s `LIFETIME_EARN_CAP` sums `source = 'earn_grant'` rows
+ * only (credits.ts:592-596) — a `group_merge` row never carries that source,
+ * so merged earn credits do NOT retroactively count against the new wallet's
+ * earn cap (decided default).
+ *
+ * **Locks both wallets, sorted, to avoid deadlock:** unlike every other write
+ * in this module (one wallet, one lock), this touches two wallets in the
+ * same transaction. Taking the locks in a fixed (lexicographic) order
+ * regardless of which one is "old" or "new" is what stops two concurrent
+ * attaches whose old/new pairs share a wallet from deadlocking each other.
+ *
+ * Transaction-atomic, not idempotency-keyed: this only ever runs once per
+ * successful attach, inside the SAME transaction that rewrites
+ * `organizations.subscription_id` — if anything later in that transaction
+ * fails, the whole thing (org move + merge) rolls back together, and a
+ * caller retrying `attachOrgToGroup` for the same org+group sees it already
+ * moved and skips the merge entirely (attachOrgToGroup's own idempotency
+ * guard, billing-groups.ts:654).
+ *
+ * Returns the credits moved per bucket (0/0 when the old wallet was empty —
+ * the common case for an org that never spun up any AI runs).
+ */
+export async function mergeWalletOnAttach(
+  tx: Tx,
+  oldWalletId: string,
+  newWalletId: string,
+): Promise<{ grant: number; pack: number }> {
+  if (oldWalletId === newWalletId) return { grant: 0, pack: 0 };
+  const [lo, hi] = [oldWalletId, newWalletId].sort();
+  await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + lo}))`;
+  await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + hi}))`;
+
+  const moved = { grant: 0, pack: 0 };
+  for (const bucket of ["grant", "pack"] as const) {
+    const amount = Math.max(0, await bucketBalance(tx, oldWalletId, bucket));
+    if (amount <= 0) continue;
+    await appendLedgerRow(tx, {
+      walletId: oldWalletId,
+      delta: -amount,
+      source: "group_merge",
+      bucket,
+      ref: newWalletId,
+      idempotencyKey: null,
+    });
+    await appendLedgerRow(tx, {
+      walletId: newWalletId,
+      delta: amount,
+      source: "group_merge",
+      bucket,
+      ref: oldWalletId,
+      idempotencyKey: null,
+    });
+    moved[bucket] = amount;
+  }
+  return moved;
+}
+
+/**
  * Net credits `orgId` has spent on `walletId` THIS calendar month (SPEC-5 §1) —
  * the derived quantity the operator allocation cap is checked against. There is
  * deliberately NO `spent_this_period` counter: the ledger is the single source

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -860,6 +860,13 @@ export async function mergeWalletOnAttach(
  *
  * Called INSIDE detachOrgFromGroup's own transaction, right after the fresh
  * subscription row is minted, so the snapshot and the move commit together.
+ *
+ * **Also used by the ATTACH path**, which reaches the same forfeit whenever the
+ * old group still holds live sibling orgs (attachOrgToGroup, billing-groups.ts)
+ * — that wallet is a shared pool too, so the joiner takes no share of it and
+ * only a SOLE org's wallet is merged. Both paths write the same action name, so
+ * `via` records which one produced the row; without it the two are
+ * indistinguishable in `staff_audit_log`.
  */
 export async function auditWalletForfeitedOnDetach(
   tx: Tx,
@@ -867,6 +874,7 @@ export async function auditWalletForfeitedOnDetach(
   orgId: string,
   oldWalletId: string,
   newWalletId: string,
+  via: "attach" | "detach",
 ): Promise<void> {
   const grant = Math.max(0, await bucketBalance(tx, oldWalletId, "grant"));
   const pack = Math.max(0, await bucketBalance(tx, oldWalletId, "pack"));
@@ -876,6 +884,7 @@ export async function auditWalletForfeitedOnDetach(
             ${tx.json({
               old_wallet_id: oldWalletId,
               new_wallet_id: newWalletId,
+              via,
               old_wallet_balance_left_behind: { grant, pack },
             } as never)})`;
 }

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -761,7 +761,11 @@ export async function sendPassCreditReversalIncompleteAlertEmail(
       `detected on the customer since the ${opts.grantedMinor} ${opts.currency} credit was granted. ` +
       `Stripe's customer balance is a single pool with no per-transaction attribution, so which part ` +
       `of the current balance belongs to this pass cannot be determined safely — nothing was ` +
-      `automatically reversed. Review the customer's balance transaction history in Stripe directly.`
+      `automatically reversed. Review the customer's balance transaction history in Stripe directly. ` +
+      `Note that the billing group's one lifetime Event Pass credit is now BLOCKED by this ` +
+      `unresolved record: it still holds the lifetime cap, so no org in this group can earn ` +
+      `another pass credit. Settling the customer's balance in Stripe does NOT release it, and there is no ` +
+      `self-serve way to clear it yet — staff resolution tooling is planned.`
     : `An Event Pass credit for "${opts.competitionName}" (org ${opts.orgName}, ${opts.orgId}) was ` +
       `refunded. ${opts.grantedMinor} ${opts.currency} was originally granted; only ` +
       `${opts.reversedMinor} ${opts.currency} of unspent credit could be reversed. The remaining ` +
@@ -782,7 +786,8 @@ export async function sendPassCreditReversalIncompleteAlertEmail(
           `granted: ${opts.grantedMinor} ${opts.currency}\n` +
           `reversed: ${opts.reversedMinor} ${opts.currency}\n` +
           (undetermined
-            ? `reason: other balance activity detected — needs manual review`
+            ? `reason: other balance activity detected — needs manual review\n` +
+              `group lifetime pass credit: BLOCKED until this record is resolved`
             : `absorbed: ${absorbed} ${opts.currency}`),
       ),
     footerNote: "Automated staff alert — pass credit refund webhook (design 2026-07-26 §5).",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -131,6 +131,7 @@ export type DictionaryKey =
   | "billing.credits.action.adminRefund"
   | "billing.credits.action.earn"
   | "billing.credits.action.expiry"
+  | "billing.credits.action.groupMerge"
   | "billing.credits.action.monthlyGrant"
   | "billing.credits.action.pack"
   | "billing.credits.action.pass"

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -545,14 +545,22 @@ describe.skipIf(!HAS_DB)("attach", () => {
       select coalesce(sum(delta),0)::text as bal from ai_credit_ledger where wallet_id = ${target}`;
     expect(Number(newBal.bal)).toBe(0);
 
-    // Forfeiting is audited, exactly as a detach's is.
+    // Forfeiting is audited, exactly as a detach's is — but the row says which
+    // path forfeited, so staff reading the trail can tell an attach-side
+    // forfeit from a detach-side one (both share the action name).
     const [audit] = await sql<
-      { detail: { old_wallet_balance_left_behind?: { grant: number; pack: number } } }[]
+      {
+        detail: {
+          old_wallet_balance_left_behind?: { grant: number; pack: number };
+          via?: string;
+        };
+      }[]
     >`
       select detail from staff_audit_log
        where target_id = ${moving} and action = 'billing_group.detach_wallet_not_carried'
        order by created_at desc limit 1`;
     expect(audit?.detail?.old_wallet_balance_left_behind).toEqual({ grant: 40, pack: 0 });
+    expect(audit?.detail?.via).toBe("attach");
   });
 
   it("lets an org join a TRIALING group and ride the trial, charging nothing today", async () => {
@@ -1035,12 +1043,20 @@ describe.skipIf(!HAS_DB)("detach leaves an audit trail for the wallet it does no
     expect(Number(newBal.bal)).toBe(0);
 
     const [audit] = await sql<
-      { detail: { old_wallet_balance_left_behind?: { grant: number; pack: number } } }[]
+      {
+        detail: {
+          old_wallet_balance_left_behind?: { grant: number; pack: number };
+          via?: string;
+        };
+      }[]
     >`
       select detail from staff_audit_log
        where target_id = ${orgId} and action = 'billing_group.detach_wallet_not_carried'
        order by created_at desc limit 1`;
     expect(audit?.detail?.old_wallet_balance_left_behind).toEqual({ grant: 40, pack: 0 });
+    // The same action name is written by the attach-side forfeit, so the row
+    // has to say which path it came from.
+    expect(audit?.detail?.via).toBe("detach");
   });
 });
 

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -963,6 +963,39 @@ describe.skipIf(!HAS_DB)("detach", () => {
   });
 });
 
+describe.skipIf(!HAS_DB)("detach leaves an audit trail for the wallet it does not carry (#285)", () => {
+  it("records the forfeited balance in staff_audit_log without moving any credits", async () => {
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const group = await makeGroup(payer, { stripeSubId: "sub_wallet_det_" + uniq() });
+    await makeOrg(group, payer);
+    const orgId = await makeOrg(group, clubOwner);
+    // The group's shared wallet holds some AI credits.
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 40, 'monthly_grant', 'grant', 40, ${"seed-" + uniq()})`;
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId });
+
+    // The wallet balance is untouched — the group keeps every credit
+    // ("leaver takes no wallet share on detach", decided default).
+    const [bal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger where wallet_id = ${group}`;
+    expect(Number(bal.bal)).toBe(40);
+    // The departing org starts a fresh, empty wallet — no share carried.
+    const [newBal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger where wallet_id = ${res.subscription_id}`;
+    expect(Number(newBal.bal)).toBe(0);
+
+    const [audit] = await sql<
+      { detail: { old_wallet_balance_left_behind?: { grant: number; pack: number } } }[]
+    >`
+      select detail from staff_audit_log
+       where target_id = ${orgId} and action = 'billing_group.detach_wallet_not_carried'
+       order by created_at desc limit 1`;
+    expect(audit?.detail?.old_wallet_balance_left_behind).toEqual({ grant: 40, pack: 0 });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Cache fan-out across a move
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -507,6 +507,54 @@ describe.skipIf(!HAS_DB)("attach", () => {
     expect(Number(packBal.bal)).toBe(30); // joiner's pack, nothing pooled from grant
   });
 
+  it("takes NO share of a shared old wallet when other orgs stay behind (#285)", async () => {
+    // The reachable shape: a payer's Pro group is cancelled (its Stripe id
+    // stays on the row forever, so it is not "live" and the attach guard lets
+    // its orgs move) but STILL holds two orgs, and its pooled wallet still
+    // holds a balance the remaining org spends from (pack credits never expire
+    // at all). Moving one org out must not hand that org the whole pool — the
+    // same "leaver takes no wallet share" rule detach enforces.
+    const payer = await makeUser("payer");
+    const shared = await makeGroup(payer, {
+      status: "canceled",
+      stripeSubId: "sub_shared_old_" + uniq(),
+    });
+    const staysBehind = await makeOrg(shared, payer);
+    const moving = await makeOrg(shared, payer);
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${shared}, 40, 'monthly_grant', 'grant', 40, ${"seed-" + uniq()})`;
+
+    const target = await makeGroup(payer, {
+      stripeSubId: "sub_shared_new_" + uniq(),
+      quantityPaid: 1,
+    });
+    await makeOrg(target, payer);
+
+    await attachOrgToGroup({ actorUserId: payer, orgId: moving, subscriptionId: target });
+
+    // The move really happened (otherwise the balances below are vacuous).
+    expect(await orgGroup(moving)).toBe(target);
+    expect(await orgGroup(staysBehind)).toBe(shared);
+
+    // The old group keeps every credit its remaining org still relies on.
+    const [oldBal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger where wallet_id = ${shared}`;
+    expect(Number(oldBal.bal)).toBe(40);
+    // And the new group gained nothing it did not pay for.
+    const [newBal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger where wallet_id = ${target}`;
+    expect(Number(newBal.bal)).toBe(0);
+
+    // Forfeiting is audited, exactly as a detach's is.
+    const [audit] = await sql<
+      { detail: { old_wallet_balance_left_behind?: { grant: number; pack: number } } }[]
+    >`
+      select detail from staff_audit_log
+       where target_id = ${moving} and action = 'billing_group.detach_wallet_not_carried'
+       order by created_at desc limit 1`;
+    expect(audit?.detail?.old_wallet_balance_left_behind).toEqual({ grant: 40, pack: 0 });
+  });
+
   it("lets an org join a TRIALING group and ride the trial, charging nothing today", async () => {
     const payer = await makeUser("payer");
     const group = await makeGroup(payer, {

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -473,6 +473,40 @@ describe.skipIf(!HAS_DB)("attach", () => {
     expect(stripeMock.subscriptionsUpdate).not.toHaveBeenCalled();
   });
 
+  it("merges the joining org's own wallet balance into the group's, bucket-preserving (#285)", async () => {
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer, { stripeSubId: "sub_wallet_" + uniq(), quantityPaid: 1 });
+    await makeOrg(group, payer);
+    // The group's own wallet already holds some credits.
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 20, 'monthly_grant', 'grant', 20, ${"seed-" + uniq()})`;
+
+    const joiner = await makeLooseOrg(payer);
+    // The joining org's OWN solo wallet (its subscription-of-one) holds
+    // credits of its own, in BOTH buckets.
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${joiner.subId}, 15, 'monthly_grant', 'grant', 15, ${"seed-" + uniq()})`;
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${joiner.subId}, 30, 'pack_purchase', 'pack', 45, ${"seed-" + uniq()})`;
+
+    await attachOrgToGroup({ actorUserId: payer, orgId: joiner.orgId, subscriptionId: group });
+
+    // The old wallet (the joiner's solo subscription) is fully drained.
+    const [oldBal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger where wallet_id = ${joiner.subId}`;
+    expect(Number(oldBal.bal)).toBe(0);
+
+    // The group's wallet now holds BOTH balances, each in its own bucket.
+    const [grantBal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger
+       where wallet_id = ${group} and bucket = 'grant'`;
+    const [packBal] = await sql<{ bal: string }[]>`
+      select coalesce(sum(delta),0)::text as bal from ai_credit_ledger
+       where wallet_id = ${group} and bucket = 'pack'`;
+    expect(Number(grantBal.bal)).toBe(35); // 20 (group's own) + 15 (joiner's)
+    expect(Number(packBal.bal)).toBe(30); // joiner's pack, nothing pooled from grant
+  });
+
   it("lets an org join a TRIALING group and ride the trial, charging nothing today", async () => {
     const payer = await makeUser("payer");
     const group = await makeGroup(payer, {

--- a/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
+++ b/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "node:crypto";
 import { sql } from "@/lib/db";
 import {
   grantMonthly,
+  mergeWalletOnAttach,
   recordEarnGrant,
   recordPackPurchase,
   reserve,
@@ -15,7 +16,7 @@ import {
   walletIdFor,
 } from "@/lib/credits";
 import { seedOrg } from "./_seed";
-import { getCreditsTab } from "../credits-tab";
+import { creditHistory, getCreditsTab } from "../credits-tab";
 
 const HAS_DB = !!process.env.DATABASE_URL;
 
@@ -62,6 +63,26 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     expect(view.balance).toBe(0);
     expect(view.sharedOrgCount).toBe(1);
     expect(view.history).toHaveLength(0);
+  });
+
+  // v17 gap #285: credits that arrive because the org joined a billing group
+  // (mergeWalletOnAttach's `group_merge` rows) must be labelled as their own
+  // thing. The actionKey mapping's `default:` arm returned "adminAdjust", so
+  // the customer — and support reading the same tab — saw a wallet merge as a
+  // staff "Account adjustment", which is a lie about where the money came from.
+  it("labels a wallet merged on billing-group attach as groupMerge, not a staff adjustment", async () => {
+    const { auth } = await seedOrg("community");
+    const walletId = await walletIdFor(auth.orgId);
+    const departing = randomUUID();
+    await recordPackPurchase(departing, 25, `pack-${randomUUID()}`);
+
+    await sql.begin((tx) => mergeWalletOnAttach(tx, departing, walletId));
+
+    const history = await creditHistory(walletId);
+    expect(history).toHaveLength(1);
+    expect(history[0]!.delta).toBe(25);
+    expect(history[0]!.action).toBe("groupMerge");
+    expect(history[0]!.action).not.toBe("adminAdjust");
   });
 
   // #267 (SPEC-5 §2): the Invite & earn card's view fields — a minted,

--- a/apps/web/src/server/usecases/__tests__/pass-credit-backfill-precheck.test.ts
+++ b/apps/web/src/server/usecases/__tests__/pass-credit-backfill-precheck.test.ts
@@ -1,0 +1,145 @@
+// The backfill's "already capped, skip this group" pre-check
+// (scripts/backfill-pass-credit-redemptions.ts) is a hand-written mirror of the
+// `pass_credit_redemptions_group_cap` partial unique index. V337 (#286) widened
+// that index to `reversed_at is null or reversal_undetermined_at is not null`
+// so an UNDETERMINED reversal keeps holding the group's one lifetime credit;
+// the script's copy was left on the narrow pre-V337 predicate.
+//
+// That divergence is not cosmetic. A group whose only redemption is
+// undetermined reads FREE to the script, so it reconstructs a redemption for a
+// group that already has one (the earlier credit was never actually clawed
+// back — that is what "undetermined" means). And because the insert is
+// `on conflict (payment_intent) do nothing` — which only absorbs the SAME
+// intent — a DIFFERENT intent for the same subscription raises 23505 against
+// the widened index, inside a loop body with no try/catch: one such group
+// aborts the entire backfill run.
+//
+// Pinned against real Postgres rather than by re-reading the SQL string,
+// because the assertion that matters is "this predicate and that index agree",
+// and only the database can answer that. Skipped without DATABASE_URL, same as
+// the sibling pass-credit suites.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import { sql } from "@/lib/db";
+import { groupAlreadyCapped } from "../../../../../../scripts/backfill-pass-credit-redemptions";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 12);
+const orgIds: string[] = [];
+
+async function seedOrgAndSubscription(): Promise<{ orgId: string; subscriptionId: string }> {
+  const suffix = uniq();
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${"Backfill Org " + suffix}, ${"backfill-org-" + suffix}) returning id`;
+  orgIds.push(orgId);
+  await sql`
+    with _owner as (
+      insert into users (email, display_name, email_verified)
+      values ('backfillowner-' || gen_random_uuid() || '@test.local', 'Backfill Owner', true)
+      returning id
+    ),
+    _seed_sub as (
+      insert into subscriptions (owner_user_id, plan_key, status, stripe_customer_id, currency)
+      select coalesce(o.created_by, (select id from _owner)), 'pro', 'active',
+             ${"cus_" + suffix}, 'gbp'
+      from organizations o where o.id = ${orgId}
+      returning id
+    )
+    update organizations set subscription_id = (select id from _seed_sub) where id = ${orgId}`;
+  const [{ subscription_id: subscriptionId }] = await sql<{ subscription_id: string }[]>`
+    select subscription_id from organizations where id = ${orgId}`;
+  return { orgId, subscriptionId };
+}
+
+async function seedRedemption(opts: {
+  subscriptionId: string;
+  orgId: string;
+  reversed?: boolean;
+  undetermined?: boolean;
+}): Promise<void> {
+  const suffix = uniq();
+  const [{ id: competitionId }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug)
+    values (${opts.orgId}, ${"Backfill Cup " + suffix}, ${"backfill-cup-" + suffix}) returning id`;
+  const now = new Date().toISOString();
+  await sql`
+    insert into pass_credit_redemptions
+      (subscription_id, org_id, competition_id, payment_intent, amount_minor, currency,
+       reversed_at, reversed_minor, reversal_undetermined_at)
+    values (
+      ${opts.subscriptionId}, ${opts.orgId}, ${competitionId}, ${"pi_" + suffix}, 2500, 'gbp',
+      ${opts.reversed ? now : null}, ${opts.reversed ? 0 : null},
+      ${opts.undetermined ? now : null}
+    )`;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  if (orgIds.length) {
+    await sql`delete from competitions where org_id = any(${orgIds})`;
+    const groups = await sql<{ subscription_id: string }[]>`
+      select subscription_id from organizations
+      where id = any(${orgIds}) and subscription_id is not null`;
+    await sql`delete from organizations where id = any(${orgIds})`;
+    if (groups.length)
+      await sql`delete from subscriptions where id = any(${groups.map((g) => g.subscription_id)})`;
+  }
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("backfill pre-check: groupAlreadyCapped", () => {
+  it("reads a group with NO redemption row as free to backfill", async () => {
+    const { subscriptionId } = await seedOrgAndSubscription();
+    expect(await groupAlreadyCapped(sql, subscriptionId)).toBe(false);
+  });
+
+  it("reads a group holding a LIVE redemption as already capped", async () => {
+    const { orgId, subscriptionId } = await seedOrgAndSubscription();
+    await seedRedemption({ subscriptionId, orgId });
+    expect(await groupAlreadyCapped(sql, subscriptionId)).toBe(true);
+  });
+
+  it("reads a group whose only redemption was UNDETERMINED as already capped", async () => {
+    // Money bug: reversed_at is stamped (the webhook-idempotency marker) but
+    // reversal_undetermined_at says nothing was actually clawed back, so the
+    // customer still holds that credit. Pre-fix the narrow `reversed_at is
+    // null` pre-check read this group as FREE.
+    const { orgId, subscriptionId } = await seedOrgAndSubscription();
+    await seedRedemption({ subscriptionId, orgId, reversed: true, undetermined: true });
+    expect(await groupAlreadyCapped(sql, subscriptionId)).toBe(true);
+  });
+
+  it("agrees with the cap index: a group it reads as capped REJECTS a fresh insert", async () => {
+    // The real reason the two must agree. `on conflict (payment_intent) do
+    // nothing` only absorbs the same intent; a DIFFERENT intent for this
+    // subscription hits pass_credit_redemptions_group_cap, and the backfill's
+    // loop body has no try/catch — a disagreement here aborts the whole run.
+    const { orgId, subscriptionId } = await seedOrgAndSubscription();
+    await seedRedemption({ subscriptionId, orgId, reversed: true, undetermined: true });
+    expect(await groupAlreadyCapped(sql, subscriptionId)).toBe(true);
+
+    const [{ id: competitionId }] = await sql<{ id: string }[]>`
+      insert into competitions (org_id, name, slug)
+      values (${orgId}, ${"Second Cup " + uniq()}, ${"second-cup-" + uniq()}) returning id`;
+    await expect(
+      sql`
+        insert into pass_credit_redemptions
+          (subscription_id, org_id, competition_id, payment_intent, amount_minor, currency)
+        values (${subscriptionId}, ${orgId}, ${competitionId}, ${"pi_" + uniq()}, 2500, 'gbp')
+        on conflict (payment_intent) do nothing`,
+    ).rejects.toMatchObject({ code: "23505" });
+  });
+
+  it("reads a group whose redemption was cleanly reversed as free to backfill", async () => {
+    // A DETERMINED reversal did claw the money back, so the index releases the
+    // group — the pre-check must not over-hold either.
+    const { orgId, subscriptionId } = await seedOrgAndSubscription();
+    await seedRedemption({ subscriptionId, orgId, reversed: true });
+    expect(await groupAlreadyCapped(sql, subscriptionId)).toBe(false);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/pass-credit-refund-reversal.test.ts
+++ b/apps/web/src/server/usecases/__tests__/pass-credit-refund-reversal.test.ts
@@ -55,7 +55,12 @@ vi.mock("@/lib/email", async (importActual) => {
 
 import { sql } from "@/lib/db";
 import { sendPassCreditReversalIncompleteAlertEmail } from "@/lib/email";
-import { PASS_CREDIT_INTENT_KEY, reversePassCreditOnRefund } from "../pass-credit";
+import {
+  PASS_CREDIT_INTENT_KEY,
+  creditPassTowardSubscription,
+  groupAlreadyRedeemed,
+  reversePassCreditOnRefund,
+} from "../pass-credit";
 
 const HAS_DB = !!process.env.DATABASE_URL;
 const uniq = () => randomUUID().slice(0, 12);
@@ -127,10 +132,30 @@ async function seedRedemption(opts: {
   return competitionId;
 }
 
+/** A second Event Pass for `orgId`, distinct competition + intent from
+ *  whatever `seedRedemption` already recorded — used to prove
+ *  `creditPassTowardSubscription` refuses a second mint while the group's
+ *  only redemption is undetermined. */
+async function seedCompetitionPass(orgId: string, intent: string): Promise<void> {
+  const suffix = uniq();
+  const [{ id: competitionId }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug)
+    values (${orgId}, ${"Second Pass " + suffix}, ${"second-pass-" + suffix}) returning id`;
+  await sql`
+    insert into competition_passes (competition_id, org_id, stripe_payment_intent, purchased_at)
+    values (${competitionId}, ${orgId}, ${intent}, now())`;
+}
+
 async function redemptionRow(intent: string) {
   const [row] = await sql<
-    { reversed_at: string | null; reversed_minor: number | null; amount_minor: number }[]
-  >`select reversed_at, reversed_minor, amount_minor from pass_credit_redemptions where payment_intent = ${intent}`;
+    {
+      reversed_at: string | null;
+      reversed_minor: number | null;
+      amount_minor: number;
+      reversal_undetermined_at: string | null;
+    }[]
+  >`select reversed_at, reversed_minor, amount_minor, reversal_undetermined_at
+    from pass_credit_redemptions where payment_intent = ${intent}`;
   return row;
 }
 
@@ -310,6 +335,7 @@ describe.skipIf(!HAS_DB)("reversePassCreditOnRefund", () => {
     const row = await redemptionRow(intent);
     expect(row?.reversed_at).not.toBeNull();
     expect(row?.reversed_minor).toBe(0);
+    expect(row?.reversal_undetermined_at).not.toBeNull();
 
     expect(sendPassCreditReversalIncompleteAlertEmail).toHaveBeenCalledTimes(1);
     const alertArgs = vi.mocked(sendPassCreditReversalIncompleteAlertEmail).mock.calls[0]![0];
@@ -338,6 +364,7 @@ describe.skipIf(!HAS_DB)("reversePassCreditOnRefund", () => {
     const row = await redemptionRow(intent);
     expect(row?.reversed_at).not.toBeNull();
     expect(row?.reversed_minor).toBe(0);
+    expect(row?.reversal_undetermined_at).not.toBeNull();
     expect(sendPassCreditReversalIncompleteAlertEmail).toHaveBeenCalledTimes(1);
     const alertArgs = vi.mocked(sendPassCreditReversalIncompleteAlertEmail).mock.calls[0]![0];
     expect(alertArgs.reason).toBe("undetermined");
@@ -362,5 +389,49 @@ describe.skipIf(!HAS_DB)("reversePassCreditOnRefund", () => {
     expect(sendPassCreditReversalIncompleteAlertEmail).toHaveBeenCalledTimes(1);
     const row = await redemptionRow(intent);
     expect(row?.reversed_minor).toBe(1000);
+  });
+
+  it("keeps the group's lifetime cap HELD after an undetermined reversal — the money bug this closes", async () => {
+    const customerId = "cus_" + uniq();
+    const { orgId, subscriptionId } = await seedOrgAndSubscription(customerId);
+    const intent = "pi_" + uniq();
+    ledger.push(grantEntry(intent));
+    ledger.push({ amount: -500, currency: "gbp" }); // unrelated credit -> unsafe
+    await seedRedemption({ subscriptionId, orgId, intent, amountMinor: 2500 });
+
+    await reversePassCreditOnRefund(intent);
+
+    // Pre-fix, reversed_at alone freed pass_credit_redemptions_group_cap the
+    // moment this ran, even though nothing was actually clawed back.
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(true);
+
+    const row = await redemptionRow(intent);
+    expect(row?.reversed_at).not.toBeNull(); // idempotency stamp still set
+    expect(row?.reversal_undetermined_at).not.toBeNull(); // the actual fix
+  });
+
+  it("refuses a second mint while the group's only redemption is undetermined", async () => {
+    const customerId = "cus_" + uniq();
+    const { orgId, subscriptionId } = await seedOrgAndSubscription(customerId);
+    const intent = "pi_" + uniq();
+    ledger.push(grantEntry(intent));
+    ledger.push({ amount: 1500, currency: "gbp" });
+    ledger.push({ amount: -500, currency: "gbp" }); // unrelated credit -> unsafe
+    await seedRedemption({ subscriptionId, orgId, intent, amountMinor: 2500 });
+    await reversePassCreditOnRefund(intent);
+
+    // A SECOND, different pass for the same group attempts to mint a fresh
+    // credit — exactly the double-£25 shape the bug allowed.
+    const secondIntent = "pi_" + uniq();
+    await seedCompetitionPass(orgId, secondIntent);
+    stripeMock.createBalance.mockClear();
+
+    const second = await creditPassTowardSubscription(orgId);
+
+    expect(second.outcome).toBe("group_already_redeemed");
+    expect(second.amountMinor).toBe(0);
+    // Caught by the CHEAP pre-check (groupAlreadyRedeemed) — never even
+    // reaches a Stripe call.
+    expect(stripeMock.createBalance).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -717,7 +717,10 @@ export async function attachOrgToGroup(args: {
     // of this transaction), so two siblings leaving at the same instant can each
     // still see the other and both forfeit. That errs in the safe direction —
     // credits stay put, nobody is paid twice — and the balance remains on the
-    // old wallet, recoverable, rather than being duplicated into two groups.
+    // old wallet rather than being duplicated into two groups. It is only
+    // recoverable while that wallet's row survives, though: a group left with
+    // no orgs and no Stripe ids is deleted by dropEmptyGroup below, which puts
+    // the balance out of reach.
     const oldWalletId = org.subscription_id ?? orgId;
     const [siblingRow] = org.subscription_id
       ? await tx<{ n: string }[]>`
@@ -726,7 +729,14 @@ export async function attachOrgToGroup(args: {
              and id <> ${orgId} and deleted_at is null`
       : [];
     if (Number(siblingRow?.n ?? 0) > 0)
-      await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, oldWalletId, subscriptionId);
+      await auditWalletForfeitedOnDetach(
+        tx,
+        actorUserId,
+        orgId,
+        oldWalletId,
+        subscriptionId,
+        "attach",
+      );
     else await mergeWalletOnAttach(tx, oldWalletId, subscriptionId);
     return { from: org.subscription_id, moved: true };
   });
@@ -905,7 +915,7 @@ export async function detachOrgFromGroup(args: {
     // #285: no wallet merge on detach (the departing org takes no share of
     // the group's pool — decided default) — just an audit trail of what was
     // left behind, for accountability.
-    await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, group.id, fresh.id);
+    await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, group.id, fresh.id, "detach");
     // `comped` drives the seat spend below: a seat is only consumed when a comp
     // was actually handed out (ride_out on a paying group), never on a release.
     return {

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -19,6 +19,7 @@ import {
   assertPriceBillsQuantity,
   syncPaymentMethodFlagForSubscription,
 } from "@/lib/billing";
+import { mergeWalletOnAttach } from "@/lib/credits";
 import {
   invalidateGroupEntitlements,
   invalidateOrgEntitlements,
@@ -697,6 +698,12 @@ export async function attachOrgToGroup(args: {
     assertWithinGroupCap(Number(heldRow?.n ?? 0), capLimit);
 
     await tx`update organizations set subscription_id = ${subscriptionId} where id = ${orgId}`;
+    // #285: merge whatever AI credits the org's OWN wallet held into the
+    // group's, in the SAME transaction as the move — org.subscription_id
+    // here is still the PRE-move value (read at the top of this function,
+    // before the UPDATE above), i.e. the wallet the org is leaving.
+    const oldWalletId = org.subscription_id ?? orgId;
+    await mergeWalletOnAttach(tx, oldWalletId, subscriptionId);
     return { from: org.subscription_id, moved: true };
   });
 

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -698,12 +698,36 @@ export async function attachOrgToGroup(args: {
     assertWithinGroupCap(Number(heldRow?.n ?? 0), capLimit);
 
     await tx`update organizations set subscription_id = ${subscriptionId} where id = ${orgId}`;
-    // #285: merge whatever AI credits the org's OWN wallet held into the
-    // group's, in the SAME transaction as the move — org.subscription_id
-    // here is still the PRE-move value (read at the top of this function,
-    // before the UPDATE above), i.e. the wallet the org is leaving.
+    // #285: what happens to the wallet the org is leaving — org.subscription_id
+    // here is still the PRE-move value (read at the top of this function, before
+    // the UPDATE above), so it names that wallet.
+    //
+    // THE RULE: merge only when this org is the LAST one on the old wallet.
+    // Merging exists to stop a SOLE org's balance stranding on a subscription
+    // nothing points at any more (dropEmptyGroup can then delete the row
+    // outright). When siblings remain, that wallet is a SHARED pool they are
+    // still spending from, and the leaver takes no share of it — the same
+    // decided default detachOrgFromGroup enforces. Merging there would let one
+    // org walk off with the whole group's grant AND pack balance, which the
+    // dead old group (cancelled, comped or community — the only states the
+    // hasLiveSubscription guard above lets an org move out of) can very much
+    // still be holding, since pack credits never expire.
+    //
+    // The old group is deliberately NOT locked (see the lock comment at the top
+    // of this transaction), so two siblings leaving at the same instant can each
+    // still see the other and both forfeit. That errs in the safe direction —
+    // credits stay put, nobody is paid twice — and the balance remains on the
+    // old wallet, recoverable, rather than being duplicated into two groups.
     const oldWalletId = org.subscription_id ?? orgId;
-    await mergeWalletOnAttach(tx, oldWalletId, subscriptionId);
+    const [siblingRow] = org.subscription_id
+      ? await tx<{ n: string }[]>`
+          select count(*)::text as n from organizations
+           where subscription_id = ${org.subscription_id}
+             and id <> ${orgId} and deleted_at is null`
+      : [];
+    if (Number(siblingRow?.n ?? 0) > 0)
+      await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, oldWalletId, subscriptionId);
+    else await mergeWalletOnAttach(tx, oldWalletId, subscriptionId);
     return { from: org.subscription_id, moved: true };
   });
 

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -19,7 +19,7 @@ import {
   assertPriceBillsQuantity,
   syncPaymentMethodFlagForSubscription,
 } from "@/lib/billing";
-import { mergeWalletOnAttach } from "@/lib/credits";
+import { auditWalletForfeitedOnDetach, mergeWalletOnAttach } from "@/lib/credits";
 import {
   invalidateGroupEntitlements,
   invalidateOrgEntitlements,
@@ -878,6 +878,10 @@ export async function detachOrgFromGroup(args: {
               ${compedUntil}, ${group.trial_used_at}, now())
       returning id`;
     await tx`update organizations set subscription_id = ${fresh.id} where id = ${orgId}`;
+    // #285: no wallet merge on detach (the departing org takes no share of
+    // the group's pool — decided default) — just an audit trail of what was
+    // left behind, for accountability.
+    await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, group.id, fresh.id);
     // `comped` drives the seat spend below: a seat is only consumed when a comp
     // was actually handed out (ride_out on a paying group), never on a release.
     return {

--- a/apps/web/src/server/usecases/credits-tab.ts
+++ b/apps/web/src/server/usecases/credits-tab.ts
@@ -93,6 +93,13 @@ function actionKey(source: string, delta: number, reason: string | null): string
       return "refund";
     case "expiry":
       return "expiry";
+    // #285: credits that moved because the org joined (or left behind) a
+    // billing group — `mergeWalletOnAttach` writes this source on BOTH
+    // wallets, so the label has to read true for a +delta arriving and a
+    // −delta leaving. Without its own case it fell through to `adminAdjust`
+    // and a wallet merge was shown to the org as a staff adjustment.
+    case "group_merge":
+      return "groupMerge";
     case "admin_adjust":
       if (delta < 0) return "adminAdjust";
       switch (reason) {

--- a/apps/web/src/server/usecases/pass-credit.ts
+++ b/apps/web/src/server/usecases/pass-credit.ts
@@ -377,7 +377,9 @@ export async function creditPassTowardSubscription(orgId: string): Promise<PassC
     // (verified live 2026-07-26: same shape for both).
     //
     //   - GROUP_CAP_CONSTRAINT (the partial index on subscription_id where
-    //     reversed_at is null): a DIFFERENT intent won the group's one
+    //     `reversed_at is null or reversal_undetermined_at is not null` — V337
+    //     widened it so an undetermined reversal keeps holding the cap): a
+    //     DIFFERENT intent won the group's one
     //     lifetime credit between `groupAlreadyRedeemed` above and this
     //     INSERT. The balance transaction above is a genuine SECOND credit
     //     for the group and must be compensated.
@@ -636,6 +638,14 @@ export async function reversePassCreditOnRefund(intent: string): Promise<void> {
   // `reversal_undetermined_at` is ALSO stamped, and V337's widened partial
   // index keeps pass_credit_redemptions_group_cap HELD for this row even
   // though reversed_at is set — the bug this migration exists to close.
+  // This wave the hold is PERMANENT: nothing ever clears
+  // `reversal_undetermined_at`, so the group's one lifetime pass credit stays
+  // blocked until staff resolution tooling ships — there is no self-serve
+  // release path, and resolving the balance in Stripe does not touch this row.
+  // The staff alert below says so in as many words
+  // (`sendPassCreditReversalIncompleteAlertEmail`, reason "undetermined"),
+  // because holding the cap forever is only defensible while a human is being
+  // told about every row that does it.
   const [won] = unsafe
     ? await sql<{ payment_intent: string }[]>`
         update pass_credit_redemptions

--- a/apps/web/src/server/usecases/pass-credit.ts
+++ b/apps/web/src/server/usecases/pass-credit.ts
@@ -244,11 +244,14 @@ async function alreadyCredited(
 /**
  * Does this billing GROUP already hold a live (un-reversed) pass credit?
  *
- * `pass_credit_redemptions_group_cap` (V335) is the real backstop — a partial
- * unique index on `subscription_id where reversed_at is null` — so this read
- * is only an optimisation to avoid the Stripe round trip and the wasted
+ * `pass_credit_redemptions_group_cap` (V335, widened by V337) is the real
+ * backstop — a partial unique index on `subscription_id where reversed_at is
+ * null or reversal_undetermined_at is not null` — so this read is only an
+ * optimisation to avoid the Stripe round trip and the wasted
  * `createBalanceTransaction` call on the common case. A race that slips past
- * this SELECT is still caught by the index at INSERT time below.
+ * this SELECT is still caught by the index at INSERT time below. The
+ * predicate here must MATCH that index's (#286): an undetermined reversal
+ * (reversed_at stamped, nothing actually clawed back) still holds the cap.
  *
  * Exported (unlike `alreadyCredited`/`netPaidForIntent`) so the fail-closed
  * behaviour on a genuine DB fault can be pinned directly — the real suite
@@ -259,7 +262,9 @@ export async function groupAlreadyRedeemed(subscriptionId: string): Promise<bool
   try {
     const [row] = await sql<{ one: number }[]>`
       select 1 as one from pass_credit_redemptions
-      where subscription_id = ${subscriptionId} and reversed_at is null limit 1`;
+      where subscription_id = ${subscriptionId}
+        and (reversed_at is null or reversal_undetermined_at is not null)
+      limit 1`;
     return !!row;
   } catch {
     // Same rule as `alreadyCredited`: this function is load-bearing for the
@@ -624,11 +629,24 @@ export async function reversePassCreditOnRefund(intent: string): Promise<void> {
   // NULL to set gets a row back, so only that caller sends the staff alert
   // below. The loser returns having done nothing further, exactly as if it
   // had lost the earlier read-check.
-  const [won] = await sql<{ payment_intent: string }[]>`
-    update pass_credit_redemptions
-    set reversed_at = now(), reversed_minor = ${reverseAmount}
-    where payment_intent = ${intent} and reversed_at is null
-    returning payment_intent`;
+  // #286: `reversed_at` is stamped on every call — it still doubles as the
+  // "this webhook delivery has been handled" idempotency guard the
+  // early-return at the top of this function reads (line 524). But when
+  // `unsafe` is true nothing was actually clawed back, so
+  // `reversal_undetermined_at` is ALSO stamped, and V337's widened partial
+  // index keeps pass_credit_redemptions_group_cap HELD for this row even
+  // though reversed_at is set — the bug this migration exists to close.
+  const [won] = unsafe
+    ? await sql<{ payment_intent: string }[]>`
+        update pass_credit_redemptions
+        set reversed_at = now(), reversed_minor = ${reverseAmount}, reversal_undetermined_at = now()
+        where payment_intent = ${intent} and reversed_at is null
+        returning payment_intent`
+    : await sql<{ payment_intent: string }[]>`
+        update pass_credit_redemptions
+        set reversed_at = now(), reversed_minor = ${reverseAmount}
+        where payment_intent = ${intent} and reversed_at is null
+        returning payment_intent`;
   if (!won) return;
 
   if (unsafe || reverseAmount < redemption.amount_minor) {

--- a/db/migration/deltas/V336__ai_credit_ledger_group_merge_source.sql
+++ b/db/migration/deltas/V336__ai_credit_ledger_group_merge_source.sql
@@ -1,0 +1,32 @@
+-- V336 — allow a `group_merge` source on the AI credit wallet ledger (#285,
+-- docs/superpowers/specs/2026-07-26-v17-gap-remediation-design.md §W1).
+--
+-- attachOrgToGroup (server/usecases/billing-groups.ts) rewrites
+-- `organizations.subscription_id` with NO wallet merge: the org's own AI
+-- credit balance stays on `ai_credit_ledger` keyed to its OLD subscription
+-- id. `walletIdFor` (lib/credits.ts) only ever resolves
+-- `coalesce(subscription_id, id)` for a LIVE organizations row, so once the
+-- org's subscription_id points at the group, nothing can ever address the
+-- old wallet again — and if that old subscription was a bare community-of-
+-- one, `dropEmptyGroup` deletes the row outright the moment the attach
+-- commits (`ai_credit_ledger.wallet_id` carries no foreign key, so the
+-- balance survives as an orphaned row rather than cascading away).
+--
+-- `mergeWalletOnAttach` (lib/credits.ts) is the fix: two compensating rows
+-- per non-zero bucket (grant and pack tracked independently, V321), written
+-- INSIDE attachOrgToGroup's own transaction so the org move and the wallet
+-- merge commit or roll back together. `group_merge` is the new provenance
+-- those rows carry, so they are attributable in the wallet run history/admin
+-- adjustments log alongside monthly_grant, trial_grant, pack_purchase,
+-- earn_grant and pass_grant.
+--
+-- Same drop-if-exists + re-add shape as V326/V330/V331; Flyway runs
+-- -defaultSchema=seazn_club.
+alter table ai_credit_ledger
+  drop constraint if exists ai_credit_ledger_source_check;
+
+alter table ai_credit_ledger
+  add constraint ai_credit_ledger_source_check
+    check (source in ('monthly_grant', 'trial_grant', 'pack_purchase',
+                      'run_spend', 'refund', 'expiry', 'admin_adjust',
+                      'earn_grant', 'pass_grant', 'group_merge'));

--- a/db/migration/deltas/V337__pass_credit_reversal_undetermined.sql
+++ b/db/migration/deltas/V337__pass_credit_reversal_undetermined.sql
@@ -1,0 +1,44 @@
+-- V337 — undetermined pass-credit reversals keep the group cap HELD (#286,
+-- docs/superpowers/specs/2026-07-26-v17-gap-remediation-design.md §W1).
+--
+-- reversePassCreditOnRefund (server/usecases/pass-credit.ts) stamps
+-- `reversed_at` on every call, even along the `otherCreditActivitySince()`
+-- "unsafe" branch where NOTHING is actually clawed back (the customer keeps
+-- the £/$ subscription credit) — which frees V335's partial-index lifetime
+-- cap (`pass_credit_redemptions_group_cap`, `where reversed_at is null`) the
+-- moment that happens, letting the SAME group redeem a second real Event
+-- Pass credit while still holding the first, unreversed one.
+--
+-- `reversal_undetermined_at` is the new, separate marker for that branch.
+-- `reversed_at` keeps being stamped on every call (it still doubles as the
+-- "this webhook delivery has been handled" idempotency guard the function's
+-- own early-return reads), but `reversal_undetermined_at` is ALSO stamped
+-- when `otherCreditActivitySince()` returned unsafe — "I could not prove
+-- what to do, so nothing moved". Staff resolution of an undetermined row is
+-- phase 2 (deferred, design decisions table).
+alter table pass_credit_redemptions
+  add column if not exists reversal_undetermined_at timestamptz;
+
+comment on column pass_credit_redemptions.reversal_undetermined_at is
+  'Set (#286) when otherCreditActivitySince() could not prove the customer '
+  'balance pool was pass-money-only: reversed_at is still stamped (webhook- '
+  'replay idempotency guard) but nothing was actually clawed back. NOT NULL '
+  'here means pass_credit_redemptions_group_cap must keep treating the row '
+  'as live. Staff resolution is phase 2 (deferred).';
+
+-- THE CAP, corrected: V335's predicate (`where reversed_at is null`) is
+-- exactly what let this bug free the cap — an undetermined row now has
+-- reversed_at SET (still the idempotency stamp) but must still hold the
+-- cap, so the predicate widens to also cover it.
+drop index if exists pass_credit_redemptions_group_cap;
+create unique index if not exists pass_credit_redemptions_group_cap
+  on pass_credit_redemptions (subscription_id)
+  where reversed_at is null or reversal_undetermined_at is not null;
+
+comment on table pass_credit_redemptions is
+  'Durable record of an Event Pass credited toward a subscription (design '
+  '2026-07-26 §2). Group-keyed: pass_credit_redemptions_group_cap is a '
+  'partial unique index on subscription_id where reversed_at is null OR '
+  'reversal_undetermined_at is not null (#286, V337) — an undetermined '
+  'reversal still holds the cap even though reversed_at is stamped. '
+  'Survives deletion of the competition_passes row it was earned from.';

--- a/scripts/backfill-pass-credit-redemptions.ts
+++ b/scripts/backfill-pass-credit-redemptions.ts
@@ -25,7 +25,8 @@
 // reconcile by hand.
 //
 // Idempotent / safe to re-run any number of times:
-//   - a group that already holds a live redemption row is skipped outright
+//   - a group that already holds a redemption row the lifetime cap counts
+//     (live, or reversed-but-undetermined) is skipped outright
 //   - every insert is `on conflict (payment_intent) do nothing`
 //
 // DRY RUN by default: prints every row it would insert (and every anomaly it
@@ -69,6 +70,42 @@ export const BALANCE_TXN_FETCH_CAP = 1000;
  */
 export function isBalanceHistoryTruncated(fetchedCount: number, cap: number): boolean {
   return fetchedCount >= cap;
+}
+
+/**
+ * Does this billing group already hold a redemption that the lifetime cap
+ * counts? If so there is nothing to backfill for it — and nothing to even read
+ * from Stripe.
+ *
+ * The predicate MUST mirror `pass_credit_redemptions_group_cap` exactly
+ * (V335, widened by V337 / #286): `reversed_at is null or
+ * reversal_undetermined_at is not null`. An UNDETERMINED reversal (reversed_at
+ * stamped as the webhook-idempotency marker, but nothing actually clawed back)
+ * still holds the index. Reading it as "free" is wrong in both directions at
+ * once:
+ *   - the group looks un-capped, so the script reconstructs a redemption for a
+ *     group that already has one — a money leak, since the earlier credit was
+ *     never recovered; and
+ *   - the insert below is `on conflict (payment_intent) do nothing`, which only
+ *     absorbs the SAME intent. A DIFFERENT intent for the same subscription
+ *     raises 23505 on the group-cap index, and this loop body is NOT wrapped in
+ *     a try/catch — one such group would abort the entire backfill run.
+ *
+ * Same shape as `groupAlreadyRedeemed` in
+ * apps/web/src/server/usecases/pass-credit.ts; kept as a separate copy because
+ * scripts/ cannot import from apps/web/src/lib (server-only). Exported so the
+ * predicate can be pinned against a real database from apps/web's test suite.
+ */
+export async function groupAlreadyCapped(
+  sql: ReturnType<typeof postgres>,
+  subscriptionId: string,
+): Promise<boolean> {
+  const [row] = await sql<{ one: number }[]>`
+    select 1 as one from pass_credit_redemptions
+    where subscription_id = ${subscriptionId}
+      and (reversed_at is null or reversal_undetermined_at is not null)
+    limit 1`;
+  return !!row;
 }
 
 interface Candidate {
@@ -127,10 +164,7 @@ async function main(): Promise<void> {
     for (const sub of subs) {
       // Already capped — nothing to backfill, and nothing to even look at on
       // Stripe for this group.
-      const [existing] = await sql<{ one: number }[]>`
-        select 1 as one from pass_credit_redemptions
-        where subscription_id = ${sub.id} and reversed_at is null limit 1`;
-      if (existing) {
+      if (await groupAlreadyCapped(sql, sub.id)) {
         alreadyCapped++;
         continue;
       }

--- a/scripts/reconcile-stranded-wallets.ts
+++ b/scripts/reconcile-stranded-wallets.ts
@@ -1,0 +1,183 @@
+// One-off reconciliation for AI-credit wallets stranded by the pre-#285
+// attachOrgToGroup bug (db/migration/deltas/V336, docs/superpowers/specs/
+// 2026-07-26-v17-gap-remediation-design.md §W1).
+//
+// Before V336/mergeWalletOnAttach shipped, attaching an org into a billing
+// group rewrote `organizations.subscription_id` with NO wallet merge: any AI
+// credit balance sitting on `ai_credit_ledger` keyed to the org's OLD
+// subscription id was left behind. If that old subscription was a bare
+// community-of-one (no Stripe ids), dropEmptyGroup then deleted the
+// `subscriptions` row outright — `ai_credit_ledger.wallet_id` carries no
+// foreign key (it's a subscription id OR an org id, so it can't reference
+// one table), so the balance survives as a ledger row nothing can ever
+// resolve to again. `walletIdFor` only ever returns
+// coalesce(subscription_id, id) for a LIVE organizations row, so a wallet
+// whose id matches neither any current `organizations.id` nor any current
+// `subscriptions.id` is provably unreachable.
+//
+// STAGING ONLY. #284's decision means production starts at V336 with no
+// pre-existing data, so this script exists purely for whatever staging/dev
+// data already carries the pre-fix stranding — never intended to run
+// against prod.
+//
+// For each stranded wallet, the only local attribution the ledger carries is
+// `run_spend`'s `spent_by_org_id` — which org actually burned credits from
+// it while it was still that org's own solo wallet. A wallet with no spend
+// at all (pure unspent grant, never used) has no such trace: rather than
+// guess, this script reports it for manual staff review and merges nothing.
+//
+// Idempotent / safe to re-run: a wallet already reconciled (drained to 0)
+// simply has nothing left to find on a second pass; every insert is
+// `on conflict (idempotency_key) do nothing`.
+//
+//   node --env-file-if-exists=apps/web/.env.local --experimental-strip-types \
+//     scripts/reconcile-stranded-wallets.ts              # dry run
+//   node --env-file-if-exists=apps/web/.env.local --experimental-strip-types \
+//     scripts/reconcile-stranded-wallets.ts --write        # applies it
+import { fileURLToPath } from "node:url";
+import postgres from "postgres";
+
+/**
+ * Which org (if any) a stranded wallet's balance should be routed to: the
+ * first non-null `spent_by_org_id` in `rows`, which the caller queries
+ * ordered `created_at desc` — the MOST RECENT org known to have spent from
+ * this wallet. Returns null when nothing in `rows` carries one (a pure
+ * unspent grant/pack) — there is no safe guess for who owns it.
+ */
+export function chooseReconcileTarget(rows: { spent_by_org_id: string | null }[]): string | null {
+  for (const row of rows) if (row.spent_by_org_id) return row.spent_by_org_id;
+  return null;
+}
+
+interface BucketBalances {
+  grant: number;
+  pack: number;
+}
+
+async function main(): Promise<void> {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is not set.");
+    process.exit(1);
+  }
+  const WRITE = process.argv.includes("--write");
+  console.log(
+    WRITE
+      ? "WRITE mode: rows WILL be inserted."
+      : "DRY RUN: nothing will be written. Pass --write to apply.",
+  );
+
+  const isLocal = /@(localhost|127\.0\.0\.1)[:/]/.test(url);
+  const sql = postgres(url, {
+    connection: { search_path: process.env.DB_SCHEMA ?? "seazn_club" },
+    ssl: process.env.DATABASE_SSL === "disable" ? false : isLocal ? false : "require",
+    prepare: !url.includes(":6543"),
+    max: 1,
+  });
+
+  try {
+    const stranded = await sql<{ wallet_id: string; grant: string; pack: string }[]>`
+      select l.wallet_id,
+             coalesce(sum(l.delta) filter (where l.bucket = 'grant'), 0)::text as grant,
+             coalesce(sum(l.delta) filter (where l.bucket = 'pack'), 0)::text as pack
+        from ai_credit_ledger l
+       where not exists (select 1 from organizations o where o.id::text = l.wallet_id)
+         and not exists (select 1 from subscriptions s where s.id::text = l.wallet_id)
+       group by l.wallet_id
+      having coalesce(sum(l.delta), 0) <> 0
+       order by l.wallet_id`;
+    console.log(`Found ${stranded.length} stranded wallet(s) with a non-zero balance.\n`);
+
+    let merged = 0;
+    let needsReview = 0;
+
+    for (const w of stranded) {
+      const balances: BucketBalances = { grant: Number(w.grant), pack: Number(w.pack) };
+
+      const spenders = await sql<{ spent_by_org_id: string | null }[]>`
+        select spent_by_org_id from ai_credit_ledger
+         where wallet_id = ${w.wallet_id} and spent_by_org_id is not null
+         order by created_at desc`;
+      const targetOrgId = chooseReconcileTarget(spenders);
+      if (!targetOrgId) {
+        needsReview++;
+        console.warn(
+          `MANUAL REVIEW: wallet=${w.wallet_id} grant=${balances.grant} pack=${balances.pack} ` +
+            `— no spend attribution on this wallet, cannot determine an owning org.`,
+        );
+        continue;
+      }
+
+      const [org] = await sql<{ subscription_id: string | null; deleted_at: Date | null }[]>`
+        select subscription_id, deleted_at from organizations where id = ${targetOrgId}`;
+      if (!org || org.deleted_at) {
+        needsReview++;
+        console.warn(
+          `MANUAL REVIEW: wallet=${w.wallet_id} attributed org=${targetOrgId} no longer exists ` +
+            `(deleted) — cannot determine a live wallet to merge into.`,
+        );
+        continue;
+      }
+      const targetWalletId = org.subscription_id ?? targetOrgId;
+      if (targetWalletId === w.wallet_id) {
+        // Should be impossible (the wallet is provably stranded above), but
+        // never merge a wallet into itself.
+        needsReview++;
+        console.warn(`MANUAL REVIEW: wallet=${w.wallet_id} resolves back to itself — skipping.`);
+        continue;
+      }
+
+      console.log(
+        `${WRITE ? "MERGE" : "WOULD MERGE"}: wallet=${w.wallet_id} grant=${balances.grant} ` +
+          `pack=${balances.pack} -> org=${targetOrgId} wallet=${targetWalletId}`,
+      );
+
+      if (WRITE) {
+        await sql.begin(async (tx) => {
+          const [lo, hi] = [w.wallet_id, targetWalletId].sort();
+          await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + lo}))`;
+          await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + hi}))`;
+          for (const [bucket, amount] of [
+            ["grant", balances.grant],
+            ["pack", balances.pack],
+          ] as const) {
+            if (amount <= 0) continue;
+            const [priorOld] = await tx<{ bal: string | null }[]>`
+              select coalesce(sum(delta), 0)::text as bal from ai_credit_ledger
+               where wallet_id = ${w.wallet_id}`;
+            await tx`
+              insert into ai_credit_ledger
+                (wallet_id, delta, source, bucket, ref, balance_after, idempotency_key)
+              values (${w.wallet_id}, ${-amount}, 'group_merge', ${bucket}, ${targetWalletId},
+                      ${Number(priorOld?.bal ?? 0) - amount},
+                      ${`reconcile-${w.wallet_id}-${bucket}`})
+              on conflict (idempotency_key) do nothing`;
+            const [priorNew] = await tx<{ bal: string | null }[]>`
+              select coalesce(sum(delta), 0)::text as bal from ai_credit_ledger
+               where wallet_id = ${targetWalletId}`;
+            await tx`
+              insert into ai_credit_ledger
+                (wallet_id, delta, source, bucket, ref, balance_after, idempotency_key)
+              values (${targetWalletId}, ${amount}, 'group_merge', ${bucket}, ${w.wallet_id},
+                      ${Number(priorNew?.bal ?? 0) + amount},
+                      ${`reconcile-${targetWalletId}-from-${w.wallet_id}-${bucket}`})
+              on conflict (idempotency_key) do nothing`;
+          }
+        });
+      }
+      merged++;
+    }
+
+    console.log("\n--- summary ---");
+    console.log(`Stranded wallets found: ${stranded.length}`);
+    console.log(`${WRITE ? "Merged" : "Would merge"}: ${merged}`);
+    console.log(`Needs manual review (no attribution / stale org): ${needsReview}`);
+    if (!WRITE) console.log("\nDry run complete. Nothing was written. Re-run with --write to apply.");
+  } finally {
+    await sql.end();
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/scripts/reconcile-stranded-wallets.ts
+++ b/scripts/reconcile-stranded-wallets.ts
@@ -30,9 +30,13 @@
 // simply has nothing left to find on a second pass; every insert is
 // `on conflict (idempotency_key) do nothing`.
 //
+// `--write` is additionally gated behind RECONCILE_ALLOW=1 so that "staging
+// only" is enforced rather than merely documented (see `writeGateBlocked`).
+//
 //   node --env-file-if-exists=apps/web/.env.local --experimental-strip-types \
 //     scripts/reconcile-stranded-wallets.ts              # dry run
-//   node --env-file-if-exists=apps/web/.env.local --experimental-strip-types \
+//   RECONCILE_ALLOW=1 node --env-file-if-exists=apps/web/.env.local \
+//     --experimental-strip-types \
 //     scripts/reconcile-stranded-wallets.ts --write        # applies it
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
@@ -54,6 +58,37 @@ interface BucketBalances {
   pack: number;
 }
 
+export type WalletDisposition = "merge" | "no_positive_balance";
+
+/**
+ * Whether a stranded wallet has anything that can actually be moved.
+ *
+ * The stranded SELECT filters on the wallet's NET balance (`<> 0`) so that a
+ * NEGATIVE net still gets surfaced — that is a real data-integrity signal and
+ * suppressing it would hide it. But nothing can be merged out of such a
+ * wallet: each insert is capped at `Math.max(0, bucketBalance)` (mirroring
+ * `mergeWalletOnAttach`), and `ai_credit_ledger`'s `balance_after >= 0` CHECK
+ * would reject the attempt regardless. Deciding this here keeps the caller
+ * from opening a transaction and taking two advisory locks to move zero.
+ */
+export function classifyBucketAmounts(b: BucketBalances): WalletDisposition {
+  return b.grant > 0 || b.pack > 0 ? "merge" : "no_positive_balance";
+}
+
+/**
+ * Whether a `--write` run must be refused. This script is STAGING ONLY —
+ * per #284 production starts at V336 with no pre-existing stranded data, so a
+ * `--write` run against prod could only ever be unreviewed ledger surgery.
+ * A comment cannot enforce that; this gate can.
+ *
+ * Requires `RECONCILE_ALLOW` to be exactly `"1"`: near-misses like `"true"`
+ * are far likelier to be a mistake than a considered opt-in. A dry run is
+ * always permitted — it writes nothing.
+ */
+export function writeGateBlocked(write: boolean, allow: string | undefined): boolean {
+  return write && allow !== "1";
+}
+
 async function main(): Promise<void> {
   const url = process.env.DATABASE_URL;
   if (!url) {
@@ -61,6 +96,16 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   const WRITE = process.argv.includes("--write");
+  if (writeGateBlocked(WRITE, process.env.RECONCILE_ALLOW)) {
+    console.error(
+      "REFUSED: --write is gated behind RECONCILE_ALLOW=1.\n" +
+        "This script is STAGING ONLY: per #284 production starts at V336 with no " +
+        "pre-existing stranded data, so there is nothing for it to fix in prod and a " +
+        "--write run there would be unreviewed ledger surgery.\n" +
+        "Confirm DATABASE_URL points at staging/dev, then re-run with RECONCILE_ALLOW=1.",
+    );
+    process.exit(1);
+  }
   console.log(
     WRITE
       ? "WRITE mode: rows WILL be inserted."
@@ -89,89 +134,149 @@ async function main(): Promise<void> {
     console.log(`Found ${stranded.length} stranded wallet(s) with a non-zero balance.\n`);
 
     let merged = 0;
+    let noop = 0;
     let needsReview = 0;
 
     for (const w of stranded) {
+      // Indicative only: read outside any lock, so it is good enough to
+      // report and to screen on, but NEVER to size a write. The amount that
+      // actually moves is re-read inside the transaction, after both locks.
       const balances: BucketBalances = { grant: Number(w.grant), pack: Number(w.pack) };
 
-      const spenders = await sql<{ spent_by_org_id: string | null }[]>`
-        select spent_by_org_id from ai_credit_ledger
-         where wallet_id = ${w.wallet_id} and spent_by_org_id is not null
-         order by created_at desc`;
-      const targetOrgId = chooseReconcileTarget(spenders);
-      if (!targetOrgId) {
-        needsReview++;
-        console.warn(
-          `MANUAL REVIEW: wallet=${w.wallet_id} grant=${balances.grant} pack=${balances.pack} ` +
-            `— no spend attribution on this wallet, cannot determine an owning org.`,
-        );
-        continue;
-      }
+      try {
+        if (classifyBucketAmounts(balances) === "no_positive_balance") {
+          needsReview++;
+          console.warn(
+            `MANUAL REVIEW: wallet=${w.wallet_id} grant=${balances.grant} pack=${balances.pack} ` +
+              `— negative or zero positive balance, data integrity: no merge is possible.`,
+          );
+          continue;
+        }
 
-      const [org] = await sql<{ subscription_id: string | null; deleted_at: Date | null }[]>`
-        select subscription_id, deleted_at from organizations where id = ${targetOrgId}`;
-      if (!org || org.deleted_at) {
-        needsReview++;
-        console.warn(
-          `MANUAL REVIEW: wallet=${w.wallet_id} attributed org=${targetOrgId} no longer exists ` +
-            `(deleted) — cannot determine a live wallet to merge into.`,
-        );
-        continue;
-      }
-      const targetWalletId = org.subscription_id ?? targetOrgId;
-      if (targetWalletId === w.wallet_id) {
-        // Should be impossible (the wallet is provably stranded above), but
-        // never merge a wallet into itself.
-        needsReview++;
-        console.warn(`MANUAL REVIEW: wallet=${w.wallet_id} resolves back to itself — skipping.`);
-        continue;
-      }
+        const spenders = await sql<{ spent_by_org_id: string | null }[]>`
+          select spent_by_org_id from ai_credit_ledger
+           where wallet_id = ${w.wallet_id} and spent_by_org_id is not null
+           order by created_at desc, id desc`;
+        const targetOrgId = chooseReconcileTarget(spenders);
+        if (!targetOrgId) {
+          needsReview++;
+          console.warn(
+            `MANUAL REVIEW: wallet=${w.wallet_id} grant=${balances.grant} pack=${balances.pack} ` +
+              `— no spend attribution on this wallet, cannot determine an owning org.`,
+          );
+          continue;
+        }
 
-      console.log(
-        `${WRITE ? "MERGE" : "WOULD MERGE"}: wallet=${w.wallet_id} grant=${balances.grant} ` +
-          `pack=${balances.pack} -> org=${targetOrgId} wallet=${targetWalletId}`,
-      );
+        const [org] = await sql<{ subscription_id: string | null; deleted_at: Date | null }[]>`
+          select subscription_id, deleted_at from organizations where id = ${targetOrgId}`;
+        if (!org || org.deleted_at) {
+          needsReview++;
+          console.warn(
+            `MANUAL REVIEW: wallet=${w.wallet_id} attributed org=${targetOrgId} no longer exists ` +
+              `(deleted) — cannot determine a live wallet to merge into.`,
+          );
+          continue;
+        }
+        const targetWalletId = org.subscription_id ?? targetOrgId;
+        if (targetWalletId === w.wallet_id) {
+          // Should be impossible (the wallet is provably stranded above), but
+          // never merge a wallet into itself.
+          needsReview++;
+          console.warn(`MANUAL REVIEW: wallet=${w.wallet_id} resolves back to itself — skipping.`);
+          continue;
+        }
 
-      if (WRITE) {
-        await sql.begin(async (tx) => {
+        if (!WRITE) {
+          merged++;
+          console.log(
+            `WOULD MERGE: wallet=${w.wallet_id} grant=${balances.grant} ` +
+              `pack=${balances.pack} -> org=${targetOrgId} wallet=${targetWalletId}`,
+          );
+          continue;
+        }
+
+        const moved = await sql.begin(async (tx) => {
+          const result = { grant: 0, pack: 0, wrote: false };
           const [lo, hi] = [w.wallet_id, targetWalletId].sort();
           await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + lo}))`;
           await tx`select pg_advisory_xact_lock(hashtext(${"ai-credit-wallet:" + hi}))`;
-          for (const [bucket, amount] of [
-            ["grant", balances.grant],
-            ["pack", balances.pack],
-          ] as const) {
+          for (const bucket of ["grant", "pack"] as const) {
+            // Re-read the bucket INSIDE the transaction, after both locks —
+            // exactly as mergeWalletOnAttach does (credits.ts:821). The
+            // pre-loop aggregate was taken with no lock held; debiting that
+            // stale number could overdraw the bucket and trip the ledger's
+            // `balance_after >= 0` CHECK.
+            const [cur] = await tx<{ bal: string | null }[]>`
+              select coalesce(sum(delta), 0)::text as bal from ai_credit_ledger
+               where wallet_id = ${w.wallet_id} and bucket = ${bucket}`;
+            const amount = Math.max(0, Number(cur?.bal ?? 0));
             if (amount <= 0) continue;
+
             const [priorOld] = await tx<{ bal: string | null }[]>`
               select coalesce(sum(delta), 0)::text as bal from ai_credit_ledger
                where wallet_id = ${w.wallet_id}`;
-            await tx`
+            const [debited] = await tx<{ id: string }[]>`
               insert into ai_credit_ledger
                 (wallet_id, delta, source, bucket, ref, balance_after, idempotency_key)
               values (${w.wallet_id}, ${-amount}, 'group_merge', ${bucket}, ${targetWalletId},
                       ${Number(priorOld?.bal ?? 0) - amount},
-                      ${`reconcile-${w.wallet_id}-${bucket}`})
-              on conflict (idempotency_key) do nothing`;
+                      ${`reconcile-${w.wallet_id}-${bucket}-to-${targetWalletId}`})
+              on conflict (idempotency_key) do nothing
+              returning id`;
+            // Conflict = this exact debit already landed on an earlier run.
+            // Skip the matching credit too: the pair is written in one
+            // transaction, so a present debit means the credit is present.
+            if (!debited) continue;
+
             const [priorNew] = await tx<{ bal: string | null }[]>`
               select coalesce(sum(delta), 0)::text as bal from ai_credit_ledger
                where wallet_id = ${targetWalletId}`;
-            await tx`
+            await tx<{ id: string }[]>`
               insert into ai_credit_ledger
                 (wallet_id, delta, source, bucket, ref, balance_after, idempotency_key)
               values (${targetWalletId}, ${amount}, 'group_merge', ${bucket}, ${w.wallet_id},
                       ${Number(priorNew?.bal ?? 0) + amount},
                       ${`reconcile-${targetWalletId}-from-${w.wallet_id}-${bucket}`})
-              on conflict (idempotency_key) do nothing`;
+              on conflict (idempotency_key) do nothing
+              returning id`;
+            result[bucket] = amount;
+            result.wrote = true;
           }
+          return result;
         });
+
+        if (moved.wrote) {
+          merged++;
+          console.log(
+            `MERGED: wallet=${w.wallet_id} grant=${moved.grant} pack=${moved.pack} ` +
+              `-> org=${targetOrgId} wallet=${targetWalletId}`,
+          );
+        } else {
+          noop++;
+          console.log(
+            `NO-OP: wallet=${w.wallet_id} -> org=${targetOrgId} wallet=${targetWalletId} ` +
+              `— already reconciled, or nothing left to move once locked.`,
+          );
+        }
+      } catch (err) {
+        // One bad wallet must not abort the remaining run.
+        needsReview++;
+        console.warn(
+          `MANUAL REVIEW: wallet=${w.wallet_id} failed — ` +
+            `${err instanceof Error ? err.message : String(err)}. ` +
+            `Nothing was written for it (its transaction rolled back); investigate and re-run.`,
+        );
       }
-      merged++;
     }
 
     console.log("\n--- summary ---");
     console.log(`Stranded wallets found: ${stranded.length}`);
     console.log(`${WRITE ? "Merged" : "Would merge"}: ${merged}`);
-    console.log(`Needs manual review (no attribution / stale org): ${needsReview}`);
+    if (WRITE) console.log(`No-op (already reconciled / nothing left to move): ${noop}`);
+    console.log(
+      `Needs manual review (no attribution / stale org / no positive balance / failed): ` +
+        `${needsReview}`,
+    );
     if (!WRITE) console.log("\nDry run complete. Nothing was written. Re-run with --write to apply.");
   } finally {
     await sql.end();

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -394,6 +394,15 @@ async function main() {
     const org2OldWalletId = org2Group!.id;
     const org2BalanceBeforeAttach = await walletBalance(org2.id);
     const groupBalanceBeforeAttach = await walletBalance(org.id);
+    // Pin the linkage BEFORE the move: org2's balance really does live on the
+    // wallet id we are about to assert is emptied. Without this, the post-attach
+    // "old wallet holds nothing" check passes for the wrong reasons — a wallet
+    // that was always empty, or one whose row was deleted rather than drained.
+    check(
+      "billing-group: the joining org's balance sits on the old group's wallet before the attach (#285)",
+      (await walletBalanceByWalletId(org2OldWalletId)) === org2BalanceBeforeAttach &&
+        org2BalanceBeforeAttach > 0,
+    );
 
     // 3. OPT-IN ATTACH. The payer pulls org2 into their Pro group explicitly —
     // the deliberate step that used to happen automatically. No live Stripe

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -383,6 +383,18 @@ async function main() {
       !!org2Group && !!payerGroup && org2Group.id !== payerGroup.id,
     );
 
+    // v17 gap #285: the group wallet a joining org leaves behind must not be
+    // stranded — its balance has to land in the group's shared wallet, not
+    // vanish on a subscription row nothing can resolve to any more.
+    // The +7 is a deliberate top-up on TOP of the community grant org2 was
+    // born with, so the balance under test is not a round plan number that
+    // could coincide with a re-grant: the merge has to carry the org's WHOLE
+    // wallet, grant included, not just the part smoke put there.
+    await topUpWallet(org2.id, 7);
+    const org2OldWalletId = org2Group!.id;
+    const org2BalanceBeforeAttach = await walletBalance(org2.id);
+    const groupBalanceBeforeAttach = await walletBalance(org.id);
+
     // 3. OPT-IN ATTACH. The payer pulls org2 into their Pro group explicitly —
     // the deliberate step that used to happen automatically. No live Stripe
     // subscription here, so nothing is charged: `charged` is always false, and
@@ -397,6 +409,15 @@ async function main() {
     check(
       "billing-group: attach moves the org into the payer's group",
       attached.subscription_id === payerGroup!.id && attached.charged === false,
+    );
+    check(
+      "billing-group: attach merges the joining org's wallet balance into the group's (#285)",
+      (await walletBalance(org.id)) ===
+        groupBalanceBeforeAttach + org2BalanceBeforeAttach,
+    );
+    check(
+      "billing-group: the joining org's OLD wallet is left holding nothing, not stranded (#285)",
+      (await walletBalanceByWalletId(org2OldWalletId)) === 0,
     );
 
     // 4. ONLY NOW does org2 inherit the group's plan — and through the RESOLVER,
@@ -4009,6 +4030,23 @@ async function walletIdForOrg(orgId: string): Promise<string> {
  *  (mirrors `lib/credits.ts`'s `balance()`). */
 async function walletBalance(orgId: string): Promise<number> {
   const walletId = await walletIdForOrg(orgId);
+  const sql = smokeDb();
+  try {
+    const [row] = await sql<{ bal: string | null }[]>`
+      select coalesce(sum(delta), 0)::text as bal
+        from ai_credit_ledger where wallet_id = ${walletId}`;
+    return Number(row?.bal ?? 0);
+  } finally {
+    await sql.end();
+  }
+}
+
+/** Same as `walletBalance` but takes the wallet id directly — used to prove
+ *  a wallet a billing-group move stepped AWAY from (its old subscription/
+ *  group id, before the attach) is left holding nothing, rather than
+ *  resolving through an org's CURRENT (post-move) wallet like
+ *  `walletBalance` does. */
+async function walletBalanceByWalletId(walletId: string): Promise<number> {
   const sql = smokeDb();
   try {
     const [row] = await sql<{ bal: string | null }[]>`


### PR DESCRIPTION
## What

Wave 1 of the v17 gap remediation (`docs/superpowers/plans/2026-07-26-v17-gap-w1-money-leaks.md`), closing the two money leaks:

**#285 — AI-credit wallet stranded on billing-group attach**
- **V336**: new `group_merge` ledger source.
- `mergeWalletOnAttach` (bucket-preserving compensating pairs, sorted dual advisory locks) wired into `attachOrgToGroup`'s own transaction — an org's balance now moves with it.
- **Sole-live-org guard**: the merge fires only when the departing org is the last live org on its old subscription; with siblings remaining the org takes no share (matching the detach default) and the forfeit is audited (`billing_group.detach_wallet_not_carried`, with `via: attach|detach` discriminator).
- Detach writes the same forfeit audit row.
- Credits history labels `group_merge` rows honestly in all 4 locales ("Moved onto this bill") instead of falling through to "Adjustment"; CSV export follows.
- `scripts/reconcile-stranded-wallets.ts`: staging-only one-off for pre-fix strandings — dry-run by default, `--write` refuses without `RECONCILE_ALLOW=1`, in-tx re-reads, honest merged/no-op/needs-review counters.
- Help page documents both join outcomes + leave behaviour.

**#286 — undetermined Event Pass refund reversal freed the lifetime cap**
- **V337**: `pass_credit_redemptions.reversal_undetermined_at` + widened partial-unique cap index (`reversed_at is null OR reversal_undetermined_at is not null`).
- `reversePassCreditOnRefund` stamps the new column on the `unsafe` branch; `reversed_at` keeps its webhook-replay idempotency role; `groupAlreadyRedeemed` widened to match.
- Backfill pre-check aligned to the widened predicate (pre-fix, an undetermined row would have ABORTED the run on the unique index).
- Staff alert email now states the group's lifetime credit is blocked until staff resolution ships.

## Scope honesty

- #285 is closed on the **attach** side. Detach of the *last* org can still strand the pool (pre-existing, not worsened here) — follow-up #304. Do not auto-close #285 without noting it.
- Undetermined reversals hold the cap **permanently** — correct in every reachable case (customer keeps the credit), but staff resolution tooling is phase 2 — follow-up #305. Ensure `STAFF_ALERT_EMAIL` is set on prod; the alert is silently skipped without it. Inventory: `select * from pass_credit_redemptions where reversal_undetermined_at is not null`.
- Self-service attaches/detaches now write `staff_audit_log` rows — the `/admin` "staff actions today" tile counts them (follow-up #308).

## Migrations

V336 + V337 — both idempotent-shaped, safe on empty and existing data. V337 drops/recreates `pass_credit_redemptions_group_cap` inside the migration transaction (no window without the cap).

## Runbook (staging only)

Per #284, prod starts at V336 with nothing to reconcile — never run the reconcile script there. On staging: dry run first and KEEP the console output (it is the manual-review inventory; machine-readable artifact = follow-up #309), then `RECONCILE_ALLOW=1 ... --write`.

## Verification

- `tsc --noEmit` 0 errors; targeted W1 suites 11 files / 143 tests green; full workspace suite 467 passed / 0 failed on a clean DB (one funnel red on the long-lived shared test DB proven environmental: stale seed rows missing `sport_variants`; green after `sync:sports`).
- i18n: gen-keys no drift; es/fr/nl parity with en at 3470 keys.
- `BILLING_LIVE=1` `pass-credit-refund-reversal.live.test.ts` green vs test-mode Stripe.
- Full smoke **552 passed / 0 failed**, including three new `(#285)` checks (pre-attach linkage pin, group gains exactly the joining org's balance, old wallet drained not stranded).
- Every behaviour change shipped a red-first regression test (red evidence captured per task in the SDD reports).
- Process: per-task Opus review + fix loops (10 tasks — 7 planned + 3 gap-routed from reviews), final whole-branch Opus review ("With fixes"), one fix wave, scoped re-review clean.

Follow-ups filed from review findings: #304 #305 #306 #307 #308 #309.

Closes #286. Addresses #285 (attach side; #304 tracks the detach mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)