### PR TITLE
fix(credits): W3 grant-correct — resolved-plan grants, trial scaling, UTC boundaries (#290, #291, #292)

### DIFF
--- a/apps/web/src/app/api/cron/billing-grant/route.ts
+++ b/apps/web/src/app/api/cron/billing-grant/route.ts
@@ -3,7 +3,7 @@ import { handler } from "@/lib/http";
 import { HttpError } from "@/lib/errors";
 import { grantMonthlyForAllWallets } from "@/lib/credits";
 
-/** POST /api/cron/billing-grant — daily: grant every live billing wallet its
+/** POST /api/cron/billing-grant — daily: grant every billing wallet its
  *  `ai.credits.monthly(plan) * quantity_paid` allowance for this period
  *  (SPEC-2 §5.4/§11.2, v17 Task 6) — Community wallets included, flat 10.
  *  Each grant first EXPIRES any unspent `grant`-bucket balance left over

--- a/apps/web/src/app/api/cron/billing-grant/route.ts
+++ b/apps/web/src/app/api/cron/billing-grant/route.ts
@@ -6,6 +6,8 @@ import { grantMonthlyForAllWallets } from "@/lib/credits";
 /** POST /api/cron/billing-grant — daily: grant every billing wallet its
  *  `ai.credits.monthly(plan) * quantity_paid` allowance for this period
  *  (SPEC-2 §5.4/§11.2, v17 Task 6) — Community wallets included, flat 10.
+ *  A TRIALING paid wallet multiplies by `max(quantity_paid, live_org_count)`
+ *  instead (#291; see `grantMonthlyForAllWallets`'s docstring for why).
  *  Each grant first EXPIRES any unspent `grant`-bucket balance left over
  *  from the prior period (D1, use-or-lose) before adding the new period's
  *  allowance; the `pack` bucket (purchased packs, D2) is never touched here

--- a/apps/web/src/lib/__tests__/credits-allocation.test.ts
+++ b/apps/web/src/lib/__tests__/credits-allocation.test.ts
@@ -5,7 +5,7 @@
 // set a per-member HARD monthly cap, enforced at spend time INSIDE reserve()'s
 // advisory-lock transaction (derive-then-check-then-write, so it's tight under
 // concurrency). The org's spend-this-period is DERIVED from the ledger (no
-// counter): the sum of its run_spend holds since date_trunc('month', now()),
+// counter): the sum of its run_spend holds since utcMonthStart() (#292),
 // each netted by its refund row (refund.ref = hold.id) so a failed/released run
 // gives its allowance back. A cap hit emits a DISTINCT 402
 // `ai.credits.allocation` (vs the pool-empty `ai.credits`).

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -87,13 +87,29 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(200);
   });
 
-  it("skips a canceled subscription (not live)", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("REGRESSION (#290): grants the resolved Community rate for a canceled (churned) subscription, not zero", { timeout: CRON_TEST_TIMEOUT }, async () => {
     const orgId = await seedOrg();
+    // comped_at stays null (setOrgPlan's default) — orgPlanKey's `canceled`
+    // arm degrades this to community, exactly like any other entitlement
+    // read of this org (hasFeature, getLimit, the billing page).
     const subId = await setOrgPlan(orgId, "pro", "canceled");
 
     await grantMonthlyForAllWallets();
 
-    expect(await balance(subId)).toBe(0);
+    // Before #290 the raw status filter (`status in ('trialing','active',
+    // 'past_due')`) skipped this row entirely — a churned org got 0 credits
+    // forever even though every OTHER entitlement read already resolves it
+    // to Community and expects the Community grant to back that up.
+    expect(await balance(subId)).toBe(10);
+  });
+
+  it("REGRESSION (#290): grants the resolved Community rate for an incomplete (never-paid) subscription", { timeout: CRON_TEST_TIMEOUT }, async () => {
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro", "incomplete");
+
+    await grantMonthlyForAllWallets();
+
+    expect(await balance(subId)).toBe(10);
   });
 
   it("expires the prior period's unspent grant balance before granting the new period (D1)", { timeout: CRON_TEST_TIMEOUT }, async () => {

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -1,7 +1,9 @@
 // v17 Task 6 (re-review, CRITICAL cadence fix): the daily cron entry point
 // (api/cron/billing-grant) that grants every LIVE wallet its
 // ai.credits.monthly(plan) * quantity_paid allowance — scaled for paid plans,
-// flat for community (SPEC-2 §11.2). Each grant first expires any unspent
+// flat for community (SPEC-2 §11.2); a TRIALING paid wallet scales by
+// max(quantity_paid, live_org_count) instead (#291, see
+// grantMonthlyForAllWallets' docstring). Each grant first expires any unspent
 // grant-bucket leftover from the prior period (D1, use-or-lose, Task 6 review
 // fix) before adding the new allowance. Idempotent per period: EVERY wallet —
 // paid or Community — keys its period off the plain calendar month

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -44,13 +44,14 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-// grantMonthlyForAllWallets full-table-scans every LIVE subscription row in
-// the schema on each call. Run in isolation that's instant, but inside the
-// FULL vitest run (thousands of fixture rows accumulated by every other
-// suite in the same session) it can comfortably exceed vitest's default 5s
-// per-test timeout — not a regression in the code path itself, just the cost
-// of "every wallet" scaling with the whole test session's row count. Every
-// test here bumps its timeout accordingly.
+// grantMonthlyForAllWallets full-table-scans every subscription row with a
+// live org in the schema on each call, plus one resolver read per row. Run in
+// isolation that's instant, but inside the FULL vitest run (thousands of
+// fixture rows accumulated by every other suite in the same session) it can
+// comfortably exceed vitest's default 5s per-test timeout — not a regression
+// in the code path itself, just the cost of "every wallet" scaling with the
+// whole test session's row count. Every test here bumps its timeout
+// accordingly.
 const CRON_TEST_TIMEOUT = 20000;
 
 describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () => {
@@ -211,5 +212,24 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     await grantMonthlyForAllWallets();
     expect(await grantBalance(subId)).toBe(60);
     expect(await balance(subId)).toBe(60);
+  });
+
+  it("REGRESSION (#291): a trialing group grants for the LIVE org count when quantity_paid is frozen below it", { timeout: CRON_TEST_TIMEOUT }, async () => {
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro", "trialing");
+    // #279 (syncGroupQuantity) freezes quantity_paid at its pre-trial
+    // baseline through the whole trial — simulate a second org that rode the
+    // trial for free without quantity_paid ever moving off its default (1).
+    const suffix = randomUUID().slice(0, 8);
+    await sql`
+      insert into organizations (name, slug, subscription_id)
+      values (${"Rider " + suffix}, ${"rider-" + suffix}, ${subId})`;
+
+    await grantMonthlyForAllWallets();
+
+    // max(quantity_paid=1, liveOrgCount=2) — not quantity_paid alone, or the
+    // rider org would spend against a wallet that only ever got 1 seat's
+    // worth of monthly credits.
+    expect(await balance(subId)).toBe(60 * 2);
   });
 });

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -232,4 +232,20 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     // worth of monthly credits.
     expect(await balance(subId)).toBe(60 * 2);
   });
+
+  it("REGRESSION (#291): a trialing group still grants for quantity_paid when it sits ABOVE the live org count", { timeout: CRON_TEST_TIMEOUT }, async () => {
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro", "trialing");
+    // The other direction of the max(): this customer PAID for 3 seats before
+    // the trial and orgs have since left (or never been created), so the live
+    // count is 1. The grant must not shrink to what's live — they are still
+    // entitled to the 3 seats' worth they're being billed for. Pins the
+    // `quantity_paid` half of max(); without it, `live_org_count` alone would
+    // satisfy every other test in this file.
+    await sql`update subscriptions set quantity_paid = 3 where id = ${subId}`;
+
+    await grantMonthlyForAllWallets();
+
+    expect(await balance(subId)).toBe(60 * 3);
+  });
 });

--- a/apps/web/src/lib/__tests__/credits-period-boundary.test.ts
+++ b/apps/web/src/lib/__tests__/credits-period-boundary.test.ts
@@ -1,0 +1,92 @@
+// AI credit wallet — UTC-safe period boundary (#292).
+//
+// spentThisPeriodByOrg (SPEC-5 §1's operator allocation derive) used to
+// bound "this period" with `date_trunc('month', now())` — truncated in the
+// DB SESSION's TimeZone GUC (Europe/London in prod), not UTC.
+// grantMonthly's own period anchor (monthlyPeriod(), a plain
+// toISOString().slice(0,7)) is always UTC. Around a month boundary the two
+// could disagree by up to an hour: a spend recorded in the last hour of
+// UTC June could read as "July" under a UTC+1 session TZ and wrongly count
+// toward July's operator allocation cap. Real Postgres required; skipped
+// without DATABASE_URL.
+//
+// Uses session TZ Europe/London specifically (production's session TZ, and
+// the exact shape V334's org_has_feature fix reproduced) rather than a
+// fixed always-offset zone like entitlements-sql-parity.test.ts's
+// Etc/GMT-14 pair — so, like that choice trades away, this test only
+// demonstrates the bug while Europe/London is genuinely ahead of UTC (BST,
+// roughly late March-late October). It is valid today (2026-07-26, BST).
+// If this ever needs to be season-proof, mirror
+// entitlements-sql-parity.test.ts's Etc/GMT-14 / Etc/GMT+12 pair instead.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { spentThisPeriodByOrg } from "@/lib/credits";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function seedOrg(): Promise<string> {
+  const [org] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${`PeriodBoundary ${uniq()}`}, ${`period-boundary-${uniq()}`})
+    returning id`;
+  return org!.id;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("spentThisPeriodByOrg — UTC period boundary (#292)", () => {
+  it("REGRESSION: excludes a hold from the PRIOR UTC month even under session TZ Europe/London, at the exact month-boundary edge", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    // 30 minutes before THIS UTC month started — genuinely last month in
+    // UTC. Computed relative to Postgres's own (TZ-safe, double-converted)
+    // clock so this holds regardless of which real day this suite runs on.
+    const [{ edge }] = await sql<{ edge: string }[]>`
+      select (date_trunc('month', now() at time zone 'utc') at time zone 'utc'
+              - interval '30 minutes')::text as edge`;
+    await sql`
+      insert into ai_credit_ledger
+        (wallet_id, delta, source, bucket, spent_by_org_id, balance_after,
+         idempotency_key, created_at)
+      values (${walletId}, -1, 'run_spend', 'grant', ${orgId}, 0,
+              ${`edge-${uniq()}`}, ${edge})`;
+
+    const spent = await sql.begin(async (tx) => {
+      await tx`set local time zone 'Europe/London'`;
+      return spentThisPeriodByOrg(tx, walletId, orgId);
+    });
+
+    // Genuinely last month — must not count toward this period's spend no
+    // matter what TZ the DB session happens to run under.
+    expect(spent).toBe(0);
+  });
+
+  it("still counts a hold recorded inside the current UTC month", async () => {
+    const walletId = randomUUID();
+    const orgId = await seedOrg();
+    const [{ edge }] = await sql<{ edge: string }[]>`
+      select (date_trunc('month', now() at time zone 'utc') at time zone 'utc'
+              + interval '1 second')::text as edge`;
+    await sql`
+      insert into ai_credit_ledger
+        (wallet_id, delta, source, bucket, spent_by_org_id, balance_after,
+         idempotency_key, created_at)
+      values (${walletId}, -3, 'run_spend', 'grant', ${orgId}, 0,
+              ${`this-month-${uniq()}`}, ${edge})`;
+
+    const spent = await sql.begin(async (tx) => {
+      await tx`set local time zone 'Europe/London'`;
+      return spentThisPeriodByOrg(tx, walletId, orgId);
+    });
+
+    expect(spent).toBe(3);
+  });
+});

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -128,17 +128,46 @@ export async function packBalance(walletId: string): Promise<number> {
   return bucketBalance(sql, walletId, "pack");
 }
 
+/** The current UTC calendar-month boundary (00:00 UTC on the 1st) — the ONE
+ *  anchor `monthlyPeriod()`'s idempotency key and `spentThisPeriodByOrg`'s
+ *  period window both derive from (#292), so the two can never
+ *  independently compute "this month" and disagree.
+ *
+ *  A real `Date`, handed to SQL as a `timestamptz` PARAMETER — comparing a
+ *  `timestamptz` column against a `timestamptz` parameter is an
+ *  absolute-instant comparison, immune to the DB session's `TimeZone` GUC
+ *  (Europe/London in prod). Deliberately NOT computed in SQL:
+ *  `date_trunc('month', now())` truncates in the SESSION timezone, and even
+ *  `date_trunc('month', now() at time zone 'utc')` — which reads as
+ *  UTC-correct — returns a bare `timestamp` (no tz); comparing THAT
+ *  directly against a `timestamptz` column forces Postgres to cast it back
+ *  to `timestamptz` using the session TZ, reintroducing the exact
+ *  divergence this fixes (proven against a live session: under TZ
+ *  Europe/London, `timestamptz '2026-06-30 23:30:00+00' >= date_trunc(
+ *  'month', now() at time zone 'utc')` evaluates TRUE — a June 30 23:30 UTC
+ *  spend wrongly counted as inside July). Only `date_trunc(...) at time
+ *  zone 'utc'` (a SECOND conversion, back to a real timestamptz) is
+ *  TZ-safe in SQL; doing the truncation in JS and passing a `Date`
+ *  sidesteps the whole subtlety, and is what every call site now does. */
+export function utcMonthStart(): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+}
+
 /** Calendar-month period the monthly grant is scoped to (server clock,
  *  `YYYY-MM`) — the ONLY anchor `grantMonthly` uses, for every wallet, paid
  *  or Community (SPEC-2 §5.4 Cadence: "grant is monthly regardless of
- *  billing cadence"). Deliberately has no notion of a subscription's Stripe
- *  billing cycle at all — an annual-billed plan's `current_period_end` only
- *  advances once a year, so keying off it (a prior version of this module
- *  did, for paid wallets) collapses 12 monthly grants into a single lump on
- *  the renewal date, which is the exact regression this cadence rule exists
- *  to forbid. */
+ *  billing cadence"). Derives from `utcMonthStart()` (#292) — the SAME
+ *  anchor `spentThisPeriodByOrg` compares against — rather than computing
+ *  its own `new Date().toISOString().slice(0, 7)` independently, so the two
+ *  can never drift apart again. Deliberately has no notion of a
+ *  subscription's Stripe billing cycle at all — an annual-billed plan's
+ *  `current_period_end` only advances once a year, so keying off it (a
+ *  prior version of this module did, for paid wallets) collapses 12
+ *  monthly grants into a single lump on the renewal date, which is the
+ *  exact regression this cadence rule exists to forbid. */
 function monthlyPeriod(): string {
-  return new Date().toISOString().slice(0, 7);
+  return utcMonthStart().toISOString().slice(0, 7);
 }
 
 /**
@@ -963,12 +992,17 @@ export async function auditWalletForfeitedOnDetach(
  * `source='refund'` but `ref` = a payment-intent id, never a `run_spend` row
  * id, so they can't match a hold here.
  *
- * **Period bound** = `date_trunc('month', now())`, the same calendar-month
- * anchor `grantMonthly` resets on — so the cap resets implicitly with the grant
- * cycle. A hold from a prior month is excluded (its refund, if any, is moot —
- * only holds inside the period are summed). Runs inside the caller's executor
- * (`reserve`'s advisory-locked tx) so the check sees this reserve's own prior
- * writes. Returns a non-negative integer.
+ * **Period bound** = `utcMonthStart()` (#292), the same UTC calendar-month
+ * anchor `grantMonthly`'s `monthlyPeriod()` resets on — so the cap resets
+ * implicitly with the grant cycle, and the two can never independently
+ * compute "this month" and disagree (a prior version compared against bare
+ * `date_trunc('month', now())`, truncated in the DB session's TimeZone GUC
+ * — Europe/London in prod — which could disagree with the UTC-anchored
+ * grant cycle by up to an hour around a month boundary). A hold from a
+ * prior month is excluded (its refund, if any, is moot — only holds inside
+ * the period are summed). Runs inside the caller's executor (`reserve`'s
+ * advisory-locked tx) so the check sees this reserve's own prior writes.
+ * Returns a non-negative integer.
  *
  * Exported (Phase 6 Task 2, SPEC-5 §1) so the operator allocation console
  * (`server/usecases/operator-allocation.ts`) reports each member org's burn
@@ -981,6 +1015,7 @@ export async function spentThisPeriodByOrg(
   walletId: string,
   orgId: string,
 ): Promise<number> {
+  const periodStart = utcMonthStart();
   const [row] = await exec<{ spent: string | null }[]>`
     select coalesce(sum(
       -h.delta - coalesce((
@@ -992,7 +1027,7 @@ export async function spentThisPeriodByOrg(
      where h.wallet_id = ${walletId}
        and h.spent_by_org_id = ${orgId}
        and h.source = 'run_spend'
-       and h.created_at >= date_trunc('month', now())`;
+       and h.created_at >= ${periodStart}`;
   return Math.max(0, Number(row?.spent ?? 0));
 }
 

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -314,6 +314,18 @@ export async function grantMonthly(
  * `groupOrgLimit` special-cases the ORG CAP; see the plan task that added
  * this function for the reasoning.
  *
+ * **Trial grant scales to live orgs, not the frozen paid count (#291):**
+ * `syncGroupQuantity` (#279) freezes `quantity_paid` at its pre-trial
+ * baseline for the whole trial — a second org that joins mid-trial rides
+ * free and raises the ACTIVE org count without moving `quantity_paid` (by
+ * design: nothing has been billed yet). Granting on the frozen
+ * `quantity_paid` alone would under-grant that org's own seat's worth of
+ * credits, so a trialing wallet's quantity is `max(quantity_paid,
+ * liveOrgCount)` — never less than what's actually live. #279's own tests
+ * (`billing-group-trial-seat.test.ts`) assert `quantity_paid` itself stays
+ * frozen — this reads `live_org_count` alongside it rather than touching
+ * that column, so both stay true at once.
+ *
  * **Anchor (README §7 item 7): calendar month for EVERY wallet, paid or
  * Community — never `current_period_end`.** SPEC-2 §5.4's Cadence rule is
  * explicit that the grant is monthly *regardless of billing cadence* (an
@@ -333,22 +345,31 @@ export async function grantMonthlyForAllWallets(): Promise<{
   failed: number;
 }> {
   const rows = await sql<
-    { id: string; quantity_paid: number; rep_org_id: string }[]
+    { id: string; status: string; quantity_paid: number; rep_org_id: string; live_org_count: number }[]
   >`
-    select s.id, s.quantity_paid, rep.id as rep_org_id
+    select s.id, s.status, s.quantity_paid, rep.id as rep_org_id, live.n as live_org_count
       from subscriptions s
       cross join lateral (
         select o.id from organizations o
          where o.subscription_id = s.id and o.deleted_at is null
          order by (o.status = 'suspended'), o.created_at
          limit 1
-      ) rep`;
+      ) rep
+      cross join lateral (
+        select count(*)::int as n from organizations o
+         where o.subscription_id = s.id and o.deleted_at is null
+      ) live`;
   let granted = 0;
   let failed = 0;
   for (const row of rows) {
     try {
       const planKey = await orgPlanKey(row.rep_org_id);
-      const qty = planKey === "community" ? 1 : row.quantity_paid;
+      const qty =
+        planKey === "community"
+          ? 1
+          : row.status === "trialing"
+            ? Math.max(row.quantity_paid, row.live_org_count)
+            : row.quantity_paid;
       granted += await grantMonthly(row.id, planKey, qty);
     } catch (err) {
       failed++;

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -148,9 +148,13 @@ export async function packBalance(walletId: string): Promise<number> {
  *  spend wrongly counted as inside July). Only `date_trunc(...) at time
  *  zone 'utc'` (a SECOND conversion, back to a real timestamptz) is
  *  TZ-safe in SQL; doing the truncation in JS and passing a `Date`
- *  sidesteps the whole subtlety, and is what every call site now does. */
-export function utcMonthStart(): Date {
-  const now = new Date();
+ *  sidesteps the whole subtlety, and is what every call site now does.
+ *
+ *  `now` defaults to the current instant; pass one explicitly when the caller
+ *  ALSO derives something else from the same clock (the Credits tab derives
+ *  both the period window and the days-until-reset), so a request that
+ *  straddles UTC midnight on the 1st cannot read two different months. */
+export function utcMonthStart(now = new Date()): Date {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 }
 

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -306,7 +306,14 @@ export async function grantMonthly(
  * `credits.ts` importing FROM `billing-group.ts` would close a second,
  * avoidable cycle on top of the one this file already takes on for
  * `orgPlanKey`. Keep this ORDER BY in step with `groupOrgLimit`'s by hand
- * if that one ever changes.
+ * if that one ever changes. The `live` lateral's predicate carries a SECOND
+ * hand-sync obligation: `subscription_id = s.id and deleted_at is null` must
+ * stay identical both to the `rep` lateral's filter above (or the
+ * representative could come from outside the set being counted) and to
+ * `syncGroupQuantity`'s own active count (`billing-groups.ts`, the
+ * `count(*) ... where subscription_id = $1 and deleted_at is null` it feeds
+ * to the Stripe item) — that agreement is exactly what makes a trialing
+ * group's grant match the quantity its trial-end invoice will bill.
  *
  * A representative org that is itself community-suspended (a fully
  * moderation-suspended group) grants flat Community — a deliberate,
