### PR TITLE
fix(entitlements): W2 resolver-truth — cache invalidation, SQL parity, lifecycle analytics (#287, #288, #289)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,9 @@ jobs:
       # pass-scoping-guard (no enforcement site drops the competition id) —
       # plus every billing-*/entitlements-* DB suite ran in NO job at all: the
       # unit job has no DATABASE_URL, so they skipped there and read as green.
-      # rate-limit.redis.test.ts is Redis-gated, so it still self-skips here and
-      # executes in the step below, which owns REDIS_URL.
+      # rate-limit.redis.test.ts and entitlements-cache-invalidation.redis.test.ts
+      # are Redis-gated, so they still self-skip here and execute in the two
+      # dedicated steps below, each of which owns REDIS_URL for itself alone.
       - name: Engine-db + service-layer + lib integration tests (real Postgres)
         run: npm test --workspace apps/web -- run src/server src/lib
 
@@ -230,6 +231,20 @@ jobs:
       # cache — stale reads, false failures. The limiter test is self-contained.
       - name: Rate-limiter integration tests (real Redis)
         run: npm test --workspace apps/web -- run src/lib/__tests__/rate-limit.redis.test.ts
+        env:
+          REDIS_URL: redis://localhost:6379
+
+      # v17 #287: the counterpart REDIS_URL-scoped step. patchCompetition
+      # (and the pass grant/refund paths) must bust ent:<org>:* the instant
+      # they write — a cached Event Pass answer must not outlive the write
+      # it rode in on. Needs its own step for the same reason as the
+      # limiter above: with REDIS_URL unset (the step above's
+      # src/server+src/lib run, and any plain local `npm test`), cacheGet
+      # always misses and every read hits Postgres fresh (lib/cache.ts) —
+      # the bug this suite catches is structurally invisible without a
+      # real Redis actually going stale.
+      - name: Entitlement cache invalidation tests (real Redis)
+        run: npm test --workspace apps/web -- run src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
         env:
           REDIS_URL: redis://localhost:6379
 

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -521,9 +521,10 @@ export async function setGroupSeatsPaidSql(groupId: string, seats: number): Prom
 }
 
 /**
- * Moderation state. V310 moved suspension off `subscriptions.status` and onto
- * the ORG, precisely so suspending one org cannot stop billing for the siblings
- * that merely share its payer — so this writes the org and nothing else.
+ * Moderation state. V314 §2b moved suspension off `subscriptions.status` and
+ * onto the ORG, precisely so suspending one org cannot stop billing for the
+ * siblings that merely share its payer — so this writes the org and nothing
+ * else.
  */
 export async function setOrgStatusSql(orgId: string, status: "active" | "suspended"): Promise<void> {
   await withDb(async (sql) => {

--- a/apps/web/src/app/api/admin/orgs/[id]/suspend/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/suspend/route.ts
@@ -1,6 +1,7 @@
 import { sql } from "@/lib/db";
-import { requireSuperadmin, logStaffAction } from "@/lib/admin";
+import { requireSuperadmin } from "@/lib/admin";
 import { handler, HttpError } from "@/lib/http";
+import { setOrgSuspension } from "@/server/usecases/admin-orgs";
 import { z } from "zod";
 
 const schema = z.object({
@@ -21,19 +22,11 @@ export async function POST(
     const [org] = await sql<{ id: string }[]>`select id from organizations where id = ${id}`;
     if (!org) throw new HttpError(404, "Organization not found");
 
-    // organizations.status ONLY. Suspension used to also stamp
-    // subscriptions.status = 'suspended', which was harmless while a
-    // subscription belonged to exactly one org. Since V314 a subscription is a
-    // shared BILLING GROUP: writing to it would stop billing and degrade
-    // entitlements for every OTHER org in the group — orgs that may belong to
-    // uninvolved people and have done nothing wrong. Suspension is moderation,
-    // not billing, so the money and the plan are left completely alone and a
-    // suspended org keeps counting toward the group's paid quantity
-    // (billing-group.ts activeOrgCount).
-    const newStatus = action === "suspend" ? "suspended" : "active";
-    await sql`update organizations set status = ${newStatus} where id = ${id}`;
-
-    await logStaffAction(staff.id, action, "org", id, { reason });
-    return { ok: true, status: newStatus };
+    // Thin wrapper: the write, the cache bust and the audit stamp live in the
+    // usecase so they can be exercised without a Next request. Reached only
+    // after requireSuperadmin and the 404 — an unauthorized or unknown-org
+    // request must never bust a live org's cache.
+    const status = await setOrgSuspension(staff.id, id, action, reason);
+    return { ok: true, status };
   });
 }

--- a/apps/web/src/app/api/admin/orgs/[id]/suspend/route.ts
+++ b/apps/web/src/app/api/admin/orgs/[id]/suspend/route.ts
@@ -23,7 +23,7 @@ export async function POST(
 
     // organizations.status ONLY. Suspension used to also stamp
     // subscriptions.status = 'suspended', which was harmless while a
-    // subscription belonged to exactly one org. Since V310 a subscription is a
+    // subscription belonged to exactly one org. Since V314 a subscription is a
     // shared BILLING GROUP: writing to it would stop billing and degrade
     // entitlements for every OTHER org in the group — orgs that may belong to
     // uninvolved people and have done nothing wrong. Suspension is moderation,

--- a/apps/web/src/app/api/billing/groups/route.test.ts
+++ b/apps/web/src/app/api/billing/groups/route.test.ts
@@ -44,15 +44,17 @@ interface Seeded {
 async function seedGroup(
   plan: string,
   orgCount: number,
-  over: { quantityPaid?: number } = {},
+  over: { quantityPaid?: number; status?: string; stripeSubId?: string } = {},
 ): Promise<Seeded> {
   const s = uniq();
   const [{ id: payerId }] = await sql<{ id: string }[]>`
     insert into users (email, display_name, email_verified)
     values (${`groups-route-${s}@test.local`}, 'Payer', true) returning id`;
   const [{ id: subId }] = await sql<{ id: string }[]>`
-    insert into subscriptions (owner_user_id, plan_key, status, quantity_paid)
-    values (${payerId}, ${plan}, 'active', ${over.quantityPaid ?? orgCount}) returning id`;
+    insert into subscriptions (owner_user_id, plan_key, status, quantity_paid,
+                               stripe_subscription_id)
+    values (${payerId}, ${plan}, ${over.status ?? "active"}, ${over.quantityPaid ?? orgCount},
+            ${over.stripeSubId ?? null}) returning id`;
   const orgIds: string[] = [];
   for (let i = 0; i < orgCount; i++) {
     const [{ id }] = await sql<{ id: string }[]>`
@@ -72,6 +74,7 @@ type Body = {
     plan_key: string;
     quantity_paid: number;
     max_orgs: number | null;
+    has_live_subscription: boolean;
     orgs: {
       id: string;
       name: string;
@@ -184,6 +187,33 @@ describe.skipIf(!HAS_DB)("GET /api/billing/groups", () => {
     expect(mine).toBeDefined();
     expect(mine!.orgs).toEqual([]);
     expect(mine!.max_orgs).toBeNull();
+  });
+
+  it("calls an 'incomplete' subscription LIVE, the same as hasLiveSubscription does", async () => {
+    // `has_live_subscription` is named after hasLiveSubscription(), which
+    // billing-groups.ts uses to answer this question for the SAME UI — but this
+    // route spelled the status list out by hand and left 'incomplete' out of
+    // it. A never-paid first invoice still owns a real Stripe subscription: it
+    // blocks a second checkout, and a transfer of it is the two-phase card
+    // handover, not a one-step move. Two answers for one group meant the
+    // confirm copy promised something the use case would not do.
+    const g = await seedGroup("pro", 1, { status: "incomplete", stripeSubId: `sub_incomplete_${uniq()}` });
+    caller.id = g.payerId;
+
+    const mine = (await call()).data.find((x) => x.id === g.subId)!;
+    expect(mine.has_live_subscription).toBe(true);
+  });
+
+  it("still calls a cancelled subscription dead, id or no id", async () => {
+    // The other half: interpolating the constant must not turn the column into
+    // "has an id". A departed customer keeps their stripe_subscription_id for
+    // ever, and 'canceled' is deliberately outside LIVE_SUBSCRIPTION_STATUSES
+    // so they can come back.
+    const g = await seedGroup("pro", 1, { status: "canceled", stripeSubId: `sub_gone_${uniq()}` });
+    caller.id = g.payerId;
+
+    const mine = (await call()).data.find((x) => x.id === g.subId)!;
+    expect(mine.has_live_subscription).toBe(false);
   });
 
   it("lists several groups for a payer who has detached one", async () => {

--- a/apps/web/src/app/api/billing/groups/route.ts
+++ b/apps/web/src/app/api/billing/groups/route.ts
@@ -2,6 +2,7 @@ import { sql } from "@/lib/db";
 import { requireUser } from "@/lib/auth";
 import { handler } from "@/lib/http";
 import { groupOrgLimit } from "@/lib/billing-group";
+import { LIVE_SUBSCRIPTION_STATUSES } from "@/lib/subscription-status";
 
 /**
  * GET /api/billing/groups — the billing groups you PAY for, with the
@@ -56,8 +57,16 @@ export async function GET() {
              -- id for ever. This is what tells the UI whether a transfer is the
              -- two-phase card handover or a one-step move, and the confirm copy
              -- promises different things in each case.
+             --
+             -- The status list is INTERPOLATED from LIVE_SUBSCRIPTION_STATUSES,
+             -- never spelled out here. This column is literally named after
+             -- hasLiveSubscription(), which billing-groups.ts uses to answer the
+             -- same question for the same UI — a hand-written list drifts from
+             -- it the moment the set changes, and it already had: 'incomplete'
+             -- (a never-paid first invoice, live enough to block a second
+             -- checkout) was missing, so the two disagreed about the same group.
              (s.stripe_subscription_id is not null
-              and s.status in ('trialing', 'active', 'past_due')) as has_live_subscription,
+              and s.status in ${sql([...LIVE_SUBSCRIPTION_STATUSES])}) as has_live_subscription,
              coalesce(
                (select json_agg(json_build_object(
                           'id', o.id, 'name', o.name, 'slug', o.slug, 'status', o.status,

--- a/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
+++ b/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
@@ -166,4 +166,31 @@ describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
     await syncSubscription(orgId, stripeSub({ id: subId, status: "incomplete" }));
     expect((await readAnchor(orgId)).status).toBe("incomplete");
   });
+
+  it("syncSubscription writes Stripe 'unpaid' as our past_due — never a literal 'unpaid' row (#288 audit)", async () => {
+    const orgId = await seedOrg();
+    const subId = `sub_unpaid_${randomUUID().slice(0, 8)}`;
+    await syncSubscription(orgId, stripeSub({ id: subId, status: "unpaid" }));
+    // STATUS_MAP (lib/billing.ts) collapses 'unpaid' into 'past_due' at
+    // write time — the resolver's existing past_due 14-day grace arm
+    // degrades it, exactly like any other dunning failure. Neither
+    // resolver needs its own 'unpaid' arm because the literal string
+    // never reaches subscriptions.status.
+    expect((await readAnchor(orgId)).status).toBe("past_due");
+  });
+
+  it("syncSubscription writes Stripe 'incomplete_expired' as our canceled — degrades immediately, no grace (#288 audit)", async () => {
+    const orgId = await seedOrg();
+    const subId = `sub_ie_${randomUUID().slice(0, 8)}`;
+    await sql`update subscriptions set plan_key = 'pro'
+              where id = (select subscription_id from organizations where id = ${orgId})`;
+    await syncSubscription(orgId, stripeSub({ id: subId, status: "incomplete_expired" }));
+    const row = await readAnchor(orgId);
+    expect(row.status).toBe("canceled");
+    // canceled + comped_at null is the immediate-degrade arm (no 14-day
+    // grace) in BOTH resolvers — unlike past_due above. Proves the
+    // DEGRADE from a paid-looking row, not just that plan_key already
+    // happened to read community.
+    expect(await orgPlanKey(orgId)).toBe("community");
+  });
 });

--- a/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
+++ b/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
@@ -234,6 +234,32 @@ describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
     err.mockRestore();
   });
 
+  it("a PROTOTYPE key is unknown too — 'constructor' does not smuggle a Function past the map", async () => {
+    // STATUS_MAP is an object literal, so every Object.prototype member is
+    // reachable through it BY NAME: `STATUS_MAP["constructor"]` is a Function,
+    // not undefined. A bare index therefore reads as "known" — it skips the
+    // unknown-status log above AND satisfies the `??` fallback, so the Function
+    // itself is what gets written to subscriptions.status. The status arrives on
+    // a webhook, so this key is attacker-reachable, and the resulting row lands
+    // outside LIVE_SUBSCRIPTION_STATUSES: silently dead, no log, no grace.
+    // `Object.hasOwn` is the fix, and it must not disturb the real keys.
+    const orgId = await seedOrg();
+    await sql`update subscriptions set plan_key = 'pro'
+              where id = (select subscription_id from organizations where id = ${orgId})`;
+    const subId = `sub_proto_${randomUUID().slice(0, 8)}`;
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    await syncSubscription(
+      orgId,
+      stripeSub({ id: subId, status: "constructor" as Stripe.Subscription.Status }),
+    );
+    // Same fail-SAFE landing as any other unheard-of status.
+    expect((await readAnchor(orgId)).status).toBe("incomplete");
+    expect(await orgPlanKey(orgId)).toBe("community");
+    // And LOUD — the bare index skipped this entirely.
+    expect(err).toHaveBeenCalledWith("syncSubscription: unknown status", "constructor", subId);
+    err.mockRestore();
+  });
+
   it("syncSubscription writes Stripe 'incomplete_expired' as our canceled — degrades immediately, no grace (#288 audit)", async () => {
     const orgId = await seedOrg();
     const subId = `sub_ie_${randomUUID().slice(0, 8)}`;

--- a/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
+++ b/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
@@ -11,6 +11,7 @@ import { sql } from "@/lib/db";
 import { syncSubscription } from "@/lib/billing";
 import { processStripeEvent } from "@/server/usecases/billing-events";
 import { orgPlanKey } from "@/lib/entitlements";
+import { LIVE_SUBSCRIPTION_STATUSES } from "@/lib/subscription-status";
 
 import { setOrgPlan } from "./_billing-group";
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -164,6 +165,9 @@ describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
     const orgId = await seedOrg();
     const subId = `sub_inc_${randomUUID().slice(0, 8)}`;
     await syncSubscription(orgId, stripeSub({ id: subId, status: "incomplete" }));
+    // Same caveat as the 'unpaid' row below, and this is the row it bites on:
+    // 'incomplete' is ALSO the `??` fallback, so deleting STATUS_MAP.incomplete
+    // leaves this green. Mutate by flipping the value.
     expect((await readAnchor(orgId)).status).toBe("incomplete");
   });
 
@@ -176,7 +180,48 @@ describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
     // degrades it, exactly like any other dunning failure. Neither
     // resolver needs its own 'unpaid' arm because the literal string
     // never reaches subscriptions.status.
+    //
+    // CAVEAT: this pins the observable WRITE, not the map entry. Mutate it by
+    // flipping the VALUE of STATUS_MAP.unpaid, never by reasoning about the
+    // key alone — behind a `?? fallback`, deleting a key is not the same
+    // mutation as changing it, and which of the two this test catches depends
+    // entirely on what the fallback currently is. It happens to catch both
+    // today (Task 8 (e) moved the fallback to 'incomplete', so a deleted
+    // 'unpaid' key now lands somewhere this assertion rejects) — but that is a
+    // property of the fallback, not of this test, and it flips back the moment
+    // the fallback changes. The deletion-blind row is now the `incomplete` one
+    // below, whose expected value IS the fallback.
     expect((await readAnchor(orgId)).status).toBe("past_due");
+  });
+
+  // v17 W2 Task 8 (e). STATUS_MAP is a fixed table against a vocabulary Stripe
+  // can extend at any time, so the `??` fallback is the arm that handles every
+  // status this codebase has never heard of. It used to be `past_due`, which
+  // fails OPEN: an unknown NEVER-PAID status (the likely shape of anything new
+  // in the incomplete family) would inherit the 14-day dunning grace and hand
+  // out Pro, paid for nothing, until someone noticed. `incomplete` is the
+  // fail-SAFE landing — it conveys no plan, and it is still a LIVE status, so
+  // the subscription is not orphaned and a second checkout stays blocked.
+  it("an UNKNOWN future Stripe status lands as incomplete — no plan, no grace", async () => {
+    const orgId = await seedOrg();
+    await sql`update subscriptions set plan_key = 'pro'
+              where id = (select subscription_id from organizations where id = ${orgId})`;
+    const subId = `sub_future_${randomUUID().slice(0, 8)}`;
+    await syncSubscription(
+      orgId,
+      stripeSub({
+        id: subId,
+        // A status no STATUS_MAP key matches — deliberately not a real one.
+        status: "some_future_status" as Stripe.Subscription.Status,
+      }),
+    );
+    // Pre-fix this wrote 'past_due', and the assertion below returned 'pro'
+    // for 14 days on a subscription that had paid nothing.
+    expect((await readAnchor(orgId)).status).toBe("incomplete");
+    expect(await orgPlanKey(orgId)).toBe("community");
+    // Still LIVE, though — the org owns a real Stripe subscription, so it must
+    // not be able to open a second checkout and mint a duplicate.
+    expect(LIVE_SUBSCRIPTION_STATUSES).toContain("incomplete");
   });
 
   it("syncSubscription writes Stripe 'incomplete_expired' as our canceled — degrades immediately, no grace (#288 audit)", async () => {

--- a/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
+++ b/apps/web/src/lib/__tests__/billing-grace-anchor.test.ts
@@ -4,7 +4,7 @@
 // when dunning STARTED — repeated invoice.payment_failed retries touch
 // updated_at but must never move the anchor.
 // Real Postgres required; skipped without DATABASE_URL.
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 import type Stripe from "stripe";
 import { sql } from "@/lib/db";
@@ -207,6 +207,7 @@ describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
     await sql`update subscriptions set plan_key = 'pro'
               where id = (select subscription_id from organizations where id = ${orgId})`;
     const subId = `sub_future_${randomUUID().slice(0, 8)}`;
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
     await syncSubscription(
       orgId,
       stripeSub({
@@ -222,6 +223,15 @@ describe.skipIf(!HAS_DB)("incomplete never-paid grace hole (#206)", () => {
     // Still LIVE, though — the org owns a real Stripe subscription, so it must
     // not be able to open a second checkout and mint a duplicate.
     expect(LIVE_SUBSCRIPTION_STATUSES).toContain("incomplete");
+    // And it is LOUD. Degrading a possibly-paying customer silently is how a
+    // STATUS_MAP drift survives in production — the subscription id is in the
+    // log because a status alone gives nobody anything to look up.
+    expect(err).toHaveBeenCalledWith(
+      "syncSubscription: unknown status",
+      "some_future_status",
+      subId,
+    );
+    err.mockRestore();
   });
 
   it("syncSubscription writes Stripe 'incomplete_expired' as our canceled — degrades immediately, no grace (#288 audit)", async () => {

--- a/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
+++ b/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
@@ -326,7 +326,13 @@ describe.skipIf(!HAS_DB)("Event Pass grants one-time AI credits", () => {
     const session = passSession(orgId, compId, {
       customer: "cus_grant_replay_" + uniq(),
       currency: "gbp",
-      payment_intent: "pi_grant_replay",
+      // Run-unique, like every sibling: recordPassGrant's idempotency key is
+      // `pass_grant:${paymentIntent}` (lib/credits.ts), so a fixed intent makes
+      // the grant single-use PER DATABASE — green on CI's fresh container,
+      // permanently red on the second run against the persistent local test DB.
+      // The replay under test is expressed by reusing THIS session, not by
+      // hardcoding a literal.
+      payment_intent: "pi_grant_replay_" + uniq(),
     });
     stripeMock.retrieve.mockResolvedValue(session);
 
@@ -348,7 +354,10 @@ describe.skipIf(!HAS_DB)("Event Pass grants one-time AI credits", () => {
     const walletId = await walletIdFor(orgId);
     // First owner records the pass and earns the grant.
     stripeMock.retrieve.mockResolvedValue(
-      passSession(orgId, compId, { payment_intent: "pi_grant_winner" }),
+      // Run-unique for the same reason as the replay test above: a hardcoded
+      // winning intent grants once per DATABASE, so the wallet reads 0 on
+      // every re-run and this test accuses the code of a bug it does not have.
+      passSession(orgId, compId, { payment_intent: "pi_grant_winner_" + uniq() }),
     );
     expect(await reconcilePassCheckout(orgId, "cs_grant_winner")).toBe(true);
     expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT);
@@ -357,7 +366,7 @@ describe.skipIf(!HAS_DB)("Event Pass grants one-time AI credits", () => {
     // the wallet must NOT be credited again (a duplicate second charge is sent
     // back, never granted — recordPassPurchase's `if (!dup)` guard).
     await processStripeEvent(
-      passEvent(passSession(orgId, compId, { payment_intent: "pi_grant_loser" })),
+      passEvent(passSession(orgId, compId, { payment_intent: "pi_grant_loser_" + uniq() })),
     );
     expect(stripeMock.refundCreate).toHaveBeenCalledTimes(1);
     expect(await balance(walletId)).toBe(PASS_CREDIT_GRANT);

--- a/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
+++ b/apps/web/src/lib/__tests__/billing-pass-financial-trace.test.ts
@@ -253,7 +253,11 @@ describe.skipIf(!HAS_DB)("Event Pass leaves a financial trace (webhook)", () => 
       passSession(orgId, compId, {
         customer: winner,
         currency: "gbp",
-        payment_intent: "pi_winner",
+        // Run-unique like every other intent in this file. These trace tests
+        // assert customer/currency, not balance, so a literal here never went
+        // red — it just quietly stopped granting from run 2 onward, hollowing
+        // out the money half of the path they exercise.
+        payment_intent: "pi_winner_" + uniq(),
       }),
     );
     expect(await reconcilePassCheckout(orgId, "cs_first")).toBe(true);
@@ -267,7 +271,7 @@ describe.skipIf(!HAS_DB)("Event Pass leaves a financial trace (webhook)", () => 
         passSession(orgId, compId, {
           customer: "cus_pass_loser_" + uniq(),
           currency: "usd",
-          payment_intent: "pi_loser",
+          payment_intent: "pi_loser_" + uniq(),
         }),
       ),
     );
@@ -284,7 +288,11 @@ describe.skipIf(!HAS_DB)("Event Pass leaves a financial trace (webhook)", () => 
     const session = passSession(orgId, compId, {
       customer: replay,
       currency: "eur",
-      payment_intent: "pi_replay",
+      // Run-unique: this test's whole claim is that a replay "re-runs BOTH
+      // writes idempotently". With a literal intent, run 2+ found the grant
+      // already keyed and no-oped it, so the assertion stood over a path that
+      // had quietly lost its grant half.
+      payment_intent: "pi_replay_" + uniq(),
     });
     stripeMock.retrieve.mockResolvedValue(session);
 

--- a/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
@@ -19,6 +19,7 @@ import type Stripe from "stripe";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { createCompetition, patchCompetition } from "@/server/usecases/competitions";
 import { processStripeEvent } from "@/server/usecases/billing-events";
+import { setOrgSuspension } from "@/server/usecases/admin-orgs";
 import { setOrgPlan } from "./_billing-group";
 
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -210,5 +211,38 @@ describe.skipIf(!HAS_DB || !HAS_REDIS)("entitlement cache invalidation (real Red
       select 1 from competition_passes where stripe_payment_intent = ${intent}`;
     expect(row).toBeUndefined();
     expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(false);
+  });
+
+  // v17 W2 Task 9. organizations.status is a RESOLVER INPUT, and the loudest
+  // one: `when o.status = 'suspended' then 'community'` is the FIRST arm of
+  // both resolvers (orgPlanKey's CASE and org_has_feature's SQL twin). The
+  // staff suspend route wrote that column and stopped, so on a Redis-backed
+  // target moderation was cosmetic for up to 300s — a suspended org kept
+  // serving its paid plan, and (worse for the innocent) a reactivated org
+  // stayed degraded just as long after staff had already restored it.
+  it("suspending an org busts the cache the instant moderation lands", async () => {
+    const auth = await seedCommunityOrg();
+    await setOrgPlan(auth.orgId, "pro", "active");
+    await invalidateOrgEntitlements(auth.orgId);
+
+    // Warm the cache on the PAID answer (`realtime` is Pro-only).
+    expect(await hasFeature(auth.orgId, "realtime")).toBe(true);
+
+    // The write under test, exactly as the route performs it — the route is a
+    // thin wrapper over this usecase, so no manual invalidate here.
+    expect(
+      await setOrgSuspension(auth.userId!, auth.orgId, "suspend", "cache bust probe"),
+    ).toBe("suspended");
+
+    // Pre-fix this read the 300s entry warmed above: suspended on paper,
+    // fully entitled in practice.
+    expect(await hasFeature(auth.orgId, "realtime")).toBe(false);
+
+    // And the same in the direction that harms the org rather than us: staff
+    // lift the suspension, the org must be whole again immediately.
+    expect(
+      await setOrgSuspension(auth.userId!, auth.orgId, "reactivate", "cache bust probe"),
+    ).toBe("active");
+    expect(await hasFeature(auth.orgId, "realtime")).toBe(true);
   });
 });

--- a/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
@@ -30,7 +30,7 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
  *  true, event_pass true — same probe key entitlements-sql-parity.test.ts
  *  uses, and for the same reason: V310 made `branding` free for community,
  *  so it can no longer show a pass LIFT). */
-export async function seedCommunityOrg(): Promise<AuthCtx> {
+async function seedCommunityOrg(): Promise<AuthCtx> {
   const suffix = randomUUID().slice(0, 8);
   const [{ id: ownerId }] = await sql<{ id: string }[]>`
     insert into users (email, display_name, email_verified)
@@ -244,5 +244,22 @@ describe.skipIf(!HAS_DB || !HAS_REDIS)("entitlement cache invalidation (real Red
       await setOrgSuspension(auth.userId!, auth.orgId, "reactivate", "cache bust probe"),
     ).toBe("active");
     expect(await hasFeature(auth.orgId, "realtime")).toBe(true);
+  });
+
+  it("refuses an org id that matched nothing, instead of logging a moderation that never happened", async () => {
+    // The suspend route looks the org up and 404s before calling this, so the
+    // update always matches TODAY. That guard belongs to the route, though, and
+    // the next caller — a cron, a staff script, a second route — inherits none
+    // of it. Without a rowcount check the use case updates zero rows and then
+    // carries on regardless: it busts a cache, writes a staff-action log naming
+    // an org it never touched, and RETURNS the new status as though it had been
+    // applied. The audit trail is the thing that must not be able to lie.
+    const ghost = randomUUID();
+    await expect(setOrgSuspension(ghost, ghost, "suspend", "no such org")).rejects.toThrow(
+      /no organization/i,
+    );
+    const [logged] = await sql`
+      select 1 from staff_audit_log where target_id = ${ghost}`;
+    expect(logged).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
@@ -1,0 +1,87 @@
+// v17 #287: lib/entitlements.ts caches resolved answers under
+// `ent:<org>:<competition>:<feature>` for 300s (ENT_TTL_SECONDS). A
+// competition write that moves status/ends_on — which the Event Pass lock
+// (isPassLocked) reads live off the row on every resolve — must bust that
+// cache in the SAME call, or a warm answer outlives the write for up to 5
+// minutes. The bug is structurally invisible without a real Redis: with
+// REDIS_URL unset, cacheGet always misses and every read hits Postgres
+// fresh (lib/cache.ts), so this suite needs BOTH a real Postgres (usecase
+// seeding) and a real Redis (an actually-warm cache to go stale). Skipped
+// without either. CI runs this in its own step, mirroring
+// rate-limit.redis.test.ts's REDIS_URL scoping (ci.yml).
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { incrWindow } from "@/lib/cache";
+import { hasFeature, invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition, patchCompetition } from "@/server/usecases/competitions";
+import { setOrgPlan } from "./_billing-group";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const HAS_REDIS = !!process.env.REDIS_URL;
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Community org an Event Pass can lift (`realtime`: community false, pro
+ *  true, event_pass true — same probe key entitlements-sql-parity.test.ts
+ *  uses, and for the same reason: V310 made `branding` free for community,
+ *  so it can no longer show a pass LIFT). */
+export async function seedCommunityOrg(): Promise<AuthCtx> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: ownerId }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`cachebust-${suffix}@test.local`}, 'Cache Bust Owner', true) returning id`;
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"Cache Bust " + suffix}, ${"cache-bust-" + suffix}, ${ownerId}) returning id`;
+  await setOrgPlan(orgId, "community", "active");
+  return { orgId, via: "session", userId: ownerId, role: "owner", keyId: null };
+}
+
+describe.skipIf(!HAS_DB || !HAS_REDIS)("entitlement cache invalidation (real Redis)", () => {
+  // The client uses enableOfflineQueue:false, so a command fired before the
+  // socket is 'ready' rejects (incrWindow returns null). A long-lived server
+  // warms the singleton once; here we warm it explicitly before asserting —
+  // same pattern as rate-limit.redis.test.ts.
+  beforeAll(async () => {
+    for (let i = 0; i < 50; i++) {
+      if ((await incrWindow(`warmup:${randomUUID()}`, 5)) !== null) return;
+      await sleep(100);
+    }
+    throw new Error("Redis did not become ready");
+  });
+
+  afterAll(async () => {
+    const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+    const dbClient = globalForDb._sql;
+    globalForDb._sql = undefined;
+    await dbClient?.end();
+    const g = globalThis as unknown as { _redis?: { quit?: () => Promise<unknown> } };
+    await g._redis?.quit?.().catch(() => {});
+  });
+
+  it("patchCompetition busts the cache the instant a pass-bearing competition locks", async () => {
+    const auth = await seedCommunityOrg();
+    const comp = await createCompetition(auth, {
+      name: `Cache Lock ${randomUUID().slice(0, 6)}`,
+      visibility: "private",
+      branding: {},
+    });
+    await sql`insert into competition_passes (competition_id, org_id) values (${comp.id}, ${auth.orgId})`;
+    await invalidateOrgEntitlements(auth.orgId);
+
+    // Warm the cache: still 'draft' (isPassLocked's active set), so the
+    // pass lifts `realtime`.
+    expect(await hasFeature(auth.orgId, "realtime", comp.id)).toBe(true);
+
+    // The write under test — no manual invalidateOrgEntitlements call here,
+    // unlike the raw-SQL seeding above. This is what proves the FIX, not
+    // just the seed.
+    const patched = await patchCompetition(auth, comp.id, { status: "completed" });
+    expect(patched.status).toBe("completed");
+
+    // Pre-#287 this reads the 300s-TTL entry warmed above and wrongly stays
+    // true for up to 5 minutes even though the competition is now terminal.
+    expect(await hasFeature(auth.orgId, "realtime", comp.id)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
@@ -14,6 +14,8 @@ import { randomUUID } from "node:crypto";
 import { sql } from "@/lib/db";
 import { incrWindow } from "@/lib/cache";
 import { hasFeature, invalidateOrgEntitlements } from "@/lib/entitlements";
+import { recordPassPurchase, revokePassForRefundedCharge } from "@/lib/billing";
+import type Stripe from "stripe";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { createCompetition, patchCompetition } from "@/server/usecases/competitions";
 import { setOrgPlan } from "./_billing-group";
@@ -83,5 +85,48 @@ describe.skipIf(!HAS_DB || !HAS_REDIS)("entitlement cache invalidation (real Red
     // Pre-#287 this reads the 300s-TTL entry warmed above and wrongly stays
     // true for up to 5 minutes even though the competition is now terminal.
     expect(await hasFeature(auth.orgId, "realtime", comp.id)).toBe(false);
+  });
+
+  it("recordPassPurchase busts the cache the instant the pass is granted", async () => {
+    const auth = await seedCommunityOrg();
+    const [{ id: compId }] = await sql<{ id: string }[]>`
+      insert into competitions (org_id, name, slug)
+      values (${auth.orgId}, ${"Grant Cup " + randomUUID().slice(0, 6)},
+              ${"grant-cup-" + randomUUID().slice(0, 6)}) returning id`;
+    await invalidateOrgEntitlements(auth.orgId);
+
+    // Warm the cache on the pre-purchase (deny) answer.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(false);
+
+    await recordPassPurchase({
+      orgId: auth.orgId,
+      competitionId: compId,
+      paymentIntent: `pi_${randomUUID().slice(0, 8)}`,
+    });
+
+    // recordPassPurchase already calls invalidateOrgEntitlements
+    // (lib/billing.ts:819) — this proves it, doesn't just assert it.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(true);
+  });
+
+  it("revokePassForRefundedCharge busts the cache the instant a refund revokes the pass", async () => {
+    const auth = await seedCommunityOrg();
+    const [{ id: compId }] = await sql<{ id: string }[]>`
+      insert into competitions (org_id, name, slug)
+      values (${auth.orgId}, ${"Refund Cup " + randomUUID().slice(0, 6)},
+              ${"refund-cup-" + randomUUID().slice(0, 6)}) returning id`;
+    const intent = `pi_${randomUUID().slice(0, 8)}`;
+    await recordPassPurchase({ orgId: auth.orgId, competitionId: compId, paymentIntent: intent });
+    await invalidateOrgEntitlements(auth.orgId);
+
+    // Warm the cache on the granted (true) answer.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(true);
+
+    const charge = { payment_intent: intent, refunded: true } as unknown as Stripe.Charge;
+    expect(await revokePassForRefundedCharge(charge)).toBe(true);
+
+    // revokePassForRefundedCharge already calls invalidateOrgEntitlements
+    // (lib/billing.ts:881) — this proves it, doesn't just assert it.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(false);
   });
 });

--- a/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts
@@ -18,6 +18,7 @@ import { recordPassPurchase, revokePassForRefundedCharge } from "@/lib/billing";
 import type Stripe from "stripe";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { createCompetition, patchCompetition } from "@/server/usecases/competitions";
+import { processStripeEvent } from "@/server/usecases/billing-events";
 import { setOrgPlan } from "./_billing-group";
 
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -109,6 +110,42 @@ describe.skipIf(!HAS_DB || !HAS_REDIS)("entitlement cache invalidation (real Red
     expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(true);
   });
 
+  it("recordPassPurchase busts the cache on the HEALING replay, not only the winning insert", async () => {
+    const auth = await seedCommunityOrg();
+    const [{ id: compId }] = await sql<{ id: string }[]>`
+      insert into competitions (org_id, name, slug)
+      values (${auth.orgId}, ${"Heal Cup " + randomUUID().slice(0, 6)},
+              ${"heal-cup-" + randomUUID().slice(0, 6)}) returning id`;
+    const intent = `pi_${randomUUID().slice(0, 8)}`;
+    await invalidateOrgEntitlements(auth.orgId);
+
+    // (1) Warm the cache on the pre-purchase DENY — a real 300s entry (denies
+    // are cached too; lib/entitlements.ts wraps them `{ v: null }`).
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(false);
+
+    // (2) Simulate a FIRST attempt that crashed between the pass insert and the
+    // invalidate: the row exists, the warm deny above was never busted. Raw SQL
+    // deliberately — going through recordPassPurchase here would bust it and
+    // destroy the very state under test.
+    await sql`insert into competition_passes (competition_id, org_id, stripe_payment_intent)
+              values (${compId}, ${auth.orgId}, ${intent})`;
+
+    // (3) The healing retry — SAME intent, so this is a replay, not a duplicate
+    // second charge: it takes the already-existed fallthrough, re-runs the
+    // credit grant and returns.
+    const result = await recordPassPurchase({
+      orgId: auth.orgId,
+      competitionId: compId,
+      paymentIntent: intent,
+    });
+    expect(result).toEqual({ recorded: false, duplicateIntent: null });
+
+    // (4) Pre-fix the fallthrough returned WITHOUT invalidating, so the stale
+    // deny warmed in (1) outlived the healed purchase for up to 5 minutes —
+    // a paid pass that does nothing. The invalidate is now unconditional.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(true);
+  });
+
   it("revokePassForRefundedCharge busts the cache the instant a refund revokes the pass", async () => {
     const auth = await seedCommunityOrg();
     const [{ id: compId }] = await sql<{ id: string }[]>`
@@ -127,6 +164,51 @@ describe.skipIf(!HAS_DB || !HAS_REDIS)("entitlement cache invalidation (real Red
 
     // revokePassForRefundedCharge already calls invalidateOrgEntitlements
     // (lib/billing.ts:881) — this proves it, doesn't just assert it.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(false);
+  });
+
+  // v17 W2 Task 8 (b). The dispute-lost revoke is a SECOND, independent delete
+  // of a competition_passes row (billing-events.ts handlePlatformDispute) — it
+  // does not go through revokePassForRefundedCharge, so the test above proves
+  // nothing about it. platform-dispute.test.ts asserts the row is gone; only a
+  // real Redis can show whether the org stops resolving the pass, and a
+  // chargeback that leaves 300s of paid-for entitlement behind is the one
+  // direction that costs money.
+  it("a lost dispute busts the cache the instant it revokes the pass", async () => {
+    const auth = await seedCommunityOrg();
+    const [{ id: compId }] = await sql<{ id: string }[]>`
+      insert into competitions (org_id, name, slug)
+      values (${auth.orgId}, ${"Dispute Cup " + randomUUID().slice(0, 6)},
+              ${"dispute-cup-" + randomUUID().slice(0, 6)}) returning id`;
+    const intent = `pi_${randomUUID().slice(0, 8)}`;
+    await recordPassPurchase({ orgId: auth.orgId, competitionId: compId, paymentIntent: intent });
+    await invalidateOrgEntitlements(auth.orgId);
+
+    // Warm the cache on the granted (true) answer.
+    expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(true);
+
+    // The pass branch of handlePlatformDispute matches on payment_intent, so
+    // this runs keyless — no Stripe call, no mock (same reason
+    // platform-dispute.test.ts's pass tests do).
+    await processStripeEvent({
+      id: `evt_${randomUUID().slice(0, 12)}`,
+      type: "charge.dispute.closed",
+      data: {
+        object: {
+          id: `dp_${randomUUID().slice(0, 8)}`,
+          status: "lost",
+          amount: 2900,
+          currency: "gbp",
+          payment_intent: intent,
+          charge: `ch_${randomUUID().slice(0, 8)}`,
+        },
+      },
+    } as unknown as Stripe.Event);
+
+    // The row is gone AND the org knows it.
+    const [row] = await sql`
+      select 1 from competition_passes where stripe_payment_intent = ${intent}`;
+    expect(row).toBeUndefined();
     expect(await hasFeature(auth.orgId, "realtime", compId)).toBe(false);
   });
 });

--- a/apps/web/src/lib/__tests__/entitlements-comp-liveness.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-comp-liveness.test.ts
@@ -95,10 +95,15 @@ describe.skipIf(!HAS_DB)("comp-expiry arm derives its status list from billing",
   // it stays as the guard for any future nullable status, since a bare NOT IN
   // over NULL yields NULL rather than true and would kill the arm silently.
 
-  // 'suspended' is written by api/admin/orgs/[id]/suspend and is in no
-  // STATUS_MAP — the column's vocabulary is wider than Stripe's. The arm negates
-  // the live list rather than naming dead statuses precisely so non-Stripe
-  // statuses like this one degrade too; hand-written dead-status SQL would miss it.
+  // 'suspended' is in no STATUS_MAP, and since V314 §2b nothing WRITES it to
+  // this column either — staff suspension moved to organizations.status and
+  // V314 reset the legacy rows. The fixture below therefore seeds a value no
+  // production writer produces, and that is the point: subscriptions.status is
+  // plain text with no CHECK constraint, so the arm negates the live list
+  // instead of naming dead statuses, and any value from outside the Stripe
+  // vocabulary — a legacy row, a hand-edited one — degrades safely. Hand-written
+  // dead-status SQL would miss it. (What suspension does TODAY is a separate,
+  // org-scoped arm: `o.status = 'suspended'` in orgPlanKey.)
   it("a non-Stripe 'suspended' status lets the lapsed comp expire", async () => {
     const orgId = await seedLapsedComp({ status: "suspended" });
     expect(await hasFeature(orgId, "exports.branded")).toBe(false);

--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -352,4 +352,20 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     expect(await hasFeature(orgId, "exports")).toBe(true);
     expect(await sqlHasFeature(orgId, "exports")).toBe(true);
   });
+
+  // v17 #288: SQL org_has_feature was missing the 'incomplete' arm entirely
+  // (fell through to coalesce(plan_key)='pro') while entitlements.ts's
+  // orgPlanKey has carried it since #206/#223-B — a never-paid first
+  // invoice read Pro on every SQL-resolved public surface until Stripe
+  // auto-expired the subscription ~23h later. V338 copies the TS arm into
+  // SQL verbatim.
+  it("degrades an INCOMPLETE subscription (never-paid first invoice) to community", async () => {
+    await sql`
+      update subscriptions
+      set plan_key = 'pro', status = 'incomplete', stripe_subscription_id = 'sub_incomplete'
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime")).toBe(false);
+    expect(await sqlHasFeature(orgId, "realtime")).toBe(false);
+  });
 });

--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -368,4 +368,21 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     expect(await hasFeature(orgId, "realtime")).toBe(false);
     expect(await sqlHasFeature(orgId, "realtime")).toBe(false);
   });
+
+  // Coverage addition, not a regression: both resolvers already agreed a
+  // suspended ORG resolves community regardless of its subscription's plan
+  // (entitlements.ts:209, org_has_feature's first CASE arm) — this suite
+  // never had a case proving it. Passes before AND after V338; it is here
+  // so a future change to either arm trips this suite instead of shipping
+  // silently.
+  it("keeps a SUSPENDED org on community regardless of its subscription's plan", async () => {
+    await sql`
+      update subscriptions
+      set plan_key = 'pro', status = 'active', stripe_subscription_id = 'sub_susp'
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    await sql`update organizations set status = 'suspended' where id = ${orgId}`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime")).toBe(false);
+    expect(await sqlHasFeature(orgId, "realtime")).toBe(false);
+  });
 });

--- a/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
+++ b/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
@@ -1,0 +1,58 @@
+// Every `*.redis.test.ts` suite must be named explicitly in ci.yml.
+//
+// These suites gate themselves on `describe.skipIf(!HAS_DB || !HAS_REDIS)`, so
+// a suite CI never runs does not fail — it reports "skipped" and looks green.
+// And REDIS_URL is deliberately NOT job-wide (setting it there switches the
+// entitlement cache on for the whole `smoke` job, which breaks the src/server
+// suites that mutate entitlements via raw SQL without invalidating), so each
+// Redis-gated file gets its own hand-wired step that owns REDIS_URL for itself
+// alone. Hand-wired means forgettable: add a new `*.redis.test.ts` file and it
+// silently never runs in CI, which is exactly the shape of bug these suites
+// exist to catch.
+//
+// This guard is pure — no DB, no Redis, no network — so it runs on every CI
+// job and never self-skips. It is the one test in the family that CANNOT be
+// silently switched off.
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+
+/** apps/web/src — this file lives at apps/web/src/lib/__tests__/. */
+const SRC = resolve(import.meta.dirname, "../..");
+/** Repo root: up out of __tests__ / lib / src / web / apps. */
+const REPO_ROOT = resolve(import.meta.dirname, "../../../../..");
+const CI_YML = join(REPO_ROOT, ".github/workflows/ci.yml");
+
+/** Every Redis-gated suite under apps/web/src, as src-relative paths. */
+function redisSuites(): string[] {
+  return readdirSync(SRC, { recursive: true, encoding: "utf8" })
+    .filter((p) => p.endsWith(".redis.test.ts"))
+    .sort();
+}
+
+describe("Redis-gated suites are wired into CI", () => {
+  it("finds the ci.yml this guard reads", () => {
+    // Cheap, but it is what stops the whole guard passing vacuously if the
+    // workflow is ever moved or renamed — an unreadable file would otherwise
+    // just make every `includes` check moot.
+    expect(readFileSync(CI_YML, "utf8").length).toBeGreaterThan(0);
+  });
+
+  it("finds at least one Redis-gated suite to check", () => {
+    // The other half of the vacuity guard: a walk that silently matched
+    // nothing (wrong SRC root, changed naming convention) would make the
+    // assertion below trivially true for ever.
+    expect(redisSuites().length).toBeGreaterThan(0);
+  });
+
+  it("names every *.redis.test.ts file in ci.yml", () => {
+    const ci = readFileSync(CI_YML, "utf8");
+    const unwired = redisSuites().filter((p) => !ci.includes(basename(p)));
+    // Matched on the BASENAME, not the src-relative path: how a step spells the
+    // path (`src/lib/...` under a workspace run vs an absolute one) is not the
+    // contract — "CI mentions this file at all" is. The message names the file
+    // because the fix is to add a step, and the person who just added the suite
+    // is the one who needs telling.
+    expect(unwired, `not run by any ci.yml step: ${unwired.join(", ")}`).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
+++ b/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
@@ -23,11 +23,40 @@ const SRC = resolve(import.meta.dirname, "../..");
 const REPO_ROOT = resolve(import.meta.dirname, "../../../../..");
 const CI_YML = join(REPO_ROOT, ".github/workflows/ci.yml");
 
-/** Every Redis-gated suite under apps/web/src, as src-relative paths. */
+/**
+ * Every Redis-gated suite under apps/web/src, as src-relative paths.
+ *
+ * Scans apps/web/src ONLY. Every Redis-gated suite lives there today; a
+ * `*.redis.test.ts` added under another workspace would not be seen, which is
+ * the known limit of this guard rather than an oversight.
+ */
 function redisSuites(): string[] {
   return readdirSync(SRC, { recursive: true, encoding: "utf8" })
     .filter((p) => p.endsWith(".redis.test.ts"))
     .sort();
+}
+
+/**
+ * ci.yml with its COMMENTS removed.
+ *
+ * Load-bearing, not tidiness: ci.yml documents these steps in prose that names
+ * the very files the steps run (the block above the Redis steps names both
+ * suites). A raw substring search over the whole file is therefore satisfied by
+ * the COMMENTARY — delete the actual `run:` step and the guard stays green,
+ * which is precisely the failure it exists to catch.
+ *
+ * Strips comments rather than whitelisting `run:` lines: a `run: |` block spans
+ * continuation lines that no line-shape filter would match, so whitelisting
+ * would false-FAIL a suite wired inside a multi-line script. Removing comments
+ * is the smaller, safer reduction — it deletes only non-executable text and
+ * leaves every executable form intact. Applies YAML's actual comment rule (`#`
+ * at line start or after whitespace), so a `#` inside a quoted command survives.
+ */
+function ciExecutableText(): string {
+  return readFileSync(CI_YML, "utf8")
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, ""))
+    .join("\n");
 }
 
 describe("Redis-gated suites are wired into CI", () => {
@@ -38,6 +67,17 @@ describe("Redis-gated suites are wired into CI", () => {
     expect(readFileSync(CI_YML, "utf8").length).toBeGreaterThan(0);
   });
 
+  it("strips the commentary that would otherwise satisfy the check", () => {
+    // The reduction itself needs a guard: if ciExecutableText ever stopped
+    // stripping, every assertion below would silently go back to being
+    // satisfiable by prose. ci.yml's comment block above the Redis steps names
+    // both suites, so `npm test` (only ever in a `run:`) must survive while
+    // that commentary does not.
+    const exec = ciExecutableText();
+    expect(exec).toContain("npm test");
+    expect(exec).not.toContain("Redis-gated, so they still self-skip here");
+  });
+
   it("finds at least one Redis-gated suite to check", () => {
     // The other half of the vacuity guard: a walk that silently matched
     // nothing (wrong SRC root, changed naming convention) would make the
@@ -45,8 +85,8 @@ describe("Redis-gated suites are wired into CI", () => {
     expect(redisSuites().length).toBeGreaterThan(0);
   });
 
-  it("names every *.redis.test.ts file in ci.yml", () => {
-    const ci = readFileSync(CI_YML, "utf8");
+  it("names every *.redis.test.ts file in an executable ci.yml step", () => {
+    const ci = ciExecutableText();
     const unwired = redisSuites().filter((p) => !ci.includes(basename(p)));
     // Matched on the BASENAME, not the src-relative path: how a step spells the
     // path (`src/lib/...` under a workspace run vs an absolute one) is not the

--- a/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
+++ b/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
@@ -52,11 +52,15 @@ function redisSuites(): string[] {
  * leaves every executable form intact. Applies YAML's actual comment rule (`#`
  * at line start or after whitespace), so a `#` inside a quoted command survives.
  */
-function ciExecutableText(): string {
-  return readFileSync(CI_YML, "utf8")
+function stripComments(text: string): string {
+  return text
     .split("\n")
     .map((line) => line.replace(/(^|\s)#.*$/, ""))
     .join("\n");
+}
+
+function ciExecutableText(): string {
+  return stripComments(readFileSync(CI_YML, "utf8"));
 }
 
 describe("Redis-gated suites are wired into CI", () => {
@@ -70,12 +74,36 @@ describe("Redis-gated suites are wired into CI", () => {
   it("strips the commentary that would otherwise satisfy the check", () => {
     // The reduction itself needs a guard: if ciExecutableText ever stopped
     // stripping, every assertion below would silently go back to being
-    // satisfiable by prose. ci.yml's comment block above the Redis steps names
-    // both suites, so `npm test` (only ever in a `run:`) must survive while
-    // that commentary does not.
-    const exec = ciExecutableText();
-    expect(exec).toContain("npm test");
-    expect(exec).not.toContain("Redis-gated, so they still self-skip here");
+    // satisfiable by prose.
+    //
+    // Asserted against a LITERAL FIXTURE, not against ci.yml's own prose. An
+    // earlier version pinned a real sentence from the workflow's comment block,
+    // which made an unrelated reword of that comment fail this test — and, worse,
+    // made the guard silently vacuous the moment someone "fixed" it by deleting
+    // the sentence. The rule is what is being tested, so the rule gets its own
+    // input: executable text survives, comments do not, and a `#` inside a
+    // quoted command is not a comment (YAML's actual rule).
+    const fixture = [
+      "# a whole comment line naming decoy-fixture.redis.test.ts",
+      "      - name: keep me",
+      "        run: npm test -- src/lib/__tests__/kept-fixture.redis.test.ts # trailing note",
+      "        run: curl https://example.test/spec#anchor-not-a-comment",
+    ].join("\n");
+    const stripped = stripComments(fixture);
+
+    // Executable text survives, including a multi-token `run:` line...
+    expect(stripped).toContain("run: npm test -- src/lib/__tests__/kept-fixture.redis.test.ts");
+    expect(stripped).toContain("- name: keep me");
+    // ...and a `#` with no whitespace before it is part of the token, not a
+    // comment, so a fragment in a URL is not silently truncated.
+    expect(stripped).toContain("https://example.test/spec#anchor-not-a-comment");
+    // Commentary does not survive — including the filename it named, which is
+    // the whole reason this stripping exists.
+    expect(stripped).not.toContain("a whole comment line");
+    expect(stripped).not.toContain("decoy-fixture.redis.test.ts");
+    expect(stripped).not.toContain("trailing note");
+    // And the real reader is wired to that same rule rather than reimplementing it.
+    expect(ciExecutableText()).toContain("npm test");
   });
 
   it("finds at least one Redis-gated suite to check", () => {
@@ -94,5 +122,21 @@ describe("Redis-gated suites are wired into CI", () => {
     // because the fix is to add a step, and the person who just added the suite
     // is the one who needs telling.
     expect(unwired, `not run by any ci.yml step: ${unwired.join(", ")}`).toEqual([]);
+  });
+
+  it("gives each Redis-gated suite a step that actually owns REDIS_URL", () => {
+    // Naming the file is not enough. These suites gate on
+    // `!HAS_DB || !HAS_REDIS`, so a suite wired into a step WITHOUT REDIS_URL
+    // self-skips and reports green — the same silent no-op as never wiring it
+    // at all, and harder to spot because the filename is right there in the
+    // workflow. REDIS_URL is deliberately step-scoped (job-wide breaks the
+    // src/server suites), so there must be at least one step-scoped occurrence
+    // per suite.
+    const exec = ciExecutableText();
+    const withRedisUrl = exec.split("REDIS_URL:").length - 1;
+    expect(
+      withRedisUrl,
+      `${redisSuites().length} Redis-gated suite(s) but only ${withRedisUrl} step(s) set REDIS_URL`,
+    ).toBeGreaterThanOrEqual(redisSuites().length);
   });
 });

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -830,6 +830,15 @@ export async function recordPassPurchase(args: {
   // attempt that recorded the pass but died before crediting — the per-
   // competition idempotency key makes it a no-op if the grant already landed.
   if (!dup) await grantPassCredits();
+  // ...and busts the cache UNCONDITIONALLY on the way out. The healing path
+  // exists precisely because a first attempt can die after the insert — and it
+  // can die between the insert and the invalidate too, leaving a warm DENY (or
+  // a stale pre-purchase answer) that outlives the pass for the full 300s TTL.
+  // A retry that heals the grant but not the cache heals nothing the buyer can
+  // see. Idempotent and fail-open by construction (cacheDelPattern swallows its
+  // own errors), so running it on the duplicate-charge branch too costs a Redis
+  // DEL of a prefix that is usually already empty and can never fail the ACK.
+  await invalidateOrgEntitlements(args.orgId);
   return { recorded: false, duplicateIntent: dup };
 }
 

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -708,7 +708,16 @@ export async function syncSubscriptionForGroup(
   // keep the org's current plan instead of silently downgrading every affected
   // customer — the stripe:sync drift is a staff problem, not the customer's.
   if (priceId && !knownPlanKey) console.error("syncSubscription: unknown price", priceId);
-  const status = STATUS_MAP[stripeSub.status] ?? "past_due";
+  // Fallback = the status Stripe invented since this map was written. It must
+  // fail SAFE, and `past_due` (the old fallback) failed OPEN: a never-paid
+  // status we don't recognise — the likely shape of anything new in the
+  // incomplete family — would inherit the 14-day dunning grace in orgPlanKey
+  // and convey full Pro, paid for nothing, until a human noticed. `incomplete`
+  // conveys no plan AND is still in LIVE_SUBSCRIPTION_STATUSES, so the org is
+  // not orphaned and cannot open a second checkout. Anything genuinely paid
+  // that lands here corrects itself on the next webhook once the status is
+  // mapped; the reverse mistake bills nobody and entitles everybody.
+  const status = STATUS_MAP[stripeSub.status] ?? "incomplete";
   // In Stripe v22, current_period_end lives on each subscription item.
   const periodEnd = stripeSub.items.data[0]?.current_period_end ?? null;
   // null = this object cannot answer; see paymentMethodFromStripeSubscription.

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -708,6 +708,13 @@ export async function syncSubscriptionForGroup(
   // keep the org's current plan instead of silently downgrading every affected
   // customer — the stripe:sync drift is a staff problem, not the customer's.
   if (priceId && !knownPlanKey) console.error("syncSubscription: unknown price", priceId);
+  // Loud for the same reason the unknown-price branch above is: the fallback
+  // below silently lands a possibly-PAYING customer on a status that conveys
+  // nothing, and a drift we never see is a drift nobody fixes. Same shape as
+  // its sibling, plus the subscription id — unlike a price, a status gives a
+  // human nothing to look up without knowing which subscription it came from.
+  if (!STATUS_MAP[stripeSub.status])
+    console.error("syncSubscription: unknown status", stripeSub.status, stripeSub.id);
   // Fallback = the status Stripe invented since this map was written. It must
   // fail SAFE, and `past_due` (the old fallback) failed OPEN: a never-paid
   // status we don't recognise — the likely shape of anything new in the

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -713,8 +713,18 @@ export async function syncSubscriptionForGroup(
   // nothing, and a drift we never see is a drift nobody fixes. Same shape as
   // its sibling, plus the subscription id — unlike a price, a status gives a
   // human nothing to look up without knowing which subscription it came from.
-  if (!STATUS_MAP[stripeSub.status])
-    console.error("syncSubscription: unknown status", stripeSub.status, stripeSub.id);
+  // `Object.hasOwn`, not a bare index: STATUS_MAP is a Record indexed by a
+  // string that comes off the wire, so `STATUS_MAP["constructor"]` (or
+  // "toString", "valueOf", …) returns an inherited FUNCTION rather than
+  // undefined. That is truthy, so a bare index would skip the error log below
+  // AND survive the `??` fallback — writing a Function into subscriptions.status
+  // and degrading a customer silently, which is the exact pair of failures both
+  // lines exist to prevent. Resolved once, so the log and the value can never
+  // disagree about what "known" means.
+  const mapped = Object.hasOwn(STATUS_MAP, stripeSub.status)
+    ? STATUS_MAP[stripeSub.status]
+    : undefined;
+  if (!mapped) console.error("syncSubscription: unknown status", stripeSub.status, stripeSub.id);
   // Fallback = the status Stripe invented since this map was written. It must
   // fail SAFE, and `past_due` (the old fallback) failed OPEN: a never-paid
   // status we don't recognise — the likely shape of anything new in the
@@ -724,7 +734,7 @@ export async function syncSubscriptionForGroup(
   // not orphaned and cannot open a second checkout. Anything genuinely paid
   // that lands here corrects itself on the next webhook once the status is
   // mapped; the reverse mistake bills nobody and entitles everybody.
-  const status = STATUS_MAP[stripeSub.status] ?? "incomplete";
+  const status = mapped ?? "incomplete";
   // In Stripe v22, current_period_end lives on each subscription item.
   const periodEnd = stripeSub.items.data[0]?.current_period_end ?? null;
   // null = this object cannot answer; see paymentMethodFromStripeSubscription.

--- a/apps/web/src/lib/entitlements.ts
+++ b/apps/web/src/lib/entitlements.ts
@@ -194,11 +194,11 @@ export async function orgPlanKey(orgId: string): Promise<string> {
       -- coalesce is load-bearing: a bare NOT IN over a null status yields NULL,
       -- not true, so the arm would silently never fire for rows with no status.
       -- Negating the live list is WIDER than the old "status = canceled" test.
-      -- It used to also fire for 'suspended' on this row; since V310 NOTHING
-      -- writes that status (staff suspension moved to organizations.status, and
-      -- V310 cleared the rows the old route left behind), so that arm is now
-      -- reachable only by genuinely dead subscriptions. Suspension is handled by
-      -- the org branch below instead.
+      -- It used to also fire for 'suspended' on this row; since V314 §2b
+      -- NOTHING writes that status (staff suspension moved to
+      -- organizations.status, and V314 reset the rows the old route left behind
+      -- to 'active'), so that arm is now reachable only by genuinely dead
+      -- subscriptions. Suspension is handled by the org branch below instead.
       --
       -- MODERATION, not billing: a suspended ORG resolves community regardless
       -- of what its group pays for. This is deliberately scoped to the one org —

--- a/apps/web/src/lib/subscription-status.ts
+++ b/apps/web/src/lib/subscription-status.ts
@@ -4,10 +4,23 @@
  *  pays), so this list is the whole non-terminal set of STRIPE-SOURCED statuses.
  *  `canceled` is terminal — a departed customer must be able to come back.
  *
- *  STATUS_MAP is NOT the whole vocabulary of subscriptions.status: 'suspended'
- *  is written in-app by the staff suspend route (api/admin/orgs/[id]/suspend)
- *  and never comes from Stripe, so it appears in no map here. It is not live —
- *  which is what makes a suspended org's lapsed comp expire like any other.
+ *  No 'suspended' here, and that is not an omission. Staff suspension USED to
+ *  stamp subscriptions.status = 'suspended', which was harmless only while a
+ *  subscription belonged to exactly one org. V314 §2b ended that: the row is a
+ *  shared billing GROUP, so writing it would stop billing and degrade
+ *  entitlements for every sibling org. api/admin/orgs/[id]/suspend now writes
+ *  organizations.status and nothing else, V314 reset every legacy 'suspended'
+ *  subscription row to 'active', and nothing in the application writes that
+ *  value to this column any more. Suspension bites through the resolver's
+ *  `o.status = 'suspended'` arm (entitlements.ts orgPlanKey, and org_has_feature
+ *  in SQL) — org-scoped, so the group keeps billing and siblings are untouched.
+ *
+ *  This list is still consumed by NEGATION rather than by enumerating the dead
+ *  statuses, because subscriptions.status is plain text with no CHECK
+ *  constraint (default 'active'). Anything outside this list — a legacy row, a
+ *  hand-edited one — therefore reads as non-live and degrades safely. Stripe
+ *  statuses cannot widen the column: STATUS_MAP maps the ones we know and
+ *  falls back to 'incomplete', which is in this list.
  *
  *  Lives in its own leaf module (no imports) because BOTH sides of a cycle need
  *  it: lib/billing.ts imports invalidateOrgEntitlements from lib/entitlements.ts,

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -1090,6 +1090,41 @@ describe.skipIf(!HAS_DB)("a move invalidates BOTH groups", () => {
     // And the moved org resolves the new group's plan immediately, not in 300s.
     expect(await hasFeature(joiner.orgId, "api.access")).toBe(true);
   });
+
+  // v17 W2 Task 8 (c): the detach half of the same property. The detach tests
+  // above read hasFeature only AFTER the call, against a cold cache — which a
+  // detach that never invalidated would also pass. This one WARMS the answer
+  // first, so the assertion can only hold if invalidateMove actually ran. It is
+  // the losing direction that matters here: a stale `true` keeps a departed org
+  // on somebody else's paid plan for up to the 300s TTL.
+  it("drops the cached entitlements of the org that LEFT and of the group it left", async () => {
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    // No period end and no comp: `release` and `ride_out` both land the leaver
+    // on Community, so the flip under test is the plan drop, not the mode.
+    const group = await makeGroup(payer, {
+      plan: "pro",
+      stripeSubId: null,
+      periodEndDays: null,
+      quantityPaid: 2,
+    });
+    const sibling = await makeOrg(group, payer);
+    const leaver = await makeOrg(group, clubOwner);
+
+    // Warm BOTH sides on the group's paid answer — real 300s entries.
+    expect(await hasFeature(leaver, "api.access")).toBe(true);
+    expect(await hasFeature(sibling, "api.access")).toBe(true);
+    expect(store.has(`ent:${leaver}:api.access`)).toBe(true);
+    expect(store.has(`ent:${sibling}:api.access`)).toBe(true);
+
+    await detachOrgFromGroup({ actorUserId: clubOwner, orgId: leaver });
+
+    expect(store.has(`ent:${leaver}:api.access`)).toBe(false);
+    expect(store.has(`ent:${sibling}:api.access`)).toBe(false);
+    // Without the bust this reads the warm `true` above and the org keeps Pro
+    // it no longer pays for.
+    expect(await hasFeature(leaver, "api.access")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -939,6 +939,53 @@ describe.skipIf(!HAS_DB)("detach", () => {
     expect(await hasFeature(orgId, "api.access")).toBe(true);
   });
 
+  it("a FAILED Stripe cancel takes the poisoned cache back with the rollback", async () => {
+    // The cancel claim COMMITS `community`/`canceled` before Stripe is called,
+    // deliberately — holding the row lock across a network round trip is worse.
+    // But that means there is a real window in which the group reads as
+    // cancelled, and an attach queued on the group's lock can land an org in it
+    // during exactly that window. That org resolves its entitlements against
+    // the committed cancellation and the Community answer caches for the full
+    // 300s TTL. Then Stripe refuses, the row rolls back to a PAYING Pro group —
+    // and the cache still says Community.
+    //
+    // The rollback therefore has to bust the cache too. It used to `return
+    // "cancel_failed"` straight out of the catch, jumping over the invalidate
+    // on the success path below it, so a paying group was served Community for
+    // up to five minutes with nothing to correct it.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const stripeSubId = "sub_cancelfail_" + uniq();
+    const group = await makeGroup(payer, { stripeSubId, periodEndDays: 30 });
+    const leaving = await makeOrg(group, clubOwner);
+    const joiner = await makeLooseOrg(payer);
+
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Stands in for the attach that wins the lock the instant the claim commits.
+    // Doing it inside the Stripe double is what puts it in the real window: the
+    // rollback has not run yet, and it is the only code that will.
+    stripeMock.subscriptionsCancel.mockImplementationOnce(async () => {
+      await sql`update organizations set subscription_id = ${group} where id = ${joiner.orgId}`;
+      // The poisoning read. Denies cache too (the resolver stores `{ v: null }`
+      // precisely so a deny is distinguishable from a miss), so this is a real
+      // 300s entry, not a no-op.
+      expect(await hasFeature(joiner.orgId, "api.access")).toBe(false);
+      throw new Error("stripe refused the cancel");
+    });
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId: leaving });
+
+    // The row is back exactly as it was: live, billable, Pro.
+    expect(res.cancelled_group).toBeNull();
+    const after = await readGroup(group);
+    expect(after.status).toBe("active");
+    expect(after.plan_key).toBe("pro");
+    // And so is the answer the group serves. This is the assertion the missing
+    // invalidate failed.
+    expect(await hasFeature(joiner.orgId, "api.access")).toBe(true);
+    err.mockRestore();
+  });
+
   it("refuses when the org already has a billing group of its own", async () => {
     const owner = await makeUser("solo");
     const loose = await makeLooseOrg(owner);

--- a/apps/web/src/server/usecases/__tests__/competition-lifecycle-event.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-lifecycle-event.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { EVENTS } from "@/lib/analytics-events";
+import { competitionLifecycleEvent } from "../competitions";
+
+// v17 #289: `statusChangedTo === "active" || statusChangedTo === "complete"`
+// compared against CompetitionStatus values that never exist — "live" and
+// "completed" are the real enum members (schemas.ts's CompetitionStatus) —
+// so COMPETITION_STARTED/COMPETITION_COMPLETED never fired. Pure decision
+// helper, mirrors shouldFireMadePublic — no DB needed.
+describe("competitionLifecycleEvent", () => {
+  it("fires COMPETITION_STARTED on the transition to live", () => {
+    expect(competitionLifecycleEvent("live")).toBe(EVENTS.COMPETITION_STARTED);
+  });
+
+  it("fires COMPETITION_COMPLETED on the transition to completed", () => {
+    expect(competitionLifecycleEvent("completed")).toBe(EVENTS.COMPETITION_COMPLETED);
+  });
+
+  it("does NOT fire on a transition to published — published is not started", () => {
+    expect(competitionLifecycleEvent("published")).toBeNull();
+  });
+
+  it("does not fire on a transition to draft or archived", () => {
+    expect(competitionLifecycleEvent("draft")).toBeNull();
+    expect(competitionLifecycleEvent("archived")).toBeNull();
+  });
+
+  it("does not fire when the status did not change (null — no transition)", () => {
+    expect(competitionLifecycleEvent(null)).toBeNull();
+  });
+});

--- a/apps/web/src/server/usecases/admin-orgs.ts
+++ b/apps/web/src/server/usecases/admin-orgs.ts
@@ -1,0 +1,47 @@
+import "server-only";
+// Staff moderation actions on an organization (v3/08 §1). Billing-shaped staff
+// tools live in admin-plan.ts; this file is the moderation side, which is
+// deliberately kept away from the money — see setOrgSuspension.
+import { sql } from "@/lib/db";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import { logStaffAction } from "@/lib/admin";
+
+export type SuspensionAction = "suspend" | "reactivate";
+
+/**
+ * Suspend or reactivate an organization.
+ *
+ * organizations.status ONLY. Suspension used to also stamp
+ * subscriptions.status = 'suspended', which was harmless while a subscription
+ * belonged to exactly one org. Since V314 a subscription is a shared BILLING
+ * GROUP: writing to it would stop billing and degrade entitlements for every
+ * OTHER org in the group — orgs that may belong to uninvolved people and have
+ * done nothing wrong. Suspension is moderation, not billing, so the money and
+ * the plan are left completely alone and a suspended org keeps counting toward
+ * the group's paid quantity (billing-group.ts activeOrgCount).
+ */
+export async function setOrgSuspension(
+  actorId: string,
+  orgId: string,
+  action: SuspensionAction,
+  reason: string,
+): Promise<"suspended" | "active"> {
+  const newStatus = action === "suspend" ? "suspended" : "active";
+  await sql`update organizations set status = ${newStatus} where id = ${orgId}`;
+
+  // organizations.status is a resolver INPUT — `when o.status = 'suspended'
+  // then 'community'` is the first arm of both orgPlanKey and the SQL
+  // org_has_feature — and resolved answers cache for ENT_TTL_SECONDS (300s).
+  // Without this the suspension took up to 5 minutes to bite, and an
+  // unsuspension took up to 5 minutes to give the org back. Org-scoped, not
+  // group-scoped: suspension is moderation of ONE org and must not disturb the
+  // siblings sharing its billing group.
+  //
+  // Fail-open by construction: cacheDelPattern swallows every Redis error, so
+  // no try/catch. Deliberately AFTER the write and outside any transaction — a
+  // cache bust must never be able to roll the moderation action back.
+  await invalidateOrgEntitlements(orgId);
+
+  await logStaffAction(actorId, action, "org", orgId, { reason });
+  return newStatus;
+}

--- a/apps/web/src/server/usecases/admin-orgs.ts
+++ b/apps/web/src/server/usecases/admin-orgs.ts
@@ -27,7 +27,18 @@ export async function setOrgSuspension(
   reason: string,
 ): Promise<"suspended" | "active"> {
   const newStatus = action === "suspend" ? "suspended" : "active";
-  await sql`update organizations set status = ${newStatus} where id = ${orgId}`;
+  // `returning id`, and a throw when it comes back empty. The route in front of
+  // this looks the org up and 404s first, so today the update always matches —
+  // but that guard belongs to the route, not to this function, and the next
+  // caller (a cron, a staff script, a second route) inherits none of it. Without
+  // this, an unknown or already-deleted org id updates zero rows and the use
+  // case still busts a cache, writes a staff-action log naming an org that was
+  // never touched, and RETURNS the status as though it had applied it. Failing
+  // here keeps the audit log truthful; the route's own 404 still fires first and
+  // its semantics are unchanged.
+  const [row] = await sql<{ id: string }[]>`
+    update organizations set status = ${newStatus} where id = ${orgId} returning id`;
+  if (!row) throw new Error(`setOrgSuspension: no organization ${orgId}`);
 
   // organizations.status is a resolver INPUT — `when o.status = 'suspended'
   // then 'community'` is the first arm of both orgPlanKey and the SQL

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -515,8 +515,10 @@ async function mayWriteGroup(
   return false;
 }
 
-/** Terminal STRIPE statuses. Everything else still owns the subscription (our
- *  STATUS_MAP collapses incomplete/unpaid/paused into past_due, which is live). */
+/** Terminal STRIPE statuses. Everything else still owns the subscription: our
+ *  STATUS_MAP collapses unpaid/paused into past_due and keeps incomplete
+ *  distinct (#206 — it conveys no plan), and every one of those is in
+ *  LIVE_SUBSCRIPTION_STATUSES, so "not terminal" still means "live". */
 function isLiveStripeStatus(status: Stripe.Subscription.Status): boolean {
   return status !== "canceled" && status !== "incomplete_expired";
 }

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -533,6 +533,13 @@ async function cancelGroupIfEmpty(
                updated_at = now()
          where id = ${subscriptionId}`;
       console.error("cancelGroupIfEmpty: Stripe cancel failed", subscriptionId, err);
+      // The rollback has to take the CACHE back with it. The claim committed
+      // `community`/`canceled` before Stripe was called, so any resolve in that
+      // window — an org an attach landed in the group while it was in flight —
+      // cached a Community answer, and the row is now a paying Pro group again.
+      // Returning straight from here jumped over the invalidate below and left
+      // that answer standing for the full 300s TTL, with nothing to correct it.
+      await invalidateGroupEntitlements(subscriptionId);
       return "cancel_failed";
     }
   }

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -4,7 +4,7 @@ import "server-only";
 // AuthCtx proves it); tenancy is enforced by withTenant + RLS.
 import { withTenant } from "@/lib/db";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
-import { requireFeature, withinLimit } from "@/lib/entitlements";
+import { invalidateOrgEntitlements, requireFeature, withinLimit } from "@/lib/entitlements";
 import { captureServer } from "@/lib/posthog-server";
 import { EVENTS } from "@/lib/analytics-events";
 import type { AuthCtx } from "@/server/api-v1/auth";
@@ -298,6 +298,16 @@ export async function patchCompetition(
         Boolean(patch.discovery ?? patch.name ?? patch.starts_on ?? patch.ends_on ?? patch.status));
     return { row, discoveryTouched };
   });
+  // v17 #287: ANY competition write can move status/ends_on, which the Event
+  // Pass lock (isPassLocked) reads live off this row on every resolve — so
+  // invalidate broadly (not gated to "did status/ends_on change") rather than
+  // reason about which columns matter. Fail-open by construction:
+  // invalidateOrgEntitlements -> cacheDelPattern swallows every Redis error
+  // internally (lib/cache.ts) and never throws, so this can never fail the
+  // write it rides on; the 300s TTL is the last-resort bound if it's ever
+  // skipped. Outside the tx, same reasoning as the discovery/slug busts below
+  // — invalidation never rolls back a write.
+  await invalidateOrgEntitlements(auth.orgId);
   // Toggle-off is immediate (doc 15 §1): drop the Redis window and fire the
   // `discovery` ISR tag. Outside the tx — invalidation never rolls back a write.
   if (discoveryTouched) {

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -2,14 +2,15 @@ import "server-only";
 // Competition use-cases (doc 08 §3). The service layer both /api/v1 routes and
 // Server Components call — the only writer. Auth happens in the route (an
 // AuthCtx proves it); tenancy is enforced by withTenant + RLS.
+import { z } from "zod";
 import { withTenant } from "@/lib/db";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
 import { invalidateOrgEntitlements, requireFeature, withinLimit } from "@/lib/entitlements";
 import { captureServer } from "@/lib/posthog-server";
-import { EVENTS } from "@/lib/analytics-events";
+import { EVENTS, type AnalyticsEvent } from "@/lib/analytics-events";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { page, type ListQuery, type Page } from "@/server/api-v1/http";
-import type { CreateCompetition, PatchCompetition } from "@/server/api-v1/schemas";
+import { CompetitionStatus, type CreateCompetition, type PatchCompetition } from "@/server/api-v1/schemas";
 import { fireDiscoveryRevalidate, invalidateDiscoveryCache } from "@/server/public-site/revalidate";
 import { invalidateSlugCache } from "@/server/slug-resolve";
 import {
@@ -198,6 +199,21 @@ export function shouldFireMadePublic(
   return newVisibility === "public" && oldVisibility !== "public";
 }
 
+/** v17 #289: `live` = play started; `completed` = wrapped up. `published`
+ *  does NOT count as started — a competition can sit published for weeks
+ *  before its first fixture. Pure like shouldFireMadePublic above, and
+ *  typed on the zod enum (not `string`) so a typo'd literal fails tsc
+ *  instead of silently comparing false forever — exactly how the
+ *  pre-#289 bug shipped: `statusChangedTo === "active"` compared against
+ *  values that could never equal any CompetitionStatus member. */
+export function competitionLifecycleEvent(
+  statusChangedTo: z.infer<typeof CompetitionStatus> | null,
+): AnalyticsEvent | null {
+  if (statusChangedTo === "live") return EVENTS.COMPETITION_STARTED;
+  if (statusChangedTo === "completed") return EVENTS.COMPETITION_COMPLETED;
+  return null;
+}
+
 // A frozen competition is read-only — but retiring it (status → completed/
 // archived) must stay possible, or the org could never get back under quota.
 function isRetirePatch(patch: PatchCompetition): boolean {
@@ -223,7 +239,7 @@ export async function patchCompetition(
   if (patch.discovery?.tagline || patch.discovery?.hero_image_path) {
     await requireFeature(auth.orgId, "discovery.branding");
   }
-  let statusChangedTo: string | null = null;
+  let statusChangedTo: z.infer<typeof CompetitionStatus> | null = null;
   let previousSlug: string | null = null;
   let oldVisibility: string | null = null;
   const { row, discoveryTouched } = await withTenant(auth.orgId, async (tx) => {
@@ -317,11 +333,12 @@ export async function patchCompetition(
   // A rename busts the cached slug resolution (old + new key) — outside the
   // tx, same reasoning as the discovery invalidation above.
   if (previousSlug) await invalidateSlugCache("competition", auth.orgId, previousSlug, row.slug);
-  // Lifecycle events (feature 1): tournament start/finish. `active` = play is on;
-  // `complete` = it's wrapped up.
-  if (statusChangedTo === "active" || statusChangedTo === "complete") {
+  // Lifecycle events (feature 1): tournament start/finish. Pure helper so
+  // the rule is unit-tested without a DB (mirrors shouldFireMadePublic).
+  const lifecycleEvent = competitionLifecycleEvent(statusChangedTo);
+  if (lifecycleEvent) {
     await captureServer({
-      event: statusChangedTo === "active" ? EVENTS.COMPETITION_STARTED : EVENTS.COMPETITION_COMPLETED,
+      event: lifecycleEvent,
       distinctId: auth.userId ?? `org:${auth.orgId}`,
       orgId: auth.orgId,
       properties: { competition_id: id },

--- a/db/migration/deltas/V338__org_has_feature_incomplete_degrade.sql
+++ b/db/migration/deltas/V338__org_has_feature_incomplete_degrade.sql
@@ -1,0 +1,116 @@
+-- V338 — org_has_feature gains the 'incomplete' degrade arm that
+-- lib/entitlements.ts's orgPlanKey has carried since #206/#223-B, closing
+-- v17 gap #287's SQL sibling (#288).
+--
+-- A subscription whose FIRST invoice never succeeded (an abandoned 3DS
+-- challenge, a declined card at the sheet) lands `status = 'incomplete'` —
+-- still a LIVE Stripe status (LIVE_SUBSCRIPTION_STATUSES), so a second
+-- checkout is blocked, but it must convey NO plan: the org has paid
+-- nothing. TS has resolved this to 'community' since #206/#223-B
+-- (entitlements.ts's orgPlanKey). The SQL resolver never got the arm, so
+-- it fell through to `coalesce(s.plan_key, 'community')` — Pro, on every
+-- public/embed surface the SQL function serves, for up to ~23h until
+-- Stripe auto-expires the subscription. Placed at the SAME position in
+-- the CASE as the TS version: after the trial_end backstop, before the
+-- cancelled-subscription arm (a subscription cannot be both).
+--
+-- Audit note (#288 "audit ALL Stripe sub statuses in one pass"): Stripe's
+-- other two "never really paid" statuses — `unpaid` and
+-- `incomplete_expired` — do NOT need their own arms here, in SQL or in
+-- TS. STATUS_MAP (lib/billing.ts, the ONE writer of subscriptions.status
+-- via syncSubscriptionForGroup) collapses them at write time — `unpaid`
+-- becomes our `past_due` (so it takes the existing 14-day dunning-grace
+-- arm, the same as any other renewal failure) and `incomplete_expired`
+-- becomes our `canceled` (so it takes the existing immediate
+-- canceled-arm, no grace). Neither literal string can ever reach this
+-- function's `s.status` column. Proven in
+-- apps/web/src/lib/__tests__/billing-grace-anchor.test.ts ("#288 audit"
+-- cases) and the suspended-org parity case this migration ships
+-- alongside (apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts).
+--
+-- The body is copied FORWARD from V334 (the current definition). The
+-- ONLY change is the new `when s.status = 'incomplete' then 'community'`
+-- arm. Every other arm — suspended org, comped_until lapse, past_due
+-- grace, trial_end backstop, cancelled-without-comp, the UTC pass-grace
+-- boundary, the override/pass/plan coalesce chain, the false default —
+-- is byte-for-byte V334.
+--
+-- Signature, security-definer and the pinned
+-- `search_path = <defaultSchema>, pg_temp` are unchanged.
+-- Replacing the function body carries public_competitions_v /
+-- public_entrants_v / public_discovery_v unchanged — they call the
+-- FUNCTION, so no view is reissued here.
+
+create or replace function org_has_feature(
+  p_org_id uuid,
+  p_feature_key text,
+  p_competition_id uuid
+) returns boolean
+  language sql stable security definer
+  set search_path = ${flyway:defaultSchema}, pg_temp as $$
+    with plan as (
+      select case
+        -- MODERATION, not billing (mirrors entitlements.ts): a suspended ORG
+        -- resolves community whatever its group pays for, scoped to that one org
+        -- so a moderator cannot degrade siblings that merely share a payer.
+        when o.status = 'suspended' then 'community'
+        when s.comped_until is not null and s.comped_until <= now()
+             and (s.stripe_subscription_id is null
+                  or coalesce(s.status, '') not in
+                     ('trialing', 'active', 'past_due'))
+             then 'community'
+        when s.status = 'past_due'
+             and coalesce(s.status_changed_at, s.updated_at) <= now() - interval '14 days'
+             then 'community'
+        -- Trial-end backstop: a trialing sub whose trial ended over a day ago is a
+        -- MISSED transition webhook (Stripe moves trialing→active/past_due/canceled at
+        -- trial_end). The resolver stops trusting the stale status, cron-free, the same
+        -- way the past_due arm above does. 1-day grace absorbs Stripe's transition lag.
+        -- trial_end IS null on a never-trialed sub → guard it so those stay on plan.
+        when s.status = 'trialing'
+             and s.trial_end is not null
+             and s.trial_end <= now() - interval '1 day'
+             then 'community'
+        -- v17 #287/#288: a never-paid first invoice conveys NO plan (mirrors
+        -- entitlements.ts's orgPlanKey — the arm this migration adds). Must NOT
+        -- inherit the past_due grace above, which is for a renewal that failed on
+        -- a subscription that WAS active; 'incomplete' never was.
+        when s.status = 'incomplete' then 'community'
+        -- A CANCELLED subscription does not convey its plan (V313). The
+        -- comped_at guard keeps an INDEFINITE staff comp alive; a lapsed comp is
+        -- already community via the comped_until arm above.
+        when s.status = 'canceled' and s.comped_at is null
+             then 'community'
+        else coalesce(s.plan_key, 'community')
+      end as plan_key
+      from organizations o
+      left join subscriptions s on s.id = o.subscription_id
+      where o.id = p_org_id
+    )
+    select coalesce(
+      (select bool_value from org_entitlement_overrides
+        where org_id = p_org_id and feature_key = p_feature_key
+          and (expires_at is null or expires_at > now())),
+      -- Event Pass: community orgs only, competition in scope. A key absent from
+      -- the pass matrix falls through to the plan row rather than denying. v17
+      -- SPEC-4 §7: the pass stops applying once its competition is archived or
+      -- long-ended (mirrors isPassLocked in lib/entitlements.ts). The grace
+      -- boundary is the UTC calendar date (V334), matching isPassLocked's
+      -- Date.UTC(getUTC*) — NOT the session-TZ `current_date`.
+      (select pe.bool_value
+         from competition_passes cp
+         join competitions c on c.id = cp.competition_id
+         join plan_entitlements pe
+           on pe.plan_key = cp.pass_key and pe.feature_key = p_feature_key
+        where p_competition_id is not null
+          and cp.competition_id = p_competition_id
+          and cp.org_id = p_org_id
+          and (select plan_key from plan) = 'community'
+          and not (c.status in ('archived', 'completed')
+                   or (c.ends_on is not null
+                       and c.ends_on + interval '7 days' < (now() at time zone 'utc')::date))),
+      (select pe.bool_value from plan_entitlements pe
+        where pe.feature_key = p_feature_key
+          and pe.plan_key = (select plan_key from plan)),
+      false)
+  $$;

--- a/db/migration/deltas/V338__org_has_feature_incomplete_degrade.sql
+++ b/db/migration/deltas/V338__org_has_feature_incomplete_degrade.sql
@@ -17,13 +17,22 @@
 -- Audit note (#288 "audit ALL Stripe sub statuses in one pass"): Stripe's
 -- other two "never really paid" statuses — `unpaid` and
 -- `incomplete_expired` — do NOT need their own arms here, in SQL or in
--- TS. STATUS_MAP (lib/billing.ts, the ONE writer of subscriptions.status
--- via syncSubscriptionForGroup) collapses them at write time — `unpaid`
--- becomes our `past_due` (so it takes the existing 14-day dunning-grace
--- arm, the same as any other renewal failure) and `incomplete_expired`
--- becomes our `canceled` (so it takes the existing immediate
--- canceled-arm, no grace). Neither literal string can ever reach this
--- function's `s.status` column. Proven in
+-- TS. STATUS_MAP (lib/billing.ts, via syncSubscriptionForGroup — the one
+-- writer of STRIPE-SOURCED status) collapses them at write time —
+-- `unpaid` becomes our `past_due` (so it takes the existing 14-day
+-- dunning-grace arm, the same as any other renewal failure) and
+-- `incomplete_expired` becomes our `canceled` (so it takes the existing
+-- immediate canceled-arm, no grace). STATUS_MAP is not the column's only
+-- writer — but it is the only one that TRANSLATES a Stripe status, and
+-- no other writer can invent one. Every other writer either stamps one
+-- of OUR OWN literals (`active`, `trialing`, `past_due`, `canceled` —
+-- org creation in lib/auth.ts, the staff comp/extend-trial tools in
+-- server/usecases/admin-plan.ts, the webhook handlers in
+-- server/usecases/billing-events.ts, the group cancel/downgrade paths in
+-- lib/billing.ts) or writes back a value it just read off the row (the
+-- comp/trial rollbacks, and cancelGroupIfEmpty's Stripe-cancel rollback
+-- in server/usecases/billing-groups.ts). So neither literal string can
+-- ever reach this function's `s.status` column. Proven in
 -- apps/web/src/lib/__tests__/billing-grace-anchor.test.ts ("#288 audit"
 -- cases) and the suspended-org parity case this migration ships
 -- alongside (apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts).

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1866,21 +1866,48 @@ async function passGrantsSuite(): Promise<void> {
       ent.entitlements["registration.fee_percent"]?.limit === 8,
   );
 
-  // === lock — a pass stops lifting once its competition is terminal (SPEC-4
-  // §7/§13.5, isPassLocked). Every grant above held while `passComp` ran; retire
-  // it to `archived` and the SAME create that a moment ago succeeded under the
-  // pass — a tiered sponsor (sponsors.tiers, 201 as passTier) — must now 402.
-  // sponsors.tiers is boolean and state-free, so it flips cleanly, where the
-  // entrant cap (already at 128) would 402 either way. The status write does NOT
-  // invalidate the resolver's (org, competition, feature) cache, so bust it the
-  // way the suite does after any raw entitlement write — no sleep on the 300s TTL.
+  // === lock (archived) — a pass stops lifting once its competition is
+  // terminal (SPEC-4 §7/§13.5, isPassLocked). Every grant above held while
+  // `passComp` ran; retire it to `archived` and the SAME create that a moment
+  // ago succeeded under the pass — a tiered sponsor (sponsors.tiers, 201 as
+  // passTier) — must now 402. sponsors.tiers is boolean and state-free, so it
+  // flips cleanly, where the entrant cap (already at 128) would 402 either
+  // way. v17 #287: the status write DOES invalidate the resolver's
+  // (org, competition, feature) cache now — patchCompetition busts it inside
+  // the same call — so, unlike every raw-SQL write elsewhere in this suite,
+  // there is deliberately NO bustOrgEntitlements call below. If that
+  // invalidation ever regresses, this 402 goes stale on any Redis-backed
+  // target (staging, a prod smoke run) for up to the 300s TTL; locally/CI
+  // REDIS_URL is normally unset so the cache is inert and this only proves
+  // the resolver logic, not the invalidation itself (see the dedicated
+  // Redis-gated suite, entitlements-cache-invalidation.redis.test.ts).
   const retire = await v1(s, `/api/v1/competitions/${passComp.id}`, "PATCH", { status: "archived" });
   check("pass grants/lock: the passed competition retires to archived (200)", retire.status === 200);
-  await bustOrgEntitlements(s, orgId);
   const lockedTier = await tierOn(passComp.id, "locked");
   check(
     "pass grants/lock: once archived the pass no longer lifts sponsors.tiers — the create that held under the pass now 402s",
     lockedTier.status === 402 && featureKey(lockedTier) === "sponsors.tiers",
+  );
+
+  // === lock (completed) — the OTHER terminal status (isPassLocked's set is
+  // {archived, completed}), on a fresh comp so it's independent of the
+  // archived case above. Also proves the pass was genuinely lifting the
+  // ENTRANT cap (not just a boolean flag): 65 seats past community's 64
+  // while live, then the 66th 402s the instant the completing PATCH commits.
+  const lockComp = await mkComp("Grants Lock Completed");
+  await grantPass(orgId, lockComp.id);
+  const lockDiv = await mkDiv(lockComp.id, "Lock Cap");
+  const lockPast64 = await v1(s, `/api/v1/divisions/${lockDiv.id}/entrants`, "POST", entrants(65, 1, "L"));
+  check(
+    "pass grants/lock(completed): the pass seats 65 — past community's 64 — while the competition is live",
+    lockPast64.status === 201,
+  );
+  const complete = await v1(s, `/api/v1/competitions/${lockComp.id}`, "PATCH", { status: "completed" });
+  check("pass grants/lock(completed): the competition completes (200)", complete.status === 200);
+  const overCap = await v1(s, `/api/v1/divisions/${lockDiv.id}/entrants`, "POST", entrants(1, 66, "L"));
+  check(
+    "pass grants/lock(completed): once completed the pass stops lifting entrants.per_division.max — the 66th create 402s with no stale-cache window",
+    overCap.status === 402 && featureKey(overCap) === "entrants.per_division.max",
   );
 }
 


### PR DESCRIPTION
## What

Wave 2 of the v17 gap remediation (`docs/superpowers/plans/2026-07-26-v17-gap-w2-resolver-truth.md`), closing the three entitlement-resolver defects — 21 commits, 7 planned tasks + 2 gap-routed tasks + final fix wave.

**#287 — competition writes never busted the entitlement cache**
- `patchCompetition` now calls `invalidateOrgEntitlements` post-transaction (fail-open by construction). The bug is structurally invisible without a real Redis (with `REDIS_URL` unset the cache is inert), which is why it shipped unnoticed and why the regression suite is Redis-gated.
- New CI step scoped to `REDIS_URL` (mirrors the rate-limiter step); a structural guard test asserts every `*.redis.test.ts` is wired into ci.yml's executable content (comment-stripped matching + REDIS_URL count) — a future Redis suite can no longer silently green-skip everywhere.
- Smoke: the manual `bustOrgEntitlements` crutch after the archived-lock PATCH is REMOVED (it would have masked regressions on staging/prod smoke); new `completed`-status + entrant-cap lock case (65 seats past community's 64, then 66th 402s post-completion).
- Gap fixes from reviews: `recordPassPurchase`'s healing branch now invalidates unconditionally (crash between insert and invalidate left a warm deny the retry never cleared); dispute-lost revoke + detach warm-flip cache tests; **staff suspension now busts the cache** (new `setOrgSuspension` usecase — suspension used to take up to 300s to bite); `cancelGroupIfEmpty`'s `cancel_failed` rollback now busts too (a racing attach could cache Community for a paying group).

**#288 — SQL resolver missing the `incomplete` arm the TS resolver has carried since #206**
- **V338**: `org_has_feature` gains `when s.status = 'incomplete' then 'community'` — V334 copied forward byte-identically otherwise (diff-verified). A never-paid first invoice no longer reads Pro on SQL-resolved public/embed surfaces.
- Status audit with evidence: `unpaid`/`incomplete_expired` can never reach `subscriptions.status` (STATUS_MAP collapses them at write time) — pinned by audit tests; suspended-org parity case added.
- `STATUS_MAP`'s unknown-status fallback flipped `past_due`→`incomplete` (**fails safe**: an unmapped future Stripe status conveys no plan instead of 14-day-grace free Pro), logged loudly, `Object.hasOwn` guard (a prototype-key status literally wrote `function Object() { [native code] }` into the column in mutation testing).
- `api/billing/groups` now derives its live-status list from `LIVE_SUBSCRIPTION_STATUSES` (was a hand list that disagreed with `hasLiveSubscription` on `incomplete`) — #311 tracks the 3 remaining hand lists.

**#289 — lifecycle analytics compared against strings outside the enum**
- `statusChangedTo === "active" | "complete"` could never be true (enum is live/completed) — COMPETITION_STARTED/COMPLETED never fired. New pure typed `competitionLifecycleEvent` helper; `statusChangedTo` narrowed to the zod enum so the bug class fails tsc. Rule: `live` = started, `completed` = finished, `published` ≠ started.
- **Note:** these two PostHog events fire for the first time ever — dashboards gain a new baseline.

## Deploy notes

- V338 changes the **public/embed** resolver the moment the migration applies (migration-then-app ordering): `incomplete` subs degrade to community on SQL surfaces immediately. That is the fix working as intended.
- The STATUS_MAP fallback flip is the only production behaviour change with no live-Stripe coverage — by construction (it needs a status Stripe hasn't invented). Unit-pinned with a fabricated status.

## Verification

- tsc clean (app + scripts configs); unit (no DB/Redis) 314/0; full DB-gated on a fresh schema 344/0; Redis-gated 9/9 with `REDIS_URL` + 9-skip clean without; V338 contiguous, flyway validate clean (180 migrations); full smoke **555 passed / 0 failed** incl. all five pass-lock checks; every behaviour change red-first or mutation-proven (verbatim evidence in per-task SDD reports).
- Process: per-task Opus review + fix loops (9 tasks), final whole-branch Opus review ("With fixes"), one fix wave (I1/I2 + 6 minors), scoped re-review clean.

Follow-ups filed: #311 #312 #313 #314 #315 #316.

Closes #287. Closes #288. Closes #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)