@@ -320,8 +327,12 @@ export async function grantMonthly(
  * free and raises the ACTIVE org count without moving `quantity_paid` (by
  * design: nothing has been billed yet). Granting on the frozen
  * `quantity_paid` alone would under-grant that org's own seat's worth of
- * credits, so a trialing wallet's quantity is `max(quantity_paid,
- * liveOrgCount)` — never less than what's actually live. #279's own tests
+ * credits, so a trialing PAID wallet's quantity is `max(quantity_paid,
+ * liveOrgCount)` — never less than what's actually live, and never less than
+ * what was actually paid for either (a customer who bought 3 seats and had
+ * orgs leave mid-trial keeps granting on 3). A trialing wallet whose
+ * representative org RESOLVES to community still grants the flat 1: the
+ * `community` arm is checked first, on purpose. #279's own tests
  * (`billing-group-trial-seat.test.ts`) assert `quantity_paid` itself stays
  * frozen — this reads `live_org_count` alongside it rather than touching
  * that column, so both stay true at once.

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -15,6 +15,16 @@ import { PaymentRequiredError } from "@/lib/errors";
 // cached snapshot carrying a `>= 0` CHECK that makes oversell impossible
 // atomically; `balance()` here reads the authoritative running sum.
 import { sql } from "@/lib/db";
+// #290: resolves the grant sweep's plan via the SAME resolver every other
+// entitlement read uses (orgPlanKey). This creates a deliberate two-file
+// import cycle — entitlements.ts already imports walletIdFor from THIS
+// file — safe because neither module calls the other's export at
+// module-evaluation time, only from inside an async function body, long
+// after both modules have finished loading. Verify with `npm run
+// typecheck` and by actually running credits-monthly-cron.test.ts: a
+// broken cycle here would surface as `orgPlanKey is not a function` at
+// call time, not a compile error.
+import { orgPlanKey } from "@/lib/entitlements";
 
 type Tx = postgres.TransactionSql;
 /** Anything the ledger's tagged-template queries can run against: the shared
@@ -267,62 +277,79 @@ export async function grantMonthly(
 }
 
 /**
- * Cron entry point (Task 6, `api/cron/billing-grant`): grant every LIVE
- * subscription row its monthly allowance for this period.
+ * Cron entry point (Task 6, `api/cron/billing-grant`): grant every wallet
+ * with at least one live org its monthly allowance for this period.
  *
- * Every org — paid or Community — has a `subscriptions` row (a group-of-one
- * when not actually grouped, `lib/auth.ts`'s `createOrgForUser`), so a single
- * scan of `subscriptions` covers both halves of SPEC-2 §11.2 without a
- * separate "orgs with no group" pass: a paid plan grants
- * `ai.credits.monthly(plan) * quantity_paid` (scaled to seats); `community`
- * grants a FLAT 10 regardless of `quantity_paid` — §11.2 is explicit that
- * Community is "never grouped" and never seat-scaled, even though its
- * group-of-one row technically carries a `quantity_paid` column.
+ * **Grants on the RESOLVED plan, not the raw subscription row (#290).** A
+ * prior version filtered `subscriptions.status in ('trialing', 'active',
+ * 'past_due')` before granting anything — so a churned subscription
+ * (`canceled`, `incomplete`, ...) was skipped by the query entirely and its
+ * org got 0 credits forever, even though `orgPlanKey` (entitlements.ts)
+ * already resolves that SAME row to `'community'` for every other
+ * entitlement read (hasFeature, getLimit, the billing page). This sweep now
+ * scans every subscription with a live org — no status filter — and calls
+ * `orgPlanKey` per wallet to learn what it should ACTUALLY be granted, so a
+ * churned org gets its Community 10/mo like any other Community wallet
+ * instead of silently nothing. No retroactive back-grant for months already
+ * missed (v17-gap design decision) — this only fixes the sweep going
+ * forward.
  *
- * The `exists (... organizations ...)` guard skips a group with no live org
- * left in it (an orphan the empty-group cleanup hasn't caught yet, or a
- * community group whose org was soft-deleted) — no wallet left to spend a
- * grant from.
+ * **Which org answers for the group:** `orgPlanKey` takes a single org id,
+ * but a wallet can back several orgs (a billing group). The `rep` lateral
+ * below picks the SAME representative `lib/billing-group.ts`'s
+ * `groupOrgLimit` does — the oldest LIVE org that is not suspended, falling
+ * back to a suspended one only if every org in the group is suspended — so
+ * a single suspended member cannot silently change which plan the whole
+ * group's credits resolve against. Re-implemented as SQL here rather than
+ * imported: `billing-group.ts` imports `lib/entitlements.ts` (for
+ * `getLimit`), which imports `lib/credits.ts` (for `walletIdFor`) — so
+ * `credits.ts` importing FROM `billing-group.ts` would close a second,
+ * avoidable cycle on top of the one this file already takes on for
+ * `orgPlanKey`. Keep this ORDER BY in step with `groupOrgLimit`'s by hand
+ * if that one ever changes.
  *
- * **Anchor (README §7 item 7; Task 6 re-review CRITICAL fix): calendar month
- * for EVERY wallet, paid or Community — never `current_period_end`.** An
- * earlier version of this sweep keyed paid subscriptions off
- * `subscriptions.current_period_end` on the theory that it tracked "the real
- * billing cycle" — but SPEC-2 §5.4's Cadence rule is explicit that the grant
- * is monthly *regardless of billing cadence* (an annual Pro at $159/yr must
- * still get 60/mo × 12, not a single 720 lump). Since `current_period_end`
- * for an annual-interval subscription only advances once a year, that
- * anchor silently collapsed 12 grants into 1 for every annual org — a
- * cadence regression, not an approximation. `grantMonthly`'s own
- * `monthlyPeriod()` (plain `YYYY-MM`, server clock) is now the only anchor
- * this function uses, for both paid and Community wallets alike; every live
- * wallet gets a fresh grant once per calendar month, independent of what
- * Stripe's billing interval or renewal date happen to be.
+ * A representative org that is itself community-suspended (a fully
+ * moderation-suspended group) grants flat Community — a deliberate,
+ * minimal reading of #290 that does NOT special-case that edge the way
+ * `groupOrgLimit` special-cases the ORG CAP; see the plan task that added
+ * this function for the reasoning.
+ *
+ * **Anchor (README §7 item 7): calendar month for EVERY wallet, paid or
+ * Community — never `current_period_end`.** SPEC-2 §5.4's Cadence rule is
+ * explicit that the grant is monthly *regardless of billing cadence* (an
+ * annual Pro at $159/yr must still get 60/mo × 12, not a single 720 lump),
+ * so `grantMonthly`'s own `monthlyPeriod()` (UTC `YYYY-MM`) is the only
+ * anchor this function uses.
  *
  * One wallet's failure (a bad plan_key, a transient DB error) is logged and
  * skipped rather than aborting the whole sweep, matching
  * `reconcileGroupQuantities`'s per-group try/catch — `failed` is returned
- * (mirroring `reconcileGroupQuantities`'s own `{checked, corrected, failed}`
- * shape) so the caller (the cron route, then `billing-grant.yml`) can warn
- * on a persistent per-wallet grant failure instead of it going unnoticed.
+ * so the caller (the cron route, then `billing-grant.yml`) can warn on a
+ * persistent per-wallet grant failure instead of it going unnoticed.
  */
 export async function grantMonthlyForAllWallets(): Promise<{
   wallets: number;
   granted: number;
   failed: number;
 }> {
-  const rows = await sql<{ id: string; plan_key: string; quantity_paid: number }[]>`
-    select s.id, s.plan_key, s.quantity_paid from subscriptions s
-     where s.status in ('trialing', 'active', 'past_due')
-       and exists (
-             select 1 from organizations o
-              where o.subscription_id = s.id and o.deleted_at is null)`;
+  const rows = await sql<
+    { id: string; quantity_paid: number; rep_org_id: string }[]
+  >`
+    select s.id, s.quantity_paid, rep.id as rep_org_id
+      from subscriptions s
+      cross join lateral (
+        select o.id from organizations o
+         where o.subscription_id = s.id and o.deleted_at is null
+         order by (o.status = 'suspended'), o.created_at
+         limit 1
+      ) rep`;
   let granted = 0;
   let failed = 0;
   for (const row of rows) {
     try {
-      const qty = row.plan_key === "community" ? 1 : row.quantity_paid;
-      granted += await grantMonthly(row.id, row.plan_key, qty);
+      const planKey = await orgPlanKey(row.rep_org_id);
+      const qty = planKey === "community" ? 1 : row.quantity_paid;
+      granted += await grantMonthly(row.id, planKey, qty);
     } catch (err) {
       failed++;
       console.error(`[credits] monthly grant failed for wallet ${row.id}`, err);

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -325,7 +325,25 @@ export async function grantMonthly(
  * churned org gets its Community 10/mo like any other Community wallet
  * instead of silently nothing. No retroactive back-grant for months already
  * missed (v17-gap design decision) — this only fixes the sweep going
- * forward.
+ * forward. Two visible deploy-day effects follow from that, both expected:
+ * a wallet ALREADY granted this month (a trialing group, say) is not topped
+ * up to a newly-resolved rate mid-month — `grantMonthly`'s
+ * `monthly:${walletId}:${period}` key short-circuits it to a no-op until the
+ * next period — and conversely the FIRST sweep to reach a previously-skipped
+ * (churned) wallet expires whatever stale grant bucket it was still carrying
+ * before granting the resolved rate, so that wallet's balance visibly DROPS,
+ * one way, to the Community 10; that is the correct outcome of D1's
+ * use-or-lose grant meeting a wallet the old sweep had frozen, not a
+ * regression.
+ *
+ * **Why one scan of `subscriptions` reaches every wallet:** every org has a
+ * `subscriptions` row — `lib/auth.ts`'s `createOrgForUser` inserts a
+ * Community group-of-one and stamps `organizations.subscription_id` with it
+ * in the same transaction as the org itself, so an ungrouped org is simply a
+ * group of one — which is why scanning `subscriptions` with the live-org
+ * lateral below covers every wallet in a single pass, with no second scan
+ * over ungrouped orgs. (`countOrgsWithoutGroup`, run daily by the
+ * billing-quantity cron, is the standing alarm on that invariant.)
  *
  * **Which org answers for the group:** `orgPlanKey` takes a single org id,
  * but a wallet can back several orgs (a billing group). The `rep` lateral

--- a/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
+++ b/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
@@ -65,6 +65,36 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     expect(view.history).toHaveLength(0);
   });
 
+  it("REGRESSION (#292): the used-this-month meter excludes a hold recorded 30 minutes before the UTC month boundary", async () => {
+    const [{ tz }] = await sql<{ tz: string }[]>`select current_setting('TimeZone') as tz`;
+    // getCreditsTab has no tx to force a TZ on (see this task's Testability
+    // note) — this only reproduces under a non-UTC ambient session TimeZone
+    // (Europe/London here and in production). Skip cleanly rather than
+    // false-fail on a UTC-default DB.
+    if (tz === "UTC" || tz === "Etc/UTC") return;
+
+    const { auth } = await seedOrg("pro");
+    const walletId = await walletIdFor(auth.orgId);
+    await grantMonthly(walletId, "pro", 1);
+
+    // 23:30 UTC on the last day of the PRIOR month — under the ambient
+    // Europe/London (BST, UTC+1) session TZ this instant reads as "00:30"
+    // on the 1st, an hour INTO the new month locally, so a session-TZ-
+    // anchored boundary wrongly counts it. Computed relative to Postgres's
+    // own clock so this holds on any run date, not hardcoded.
+    await sql`
+      insert into ai_credit_ledger
+        (wallet_id, delta, source, bucket, spent_by_org_id, balance_after,
+         idempotency_key, created_at)
+      values (${walletId}, -7, 'run_spend', 'grant', ${auth.orgId}, 53,
+              ${`edge-${randomUUID()}`},
+              date_trunc('month', now() at time zone 'utc') at time zone 'utc' - interval '30 minutes')`;
+
+    const view = await getCreditsTab(auth.orgId);
+
+    expect(view.grantUsed).toBe(0); // must NOT count toward the current UTC month
+  });
+
   // v17 gap #285: credits that arrive because the org joined a billing group
   // (mergeWalletOnAttach's `group_merge` rows) must be labelled as their own
   // thing. The actionKey mapping's `default:` arm returned "adminAdjust", so

--- a/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
+++ b/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
@@ -111,13 +111,18 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     expect(view.sharedOrgCount).toBe(2);
   });
 
-  it("REGRESSION (#292): the used-this-month meter excludes a hold recorded 30 minutes before the UTC month boundary", async () => {
+  it("REGRESSION (#292): the used-this-month meter excludes a hold recorded 30 minutes before the UTC month boundary", async (ctx) => {
     const [{ tz }] = await sql<{ tz: string }[]>`select current_setting('TimeZone') as tz`;
     // getCreditsTab has no tx to force a TZ on (see this task's Testability
     // note) — this only reproduces under a non-UTC ambient session TimeZone
-    // (Europe/London here and in production). Skip cleanly rather than
-    // false-fail on a UTC-default DB.
-    if (tz === "UTC" || tz === "Etc/UTC") return;
+    // (Europe/London here and in production). On a UTC-default database (CI's
+    // postgres) this is genuinely unable to run, so SKIP it rather than
+    // early-`return`: a bare return reports PASSED and hides the fact that the
+    // regression went unexercised.
+    ctx.skip(
+      tz === "UTC" || tz === "Etc/UTC",
+      `needs a non-UTC ambient session TimeZone to reproduce (DB TimeZone is ${tz})`,
+    );
 
     const { auth } = await seedOrg("pro");
     const walletId = await walletIdFor(auth.orgId);

--- a/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
+++ b/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
@@ -15,6 +15,7 @@ import {
   settle,
   walletIdFor,
 } from "@/lib/credits";
+import { orgGroupId } from "@/lib/__tests__/_billing-group";
 import { seedOrg } from "./_seed";
 import { creditHistory, getCreditsTab } from "../credits-tab";
 
@@ -63,6 +64,31 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     expect(view.balance).toBe(0);
     expect(view.sharedOrgCount).toBe(1);
     expect(view.history).toHaveLength(0);
+  });
+
+  // v17 gap #291, second call site: `grantMonthlyForAllWallets` grants a
+  // TRIALING wallet on max(quantity_paid, liveOrgCount) because
+  // syncGroupQuantity freezes quantity_paid for the whole trial. The tab's
+  // grantCap divided by the frozen quantity_paid alone, so a trialing group
+  // with a mid-trial rider read "used 70 / 60" — a meter over its own cap.
+  it("scales the trialing grant cap to live orgs, matching what was actually granted", async () => {
+    const { auth } = await seedOrg("pro");
+    const groupId = (await orgGroupId(auth.orgId))!;
+    await sql`update subscriptions set status = 'trialing', quantity_paid = 1 where id = ${groupId}`;
+
+    // A second org rides the trial free: live count 2, quantity_paid still 1.
+    const { auth: rider } = await seedOrg("community");
+    await sql`update organizations set subscription_id = ${groupId} where id = ${rider.orgId}`;
+
+    const walletId = await walletIdFor(auth.orgId);
+    expect(await grantMonthly(walletId, "pro", 2)).toBe(120); // what the sweep grants
+    const hold = await reserve(walletId, auth.orgId, 70);
+    await settle(hold, randomUUID());
+
+    const view = await getCreditsTab(auth.orgId);
+    expect(view.grantCap).toBe(120); // NOT 60 — 70 used must not exceed the cap
+    expect(view.grantUsed).toBe(70);
+    expect(view.sharedOrgCount).toBe(2);
   });
 
   it("REGRESSION (#292): the used-this-month meter excludes a hold recorded 30 minutes before the UTC month boundary", async () => {

--- a/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
+++ b/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
@@ -91,6 +91,26 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     expect(view.sharedOrgCount).toBe(2);
   });
 
+  // The other side of the same rule: the trial max() must NOT leak into an
+  // ACTIVE sub. Once billing is live, quantity_paid is no longer frozen —
+  // syncGroupQuantity tracks the org count — so an extra live org that is not
+  // yet paid for must not inflate the cap above what was granted.
+  it("does NOT scale an ACTIVE sub's cap to live orgs — quantity_paid is the cap", async () => {
+    const { auth } = await seedOrg("pro");
+    const groupId = (await orgGroupId(auth.orgId))!;
+    await sql`update subscriptions set status = 'active', quantity_paid = 1 where id = ${groupId}`;
+
+    const { auth: extra } = await seedOrg("community");
+    await sql`update organizations set subscription_id = ${groupId} where id = ${extra.orgId}`;
+
+    const walletId = await walletIdFor(auth.orgId);
+    expect(await grantMonthly(walletId, "pro", 1)).toBe(60); // what the sweep grants
+
+    const view = await getCreditsTab(auth.orgId);
+    expect(view.grantCap).toBe(60); // NOT 120 — the trial max() must not apply
+    expect(view.sharedOrgCount).toBe(2);
+  });
+
   it("REGRESSION (#292): the used-this-month meter excludes a hold recorded 30 minutes before the UTC month boundary", async () => {
     const [{ tz }] = await sql<{ tz: string }[]>`select current_setting('TimeZone') as tz`;
     // getCreditsTab has no tx to force a TZ on (see this task's Testability

--- a/apps/web/src/server/usecases/credits-tab.ts
+++ b/apps/web/src/server/usecases/credits-tab.ts
@@ -124,8 +124,11 @@ function actionKey(source: string, delta: number, reason: string | null): string
 /** Whole days from `now` until the first of next calendar month, derived from
  *  the SAME `utcMonthStart()` anchor the meter's period window is bounded by
  *  (#292) — so the days-remaining number and the window can never disagree
- *  about which month it is. */
-function daysUntilMonthReset(periodStart: Date, now = new Date()): number {
+ *  about which month it is. Both args come from ONE clock sample in the
+ *  caller: sampling `now` here independently would, for a request straddling
+ *  UTC midnight on the 1st, measure to a boundary that had already passed and
+ *  report 0 days left instead of a full fresh month. */
+function daysUntilMonthReset(periodStart: Date, now: Date): number {
   const next = Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth() + 1, 1);
   return Math.max(0, Math.ceil((next - now.getTime()) / 86_400_000));
 }
@@ -178,7 +181,10 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
      where plan_key = ${planKey} and feature_key = 'ai.credits.monthly'`;
   const perSeat = entitlement?.int_value ?? 0;
 
-  const periodStart = utcMonthStart();
+  // ONE clock sample for every month-derived number on this view (see
+  // daysUntilMonthReset) — never two independent `new Date()`s.
+  const now = new Date();
+  const periodStart = utcMonthStart(now);
 
   const [bal, packBal, spent, history, shared, referralCode, referred, referralEarned] =
     await Promise.all([
@@ -215,12 +221,20 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
     ]);
 
   const sharedOrgCount = Math.max(1, shared[0]?.n ?? 1);
-  // The cap must be what `grantMonthlyForAllWallets` ACTUALLY granted, not an
-  // independent formula: Community is flat (never seat-scaled — SPEC-2 §11.2),
-  // and a TRIALING paid wallet grants on max(quantity_paid, live orgs) because
-  // syncGroupQuantity freezes quantity_paid for the trial's duration (#291 —
-  // see that function's docstring for the full rule). Reading the frozen count
-  // alone showed a trialing group with a mid-trial rider "70 used / 60".
+  // QUANTITY follows `grantMonthlyForAllWallets`'s rule exactly: Community is
+  // flat (never seat-scaled — SPEC-2 §11.2), and a TRIALING paid wallet grants
+  // on max(quantity_paid, live orgs) because syncGroupQuantity freezes
+  // quantity_paid for the trial's duration (#291 — see that function's
+  // docstring for the full rule). Reading the frozen count alone showed a
+  // trialing group with a mid-trial rider "70 used / 60".
+  //
+  // KNOWN DIVERGENCE, quantity only — the PLAN dimension is NOT unified: this
+  // reads the raw `s.plan_key` (:173) while the sweep resolves it through
+  // `orgPlanKey`, which degrades a suspended / past_due>14d / expired-comp
+  // wallet to Community. So a suspended Pro org is granted 10 but this tab
+  // still shows a cap of 60. Display-level only (the ledger and every spend
+  // path use the resolved plan); deliberately left for a follow-up rather than
+  // changed here, since switching it changes what customers see.
   const grantCap =
     perSeat *
     (planKey === "community" ? 1 : trialing ? Math.max(quantityPaid, sharedOrgCount) : quantityPaid);
@@ -230,7 +244,7 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
     balance: bal,
     grantUsed,
     grantCap,
-    grantResetsInDays: daysUntilMonthReset(periodStart),
+    grantResetsInDays: daysUntilMonthReset(periodStart, now),
     packBalance: packBal,
     sharedOrgCount,
     history,

--- a/apps/web/src/server/usecases/credits-tab.ts
+++ b/apps/web/src/server/usecases/credits-tab.ts
@@ -45,8 +45,10 @@ export interface CreditsTabView {
    *  has grantBalance 0 yet has used nothing, which that formula would misreport as
    *  a full meter. */
   grantUsed: number;
-  /** This period's monthly grant = `ai.credits.monthly(plan) * quantityPaid`
-   *  (Community is flat, never seat-scaled — SPEC-2 §11.2). */
+  /** This period's monthly grant = `ai.credits.monthly(plan) * quantity`, where
+   *  quantity is what `grantMonthlyForAllWallets` grants on: 1 for Community
+   *  (flat, never seat-scaled — SPEC-2 §11.2), `max(quantityPaid, live orgs)`
+   *  while the sub is TRIALING (#291), else `quantityPaid`. */
   grantCap: number;
   /** Whole days until the calendar-month reset `grantMonthly` anchors on. */
   grantResetsInDays: number;
@@ -119,10 +121,12 @@ function actionKey(source: string, delta: number, reason: string | null): string
   }
 }
 
-/** Whole days from now until the first of next calendar month (UTC, matching
- *  `credits.ts`'s `monthlyPeriod()` which slices `toISOString()`). */
-function daysUntilMonthReset(now = new Date()): number {
-  const next = Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1);
+/** Whole days from `now` until the first of next calendar month, derived from
+ *  the SAME `utcMonthStart()` anchor the meter's period window is bounded by
+ *  (#292) — so the days-remaining number and the window can never disagree
+ *  about which month it is. */
+function daysUntilMonthReset(periodStart: Date, now = new Date()): number {
+  const next = Date.UTC(periodStart.getUTCFullYear(), periodStart.getUTCMonth() + 1, 1);
   return Math.max(0, Math.ceil((next - now.getTime()) / 86_400_000));
 }
 
@@ -158,22 +162,21 @@ export async function creditHistory(walletId: string, limit = HISTORY_LIMIT): Pr
 export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
   const walletId = await walletIdFor(orgId);
 
-  const [plan] = await sql<{ plan_key: string; quantity_paid: number }[]>`
+  const [plan] = await sql<{ plan_key: string; quantity_paid: number; status: string | null }[]>`
     select coalesce(s.plan_key, 'community') as plan_key,
-           coalesce(s.quantity_paid, 1) as quantity_paid
+           coalesce(s.quantity_paid, 1) as quantity_paid,
+           s.status
       from organizations o
       left join subscriptions s on s.id = o.subscription_id
      where o.id = ${orgId}`;
   const planKey = plan?.plan_key ?? "community";
   const quantityPaid = plan?.quantity_paid ?? 1;
+  const trialing = plan?.status === "trialing";
 
   const [entitlement] = await sql<{ int_value: number | null }[]>`
     select int_value from plan_entitlements
      where plan_key = ${planKey} and feature_key = 'ai.credits.monthly'`;
-  // Community is flat (never seat-scaled — SPEC-2 §11.2); everyone else scales
-  // the per-seat grant by the group's paid seats, matching grantMonthly().
   const perSeat = entitlement?.int_value ?? 0;
-  const grantCap = perSeat * (planKey === "community" ? 1 : quantityPaid);
 
   const periodStart = utcMonthStart();
 
@@ -211,15 +214,25 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
          and idempotency_key like 'earn:referral:%'`,
     ]);
 
+  const sharedOrgCount = Math.max(1, shared[0]?.n ?? 1);
+  // The cap must be what `grantMonthlyForAllWallets` ACTUALLY granted, not an
+  // independent formula: Community is flat (never seat-scaled — SPEC-2 §11.2),
+  // and a TRIALING paid wallet grants on max(quantity_paid, live orgs) because
+  // syncGroupQuantity freezes quantity_paid for the trial's duration (#291 —
+  // see that function's docstring for the full rule). Reading the frozen count
+  // alone showed a trialing group with a mid-trial rider "70 used / 60".
+  const grantCap =
+    perSeat *
+    (planKey === "community" ? 1 : trialing ? Math.max(quantityPaid, sharedOrgCount) : quantityPaid);
   const grantUsed = Math.max(0, Math.min(grantCap, Number(spent[0]?.used ?? 0)));
 
   return {
     balance: bal,
     grantUsed,
     grantCap,
-    grantResetsInDays: daysUntilMonthReset(),
+    grantResetsInDays: daysUntilMonthReset(periodStart),
     packBalance: packBal,
-    sharedOrgCount: Math.max(1, shared[0]?.n ?? 1),
+    sharedOrgCount,
     history,
     referralCode,
     referredCount: referred[0]?.n ?? 0,

--- a/apps/web/src/server/usecases/credits-tab.ts
+++ b/apps/web/src/server/usecases/credits-tab.ts
@@ -229,7 +229,8 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
   // trialing group with a mid-trial rider "70 used / 60".
   //
   // KNOWN DIVERGENCE, quantity only — the PLAN dimension is NOT unified: this
-  // reads the raw `s.plan_key` (:173) while the sweep resolves it through
+  // reads the raw `s.plan_key` from the `plan` query above while the sweep
+  // resolves it through
   // `orgPlanKey`, which degrades a suspended / past_due>14d / expired-comp
   // wallet to Community. So a suspended Pro org is granted 10 but this tab
   // still shows a cap of 60. Display-level only (the ledger and every spend

--- a/apps/web/src/server/usecases/credits-tab.ts
+++ b/apps/web/src/server/usecases/credits-tab.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { sql } from "@/lib/db";
-import { balance, packBalance, walletIdFor } from "@/lib/credits";
+import { balance, packBalance, utcMonthStart, walletIdFor } from "@/lib/credits";
 import { getOrCreateReferralCode } from "@/lib/referral";
 
 /**
@@ -175,6 +175,8 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
   const perSeat = entitlement?.int_value ?? 0;
   const grantCap = perSeat * (planKey === "community" ? 1 : quantityPaid);
 
+  const periodStart = utcMonthStart();
+
   const [bal, packBal, spent, history, shared, referralCode, referred, referralEarned] =
     await Promise.all([
       balance(walletId),
@@ -183,10 +185,14 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
       // numerator. Derived straight from run_spend rows, NOT `grantCap −
       // grantBalance`: an org that hasn't been granted yet this period has an
       // empty grant bucket but has spent nothing, and must read 0 used, not full.
+      // Bound by the shared `utcMonthStart()` anchor passed as a timestamptz
+      // PARAMETER (#292) — `date_trunc('month', now())` truncated in the DB
+      // session's TimeZone (Europe/London in prod), so a spend at 23:30 UTC on
+      // the last of the month counted into the NEXT month's meter.
       sql<{ used: string | null }[]>`
       select coalesce(sum(-delta), 0)::text as used from ai_credit_ledger
        where wallet_id = ${walletId} and bucket = 'grant' and source = 'run_spend'
-         and created_at >= date_trunc('month', now())`,
+         and created_at >= ${periodStart}`,
       creditHistory(walletId),
       sql<{ n: number }[]>`
       select count(*)::int as n from organizations

--- a/design/v17-pricing-entitlements/SPEC-2-addons-and-ai-credit-wallet.md
+++ b/design/v17-pricing-entitlements/SPEC-2-addons-and-ai-credit-wallet.md
@@ -220,6 +220,14 @@ monthly_grant(group) = ai.credits.monthly(plan) * quantity_paid
 
 e.g. a Pro Plus group of 3 paid org-seats → 200 * 3 = **600 credits/mo** shared. Fair to big operators, still bounded by seats paid. Resets (D1). A standalone org = *1. Community (never grouped) = flat 10.
 
+**Trial exception (#291, 2026-07-26):** `quantity_paid` is frozen at its pre-trial baseline for the whole trial (#279, `syncGroupQuantity`) — a seat added mid-trial rides free and raises the live org count without moving `quantity_paid`. Granting on the frozen number alone would under-grant that seat's own credits, so while trialing:
+
+```
+monthly_grant(group) = ai.credits.monthly(plan) * max(quantity_paid, live_org_count)
+```
+
+`quantity_paid` itself is never rewritten by the grant — only what it's multiplied by for THIS grant. It converges back to plain `quantity_paid` once the trial converts (`syncGroupQuantity`'s renewal path sets `quantity_paid` to what was actually invoiced).
+
 ### 11.3 Add-on scope follows the resource
 
 | Add-on | Applies | Table shape |

--- a/docs/superpowers/plans/2026-07-26-v17-gap-w3-grant-correct.md
+++ b/docs/superpowers/plans/2026-07-26-v17-gap-w3-grant-correct.md
@@ -316,7 +316,7 @@
 
   Then run #279's own suite (verification step, not a new test — it exercises `syncGroupQuantity`/`attachOrgToGroup`/`detachOrgFromGroup`/`previewAttachCharge`, none of which this task touches, but it starts a real `e2e/stripe-fixture-server` on a fixed port so it must be run alone):
   ```
-  DATABASE_URL=postgresql://postgres@127.0.0.1:54329/seazn_smoke DATABASE_SSL=disable DB_SCHEMA=v17gap_w3 npx vitest run src/server/usecases/__tests__/billing-group-trial-seat.test.ts
+  cd apps/web && DATABASE_URL=postgresql://postgres@127.0.0.1:54329/seazn_smoke DATABASE_SSL=disable DB_SCHEMA=v17gap_w3 npx vitest run src/server/usecases/__tests__/billing-group-trial-seat.test.ts
   ```
   Expected: all 4 tests pass unchanged — "freezes quantity_paid through a trial attach and detach", "previews a trial attach as free", "lets the trial-end renewal set quantity_paid to the active count", "still inflates quantity_paid on an ACTIVE (non-trial) group". This confirms `quantity_paid` itself is never written by this task's change — only what it's multiplied by for the grant — so #279's freeze guarantee and this task's grant-scaling coexist without either function touching the other's invariant.
 


### PR DESCRIPTION
## What

Wave 3 of the v17 gap remediation (`docs/superpowers/plans/2026-07-26-v17-gap-w3-grant-correct.md`) — 9 commits, code-only (no migration, no i18n, no UI, no smoke changes; the plan documents why each is N/A).

**#290 — churned orgs got 0 credits forever**
- `grantMonthlyForAllWallets` drops the raw `status in (...)` filter (the last of #311's four hand-lists in credits.ts): it now scans every subscription with a live org and resolves each wallet via `orgPlanKey` — the SAME resolver every other entitlement read uses. A canceled/incomplete org gets the Community 10 it already resolves to everywhere else; a staff win-back comp (canceled + comped_at) grants its comped rate instead of nothing.
- Representative-org selection is a SQL lateral byte-matched to `groupOrgLimit`'s rule (reviewer-verified line-by-line); a deliberate, documented `credits ↔ entitlements` import cycle (function-body-only calls — no module-eval interaction under Next or vitest).
- Recorded decision: a legacy/hand-edited status outside every resolver arm now falls to `coalesce(plan_key)` and grants the paid rate (was 0) — consistency with every other read is the point of #290.

**#291 — trialing groups under-granted mid-trial riders**
- While `trialing`, grant qty = `max(quantity_paid, live_org_count)` — the live count is predicate-identical to `syncGroupQuantity`'s active count, so the grant matches what the trial-end invoice will bill. Both `max()` arms mutation-pinned. `quantity_paid` itself is never written (#279's freeze suite 4/4 green). SPEC-2 §11.2 records the rule; the Credits-tab `grantCap` follows the same quantity rule.

**#292 — session-TZ month boundaries disagreed with the UTC grant cycle**
- One shared `utcMonthStart()` anchor (JS `Date` passed as a timestamptz param — immune to the session TimeZone GUC by construction; the SQL double-conversion trap is documented in-code with a live-session proof). `spentThisPeriodByOrg` (operator allocation cap) and the Credits-tab meter both derive from it; `monthlyPeriod()`'s idempotency key is provably byte-identical (no double-grant on deploy). Single clock sample in `getCreditsTab` (midnight-straddle bug fixed).

## Deploy-day effects (read before deploying)

- **First sweep over a previously-skipped (churned) wallet expires its stale grant bucket then grants the resolved rate** — a one-way, customer-visible drop to Community 10. Correct per D1 use-or-lose; documented in the sweep's docstring.
- **No mid-month re-grant**: a trialing group already granted this month is not topped up until the next UTC month.
- No retroactive back-grants for months missed (design decision).

## Verification

- tsc clean (incl. the import cycle); the plan's 14-suite run **120/120 with zero skips** (true green — env verified); `billing-group-trial-seat` 4/4 in its own invocation; full DB sweep 2647 passed / 1 environmental (orphan-orgs order-dependence, passes alone — #321); unit suite clean; scope greps empty (only .md touched is SPEC-2 + the wave plan's own snippet fix).
- Every behaviour change red-first or mutation-proven (evidence in per-task SDD reports); 3 fix rounds total, all re-reviewed clean; final whole-branch review verdict "Ready to merge: Yes".
- CI note: the two #292 TZ-boundary tests report SKIPPED on CI's UTC postgres (previously one would have silently passed) — CI TZ pin tracked in #320.

Follow-ups filed: #318 tab plan-dimension cap, #319 meter refund netting, #320 CI postgres TZ, #321 orphan-orgs test.

Closes #290. Closes #291. Closes #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)