### PR TITLE
Token-weighted AI credits: predictor, hard token budget, and the pricing seam #350 reuses

### DIFF
--- a/apps/web/src/lib/__tests__/ai-rung.test.ts
+++ b/apps/web/src/lib/__tests__/ai-rung.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clampRoundTokens,
+  hasRoundBudget,
+  isRung,
+  minRoundReserve,
+  officialsRungWeights,
+  predictRung,
+  schedulingRungWeights,
+  TOKEN_BUDGETS,
+  tokenBudgetForRung,
+  type RungWeights,
+} from "../ai-rung";
+
+// A fixed weight set so boundary math is easy to hand-verify: sizeScore =
+// movableFixtures + 1*entrants + 1*courts, s1=100, s2=300.
+const W: RungWeights = {
+  entrantWeight: 1,
+  courtWeight: 1,
+  s1: 100,
+  s2: 300,
+  estTokensAtS1: 20_000,
+  estTokensAtS2: 60_000,
+};
+
+describe("isRung", () => {
+  it("accepts exactly 1, 2, 3", () => {
+    expect(isRung(1)).toBe(true);
+    expect(isRung(2)).toBe(true);
+    expect(isRung(3)).toBe(true);
+  });
+
+  it("rejects anything else", () => {
+    expect(isRung(0)).toBe(false);
+    expect(isRung(4)).toBe(false);
+    expect(isRung(1.5)).toBe(false);
+  });
+});
+
+describe("TOKEN_BUDGETS / tokenBudgetForRung", () => {
+  it("hard budgets per rung (design §5): 1→32K, 2→64K, 3→128K", () => {
+    expect(TOKEN_BUDGETS).toEqual({ 1: 32_000, 2: 64_000, 3: 128_000 });
+    expect(tokenBudgetForRung(1)).toBe(32_000);
+    expect(tokenBudgetForRung(2)).toBe(64_000);
+    expect(tokenBudgetForRung(3)).toBe(128_000);
+  });
+});
+
+describe("predictRung — threshold boundaries", () => {
+  it("sizeScore at or under s1 → rung 1", () => {
+    expect(predictRung({ movableFixtures: 100, entrants: 0, courts: 0 }, W).rung).toBe(1);
+    expect(predictRung({ movableFixtures: 100, entrants: 0, courts: 0 }, W).sizeScore).toBe(100);
+  });
+
+  it("one unit over s1 → rung 2 (the boundary is inclusive on rung 1's side)", () => {
+    expect(predictRung({ movableFixtures: 101, entrants: 0, courts: 0 }, W).rung).toBe(2);
+  });
+
+  it("sizeScore at or under s2 → rung 2", () => {
+    expect(predictRung({ movableFixtures: 300, entrants: 0, courts: 0 }, W).rung).toBe(2);
+  });
+
+  it("one unit over s2 → rung 3", () => {
+    expect(predictRung({ movableFixtures: 301, entrants: 0, courts: 0 }, W).rung).toBe(3);
+  });
+
+  it("entrants and courts are weighted into the score, not just fixtures", () => {
+    // 50 fixtures + 40 entrants*1 + 20 courts*1 = 110 > s1(100) → rung 2.
+    const p = predictRung({ movableFixtures: 50, entrants: 40, courts: 20 }, W);
+    expect(p.sizeScore).toBe(110);
+    expect(p.rung).toBe(2);
+  });
+
+  it("zero-size input predicts rung 1 and zero est tokens", () => {
+    const p = predictRung({ movableFixtures: 0, entrants: 0, courts: 0 }, W);
+    expect(p.rung).toBe(1);
+    expect(p.estTokens).toBe(0);
+  });
+
+  it("est tokens is piecewise-linear over the anchors and monotonic in size", () => {
+    const at0 = predictRung({ movableFixtures: 0, entrants: 0, courts: 0 }, W).estTokens;
+    const atS1 = predictRung({ movableFixtures: 100, entrants: 0, courts: 0 }, W).estTokens;
+    const atS2 = predictRung({ movableFixtures: 300, entrants: 0, courts: 0 }, W).estTokens;
+    const beyondS2 = predictRung({ movableFixtures: 400, entrants: 0, courts: 0 }, W).estTokens;
+    expect(atS1).toBe(W.estTokensAtS1);
+    expect(atS2).toBe(W.estTokensAtS2);
+    expect(at0).toBeLessThan(atS1);
+    expect(atS1).toBeLessThan(atS2);
+    expect(beyondS2).toBeGreaterThan(atS2); // extrapolated past s2, never flat
+  });
+});
+
+describe("schedulingRungWeights / officialsRungWeights — env overrides", () => {
+  const keys = [
+    "AI_RUNG_ENTRANT_WEIGHT",
+    "AI_RUNG_COURT_WEIGHT",
+    "AI_RUNG_S1",
+    "AI_RUNG_S2",
+    "AI_RUNG_EST_TOKENS_AT_S1",
+    "AI_RUNG_EST_TOKENS_AT_S2",
+    "AI_RUNG_OFFICIALS_ENTRANT_WEIGHT",
+    "AI_RUNG_OFFICIALS_COURT_WEIGHT",
+    "AI_RUNG_OFFICIALS_S1",
+    "AI_RUNG_OFFICIALS_S2",
+    "AI_RUNG_OFFICIALS_EST_TOKENS_AT_S1",
+    "AI_RUNG_OFFICIALS_EST_TOKENS_AT_S2",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+  afterEach(() => {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+      delete saved[k];
+    }
+  });
+
+  it("defaults match the design doc's code constants when unset", () => {
+    for (const k of keys) delete process.env[k];
+    expect(schedulingRungWeights()).toEqual({
+      entrantWeight: 0.5,
+      courtWeight: 2,
+      s1: 60,
+      s2: 200,
+      estTokensAtS1: 18_000,
+      estTokensAtS2: 50_000,
+    });
+    // Officials lands rung 1 almost always — higher thresholds, lighter weights.
+    expect(officialsRungWeights()).toEqual({
+      entrantWeight: 0.25,
+      courtWeight: 1,
+      s1: 120,
+      s2: 400,
+      estTokensAtS1: 10_000,
+      estTokensAtS2: 30_000,
+    });
+  });
+
+  it("AI_RUNG_S1/S2 override the schedule thresholds independently of officials", () => {
+    saved.AI_RUNG_S1 = process.env.AI_RUNG_S1;
+    saved.AI_RUNG_S2 = process.env.AI_RUNG_S2;
+    process.env.AI_RUNG_S1 = "10";
+    process.env.AI_RUNG_S2 = "20";
+    expect(schedulingRungWeights().s1).toBe(10);
+    expect(schedulingRungWeights().s2).toBe(20);
+    expect(officialsRungWeights().s1).toBe(120); // untouched
+  });
+});
+
+describe("minRoundReserve / hasRoundBudget / clampRoundTokens — meter math", () => {
+  const saved = process.env.AI_RUNG_MIN_ROUND_RESERVE;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AI_RUNG_MIN_ROUND_RESERVE;
+    else process.env.AI_RUNG_MIN_ROUND_RESERVE = saved;
+  });
+
+  it("defaults to 2_000 and is env-overridable", () => {
+    delete process.env.AI_RUNG_MIN_ROUND_RESERVE;
+    expect(minRoundReserve()).toBe(2_000);
+    process.env.AI_RUNG_MIN_ROUND_RESERVE = "500";
+    expect(minRoundReserve()).toBe(500);
+  });
+
+  it("hasRoundBudget is true while spent + reserve fits the budget, false once it doesn't", () => {
+    process.env.AI_RUNG_MIN_ROUND_RESERVE = "2000";
+    expect(hasRoundBudget(32_000, 30_000)).toBe(true); // 30,000 + 2,000 == 32,000 → fits exactly
+    expect(hasRoundBudget(32_000, 30_001)).toBe(false); // one token over the reserve line
+  });
+
+  it("clampRoundTokens never exceeds the round ceiling nor the remaining budget", () => {
+    expect(clampRoundTokens(32_000, 64_000, 0)).toBe(32_000); // plenty left — capped by the ceiling
+    expect(clampRoundTokens(32_000, 64_000, 40_000)).toBe(24_000); // budget is the binding constraint
+    expect(clampRoundTokens(32_000, 64_000, 64_000)).toBe(0); // budget fully spent
+    expect(clampRoundTokens(32_000, 64_000, 70_000)).toBe(0); // never negative
+  });
+});

--- a/apps/web/src/lib/__tests__/ai-rung.test.ts
+++ b/apps/web/src/lib/__tests__/ai-rung.test.ts
@@ -1,14 +1,16 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
-  clampRoundTokens,
-  hasRoundBudget,
+  createTokenMeter,
+  freeDraftQuote,
   isRung,
+  meterStamp,
   minRoundReserve,
   officialsRungWeights,
   predictRung,
+  quoteRun,
   schedulingRungWeights,
-  TOKEN_BUDGETS,
-  tokenBudgetForRung,
+  tokenBudgetForCredits,
+  unmeteredTokenMeter,
   type RungWeights,
 } from "../ai-rung";
 
@@ -22,6 +24,37 @@ const W: RungWeights = {
   estTokensAtS1: 20_000,
   estTokensAtS2: 60_000,
 };
+
+/** A line whose sizeScore is exactly `n` under W. */
+const sized = (key: string, n: number, chosen?: number) => ({
+  key,
+  input: { movableFixtures: n, entrants: 0, courts: 0 },
+  ...(chosen !== undefined ? { chosen } : {}),
+});
+
+const BUDGET_ENV = [
+  "AI_RUNG_BUDGET_1",
+  "AI_RUNG_BUDGET_2",
+  "AI_RUNG_BUDGET_3",
+  "AI_RUNG_BUDGET_STEP",
+  "AI_RUNG_MIN_ROUND_RESERVE",
+  "AI_RUNG_RESERVE_PER_UNIT",
+] as const;
+
+/** Clear `keys` for the duration of a test; returns the restore thunk. */
+function withCleanEnv(keys: readonly string[]) {
+  const saved: Record<string, string | undefined> = {};
+  for (const k of keys) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  return () => {
+    for (const k of keys) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  };
+}
 
 describe("isRung", () => {
   it("accepts exactly 1, 2, 3", () => {
@@ -37,14 +70,9 @@ describe("isRung", () => {
   });
 });
 
-describe("TOKEN_BUDGETS / tokenBudgetForRung", () => {
-  it("hard budgets per rung (design §5): 1→32K, 2→64K, 3→128K", () => {
-    expect(TOKEN_BUDGETS).toEqual({ 1: 32_000, 2: 64_000, 3: 128_000 });
-    expect(tokenBudgetForRung(1)).toBe(32_000);
-    expect(tokenBudgetForRung(2)).toBe(64_000);
-    expect(tokenBudgetForRung(3)).toBe(128_000);
-  });
-});
+// ---------------------------------------------------------------------------
+// 1. SIZING
+// ---------------------------------------------------------------------------
 
 describe("predictRung — threshold boundaries", () => {
   it("sizeScore at or under s1 → rung 1", () => {
@@ -105,17 +133,11 @@ describe("schedulingRungWeights / officialsRungWeights — env overrides", () =>
     "AI_RUNG_OFFICIALS_EST_TOKENS_AT_S1",
     "AI_RUNG_OFFICIALS_EST_TOKENS_AT_S2",
   ] as const;
-  const saved: Record<string, string | undefined> = {};
-  afterEach(() => {
-    for (const k of keys) {
-      if (saved[k] === undefined) delete process.env[k];
-      else process.env[k] = saved[k];
-      delete saved[k];
-    }
-  });
+  let restore = () => {};
+  afterEach(() => restore());
 
   it("defaults match the design doc's code constants when unset", () => {
-    for (const k of keys) delete process.env[k];
+    restore = withCleanEnv(keys);
     expect(schedulingRungWeights()).toEqual({
       entrantWeight: 0.5,
       courtWeight: 2,
@@ -136,40 +158,335 @@ describe("schedulingRungWeights / officialsRungWeights — env overrides", () =>
   });
 
   it("AI_RUNG_S1/S2 override the schedule thresholds independently of officials", () => {
-    saved.AI_RUNG_S1 = process.env.AI_RUNG_S1;
-    saved.AI_RUNG_S2 = process.env.AI_RUNG_S2;
+    restore = withCleanEnv(keys);
     process.env.AI_RUNG_S1 = "10";
     process.env.AI_RUNG_S2 = "20";
     expect(schedulingRungWeights().s1).toBe(10);
     expect(schedulingRungWeights().s2).toBe(20);
     expect(officialsRungWeights().s1).toBe(120); // untouched
   });
+
+  it("the entrant/court weights are env-overridable too", () => {
+    restore = withCleanEnv(keys);
+    process.env.AI_RUNG_ENTRANT_WEIGHT = "3";
+    process.env.AI_RUNG_COURT_WEIGHT = "7";
+    expect(schedulingRungWeights().entrantWeight).toBe(3);
+    expect(schedulingRungWeights().courtWeight).toBe(7);
+  });
 });
 
-describe("minRoundReserve / hasRoundBudget / clampRoundTokens — meter math", () => {
-  const saved = process.env.AI_RUNG_MIN_ROUND_RESERVE;
-  afterEach(() => {
-    if (saved === undefined) delete process.env.AI_RUNG_MIN_ROUND_RESERVE;
-    else process.env.AI_RUNG_MIN_ROUND_RESERVE = saved;
+// ---------------------------------------------------------------------------
+// 3. BUDGET — keyed on CREDITS, not on rung
+// ---------------------------------------------------------------------------
+
+describe("tokenBudgetForCredits", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("keeps the owner-approved #348 curve for 1/2/3 credits", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    expect(tokenBudgetForCredits(1)).toBe(32_000);
+    expect(tokenBudgetForCredits(2)).toBe(64_000);
+    expect(tokenBudgetForCredits(3)).toBe(128_000);
   });
 
-  it("defaults to 2_000 and is env-overridable", () => {
-    delete process.env.AI_RUNG_MIN_ROUND_RESERVE;
+  // The whole reason the budget keys on CREDITS rather than on a Rung: #350's
+  // joint solve charges max(1, Σ rungs − 1), which reaches 5, 8, 11 credits —
+  // values a Record<1|2|3, number> cannot key.
+  it("extends past 3 credits at a flat step, so a joint run can be priced at all", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    expect(tokenBudgetForCredits(4)).toBe(160_000);
+    expect(tokenBudgetForCredits(5)).toBe(192_000);
+    expect(tokenBudgetForCredits(9)).toBe(128_000 + 32_000 * 6);
+  });
+
+  it("is monotonic, and zero at or below zero credits", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    expect(tokenBudgetForCredits(0)).toBe(0);
+    expect(tokenBudgetForCredits(-2)).toBe(0);
+    for (let n = 1; n < 12; n++) {
+      expect(tokenBudgetForCredits(n + 1)).toBeGreaterThan(tokenBudgetForCredits(n));
+    }
+  });
+
+  // The escape hatch for uncalibrated constants: loosen the budget in prod
+  // without a deploy, once `stopped_on_budget` shows runs being cut short.
+  it("every rung's budget is env-overridable", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    process.env.AI_RUNG_BUDGET_1 = "50000";
+    process.env.AI_RUNG_BUDGET_3 = "200000";
+    process.env.AI_RUNG_BUDGET_STEP = "10000";
+    expect(tokenBudgetForCredits(1)).toBe(50_000);
+    expect(tokenBudgetForCredits(3)).toBe(200_000);
+    expect(tokenBudgetForCredits(4)).toBe(210_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. PRICING
+// ---------------------------------------------------------------------------
+
+describe("quoteRun — single line (one division, issue #348)", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("charges the predicted rung and sizes the budget from it", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("d1", 150)], W); // 100 < 150 <= 300 → rung 2
+    expect(q.credits).toBe(2);
+    expect(q.discount).toBe(0);
+    expect(q.budget).toBe(64_000);
+    expect(q.underfunded).toBe(false);
+    expect(q.lines[0]!.predictedRung).toBe(2);
+  });
+
+  it("honours a rung chosen ABOVE the prediction — never underfunded", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("d1", 10, 3)], W); // predicts 1, picks 3
+    expect(q.credits).toBe(3);
+    expect(q.budget).toBe(128_000);
+    expect(q.underfunded).toBe(false);
+    expect(q.lines[0]!.predictedRung).toBe(1);
+  });
+
+  it("honours a rung chosen BELOW the prediction and flags underfunded", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("d1", 400, 1)], W); // predicts 3, picks 1
+    expect(q.credits).toBe(1);
+    expect(q.budget).toBe(32_000);
+    expect(q.underfunded).toBe(true);
+    expect(q.lines[0]!.predictedRung).toBe(3);
+  });
+
+  it("ignores an out-of-range override rather than charging a bogus amount", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    for (const bad of [0, 4, 2.5, -1, Number.NaN]) {
+      expect(quoteRun([sized("d1", 150, bad)], W).credits).toBe(2); // fell back to the prediction
+    }
+  });
+});
+
+describe("quoteRun — joint lines (one competition, issue #350)", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("applies the Σ − 1 batch discount across divisions", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    // rungs 1 + 2 + 3 = 6 → charge 5.
+    const q = quoteRun([sized("a", 10), sized("b", 150), sized("c", 400)], W);
+    expect(q.lines.map((l) => l.rung)).toEqual([1, 2, 3]);
+    expect(q.rungTotal).toBe(6);
+    expect(q.credits).toBe(5);
+    expect(q.discount).toBe(1);
+  });
+
+  it("never charges below 1 credit", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("a", 10), sized("b", 10)], W); // 1 + 1 = 2 → max(1, 1)
+    expect(q.credits).toBe(1);
+    expect(q.discount).toBe(1);
+  });
+
+  // Owner decision: the discount is a margin gift, NOT a capability cut. Two
+  // joint rung-1 divisions pay for one credit but still get the token budget
+  // two divisions' worth of work needs — otherwise a joint run would be
+  // strictly worse than running the divisions separately.
+  it("sizes the budget from the UNDISCOUNTED rung total, not the charged credits", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("a", 10), sized("b", 10)], W);
+    expect(q.credits).toBe(1);
+    expect(q.budget).toBe(tokenBudgetForCredits(2)); // 64K, not 32K
+    expect(q.budget).toBe(64_000);
+  });
+
+  it("flags underfunded when ANY division was picked below its prediction", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("a", 10), sized("b", 400, 1)], W);
+    expect(q.underfunded).toBe(true);
+    expect(q.lines[0]!.underfunded).toBe(false);
+    expect(q.lines[1]!.underfunded).toBe(true);
+  });
+
+  it("sums the advisory est-token helper text across lines", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    expect(quoteRun([sized("a", 100), sized("b", 100)], W).estTokens).toBe(2 * W.estTokensAtS1);
+  });
+});
+
+describe("freeDraftQuote — the zero-token deterministic path", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  // Regression: sizing this path by the pack charged a large division 2-3
+  // credits for a run that makes NO model call at all. It cost 1 credit before
+  // rung pricing existed and must keep costing 1.
+  it("always costs exactly 1 credit whatever the division size", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = freeDraftQuote("d1");
+    expect(q.credits).toBe(1);
+    expect(q.lines[0]!.rung).toBe(1);
+    expect(q.lines[0]!.predictedRung).toBe(1);
+    expect(q.underfunded).toBe(false);
+    expect(q.estTokens).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. METER
+// ---------------------------------------------------------------------------
+
+describe("minRoundReserve", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("defaults to a 2_000-token floor and is env-overridable", () => {
+    restore = withCleanEnv(BUDGET_ENV);
     expect(minRoundReserve()).toBe(2_000);
     process.env.AI_RUNG_MIN_ROUND_RESERVE = "500";
     expect(minRoundReserve()).toBe(500);
   });
 
-  it("hasRoundBudget is true while spent + reserve fits the budget, false once it doesn't", () => {
-    process.env.AI_RUNG_MIN_ROUND_RESERVE = "2000";
-    expect(hasRoundBudget(32_000, 30_000)).toBe(true); // 30,000 + 2,000 == 32,000 → fits exactly
-    expect(hasRoundBudget(32_000, 30_001)).toBe(false); // one token over the reserve line
+  // A flat 2_000 floor is wrong for a big pack: emitting 200 assignments alone
+  // costs several thousand output tokens, so a round clamped to 2_000 truncates,
+  // fails to parse, and burns the rest of the budget for nothing.
+  it("scales with the pack size so a big pack's round can actually be emitted", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    expect(minRoundReserve(10)).toBe(2_000); // the floor still binds on a small pack
+    expect(minRoundReserve(200)).toBe(8_000); // 200 * 40
+    process.env.AI_RUNG_RESERVE_PER_UNIT = "100";
+    expect(minRoundReserve(200)).toBe(20_000);
   });
 
-  it("clampRoundTokens never exceeds the round ceiling nor the remaining budget", () => {
-    expect(clampRoundTokens(32_000, 64_000, 0)).toBe(32_000); // plenty left — capped by the ceiling
-    expect(clampRoundTokens(32_000, 64_000, 40_000)).toBe(24_000); // budget is the binding constraint
-    expect(clampRoundTokens(32_000, 64_000, 64_000)).toBe(0); // budget fully spent
-    expect(clampRoundTokens(32_000, 64_000, 70_000)).toBe(0); // never negative
+  it("treats a negative unit count as zero", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    expect(minRoundReserve(-5)).toBe(2_000);
+  });
+});
+
+describe("createTokenMeter", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("accumulates spend and refuses a round once the reserve no longer fits", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const m = createTokenMeter(32_000);
+    expect(m.canStartRound()).toBe(true);
+    m.add(30_000);
+    expect(m.spent).toBe(30_000);
+    expect(m.canStartRound()).toBe(true); // 30,000 + 2,000 == 32,000 → fits exactly
+    m.add(1);
+    expect(m.canStartRound()).toBe(false); // one token over the reserve line
+  });
+
+  it("flags stoppedOnBudget only once a round has actually been refused", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const m = createTokenMeter(32_000);
+    m.add(10_000);
+    m.canStartRound();
+    expect(m.stoppedOnBudget).toBe(false); // finished under budget → not a cliff
+    m.add(25_000);
+    m.canStartRound();
+    expect(m.stoppedOnBudget).toBe(true);
+  });
+
+  it("clamps a round to the ceiling, then to the remaining budget, never below zero", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const m = createTokenMeter(64_000);
+    expect(m.clampRound(32_000)).toBe(32_000); // plenty left — the ceiling binds
+    m.add(40_000);
+    expect(m.clampRound(32_000)).toBe(24_000); // the budget binds
+    m.add(30_000);
+    expect(m.clampRound(32_000)).toBe(0); // overspent — never negative
+  });
+
+  it("ignores non-positive and non-finite round usage", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const m = createTokenMeter(32_000);
+    m.add(0);
+    m.add(-5);
+    m.add(Number.NaN);
+    expect(m.spent).toBe(0);
+  });
+
+  it("sizes its reserve from the pack it was built for", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const big = createTokenMeter(32_000, { units: 200 }); // reserve 8_000
+    big.add(25_000);
+    expect(big.canStartRound()).toBe(false); // 25,000 + 8,000 > 32,000
+    const small = createTokenMeter(32_000, { units: 10 }); // reserve 2_000
+    small.add(25_000);
+    expect(small.canStartRound()).toBe(true);
+  });
+});
+
+describe("unmeteredTokenMeter", () => {
+  it("never refuses a round but still counts spend", () => {
+    const m = unmeteredTokenMeter();
+    m.add(10_000_000);
+    expect(m.canStartRound()).toBe(true);
+    expect(m.stoppedOnBudget).toBe(false);
+    expect(m.spent).toBe(10_000_000);
+  });
+
+  it("clamps to the caller's own ceiling, not to Infinity", () => {
+    expect(unmeteredTokenMeter().clampRound(32_000)).toBe(32_000);
+  });
+
+  // A shared mutable singleton would carry one run's spend into the next.
+  it("returns a fresh instance per call", () => {
+    const a = unmeteredTokenMeter();
+    a.add(5_000);
+    expect(unmeteredTokenMeter().spent).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STAMP
+// ---------------------------------------------------------------------------
+
+describe("meterStamp", () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it("emits the flat rung fields for a single-division run", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("d1", 400, 1)], W);
+    const m = createTokenMeter(q.budget);
+    m.add(12_345);
+    expect(meterStamp(q, m)).toEqual({
+      credits: 1,
+      budget: 32_000,
+      spent_tokens: 12_345,
+      underfunded: true,
+      stopped_on_budget: false,
+      est_tokens: q.estTokens,
+      rung: 1,
+      predicted_rung: 3,
+    });
+  });
+
+  it("emits the per-division breakdown and discount for a joint run", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("a", 10), sized("b", 400)], W);
+    const stamp = meterStamp(q, createTokenMeter(q.budget));
+    expect(stamp.rung).toBeUndefined();
+    expect(stamp.credits).toBe(3); // 1 + 3 − 1
+    expect(stamp.discount).toBe(1);
+    expect(stamp.divisions).toEqual([
+      { id: "a", rung: 1, predicted_rung: 1, underfunded: false },
+      { id: "b", rung: 3, predicted_rung: 3, underfunded: false },
+    ]);
+  });
+
+  // What makes a mispriced rung visible in analytics: without this a run cut
+  // off by the budget is indistinguishable from one that merely returned a
+  // degraded plan.
+  it("reports stopped_on_budget once the meter refused a round", () => {
+    restore = withCleanEnv(BUDGET_ENV);
+    const q = quoteRun([sized("d1", 10)], W);
+    const m = createTokenMeter(q.budget);
+    m.add(q.budget);
+    m.canStartRound();
+    expect(meterStamp(q, m).stopped_on_budget).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai-rung.ts
+++ b/apps/web/src/lib/ai-rung.ts
@@ -1,14 +1,26 @@
 // Token-weighted AI credit pricing (docs/superpowers/specs/2026-07-28-ai-credit-
-// token-weight-design.md). Pure, no I/O: predicts the 1/2/3 credit "rung" a run
-// needs from data already loaded to build its pack (fixtures, entrants,
-// courts), and defines the hard token budget each rung buys. Imported by both
-// server usecases (schedule-ai.ts, officials-ai.ts) and, eventually, a
-// confirm-card client component — no I/O means no server-only import ever
-// leaks into a client bundle (same discipline as lib/pass-ladder.ts).
+// token-weight-design.md, issue #348) and the seam the multi-division joint
+// solve (issue #350) plugs into. Pure, no I/O: imported by both server usecases
+// (schedule-ai.ts, officials-ai.ts) and, eventually, a confirm-card client
+// component — no I/O means no server-only import ever leaks into a client
+// bundle (same discipline as lib/pass-ladder.ts).
 //
 // APPROACH 1 (heuristic predictor + harness token meter), per the design doc:
-// no regression fitting, no Anthropic `task_budget` beta — enforcement lives
-// in the ladder loop as a cumulative token meter, provider-agnostic.
+// no regression fitting, no Anthropic `task_budget` beta — enforcement lives in
+// the ladder loop as a cumulative token meter, provider-agnostic.
+//
+// THREE SEPARATE CONCERNS, deliberately not collapsed into one another. #350
+// needs each of them independently, and an earlier shape that keyed the token
+// budget off the RUNG could not express its pricing at all:
+//
+//   1. SIZING   pack shape   -> sizeScore -> Rung (1|2|3)   `predictRung`
+//   2. PRICING  chosen rungs -> credits charged             `quoteRun`
+//   3. BUDGET   credits      -> hard generation-token cap   `tokenBudgetForCredits`
+//
+// A single-division run prices at its own rung, so (2) is the identity. A joint
+// run over N divisions prices at `max(1, Σ rungs − 1)` — a batch discount that
+// can reach 5, 8, 11 credits, values a `Record<Rung, number>` budget table
+// cannot key. Hence (3) keys on CREDITS, and extends past 3 linearly.
 
 export type Rung = 1 | 2 | 3;
 
@@ -16,41 +28,14 @@ export function isRung(n: number): n is Rung {
   return n === 1 || n === 2 || n === 3;
 }
 
-/** Hard per-run generation-token budget a rung buys (design §5). Credits buy a
- *  token BUDGET, not usage — price is fixed at confirm time regardless of how
- *  much of the budget a run actually spends; no refunds, no true-up. */
-export const TOKEN_BUDGETS: Record<Rung, number> = {
-  1: 32_000,
-  2: 64_000,
-  3: 128_000,
-};
-
-export function tokenBudgetForRung(rung: Rung): number {
-  return TOKEN_BUDGETS[rung];
+function envNumber(name: string, fallback: number): number {
+  const n = Number(process.env[name]);
+  return Number.isFinite(n) ? n : fallback;
 }
 
-/** A round smaller than this can't produce a useful plan/repair — stop
- *  escalating (a new ladder rung, or a repair round) once the remaining
- *  budget drops below it, rather than spending down to a sliver that could
- *  never finish a round anyway. */
-export function minRoundReserve(): number {
-  const n = Number(process.env.AI_RUNG_MIN_ROUND_RESERVE);
-  return Number.isFinite(n) && n >= 0 ? n : 2_000;
-}
-
-/** Is there enough of the run's hard budget left to justify starting another
- *  round? `spent` is the run's total generation tokens so far (every rung,
- *  every round, summed — the same usage numbers already captured for COGS). */
-export function hasRoundBudget(budget: number, spent: number): boolean {
-  return spent + minRoundReserve() <= budget;
-}
-
-/** Per-round token cap given how much of the run's budget remains: never more
- *  than `roundCeiling` (the existing MAX_TOKENS-style per-round cap), never
- *  more than what's left of the run's hard budget. */
-export function clampRoundTokens(roundCeiling: number, budget: number, spent: number): number {
-  return Math.max(0, Math.min(roundCeiling, budget - spent));
-}
+// ---------------------------------------------------------------------------
+// 1. SIZING — pack shape -> rung prediction
+// ---------------------------------------------------------------------------
 
 export interface RungWeights {
   entrantWeight: number;
@@ -60,18 +45,13 @@ export interface RungWeights {
   /** sizeScore at/under which the predictor picks rung 2 (above → rung 3). */
   s2: number;
   /** Helper-text-only anchors for the est-tokens curve — never used for
-   *  billing/enforcement (TOKEN_BUDGETS is the hard budget, enforced
+   *  billing/enforcement (the credit budget below is the hard cap, enforced
    *  independent of this estimate). UNCALIBRATED until the design's one-time
    *  SQL pass over competition_events buckets real output_tokens by
-   *  pack_units (design §4) — edit these anchors, not the code, once that
-   *  data exists. */
+   *  pack_units (design §4, scripts/ai-rung-calibration.sql) — edit these
+   *  anchors, not the code, once that data exists. */
   estTokensAtS1: number;
   estTokensAtS2: number;
-}
-
-function envNumber(name: string, fallback: number): number {
-  const n = Number(process.env[name]);
-  return Number.isFinite(n) ? n : fallback;
 }
 
 /** Phase A (schedule) predictor weights. AI_RUNG_* env overrides per design §4. */
@@ -130,12 +110,257 @@ function computeEstTokens(score: number, weights: RungWeights): number {
   return Math.round(estTokensAtS2 + (score - s2) * slope);
 }
 
-/** Predict the credit rung a run needs, purely from pack data already loaded
- *  to build it — no I/O, no new estimate endpoint (design §4/§6). The server
- *  always recomputes this at run time; a client's displayed prediction is
- *  advisory only. */
+/** Predict the credit rung a unit of work needs, purely from pack data already
+ *  loaded to build it — no I/O, no new estimate endpoint (design §4/§6). The
+ *  server always recomputes this at run time; a client's displayed prediction
+ *  is advisory only. */
 export function predictRung(input: RungInput, weights: RungWeights): RungPrediction {
   const sizeScore = computeSizeScore(input, weights);
   const rung: Rung = sizeScore <= weights.s1 ? 1 : sizeScore <= weights.s2 ? 2 : 3;
   return { sizeScore, rung, estTokens: computeEstTokens(sizeScore, weights) };
+}
+
+// ---------------------------------------------------------------------------
+// 3. BUDGET — credits -> hard generation-token cap
+// ---------------------------------------------------------------------------
+
+/** Hard per-run generation-token budget N credits buy. Credits buy a token
+ *  BUDGET, not usage — price is fixed at confirm time regardless of how much of
+ *  the budget a run actually spends; no refunds, no true-up (design §5).
+ *
+ *  1/2/3 are the owner-approved #348 values. Past 3 (only reachable via #350's
+ *  joint solve) the curve continues at a flat step per extra credit — #350 §2's
+ *  "32K × credits" line is superseded, since it would have CUT rung 3 from
+ *  128K to 96K.
+ *
+ *  Every value is env-overridable so a live cliff (visible via the
+ *  `stopped_on_budget` stamp) can be loosened without a deploy while the
+ *  calibration data is still being gathered. */
+export function tokenBudgetForCredits(credits: number): number {
+  if (!Number.isFinite(credits) || credits <= 0) return 0;
+  const b3 = envNumber("AI_RUNG_BUDGET_3", 128_000);
+  const n = Math.floor(credits);
+  if (n === 1) return envNumber("AI_RUNG_BUDGET_1", 32_000);
+  if (n === 2) return envNumber("AI_RUNG_BUDGET_2", 64_000);
+  if (n === 3) return b3;
+  return b3 + envNumber("AI_RUNG_BUDGET_STEP", 32_000) * (n - 3);
+}
+
+// ---------------------------------------------------------------------------
+// 2. PRICING — chosen rungs -> credits charged (+ the budget they buy)
+// ---------------------------------------------------------------------------
+
+/** One priced unit of work. Single-division runs pass one; #350's joint solve
+ *  passes one per selected division, `key` being the division id. */
+export interface QuoteLineInput {
+  key: string;
+  input: RungInput;
+  /** Caller's rung override. Ignored when it is not 1|2|3. A pick BELOW the
+   *  prediction is honoured and stamps `underfunded` — the run still executes,
+   *  capped to the smaller budget. */
+  chosen?: number;
+}
+
+export interface QuoteLine {
+  key: string;
+  sizeScore: number;
+  predictedRung: Rung;
+  rung: Rung;
+  estTokens: number;
+  underfunded: boolean;
+}
+
+export interface Quote {
+  lines: QuoteLine[];
+  /** Σ of the chosen rungs, before the batch discount. Sizes the budget. */
+  rungTotal: number;
+  /** Credits actually charged: `rungTotal` for one line, `max(1, rungTotal−1)`
+   *  for a joint run (#350 §7). */
+  credits: number;
+  /** Credits forgiven by the batch discount (0 or 1) — shown in the breakdown. */
+  discount: number;
+  /** Hard generation-token budget this run gets. Sized from `rungTotal`, NOT
+   *  from the discounted `credits`: the batch discount is a margin gift, not a
+   *  capability cut, so two joint rung-1 divisions pay 1 credit and still get
+   *  the 64K two divisions' worth of work needs. */
+  budget: number;
+  /** Advisory sum of the lines' est-token helper text. */
+  estTokens: number;
+  /** Any line picked below its prediction. */
+  underfunded: boolean;
+}
+
+/** Price a run. One line → the single-division path (credits = that rung).
+ *  Two or more → #350's joint solve, with the `Σ − 1` batch discount.
+ *
+ *  Callers gate the ≥2-line requirement themselves (the competition endpoint
+ *  400s on a single division so the discount cannot be arbitraged); this
+ *  function stays total, and simply applies no discount to a lone line. */
+export function quoteRun(lines: QuoteLineInput[], weights: RungWeights): Quote {
+  const priced: QuoteLine[] = lines.map((l) => {
+    const p = predictRung(l.input, weights);
+    const rung: Rung = l.chosen !== undefined && isRung(l.chosen) ? l.chosen : p.rung;
+    return {
+      key: l.key,
+      sizeScore: p.sizeScore,
+      predictedRung: p.rung,
+      rung,
+      estTokens: p.estTokens,
+      underfunded: rung < p.rung,
+    };
+  });
+  const rungTotal = priced.reduce((n, l) => n + l.rung, 0);
+  const credits = priced.length > 1 ? Math.max(1, rungTotal - 1) : rungTotal;
+  return {
+    lines: priced,
+    rungTotal,
+    credits,
+    discount: rungTotal - credits,
+    budget: tokenBudgetForCredits(rungTotal),
+    estTokens: priced.reduce((n, l) => n + l.estTokens, 0),
+    underfunded: priced.some((l) => l.underfunded),
+  };
+}
+
+/** A run that charges credits but makes no model call — Phase B's
+ *  empty-instruction path returns the deterministic solver draft with zero
+ *  tokens, and must never cost more than the 1 credit it cost before rung
+ *  pricing existed ("the sensible spread costs nothing", design/v4/03 §2). */
+export function freeDraftQuote(key: string): Quote {
+  return {
+    lines: [{ key, sizeScore: 0, predictedRung: 1, rung: 1, estTokens: 0, underfunded: false }],
+    rungTotal: 1,
+    credits: 1,
+    discount: 0,
+    budget: tokenBudgetForCredits(1),
+    estTokens: 0,
+    underfunded: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. METER — enforcement, shared across every rung and round of one run
+// ---------------------------------------------------------------------------
+
+/** A round smaller than this cannot produce a useful plan or repair, so stop
+ *  escalating rather than spending down to a sliver that could never finish.
+ *  SIZE-AWARE: a flat floor is wrong for a 200-fixture pack, where the
+ *  assignment list ALONE is several thousand tokens — a round clamped under
+ *  that truncates, fails to parse, and burns the remaining budget for nothing. */
+export function minRoundReserve(units = 0): number {
+  const base = envNumber("AI_RUNG_MIN_ROUND_RESERVE", 2_000);
+  const perUnit = envNumber("AI_RUNG_RESERVE_PER_UNIT", 40);
+  return Math.max(base, Math.round(Math.max(units, 0) * perUnit));
+}
+
+/**
+ * The run's cumulative generation-token meter. ONE instance is threaded through
+ * the whole ladder — every model rung, every repair round — so the budget is
+ * enforced across the run rather than reset per rung, and the "how much did
+ * prior rungs spend" bookkeeping lives in one place instead of travelling as a
+ * number each layer has to remember to forward.
+ *
+ * Only generation (output, incl. thinking) tokens are metered. On
+ * adaptive-thinking models thinking bills as output, which is exactly the cost
+ * the rung is scaling for; input tokens are not metered (design §5).
+ */
+export interface TokenMeter {
+  readonly budget: number;
+  readonly spent: number;
+  /** True once `canStartRound()` has refused a round — the run ended EARLY, cut
+   *  off by the budget rather than by finding a clean plan. Stamped on the
+   *  ledger event so a mispriced rung shows up in analytics instead of looking
+   *  like a normal (if degraded) result. */
+  readonly stoppedOnBudget: boolean;
+  /** Record a round's output tokens. Call it as soon as usage is known, on the
+   *  failure path too — an un-metered failed round is a budget leak. */
+  add(outputTokens: number): void;
+  /** Is there enough budget left to justify another round? Refusing flips
+   *  `stoppedOnBudget`. */
+  canStartRound(): boolean;
+  /** Per-round `max_tokens`: never more than the caller's own ceiling, never
+   *  more than what is left of the run's budget. */
+  clampRound(ceiling: number): number;
+}
+
+export function createTokenMeter(budget: number, opts: { units?: number } = {}): TokenMeter {
+  const reserve = minRoundReserve(opts.units ?? 0);
+  let spent = 0;
+  let stopped = false;
+  return {
+    get budget() {
+      return budget;
+    },
+    get spent() {
+      return spent;
+    },
+    get stoppedOnBudget() {
+      return stopped;
+    },
+    add(outputTokens: number) {
+      if (Number.isFinite(outputTokens) && outputTokens > 0) spent += outputTokens;
+    },
+    canStartRound() {
+      const ok = spent + reserve <= budget;
+      if (!ok) stopped = true;
+      return ok;
+    },
+    clampRound(ceiling: number) {
+      return Math.max(0, Math.min(ceiling, budget - spent));
+    },
+  };
+}
+
+/** A meter that never refuses a round — the default for callers that do not
+ *  price a run (unit tests, internal replays). Still counts spend, so the same
+ *  telemetry works either way. Returns a FRESH meter per call: a shared mutable
+ *  singleton would leak one run's spend into the next. */
+export function unmeteredTokenMeter(): TokenMeter {
+  return createTokenMeter(Number.POSITIVE_INFINITY);
+}
+
+// ---------------------------------------------------------------------------
+// Ledger / API stamp — one shape, so every surface reports the same fields
+// ---------------------------------------------------------------------------
+
+export interface RunMeterStamp {
+  credits: number;
+  budget: number;
+  spent_tokens: number;
+  underfunded: boolean;
+  stopped_on_budget: boolean;
+  est_tokens: number;
+  /** Single-line runs only: the flat rung fields the confirm card reads. */
+  rung?: Rung;
+  predicted_rung?: Rung;
+  /** Joint runs only (#350): the per-division breakdown behind `credits`. */
+  divisions?: { id: string; rung: Rung; predicted_rung: Rung; underfunded: boolean }[];
+  discount?: number;
+}
+
+/** The `schedule.ai_generated` / `ai_failed` payload fragment and the API
+ *  response fragment, built once so the call sites cannot drift. */
+export function meterStamp(quote: Quote, meter: TokenMeter): RunMeterStamp {
+  const base = {
+    credits: quote.credits,
+    budget: quote.budget,
+    spent_tokens: meter.spent,
+    underfunded: quote.underfunded,
+    stopped_on_budget: meter.stoppedOnBudget,
+    est_tokens: quote.estTokens,
+  };
+  if (quote.lines.length === 1) {
+    const only = quote.lines[0]!;
+    return { ...base, rung: only.rung, predicted_rung: only.predictedRung };
+  }
+  return {
+    ...base,
+    discount: quote.discount,
+    divisions: quote.lines.map((l) => ({
+      id: l.key,
+      rung: l.rung,
+      predicted_rung: l.predictedRung,
+      underfunded: l.underfunded,
+    })),
+  };
 }

--- a/apps/web/src/lib/ai-rung.ts
+++ b/apps/web/src/lib/ai-rung.ts
@@ -1,0 +1,141 @@
+// Token-weighted AI credit pricing (docs/superpowers/specs/2026-07-28-ai-credit-
+// token-weight-design.md). Pure, no I/O: predicts the 1/2/3 credit "rung" a run
+// needs from data already loaded to build its pack (fixtures, entrants,
+// courts), and defines the hard token budget each rung buys. Imported by both
+// server usecases (schedule-ai.ts, officials-ai.ts) and, eventually, a
+// confirm-card client component — no I/O means no server-only import ever
+// leaks into a client bundle (same discipline as lib/pass-ladder.ts).
+//
+// APPROACH 1 (heuristic predictor + harness token meter), per the design doc:
+// no regression fitting, no Anthropic `task_budget` beta — enforcement lives
+// in the ladder loop as a cumulative token meter, provider-agnostic.
+
+export type Rung = 1 | 2 | 3;
+
+export function isRung(n: number): n is Rung {
+  return n === 1 || n === 2 || n === 3;
+}
+
+/** Hard per-run generation-token budget a rung buys (design §5). Credits buy a
+ *  token BUDGET, not usage — price is fixed at confirm time regardless of how
+ *  much of the budget a run actually spends; no refunds, no true-up. */
+export const TOKEN_BUDGETS: Record<Rung, number> = {
+  1: 32_000,
+  2: 64_000,
+  3: 128_000,
+};
+
+export function tokenBudgetForRung(rung: Rung): number {
+  return TOKEN_BUDGETS[rung];
+}
+
+/** A round smaller than this can't produce a useful plan/repair — stop
+ *  escalating (a new ladder rung, or a repair round) once the remaining
+ *  budget drops below it, rather than spending down to a sliver that could
+ *  never finish a round anyway. */
+export function minRoundReserve(): number {
+  const n = Number(process.env.AI_RUNG_MIN_ROUND_RESERVE);
+  return Number.isFinite(n) && n >= 0 ? n : 2_000;
+}
+
+/** Is there enough of the run's hard budget left to justify starting another
+ *  round? `spent` is the run's total generation tokens so far (every rung,
+ *  every round, summed — the same usage numbers already captured for COGS). */
+export function hasRoundBudget(budget: number, spent: number): boolean {
+  return spent + minRoundReserve() <= budget;
+}
+
+/** Per-round token cap given how much of the run's budget remains: never more
+ *  than `roundCeiling` (the existing MAX_TOKENS-style per-round cap), never
+ *  more than what's left of the run's hard budget. */
+export function clampRoundTokens(roundCeiling: number, budget: number, spent: number): number {
+  return Math.max(0, Math.min(roundCeiling, budget - spent));
+}
+
+export interface RungWeights {
+  entrantWeight: number;
+  courtWeight: number;
+  /** sizeScore at/under which the predictor picks rung 1. */
+  s1: number;
+  /** sizeScore at/under which the predictor picks rung 2 (above → rung 3). */
+  s2: number;
+  /** Helper-text-only anchors for the est-tokens curve — never used for
+   *  billing/enforcement (TOKEN_BUDGETS is the hard budget, enforced
+   *  independent of this estimate). UNCALIBRATED until the design's one-time
+   *  SQL pass over competition_events buckets real output_tokens by
+   *  pack_units (design §4) — edit these anchors, not the code, once that
+   *  data exists. */
+  estTokensAtS1: number;
+  estTokensAtS2: number;
+}
+
+function envNumber(name: string, fallback: number): number {
+  const n = Number(process.env[name]);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/** Phase A (schedule) predictor weights. AI_RUNG_* env overrides per design §4. */
+export function schedulingRungWeights(): RungWeights {
+  return {
+    entrantWeight: envNumber("AI_RUNG_ENTRANT_WEIGHT", 0.5),
+    courtWeight: envNumber("AI_RUNG_COURT_WEIGHT", 2),
+    s1: envNumber("AI_RUNG_S1", 60),
+    s2: envNumber("AI_RUNG_S2", 200),
+    estTokensAtS1: envNumber("AI_RUNG_EST_TOKENS_AT_S1", 18_000),
+    estTokensAtS2: envNumber("AI_RUNG_EST_TOKENS_AT_S2", 50_000),
+  };
+}
+
+/** Phase B (officials) predictor weights — officials packs are lighter, so
+ *  these thresholds sit higher; a typical run lands rung 1 (design §4). */
+export function officialsRungWeights(): RungWeights {
+  return {
+    entrantWeight: envNumber("AI_RUNG_OFFICIALS_ENTRANT_WEIGHT", 0.25),
+    courtWeight: envNumber("AI_RUNG_OFFICIALS_COURT_WEIGHT", 1),
+    s1: envNumber("AI_RUNG_OFFICIALS_S1", 120),
+    s2: envNumber("AI_RUNG_OFFICIALS_S2", 400),
+    estTokensAtS1: envNumber("AI_RUNG_OFFICIALS_EST_TOKENS_AT_S1", 10_000),
+    estTokensAtS2: envNumber("AI_RUNG_OFFICIALS_EST_TOKENS_AT_S2", 30_000),
+  };
+}
+
+export interface RungInput {
+  movableFixtures: number;
+  entrants: number;
+  courts: number;
+}
+
+export interface RungPrediction {
+  sizeScore: number;
+  rung: Rung;
+  /** Helper-text-only estimate ("~45K tokens") — advisory, not enforced. */
+  estTokens: number;
+}
+
+function computeSizeScore(input: RungInput, weights: RungWeights): number {
+  return input.movableFixtures + weights.entrantWeight * input.entrants + weights.courtWeight * input.courts;
+}
+
+/** Piecewise-linear over the anchors (0,0) → (s1, estTokensAtS1) →
+ *  (s2, estTokensAtS2), extrapolating the last segment's slope beyond s2. */
+function computeEstTokens(score: number, weights: RungWeights): number {
+  const { s1, s2, estTokensAtS1, estTokensAtS2 } = weights;
+  if (score <= 0) return 0;
+  if (score <= s1) return Math.round((score / Math.max(s1, 1)) * estTokensAtS1);
+  if (score <= s2) {
+    const frac = (score - s1) / Math.max(s2 - s1, 1);
+    return Math.round(estTokensAtS1 + frac * (estTokensAtS2 - estTokensAtS1));
+  }
+  const slope = (estTokensAtS2 - estTokensAtS1) / Math.max(s2 - s1, 1);
+  return Math.round(estTokensAtS2 + (score - s2) * slope);
+}
+
+/** Predict the credit rung a run needs, purely from pack data already loaded
+ *  to build it — no I/O, no new estimate endpoint (design §4/§6). The server
+ *  always recomputes this at run time; a client's displayed prediction is
+ *  advisory only. */
+export function predictRung(input: RungInput, weights: RungWeights): RungPrediction {
+  const sizeScore = computeSizeScore(input, weights);
+  const rung: Rung = sizeScore <= weights.s1 ? 1 : sizeScore <= weights.s2 ? 2 : 3;
+  return { sizeScore, rung, estTokens: computeEstTokens(sizeScore, weights) };
+}

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -1569,6 +1569,11 @@ export const AiPlanRequest = z.object({
     })
     .optional(),
   officials_policy: AssignPolicyBody.optional(),
+  // Token-weighted AI credit rung (design ai-rung.ts): defaults to the server
+  // prediction when omitted. A caller may pick below the prediction — the run
+  // still executes, capped to the chosen rung's token budget, and the ledger
+  // stamps `underfunded: true`.
+  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
 });
 export type AiPlanRequest = z.infer<typeof AiPlanRequest>;
 
@@ -1637,6 +1642,14 @@ export const AiPlanResponse = z.object({
       unfilled: z.array(z.object({ fixture_id: z.string(), role_key: z.string() })),
     })
     .nullable(),
+  // Token-weighted AI credit rung (design ai-rung.ts). Optional so older
+  // fixtures/clients built before this field set still satisfy the type —
+  // every real response always sends them.
+  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  predicted_rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  budget: z.number().int().optional(),
+  spent_tokens: z.number().int().optional(),
+  underfunded: z.boolean().optional(),
 });
 export type AiPlanResponse = z.infer<typeof AiPlanResponse>;
 
@@ -1665,6 +1678,9 @@ export const AiOfficialsPlanRequest = z.object({
       ),
     })
     .optional(),
+  // Token-weighted AI credit rung (design ai-rung.ts): defaults to the server
+  // prediction when omitted; see AiPlanRequest.rung for the full contract.
+  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
 });
 export type AiOfficialsPlanRequest = z.infer<typeof AiOfficialsPlanRequest>;
 
@@ -1711,6 +1727,14 @@ export const AiOfficialsPlanResponse = z.object({
     output_tokens: z.number().int(),
     repair_rounds: z.number().int(),
   }),
+  // Token-weighted AI credit rung (design ai-rung.ts). Optional so older
+  // fixtures/clients built before this field set still satisfy the type —
+  // every real response always sends them.
+  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  predicted_rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  budget: z.number().int().optional(),
+  spent_tokens: z.number().int().optional(),
+  underfunded: z.boolean().optional(),
 });
 export type AiOfficialsPlanResponse = z.infer<typeof AiOfficialsPlanResponse>;
 

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -1545,6 +1545,50 @@ export const ScheduleShift = z.object({
   delta_minutes: z.number().int().min(-1440).max(1440),
 });
 
+// Token-weighted AI credit rung (lib/ai-rung.ts, issue #348).
+const RungLiteral = z.union([z.literal(1), z.literal(2), z.literal(3)]);
+
+/**
+ * What an AI run cost and what that bought, spread into every AI response so
+ * the confirm card reads one shape whatever endpoint answered it. Mirrors
+ * `RunMeterStamp` in lib/ai-rung.ts — the single builder both phases (and #350's
+ * joint solve) stamp their ledger event and response with.
+ *
+ * Optional so fixtures and clients written before this field set still satisfy
+ * the type; every real response sends `credits`, `budget`, `spent_tokens`,
+ * `underfunded`, `stopped_on_budget` and `est_tokens`. `rung`/`predicted_rung`
+ * are the single-division flat form; `divisions`/`discount` the joint form.
+ */
+const AiRunPriceFields = {
+  /** Credits actually charged (after any joint batch discount). */
+  credits: z.number().int().optional(),
+  /** Hard generation-token budget those credits bought. */
+  budget: z.number().int().optional(),
+  /** Generation tokens the run actually spent. */
+  spent_tokens: z.number().int().optional(),
+  /** Advisory pre-run estimate the confirm card showed. */
+  est_tokens: z.number().int().optional(),
+  /** A rung below the prediction was chosen. */
+  underfunded: z.boolean().optional(),
+  /** The run ended because the budget ran out, not because it was done. */
+  stopped_on_budget: z.boolean().optional(),
+  /** Single-division form. */
+  rung: RungLiteral.optional(),
+  predicted_rung: RungLiteral.optional(),
+  /** Joint (multi-division) form — issue #350. */
+  discount: z.number().int().optional(),
+  divisions: z
+    .array(
+      z.object({
+        id: z.string(),
+        rung: RungLiteral,
+        predicted_rung: RungLiteral,
+        underfunded: z.boolean(),
+      }),
+    )
+    .optional(),
+};
+
 // v4 AI Schedule Architect (design/v4/00-03) — Phase A propose-only endpoint.
 // The model proposes times+courts; the engine verifier is authoritative. This
 // contract carries the request instruction, an optional repair scope, an
@@ -1569,11 +1613,11 @@ export const AiPlanRequest = z.object({
     })
     .optional(),
   officials_policy: AssignPolicyBody.optional(),
-  // Token-weighted AI credit rung (design ai-rung.ts): defaults to the server
+  // Token-weighted AI credit rung (lib/ai-rung.ts): defaults to the server
   // prediction when omitted. A caller may pick below the prediction — the run
   // still executes, capped to the chosen rung's token budget, and the ledger
   // stamps `underfunded: true`.
-  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  rung: RungLiteral.optional(),
 });
 export type AiPlanRequest = z.infer<typeof AiPlanRequest>;
 
@@ -1642,14 +1686,7 @@ export const AiPlanResponse = z.object({
       unfilled: z.array(z.object({ fixture_id: z.string(), role_key: z.string() })),
     })
     .nullable(),
-  // Token-weighted AI credit rung (design ai-rung.ts). Optional so older
-  // fixtures/clients built before this field set still satisfy the type —
-  // every real response always sends them.
-  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
-  predicted_rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
-  budget: z.number().int().optional(),
-  spent_tokens: z.number().int().optional(),
-  underfunded: z.boolean().optional(),
+  ...AiRunPriceFields,
 });
 export type AiPlanResponse = z.infer<typeof AiPlanResponse>;
 
@@ -1678,9 +1715,11 @@ export const AiOfficialsPlanRequest = z.object({
       ),
     })
     .optional(),
-  // Token-weighted AI credit rung (design ai-rung.ts): defaults to the server
+  // Token-weighted AI credit rung (lib/ai-rung.ts): defaults to the server
   // prediction when omitted; see AiPlanRequest.rung for the full contract.
-  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  // Ignored on the empty-instruction path, which makes no model call and is
+  // always priced at 1 credit.
+  rung: RungLiteral.optional(),
 });
 export type AiOfficialsPlanRequest = z.infer<typeof AiOfficialsPlanRequest>;
 
@@ -1727,14 +1766,7 @@ export const AiOfficialsPlanResponse = z.object({
     output_tokens: z.number().int(),
     repair_rounds: z.number().int(),
   }),
-  // Token-weighted AI credit rung (design ai-rung.ts). Optional so older
-  // fixtures/clients built before this field set still satisfy the type —
-  // every real response always sends them.
-  rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
-  predicted_rung: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
-  budget: z.number().int().optional(),
-  spent_tokens: z.number().int().optional(),
-  underfunded: z.boolean().optional(),
+  ...AiRunPriceFields,
 });
 export type AiOfficialsPlanResponse = z.infer<typeof AiOfficialsPlanResponse>;
 

--- a/apps/web/src/server/usecases/__tests__/ai-credit-wallet-spend.test.ts
+++ b/apps/web/src/server/usecases/__tests__/ai-credit-wallet-spend.test.ts
@@ -298,9 +298,46 @@ describe.skipIf(!HAS_DB)("AI credit wallet metering — schedule-ai (SPEC-2 §5.
         where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}`;
       expect(event!.payload.underfunded).toBe(true);
       expect(event!.payload.rung).toBe(1);
+      expect(event!.payload.credits).toBe(1);
+      // Finished inside its budget — this is what a healthy run looks like, so
+      // the cliff stamp below means something.
+      expect(event!.payload.stopped_on_budget).toBe(false);
     } finally {
       if (savedS1 === undefined) delete process.env.AI_RUNG_S1;
       else process.env.AI_RUNG_S1 = savedS1;
+    }
+  });
+
+  // `underfunded` only records what the USER picked. It cannot tell a run that
+  // finished cleanly from one the budget cut short — which is exactly the
+  // signal needed to spot a mispriced rung while the predictor is still
+  // uncalibrated. `stopped_on_budget` is that signal, and it must survive onto
+  // the ledger on the failure path too.
+  it("stamps stopped_on_budget on a run the token budget cut short, and charges nothing", async () => {
+    const savedBudget = process.env.AI_RUNG_BUDGET_1;
+    process.env.AI_RUNG_BUDGET_1 = "500"; // below the per-round reserve → no round can start
+    try {
+      const { auth } = await seedOrg("community");
+      const { divisionId } = await seedPlannableDivision(auth);
+      const walletId = await walletIdFor(auth.orgId);
+      await grantCredits(walletId, 5);
+
+      await expect(
+        aiPlanForDivision(auth, divisionId, { instruction: "plan it", mode: "generate", rung: 1 }),
+      ).rejects.toMatchObject({ code: "AI_PLAN_FAILED" });
+
+      expect(chat).not.toHaveBeenCalled(); // refused before any COGS
+      expect(await balance(walletId)).toBe(5); // hold released — a failed run is free
+
+      const [event] = await sql<{ payload: Record<string, unknown> }[]>`
+        select payload from competition_events
+        where type = 'schedule.ai_failed' and payload->>'division_id' = ${divisionId}`;
+      expect(event!.payload.stopped_on_budget).toBe(true);
+      expect(event!.payload.budget).toBe(500);
+      expect(event!.payload.credits).toBe(1);
+    } finally {
+      if (savedBudget === undefined) delete process.env.AI_RUNG_BUDGET_1;
+      else process.env.AI_RUNG_BUDGET_1 = savedBudget;
     }
   });
 });
@@ -406,5 +443,44 @@ describe.skipIf(!HAS_DB)("AI credit wallet metering — officials-ai (SPEC-2 §5
     ).rejects.toMatchObject({ status: 402, featureKey: "ai.credits" });
     expect(chat).not.toHaveBeenCalled();
     expect(await balance(walletId)).toBe(0);
+  });
+
+  // REGRESSION (token-weighted rungs, lib/ai-rung.ts): the empty-instruction
+  // path returns the deterministic solver draft with ZERO model calls, so it
+  // burns no COGS at all. Pricing it from the pack — as every other run is
+  // priced — charged a large division 2 or 3 credits for that free draft. It
+  // cost 1 credit before rung pricing existed; it must still cost 1.
+  it("prices the zero-LLM-call solver draft at 1 credit even when the pack predicts a higher rung", async () => {
+    const savedS1 = process.env.AI_RUNG_OFFICIALS_S1;
+    const savedS2 = process.env.AI_RUNG_OFFICIALS_S2;
+    process.env.AI_RUNG_OFFICIALS_S1 = "0"; // force this pack above rung 1...
+    process.env.AI_RUNG_OFFICIALS_S2 = "0"; // ...all the way to rung 3
+    try {
+      const { auth } = await seedOrg("community");
+      const { divisionId, fixtureIds } = await seedPlannableDivision(auth, { officials: 1 });
+      const walletId = await walletIdFor(auth.orgId);
+      await grantCredits(walletId, 3);
+
+      const out = await officialsAiPlanForDivision(auth, divisionId, {
+        instruction: "",
+        policy: POLICY,
+        schedule: spread(fixtureIds),
+      });
+
+      expect(chat).not.toHaveBeenCalled();
+      expect(out.credits).toBe(1);
+      expect(out.rung).toBe(1);
+      expect(out.underfunded).toBe(false); // not "cheaped out" — there is nothing to fund
+      expect(await balance(walletId)).toBe(2); // 3 − 1, NOT 3 − 3
+
+      const spends = (await ledgerRows(walletId)).filter((r) => r.source === "run_spend");
+      expect(spends).toHaveLength(1);
+      expect(spends[0]).toMatchObject({ delta: -1 });
+    } finally {
+      if (savedS1 === undefined) delete process.env.AI_RUNG_OFFICIALS_S1;
+      else process.env.AI_RUNG_OFFICIALS_S1 = savedS1;
+      if (savedS2 === undefined) delete process.env.AI_RUNG_OFFICIALS_S2;
+      else process.env.AI_RUNG_OFFICIALS_S2 = savedS2;
+    }
   });
 });

--- a/apps/web/src/server/usecases/__tests__/ai-credit-wallet-spend.test.ts
+++ b/apps/web/src/server/usecases/__tests__/ai-credit-wallet-spend.test.ts
@@ -234,6 +234,75 @@ describe.skipIf(!HAS_DB)("AI credit wallet metering — schedule-ai (SPEC-2 §5.
     expect(refunds).toHaveLength(1);
     expect(spends[0]!.ref).toBeNull(); // never settled — the run never happened
   });
+
+  // Token-weighted AI credit rung (design ai-rung.ts): the amount spendCredit
+  // reserves is now `rung`, not a hardcoded 1 — these pin that the wallet and
+  // the audit ledger both follow the chosen rung, not the prediction.
+  it("an explicit rung above the prediction charges that many credits and stamps the ledger", async () => {
+    const { auth } = await seedOrg("community");
+    const { divisionId, fixtureIds } = await seedPlannableDivision(auth);
+    const walletId = await walletIdFor(auth.orgId);
+    await grantCredits(walletId, 5);
+
+    // This pack (4 entrants, 2 courts, a handful of fixtures) predicts rung 1
+    // under the default AI_RUNG_* thresholds — picking rung 2 is a deliberate
+    // over-spend, never `underfunded`.
+    chat.mockResolvedValueOnce(chatResponse(legalPlan(fixtureIds)));
+    const out = await aiPlanForDivision(auth, divisionId, {
+      instruction: "plan it",
+      mode: "generate",
+      rung: 2,
+    });
+    expect(out.rung).toBe(2);
+    expect(out.predicted_rung).toBe(1);
+    expect(out.underfunded).toBe(false);
+    expect(out.budget).toBe(64_000);
+    expect(await balance(walletId)).toBe(3); // 5 - 2
+
+    const rows = await ledgerRows(walletId);
+    const spends = rows.filter((r) => r.source === "run_spend");
+    expect(spends).toHaveLength(1);
+    expect(spends[0]).toMatchObject({ delta: -2 });
+
+    const [event] = await sql<{ payload: Record<string, unknown> }[]>`
+      select payload from competition_events
+      where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}`;
+    expect(event!.payload.rung).toBe(2);
+    expect(event!.payload.predicted_rung).toBe(1);
+    expect(event!.payload.underfunded).toBe(false);
+    expect(event!.payload.budget).toBe(64_000);
+  });
+
+  it("choosing below the predicted rung is honoured and stamps underfunded", async () => {
+    const savedS1 = process.env.AI_RUNG_S1;
+    process.env.AI_RUNG_S1 = "0"; // force this pack's prediction above rung 1
+    try {
+      const { auth } = await seedOrg("community");
+      const { divisionId, fixtureIds } = await seedPlannableDivision(auth);
+      const walletId = await walletIdFor(auth.orgId);
+      await grantCredits(walletId, 5);
+
+      chat.mockResolvedValueOnce(chatResponse(legalPlan(fixtureIds)));
+      const out = await aiPlanForDivision(auth, divisionId, {
+        instruction: "plan it",
+        mode: "generate",
+        rung: 1,
+      });
+      expect(out.predicted_rung).toBeGreaterThan(1);
+      expect(out.rung).toBe(1);
+      expect(out.underfunded).toBe(true);
+      expect(await balance(walletId)).toBe(4); // charged only the chosen rung (1)
+
+      const [event] = await sql<{ payload: Record<string, unknown> }[]>`
+        select payload from competition_events
+        where type = 'schedule.ai_generated' and payload->>'division_id' = ${divisionId}`;
+      expect(event!.payload.underfunded).toBe(true);
+      expect(event!.payload.rung).toBe(1);
+    } finally {
+      if (savedS1 === undefined) delete process.env.AI_RUNG_S1;
+      else process.env.AI_RUNG_S1 = savedS1;
+    }
+  });
 });
 
 const POLICY = {

--- a/apps/web/src/server/usecases/__tests__/officials-ai-provider.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-provider.test.ts
@@ -6,6 +6,7 @@
 // without caring how the adapter fills that interface in. Mirrors
 // schedule-ai-provider.test.ts (Task 4).
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTokenMeter } from "@/lib/ai-rung";
 
 const anthropicProvider = vi.fn();
 vi.mock("@/server/ai/anthropic-provider", () => ({ anthropicProvider }));
@@ -141,15 +142,15 @@ describe("officials runner ↔ provider seam", () => {
     expect(out.usage.cost_usd).toBeCloseTo(0.12);
   });
 
-  // Token-weighted AI credit rung (design ai-rung.ts): runOfficialsAiPlan's
-  // optional 4th param is the hard per-run token budget an escalation-aware
-  // caller enforces. Omitted (every test above), behaviour is unchanged.
+  // Token-weighted AI credit pricing (lib/ai-rung.ts): runOfficialsAiPlan's
+  // optional 4th param is the run's TokenMeter. Omitted (every test above), an
+  // unmetered meter is used and behaviour is unchanged.
   it("clamps maxTokens to what's left of the budget", async () => {
     const chat = vi.fn().mockResolvedValue(round(assignAll(fixtureIds, refA)));
     anthropicProvider.mockReturnValue({ id: "anthropic", isConfigured: () => true, chat });
 
     const { runOfficialsAiPlan } = await import("../officials-ai");
-    await runOfficialsAiPlan(pack, undefined, undefined, { tokens: 5_000, spentBefore: 0 });
+    await runOfficialsAiPlan(pack, undefined, undefined, createTokenMeter(5_000));
 
     expect(chat.mock.calls[0]![0].maxTokens).toBe(5_000);
   });
@@ -158,10 +159,30 @@ describe("officials runner ↔ provider seam", () => {
     const chat = vi.fn();
     anthropicProvider.mockReturnValue({ id: "anthropic", isConfigured: () => true, chat });
 
+    const meter = createTokenMeter(10_000);
+    meter.add(9_000); // an earlier rung already spent this
     const { runOfficialsAiPlan } = await import("../officials-ai");
-    await expect(
-      runOfficialsAiPlan(pack, undefined, undefined, { tokens: 10_000, spentBefore: 9_000 }),
-    ).rejects.toMatchObject({ code: "AI_PLAN_FAILED" });
+    await expect(runOfficialsAiPlan(pack, undefined, undefined, meter)).rejects.toMatchObject({
+      code: "AI_PLAN_FAILED",
+    });
     expect(chat).not.toHaveBeenCalled();
+    expect(meter.stoppedOnBudget).toBe(true);
+  });
+
+  // Phase B's empty-instruction path returns the deterministic solver draft
+  // with no model call at all — the meter must never refuse it, whatever the
+  // budget, because there is nothing to spend.
+  it("returns the solver draft on an empty instruction even with an exhausted meter", async () => {
+    const chat = vi.fn();
+    anthropicProvider.mockReturnValue({ id: "anthropic", isConfigured: () => true, chat });
+
+    const meter = createTokenMeter(1_000);
+    meter.add(1_000);
+    const { runOfficialsAiPlan } = await import("../officials-ai");
+    const out = await runOfficialsAiPlan({ ...pack, instruction: "  " }, undefined, undefined, meter);
+
+    expect(chat).not.toHaveBeenCalled();
+    expect(out.usage.output_tokens).toBe(0);
+    expect(meter.stoppedOnBudget).toBe(false);
   });
 });

--- a/apps/web/src/server/usecases/__tests__/officials-ai-provider.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-provider.test.ts
@@ -140,4 +140,28 @@ describe("officials runner ↔ provider seam", () => {
     expect(out.usage.output_tokens).toBe(220);
     expect(out.usage.cost_usd).toBeCloseTo(0.12);
   });
+
+  // Token-weighted AI credit rung (design ai-rung.ts): runOfficialsAiPlan's
+  // optional 4th param is the hard per-run token budget an escalation-aware
+  // caller enforces. Omitted (every test above), behaviour is unchanged.
+  it("clamps maxTokens to what's left of the budget", async () => {
+    const chat = vi.fn().mockResolvedValue(round(assignAll(fixtureIds, refA)));
+    anthropicProvider.mockReturnValue({ id: "anthropic", isConfigured: () => true, chat });
+
+    const { runOfficialsAiPlan } = await import("../officials-ai");
+    await runOfficialsAiPlan(pack, undefined, undefined, { tokens: 5_000, spentBefore: 0 });
+
+    expect(chat.mock.calls[0]![0].maxTokens).toBe(5_000);
+  });
+
+  it("fails without a model call when a later ladder rung inherits an already-exhausted budget", async () => {
+    const chat = vi.fn();
+    anthropicProvider.mockReturnValue({ id: "anthropic", isConfigured: () => true, chat });
+
+    const { runOfficialsAiPlan } = await import("../officials-ai");
+    await expect(
+      runOfficialsAiPlan(pack, undefined, undefined, { tokens: 10_000, spentBefore: 9_000 }),
+    ).rejects.toMatchObject({ code: "AI_PLAN_FAILED" });
+    expect(chat).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-ladder.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-ladder.test.ts
@@ -296,4 +296,18 @@ describe("runLadder", () => {
     const out = await runLadder<AiPlanResult>(R, attempt, (r) => r.warnings.length === 0);
     expect(out.usage.cost_usd).toBeNull();
   });
+
+  // Token-weighted AI credit rung (design ai-rung.ts): a budget-aware caller
+  // needs to know how many output tokens every PRIOR rung already spent, so it
+  // can enforce one hard budget across the whole ladder rather than resetting
+  // it per rung.
+  it("hands each attempt the output tokens spent by every prior rung (0 on the first)", async () => {
+    const attempt = vi
+      .fn()
+      .mockResolvedValueOnce(fakeResult({ warnings: 9, usage: usage(200, 100, 0.02) }))
+      .mockResolvedValueOnce(fakeResult({ usage: usage(300, 150, 0.05) }));
+    await runLadder<AiPlanResult>(R, attempt, (r) => r.warnings.length === 0);
+    expect(attempt.mock.calls[0]![1]).toBe(0);
+    expect(attempt.mock.calls[1]![1]).toBe(100); // the first rung's output tokens
+  });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-ladder.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-ladder.test.ts
@@ -297,17 +297,50 @@ describe("runLadder", () => {
     expect(out.usage.cost_usd).toBeNull();
   });
 
-  // Token-weighted AI credit rung (design ai-rung.ts): a budget-aware caller
-  // needs to know how many output tokens every PRIOR rung already spent, so it
-  // can enforce one hard budget across the whole ladder rather than resetting
-  // it per rung.
-  it("hands each attempt the output tokens spent by every prior rung (0 on the first)", async () => {
-    const attempt = vi
-      .fn()
-      .mockResolvedValueOnce(fakeResult({ warnings: 9, usage: usage(200, 100, 0.02) }))
-      .mockResolvedValueOnce(fakeResult({ usage: usage(300, 150, 0.05) }));
-    await runLadder<AiPlanResult>(R, attempt, (r) => r.warnings.length === 0);
-    expect(attempt.mock.calls[0]![1]).toBe(0);
-    expect(attempt.mock.calls[1]![1]).toBe(100); // the first rung's output tokens
+  // Token-weighted AI credit pricing (lib/ai-rung.ts): a budget-exhausted run
+  // must stop escalating. Without this, every remaining rung is entered only to
+  // throw before any network call — free, but it writes models into
+  // `rungs_tried` that were never actually asked.
+  describe("canEscalate", () => {
+    it("is never consulted before the first rung", async () => {
+      const canEscalate = vi.fn().mockReturnValue(false);
+      const attempt = vi.fn().mockResolvedValueOnce(fakeResult({}));
+      await runLadder<AiPlanResult>(R, attempt, () => true, canEscalate);
+      expect(canEscalate).not.toHaveBeenCalled();
+      expect(attempt).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops escalation and ships the degraded best-so-far without trying the next rung", async () => {
+      const attempt = vi.fn().mockResolvedValueOnce(fakeResult({ warnings: 9, usage: usage(200, 100, 0.02) }));
+      const out = await runLadder<AiPlanResult>(
+        R,
+        attempt,
+        (r) => r.warnings.length === 0, // rung 1's result is NOT acceptable
+        () => false, // ...but the budget is gone
+      );
+      expect(attempt).toHaveBeenCalledTimes(1);
+      expect(out.served_model).toBe(R[0]!.model);
+      expect(out.rungs_tried).toEqual([R[0]!.model]); // NOT polluted with rung 2
+    });
+
+    it("throws the earlier rung's failure when nothing usable was produced", async () => {
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(new HttpError(422, "no plan", "AI_PLAN_FAILED", { usage: usage(10, 20, 0.01) }));
+      const err = await runLadder<AiPlanResult>(R, attempt, () => true, () => false).catch((e) => e);
+      expect(attempt).toHaveBeenCalledTimes(1);
+      expect(err).toMatchObject({ code: "AI_PLAN_FAILED" });
+      expect((err as HttpError).extra?.usage).toMatchObject({ output_tokens: 20 });
+    });
+
+    it("keeps escalating while it returns true", async () => {
+      const attempt = vi
+        .fn()
+        .mockResolvedValueOnce(fakeResult({ warnings: 9, usage: usage(200, 100, 0.02) }))
+        .mockResolvedValueOnce(fakeResult({ usage: usage(300, 150, 0.05) }));
+      const out = await runLadder<AiPlanResult>(R, attempt, (r) => r.warnings.length === 0, () => true);
+      expect(attempt).toHaveBeenCalledTimes(2);
+      expect(out.served_model).toBe(R[1]!.model);
+    });
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -20,6 +20,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
 
 import { aiReasoningParams, runAiPlan } from "../schedule-ai";
 import type { SchedulePack } from "../schedule-ai";
+import { createTokenMeter } from "@/lib/ai-rung";
 
 // --- Fixed ids -------------------------------------------------------------
 const F1 = "11111111-1111-4111-8111-111111111111";
@@ -487,13 +488,14 @@ describe("runAiPlan (v4/00 §3-4)", () => {
   });
 });
 
-// Token-weighted AI credit rung (design ai-rung.ts): runAiPlan's optional 5th
-// param is the hard per-run token budget an escalation-aware caller enforces.
-// Omitted (every test above), behaviour is unchanged — these pin the opt-in path.
-describe("runAiPlan — hard token budget (design ai-rung.ts)", () => {
+// Token-weighted AI credit pricing (lib/ai-rung.ts): runAiPlan's optional 5th
+// param is the run's TokenMeter — one instance shared by every ladder rung, so
+// the hard budget spans the whole run. Omitted (every test above), an unmetered
+// meter is used and behaviour is unchanged; these pin the opt-in path.
+describe("runAiPlan — hard token budget (lib/ai-rung.ts)", () => {
   it("clamps the round's max_tokens to what's left of the budget", async () => {
     parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
-    await runAiPlan(pack, movableIds, undefined, undefined, { tokens: 3_000, spentBefore: 0 });
+    await runAiPlan(pack, movableIds, undefined, undefined, createTokenMeter(3_000));
     const body = parse.mock.calls[0]![0] as { max_tokens: number };
     expect(body.max_tokens).toBe(3_000);
   });
@@ -501,18 +503,54 @@ describe("runAiPlan — hard token budget (design ai-rung.ts)", () => {
   it("stops before a round that would exceed the budget and ships the best plan so far", async () => {
     // Round 1: a clash (blocking) that alone spends nearly the whole budget.
     parse.mockResolvedValueOnce(planResponse(clashingPlan, { input_tokens: 1000, output_tokens: 30_001 }));
-    const out = await runAiPlan(pack, movableIds, undefined, undefined, { tokens: 32_000, spentBefore: 0 });
+    const meter = createTokenMeter(32_000);
+    const out = await runAiPlan(pack, movableIds, undefined, undefined, meter);
     // The repair round never fires: 30,001 spent + the 2,000 reserve would
     // exceed the 32,000 budget, so only round 1 ran.
     expect(parse).toHaveBeenCalledTimes(1);
     expect(out.blocking.length).toBeGreaterThan(0); // degraded best-so-far, not a clean plan
     expect(out.usage.output_tokens).toBe(30_001);
+    expect(meter.stoppedOnBudget).toBe(true); // the ledger stamp that says "cut off"
   });
 
   it("fails without a model call when a later ladder rung inherits an already-exhausted budget", async () => {
-    await expect(
-      runAiPlan(pack, movableIds, undefined, undefined, { tokens: 10_000, spentBefore: 9_000 }),
-    ).rejects.toMatchObject({ code: "AI_PLAN_FAILED" });
+    const meter = createTokenMeter(10_000);
+    meter.add(9_000); // an earlier rung already spent this
+    await expect(runAiPlan(pack, movableIds, undefined, undefined, meter)).rejects.toMatchObject({
+      code: "AI_PLAN_FAILED",
+    });
     expect(parse).not.toHaveBeenCalled();
+  });
+
+  // The meter is charged BEFORE the refusal/parse-failure throws, so a round
+  // that spent tokens and then failed still counts against the budget — a run
+  // cannot loop past its cap on failures alone.
+  it("charges the meter for a round that spent tokens and then refused", async () => {
+    parse.mockResolvedValueOnce({
+      parsed_output: null,
+      stop_reason: "refusal",
+      usage: { input_tokens: 100, output_tokens: 7_000 },
+      content: [],
+    });
+    const meter = createTokenMeter(64_000);
+    await expect(runAiPlan(pack, movableIds, undefined, undefined, meter)).rejects.toMatchObject({
+      code: "AI_PLAN_FAILED",
+    });
+    expect(meter.spent).toBe(7_000);
+  });
+
+  // One meter, many rungs: the second rung starts where the first left off
+  // rather than resetting to a fresh budget.
+  it("carries spend from one rung into the next through the shared meter", async () => {
+    const meter = createTokenMeter(32_000);
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan, { input_tokens: 100, output_tokens: 25_000 }));
+    await runAiPlan(pack, movableIds, undefined, undefined, meter);
+    expect(meter.spent).toBe(25_000);
+    // A second rung on the SAME meter has 7,000 left — under the 2,000 reserve
+    // it still fits, but the round is clamped to what remains.
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds, undefined, undefined, meter);
+    const secondCall = parse.mock.calls[1]![0] as { max_tokens: number };
+    expect(secondCall.max_tokens).toBe(7_000);
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -486,3 +486,33 @@ describe("runAiPlan (v4/00 §3-4)", () => {
     expect(out.diff.unscheduled).toEqual([F4]);
   });
 });
+
+// Token-weighted AI credit rung (design ai-rung.ts): runAiPlan's optional 5th
+// param is the hard per-run token budget an escalation-aware caller enforces.
+// Omitted (every test above), behaviour is unchanged — these pin the opt-in path.
+describe("runAiPlan — hard token budget (design ai-rung.ts)", () => {
+  it("clamps the round's max_tokens to what's left of the budget", async () => {
+    parse.mockResolvedValueOnce(planResponse(finishBy18Plan));
+    await runAiPlan(pack, movableIds, undefined, undefined, { tokens: 3_000, spentBefore: 0 });
+    const body = parse.mock.calls[0]![0] as { max_tokens: number };
+    expect(body.max_tokens).toBe(3_000);
+  });
+
+  it("stops before a round that would exceed the budget and ships the best plan so far", async () => {
+    // Round 1: a clash (blocking) that alone spends nearly the whole budget.
+    parse.mockResolvedValueOnce(planResponse(clashingPlan, { input_tokens: 1000, output_tokens: 30_001 }));
+    const out = await runAiPlan(pack, movableIds, undefined, undefined, { tokens: 32_000, spentBefore: 0 });
+    // The repair round never fires: 30,001 spent + the 2,000 reserve would
+    // exceed the 32,000 budget, so only round 1 ran.
+    expect(parse).toHaveBeenCalledTimes(1);
+    expect(out.blocking.length).toBeGreaterThan(0); // degraded best-so-far, not a clean plan
+    expect(out.usage.output_tokens).toBe(30_001);
+  });
+
+  it("fails without a model call when a later ladder rung inherits an already-exhausted budget", async () => {
+    await expect(
+      runAiPlan(pack, movableIds, undefined, undefined, { tokens: 10_000, spentBefore: 9_000 }),
+    ).rejects.toMatchObject({ code: "AI_PLAN_FAILED" });
+    expect(parse).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -54,12 +54,13 @@ import {
 } from "./schedule-ai";
 import { aiRunCostUsd } from "@/lib/ai-pricing";
 import {
-  clampRoundTokens,
-  hasRoundBudget,
+  createTokenMeter,
+  freeDraftQuote,
+  meterStamp,
   officialsRungWeights,
-  predictRung,
-  tokenBudgetForRung,
-  type Rung,
+  quoteRun,
+  unmeteredTokenMeter,
+  type TokenMeter,
 } from "@/lib/ai-rung";
 import { deferred } from "@/lib/deferred";
 import { maybeAlertExpensiveRun } from "@/server/usecases/ai-runs-admin";
@@ -853,7 +854,11 @@ export async function runOfficialsAiPlan(
   pack: OfficialsPack,
   modelOverride?: string,
   providerName?: ProviderName,
-  budget?: { tokens: number; spentBefore: number },
+  /** The run's cumulative token meter (lib/ai-rung.ts). ONE instance is shared
+   *  by every ladder rung, so the hard budget spans the whole run instead of
+   *  resetting per rung. Defaults to an unmetered one — behaviour is unchanged
+   *  for callers that do not price a run. */
+  meter: TokenMeter = unmeteredTokenMeter(),
 ): Promise<OfficialsPlanResult> {
   if (pack.instruction.trim() === "") {
     return finalizeOfficials(pack, draftAsPlan(pack), {
@@ -895,12 +900,11 @@ export async function runOfficialsAiPlan(
   });
 
   for (;;) {
-    // Hard token budget (design ai-rung.ts): spent so far is this rung's own
-    // output tokens plus whatever prior ladder rungs already spent. Below the
-    // reserve, stop asking for another round — ship the best plan already
-    // produced, or (nothing produced yet) fail in a way runLadder can recover
-    // from.
-    if (budget && !hasRoundBudget(budget.tokens, budget.spentBefore + outputTokens)) {
+    // Hard token budget (lib/ai-rung.ts). The meter already holds every prior
+    // round's AND every prior ladder rung's output tokens. Below the reserve,
+    // stop asking for another round — ship the best plan already produced, or
+    // (nothing produced yet) fail in a way runLadder can recover from.
+    if (!meter.canStartRound()) {
       if (best !== null) return finalizeOfficials(pack, best.plan, usageNow());
       throw new HttpError(
         422,
@@ -909,9 +913,7 @@ export async function runOfficialsAiPlan(
         { usage: usageNow() },
       );
     }
-    const roundMaxTokens = budget
-      ? clampRoundTokens(32_000, budget.tokens, budget.spentBefore + outputTokens)
-      : 32_000;
+    const roundMaxTokens = meter.clampRound(32_000);
 
     let response: Awaited<ReturnType<typeof callOfficialsModel>>;
     try {
@@ -928,6 +930,10 @@ export async function runOfficialsAiPlan(
     const roundOutput = response?.usage?.outputTokens ?? 0;
     inputTokens += roundInput;
     outputTokens += roundOutput;
+    // Charge the run's meter the moment usage is known — BEFORE any of the
+    // throw paths below, so a round that spent tokens and then refused still
+    // counts against the budget.
+    meter.add(roundOutput);
     // Prefer the cost the provider reports; fall back to a derived estimate
     // only when the round produced no reported cost. Never a guess.
     const roundCost =
@@ -1022,18 +1028,15 @@ export function officialsPlanRungs(): LadderRung[] {
  *  runLadder exactly as in Phase A. */
 async function runOfficialsAiPlanLadder(
   pack: OfficialsPack,
-  budgetTokens?: number,
+  meter: TokenMeter,
 ): Promise<OfficialsPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] }> {
   return runLadder(
     officialsPlanRungs(),
-    (rung, spentBefore) =>
-      runOfficialsAiPlan(
-        pack,
-        rung.model,
-        rung.provider,
-        budgetTokens !== undefined ? { tokens: budgetTokens, spentBefore } : undefined,
-      ),
+    (rung) => runOfficialsAiPlan(pack, rung.model, rung.provider, meter),
     () => true,
+    // A budget-exhausted run must not escalate: the next rung would throw
+    // before any network call and only pollute `rungs_tried`.
+    () => !meter.stoppedOnBudget,
   );
 }
 
@@ -1088,29 +1091,45 @@ export async function officialsAiPlanForDivision(
       : {}),
   });
 
-  // Token-weighted credit rung (design ai-rung.ts): predict from the pack data
+  // Token-weighted credit pricing (lib/ai-rung.ts): quote from the pack data
   // already loaded, let the caller override up or down, and stamp `underfunded`
   // when they picked below the prediction. Officials packs carry no separate
   // entrant/court lists — derive both from the fixtures already loaded.
-  const entrants = new Set(pack.fixtures.flatMap((f) => f.entrants)).size;
-  const courts = new Set(pack.fixtures.map((f) => f.court).filter((c): c is string => c !== null)).size;
-  const prediction = predictRung(
-    { movableFixtures: pack.fixtures.length, entrants, courts },
-    officialsRungWeights(),
-  );
-  const rung: Rung = input.rung ?? prediction.rung;
-  const budget = tokenBudgetForRung(rung);
-  const underfunded = rung < prediction.rung;
+  //
+  // EMPTY INSTRUCTION IS FREE OF MODEL COST and must stay cheap: that path
+  // returns the deterministic solver draft with zero LLM calls (design/v4/03
+  // §2), so it is quoted at a flat 1 credit — exactly what it cost before rung
+  // pricing existed. Sizing it by the pack would charge a large division 2-3
+  // credits for a run that spends no tokens at all.
+  const drafting = input.instruction.trim() === "";
+  const quote = drafting
+    ? freeDraftQuote(divisionId)
+    : quoteRun(
+        [
+          {
+            key: divisionId,
+            input: {
+              movableFixtures: pack.fixtures.length,
+              entrants: new Set(pack.fixtures.flatMap((f) => f.entrants)).size,
+              courts: new Set(pack.fixtures.map((f) => f.court).filter((c): c is string => c !== null)).size,
+            },
+            ...(input.rung !== undefined ? { chosen: input.rung } : {}),
+          },
+        ],
+        officialsRungWeights(),
+      );
+  // One meter for the whole run — every ladder rung and repair round charges it.
+  const meter = createTokenMeter(quote.budget, { units: pack.fixtures.length });
 
   let result: OfficialsPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] };
   try {
-    // Reserve `rung` credits → run the architect → settle on success / release
+    // Reserve `quote.credits` → run the architect → settle on success / release
     // on failure (SPEC-2 §5.2). PaymentRequiredError("ai.credits") from an empty
     // wallet falls through untouched below (matches no HttpError code here)
     // and rethrows as the 402.
-    result = await spendCredit(walletId, auth.orgId, rung, async () => ({
+    result = await spendCredit(walletId, auth.orgId, quote.credits, async () => ({
       aiRunId: crypto.randomUUID(),
-      result: await runOfficialsAiPlanLadder(pack, budget),
+      result: await runOfficialsAiPlanLadder(pack, meter),
     }));
   } catch (err) {
     // Meter a refused / un-correctable / timed-out run's token spend too —
@@ -1145,14 +1164,10 @@ export async function officialsAiPlanForDivision(
         // later): the fixture count the pack builder already computed, the
         // same number already reported to PostHog as `fixtures`.
         pack_units: pack.fixtures.length,
-        // Token-weighted credit rung (design ai-rung.ts) — even on a failed
-        // run the credit was reserved at this rung, so the ledger stamps it.
-        rung,
-        budget,
-        predicted_rung: prediction.rung,
-        est_tokens: prediction.estTokens,
-        spent_tokens: usage.output_tokens ?? 0,
-        underfunded,
+        // Token-weighted credit pricing (lib/ai-rung.ts) — even on a failed run
+        // the credits were reserved, so the ledger stamps what was charged,
+        // what it bought, and whether the budget cut the run short.
+        ...meterStamp(quote, meter),
       });
       await captureServer({
         event: "ai_plan_run",
@@ -1194,16 +1209,11 @@ export async function officialsAiPlanForDivision(
     // builder already computed — the smallest correct instrumentation ahead
     // of any size-weighted pricing decision (deferred, SPEC-2 §5.1).
     pack_units: pack.fixtures.length,
-    // Token-weighted credit rung (design ai-rung.ts): what was charged, what
-    // token budget it bought, what the predictor said, how much of the
-    // budget this run actually spent, and whether the org picked below the
-    // prediction.
-    rung,
-    budget,
-    predicted_rung: prediction.rung,
-    est_tokens: prediction.estTokens,
-    spent_tokens: result.usage.output_tokens,
-    underfunded,
+    // Token-weighted credit pricing (lib/ai-rung.ts): what was charged, what
+    // token budget it bought, what the predictor said, how much of the budget
+    // this run actually spent, whether the org picked below the prediction, and
+    // whether the budget cut the run short.
+    ...meterStamp(quote, meter),
     // Ladder telemetry: the first rung tried and the full ordered chain, when a
     // fallback happened (model above is only the winner).
     ...(result.escalated_from
@@ -1274,13 +1284,10 @@ export async function officialsAiPlanForDivision(
       output_tokens: result.usage.output_tokens,
       repair_rounds: result.usage.repair_rounds,
     },
-    // Token-weighted credit rung (design ai-rung.ts) — what was charged, what
-    // the predictor said, and whether the confirm-card's warning applies.
-    rung,
-    predicted_rung: prediction.rung,
-    budget,
-    spent_tokens: result.usage.output_tokens,
-    underfunded,
+    // Token-weighted credit pricing (lib/ai-rung.ts) — what was charged, what
+    // the predictor said, whether the confirm card's warning applies, and
+    // whether the budget cut the run short.
+    ...meterStamp(quote, meter),
   };
 }
 

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -53,6 +53,14 @@ import {
   type LadderRung,
 } from "./schedule-ai";
 import { aiRunCostUsd } from "@/lib/ai-pricing";
+import {
+  clampRoundTokens,
+  hasRoundBudget,
+  officialsRungWeights,
+  predictRung,
+  tokenBudgetForRung,
+  type Rung,
+} from "@/lib/ai-rung";
 import { deferred } from "@/lib/deferred";
 import { maybeAlertExpensiveRun } from "@/server/usecases/ai-runs-admin";
 import { divisionFixtures, loadSettings } from "./schedule";
@@ -787,11 +795,13 @@ function finalizeOfficials(
  *  wire format, the reasoning shape, structured-output parsing, and echoing
  *  the assistant turn back unchanged on repair — callers just replay
  *  `response.assistantTurn`. Phase B has no legacy-model branch and does not
- *  gain one: always effort, never a token budget. */
+ *  gain one: always effort, never a legacy `thinking.budget_tokens` cap (the
+ *  ai-rung.ts hard token budget below is a separate, per-run concept). */
 async function callOfficialsModel(
   provider: AiProvider,
   model: string,
   messages: AiTurn[],
+  maxTokens: number = 32_000,
 ): Promise<AiChatResponse<AiOfficialsPlan> | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), OFFICIALS_ROUND_TIMEOUT_MS);
@@ -800,7 +810,7 @@ async function callOfficialsModel(
       model,
       system: OFFICIALS_SYSTEM_PROMPT,
       messages,
-      maxTokens: 32_000,
+      maxTokens,
       reasoning: { kind: "effort", effort: officialsAiEffort(), thinking: "adaptive" },
       schema: { name: "officials_plan", zod: AiOfficialsPlan },
       signal: controller.signal,
@@ -843,6 +853,7 @@ export async function runOfficialsAiPlan(
   pack: OfficialsPack,
   modelOverride?: string,
   providerName?: ProviderName,
+  budget?: { tokens: number; spentBefore: number },
 ): Promise<OfficialsPlanResult> {
   if (pack.instruction.trim() === "") {
     return finalizeOfficials(pack, draftAsPlan(pack), {
@@ -884,9 +895,27 @@ export async function runOfficialsAiPlan(
   });
 
   for (;;) {
+    // Hard token budget (design ai-rung.ts): spent so far is this rung's own
+    // output tokens plus whatever prior ladder rungs already spent. Below the
+    // reserve, stop asking for another round — ship the best plan already
+    // produced, or (nothing produced yet) fail in a way runLadder can recover
+    // from.
+    if (budget && !hasRoundBudget(budget.tokens, budget.spentBefore + outputTokens)) {
+      if (best !== null) return finalizeOfficials(pack, best.plan, usageNow());
+      throw new HttpError(
+        422,
+        "AI officials assignment stopped: token budget exhausted before a usable plan was produced",
+        "AI_PLAN_FAILED",
+        { usage: usageNow() },
+      );
+    }
+    const roundMaxTokens = budget
+      ? clampRoundTokens(32_000, budget.tokens, budget.spentBefore + outputTokens)
+      : 32_000;
+
     let response: Awaited<ReturnType<typeof callOfficialsModel>>;
     try {
-      response = await callOfficialsModel(provider, model, conversation);
+      response = await callOfficialsModel(provider, model, conversation, roundMaxTokens);
     } catch (err) {
       // A timed-out round still spent the earlier rounds' tokens — ride the
       // accumulated usage on the 422 (same contract as AI_PLAN_FAILED).
@@ -993,10 +1022,17 @@ export function officialsPlanRungs(): LadderRung[] {
  *  runLadder exactly as in Phase A. */
 async function runOfficialsAiPlanLadder(
   pack: OfficialsPack,
+  budgetTokens?: number,
 ): Promise<OfficialsPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] }> {
   return runLadder(
     officialsPlanRungs(),
-    (rung) => runOfficialsAiPlan(pack, rung.model, rung.provider),
+    (rung, spentBefore) =>
+      runOfficialsAiPlan(
+        pack,
+        rung.model,
+        rung.provider,
+        budgetTokens !== undefined ? { tokens: budgetTokens, spentBefore } : undefined,
+      ),
     () => true,
   );
 }
@@ -1052,15 +1088,29 @@ export async function officialsAiPlanForDivision(
       : {}),
   });
 
+  // Token-weighted credit rung (design ai-rung.ts): predict from the pack data
+  // already loaded, let the caller override up or down, and stamp `underfunded`
+  // when they picked below the prediction. Officials packs carry no separate
+  // entrant/court lists — derive both from the fixtures already loaded.
+  const entrants = new Set(pack.fixtures.flatMap((f) => f.entrants)).size;
+  const courts = new Set(pack.fixtures.map((f) => f.court).filter((c): c is string => c !== null)).size;
+  const prediction = predictRung(
+    { movableFixtures: pack.fixtures.length, entrants, courts },
+    officialsRungWeights(),
+  );
+  const rung: Rung = input.rung ?? prediction.rung;
+  const budget = tokenBudgetForRung(rung);
+  const underfunded = rung < prediction.rung;
+
   let result: OfficialsPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] };
   try {
-    // Reserve 1 credit → run the architect → settle on success / release on
-    // failure (SPEC-2 §5.2). PaymentRequiredError("ai.credits") from an empty
+    // Reserve `rung` credits → run the architect → settle on success / release
+    // on failure (SPEC-2 §5.2). PaymentRequiredError("ai.credits") from an empty
     // wallet falls through untouched below (matches no HttpError code here)
     // and rethrows as the 402.
-    result = await spendCredit(walletId, auth.orgId, 1, async () => ({
+    result = await spendCredit(walletId, auth.orgId, rung, async () => ({
       aiRunId: crypto.randomUUID(),
-      result: await runOfficialsAiPlanLadder(pack),
+      result: await runOfficialsAiPlanLadder(pack, budget),
     }));
   } catch (err) {
     // Meter a refused / un-correctable / timed-out run's token spend too —
@@ -1095,6 +1145,14 @@ export async function officialsAiPlanForDivision(
         // later): the fixture count the pack builder already computed, the
         // same number already reported to PostHog as `fixtures`.
         pack_units: pack.fixtures.length,
+        // Token-weighted credit rung (design ai-rung.ts) — even on a failed
+        // run the credit was reserved at this rung, so the ledger stamps it.
+        rung,
+        budget,
+        predicted_rung: prediction.rung,
+        est_tokens: prediction.estTokens,
+        spent_tokens: usage.output_tokens ?? 0,
+        underfunded,
       });
       await captureServer({
         event: "ai_plan_run",
@@ -1136,6 +1194,16 @@ export async function officialsAiPlanForDivision(
     // builder already computed — the smallest correct instrumentation ahead
     // of any size-weighted pricing decision (deferred, SPEC-2 §5.1).
     pack_units: pack.fixtures.length,
+    // Token-weighted credit rung (design ai-rung.ts): what was charged, what
+    // token budget it bought, what the predictor said, how much of the
+    // budget this run actually spent, and whether the org picked below the
+    // prediction.
+    rung,
+    budget,
+    predicted_rung: prediction.rung,
+    est_tokens: prediction.estTokens,
+    spent_tokens: result.usage.output_tokens,
+    underfunded,
     // Ladder telemetry: the first rung tried and the full ordered chain, when a
     // fallback happened (model above is only the winner).
     ...(result.escalated_from
@@ -1206,6 +1274,13 @@ export async function officialsAiPlanForDivision(
       output_tokens: result.usage.output_tokens,
       repair_rounds: result.usage.repair_rounds,
     },
+    // Token-weighted credit rung (design ai-rung.ts) — what was charged, what
+    // the predictor said, and whether the confirm-card's warning applies.
+    rung,
+    predicted_rung: prediction.rung,
+    budget,
+    spent_tokens: result.usage.output_tokens,
+    underfunded,
   };
 }
 

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -25,6 +25,14 @@ import { spendCredit, walletIdFor } from "@/lib/credits";
 import { rateLimit } from "@/lib/rate-limit";
 import { captureServer, isServerFeatureEnabled } from "@/lib/posthog-server";
 import { aiRunCostUsd } from "@/lib/ai-pricing";
+import {
+  clampRoundTokens,
+  hasRoundBudget,
+  predictRung,
+  schedulingRungWeights,
+  tokenBudgetForRung,
+  type Rung,
+} from "@/lib/ai-rung";
 import { deferred } from "@/lib/deferred";
 import { maybeAlertExpensiveRun } from "@/server/usecases/ai-runs-admin";
 import {
@@ -944,6 +952,7 @@ async function callModel(
   provider: AiProvider,
   model: string,
   messages: AiTurn[],
+  maxTokens: number = MAX_TOKENS,
 ): Promise<AiChatResponse<AiSchedulePlan> | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), ROUND_TIMEOUT_MS);
@@ -952,7 +961,7 @@ async function callModel(
       model,
       system: SYSTEM_PROMPT,
       messages,
-      maxTokens: MAX_TOKENS,
+      maxTokens,
       reasoning: aiReasoning(model),
       schema: { name: "schedule_plan", zod: AiSchedulePlan },
       signal: controller.signal,
@@ -996,6 +1005,7 @@ export async function runAiPlan(
   movableIds: Set<string>,
   modelOverride?: string,
   providerName?: ProviderName,
+  budget?: { tokens: number; spentBefore: number },
 ): Promise<AiPlanResult> {
   // One provider per run: reasoning blocks are provider-specific and replayed
   // verbatim on repair, so a run that resolved a provider per round could send
@@ -1034,10 +1044,46 @@ export async function runAiPlan(
     cost_usd: costUsd,
   });
 
+  const finalizeFrom = (chosen: NonNullable<typeof best>): AiPlanResult => ({
+    proposal: chosen.plan.assignments.map((a) => ({
+      fixture_id: a.fixture_id,
+      scheduled_at: a.scheduled_at,
+      court_label: a.court_label,
+      ...(a.schedule_locked !== undefined ? { schedule_locked: a.schedule_locked } : {}),
+    })),
+    unschedulable: chosen.plan.unschedulable,
+    warnings: chosen.warnings,
+    blocking: chosen.blocking,
+    diff: computeDiff(chosen.plan, pack),
+    explanations: chosen.plan.explanations,
+    ...(chosen.plan.constraint_suggestions !== undefined
+      ? { constraint_suggestions: chosen.plan.constraint_suggestions }
+      : {}),
+    summary: chosen.plan.summary,
+    usage: usageNow(),
+  });
+
   for (;;) {
+    // Hard token budget (design §5): spent so far is this rung's own output
+    // tokens plus whatever prior ladder rungs already spent. Below the reserve,
+    // stop asking for another round — ship the best plan already produced, or
+    // (nothing produced yet) fail in a way runLadder can recover from.
+    if (budget && !hasRoundBudget(budget.tokens, budget.spentBefore + outputTokens)) {
+      if (best !== null) return finalizeFrom(best);
+      throw new HttpError(
+        422,
+        "AI scheduling stopped: token budget exhausted before a usable plan was produced",
+        "AI_PLAN_FAILED",
+        { usage: usageNow() },
+      );
+    }
+    const roundMaxTokens = budget
+      ? clampRoundTokens(MAX_TOKENS, budget.tokens, budget.spentBefore + outputTokens)
+      : MAX_TOKENS;
+
     let response: Awaited<ReturnType<typeof callModel>>;
     try {
-      response = await callModel(provider, model, conversation);
+      response = await callModel(provider, model, conversation, roundMaxTokens);
     } catch (err) {
       // A timed-out round still spent the earlier rounds' tokens — ride the
       // accumulated usage on the 422 so callers can meter it (same contract
@@ -1106,25 +1152,7 @@ export async function runAiPlan(
     }
 
     if (blocking.length === 0 || repairRounds >= MAX_REPAIR_ROUNDS) {
-      const chosen = best;
-      return {
-        proposal: chosen.plan.assignments.map((a) => ({
-          fixture_id: a.fixture_id,
-          scheduled_at: a.scheduled_at,
-          court_label: a.court_label,
-          ...(a.schedule_locked !== undefined ? { schedule_locked: a.schedule_locked } : {}),
-        })),
-        unschedulable: chosen.plan.unschedulable,
-        warnings: chosen.warnings,
-        blocking: chosen.blocking,
-        diff: computeDiff(chosen.plan, pack),
-        explanations: chosen.plan.explanations,
-        ...(chosen.plan.constraint_suggestions !== undefined
-          ? { constraint_suggestions: chosen.plan.constraint_suggestions }
-          : {}),
-        summary: chosen.plan.summary,
-        usage: usageNow(),
-      };
+      return finalizeFrom(best!);
     }
 
     // Blocking conflicts remain and rounds are left — send the report back and
@@ -1368,10 +1396,15 @@ function isRecoverable(err: unknown): boolean {
  * Pure over `attempt`/`acceptable` so it is unit-tested without a network.
  * Generic over the result so both phases reuse it — schedule (AiPlanResult) and
  * officials (OfficialsPlanResult) both carry a `usage` with the same shape.
+ *
+ * `attempt` also receives the output tokens spent by every PRIOR rung (0 on
+ * the first) — a budget-aware caller can hand this on to the per-rung runner
+ * so a hard token budget (design ai-rung.ts) is enforced across the whole
+ * ladder, not reset per rung.
  */
 export async function runLadder<T extends { usage: Usage }>(
   rungs: LadderRung[],
-  attempt: (rung: LadderRung) => Promise<T>,
+  attempt: (rung: LadderRung, spentOutputTokensSoFar: number) => Promise<T>,
   acceptable: (result: T) => boolean,
 ): Promise<T & { served_model: string; escalated_from?: string; rungs_tried: string[] }> {
   let acc: Usage = { input_tokens: 0, output_tokens: 0, repair_rounds: 0, cost_usd: 0 };
@@ -1399,7 +1432,7 @@ export async function runLadder<T extends { usage: Usage }>(
     const last = i === rungs.length - 1;
     tried.push(rung.model);
     try {
-      const result = await attempt(rung);
+      const result = await attempt(rung, acc.output_tokens);
       acc = addUsage(acc, result.usage);
       if (acceptable(result)) return finalize(result, rung.model); // clean win — stop
       bestEffort = { result, model: rung.model }; // usable but degraded — remember
@@ -1435,14 +1468,25 @@ export async function runLadder<T extends { usage: Usage }>(
 }
 
 /** Wire the ladder to the real architect: each rung runs on its own provider,
- *  and a degraded plan escalates via the existing quality gate. */
+ *  and a degraded plan escalates via the existing quality gate. `budgetTokens`
+ *  (the rung's hard token budget, design ai-rung.ts) is enforced across every
+ *  rung tried, not reset per rung — `runLadder` hands each attempt the output
+ *  tokens every prior rung already spent. */
 async function runAiPlanLadder(
   pack: SchedulePack,
   movableIds: Set<string>,
+  budgetTokens?: number,
 ): Promise<AiPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] }> {
   return runLadder(
     planRungs(),
-    (rung) => runAiPlan(pack, movableIds, rung.model, rung.provider),
+    (rung, spentBefore) =>
+      runAiPlan(
+        pack,
+        movableIds,
+        rung.model,
+        rung.provider,
+        budgetTokens !== undefined ? { tokens: budgetTokens, spentBefore } : undefined,
+      ),
     (result) => planIsAcceptable(result, movableIds.size),
   );
 }
@@ -1517,15 +1561,27 @@ export async function aiPlanForDivision(
 
   const { pack, movableIds } = await buildSchedulePack(auth, divisionId, input);
 
+  // Token-weighted credit rung (design ai-rung.ts): predict from the pack data
+  // already loaded, let the caller override up or down, and stamp `underfunded`
+  // when they picked below the prediction. The server always recomputes this —
+  // a client's displayed prediction is advisory only.
+  const prediction = predictRung(
+    { movableFixtures: movableIds.size, entrants: pack.entrants.length, courts: pack.settings.courts.length },
+    schedulingRungWeights(),
+  );
+  const rung: Rung = input.rung ?? prediction.rung;
+  const budget = tokenBudgetForRung(rung);
+  const underfunded = rung < prediction.rung;
+
   let result: AiPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] };
   try {
-    // Reserve 1 credit → run the architect → settle on success / release on
-    // failure (SPEC-2 §5.2). PaymentRequiredError("ai.credits") from an empty
+    // Reserve `rung` credits → run the architect → settle on success / release
+    // on failure (SPEC-2 §5.2). PaymentRequiredError("ai.credits") from an empty
     // wallet falls through the catch below untouched (it matches neither
     // planErr nor providerErr) and rethrows as the 402.
-    result = await spendCredit(walletId, auth.orgId, 1, async () => ({
+    result = await spendCredit(walletId, auth.orgId, rung, async () => ({
       aiRunId: crypto.randomUUID(),
-      result: await runAiPlanLadder(pack, movableIds),
+      result: await runAiPlanLadder(pack, movableIds, budget),
     }));
   } catch (err) {
     // Meter a refused / un-correctable / timed-out run's token spend too —
@@ -1590,6 +1646,17 @@ export async function aiPlanForDivision(
                     // already computed, the same number already reported to
                     // PostHog as `fixtures`.
                     pack_units: movableIds.size,
+                    // Token-weighted credit rung (design ai-rung.ts): what was
+                    // charged, what it bought, what the predictor said, and
+                    // whether the org picked below the prediction — even on a
+                    // failed run the credit was reserved at this rung, so the
+                    // ledger stamps it here too.
+                    rung,
+                    budget,
+                    predicted_rung: prediction.rung,
+                    est_tokens: prediction.estTokens,
+                    spent_tokens: usage.output_tokens ?? 0,
+                    underfunded,
                     // Provider diagnostics stay server-side (ops needs the real
                     // status; the tenant gets a bare 503).
                     ...(providerErr
@@ -1644,6 +1711,16 @@ export async function aiPlanForDivision(
                 // correct instrumentation ahead of any size-weighted pricing
                 // decision (deferred, SPEC-2 §5.1).
                 pack_units: movableIds.size,
+                // Token-weighted credit rung (design ai-rung.ts): what was
+                // charged, what token budget it bought, what the predictor
+                // said, how much of the budget this run actually spent, and
+                // whether the org picked below the prediction.
+                rung,
+                budget,
+                predicted_rung: prediction.rung,
+                est_tokens: prediction.estTokens,
+                spent_tokens: result.usage.output_tokens,
+                underfunded,
                 // Ladder telemetry: which model was tried first and rejected,
                 // the full ordered chain of rungs attempted (so a 3-rung fall
                 // gemini→sonnet→grok is auditable — `model` above is only the
@@ -1732,5 +1809,13 @@ export async function aiPlanForDivision(
       repair_rounds: result.usage.repair_rounds,
     },
     officials_coverage,
+    // Token-weighted credit rung (design ai-rung.ts) — what was charged, what
+    // the predictor said, and whether the confirm-card's warning applies, so
+    // the client can reconcile against its own (advisory) prediction.
+    rung,
+    predicted_rung: prediction.rung,
+    budget,
+    spent_tokens: result.usage.output_tokens,
+    underfunded,
   };
 }

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -26,12 +26,12 @@ import { rateLimit } from "@/lib/rate-limit";
 import { captureServer, isServerFeatureEnabled } from "@/lib/posthog-server";
 import { aiRunCostUsd } from "@/lib/ai-pricing";
 import {
-  clampRoundTokens,
-  hasRoundBudget,
-  predictRung,
+  createTokenMeter,
+  meterStamp,
+  quoteRun,
   schedulingRungWeights,
-  tokenBudgetForRung,
-  type Rung,
+  unmeteredTokenMeter,
+  type TokenMeter,
 } from "@/lib/ai-rung";
 import { deferred } from "@/lib/deferred";
 import { maybeAlertExpensiveRun } from "@/server/usecases/ai-runs-admin";
@@ -1005,7 +1005,11 @@ export async function runAiPlan(
   movableIds: Set<string>,
   modelOverride?: string,
   providerName?: ProviderName,
-  budget?: { tokens: number; spentBefore: number },
+  /** The run's cumulative token meter (lib/ai-rung.ts). ONE instance is shared
+   *  by every ladder rung, so the hard budget spans the whole run instead of
+   *  resetting per rung. Defaults to an unmetered one — behaviour is unchanged
+   *  for callers that do not price a run. */
+  meter: TokenMeter = unmeteredTokenMeter(),
 ): Promise<AiPlanResult> {
   // One provider per run: reasoning blocks are provider-specific and replayed
   // verbatim on repair, so a run that resolved a provider per round could send
@@ -1064,11 +1068,12 @@ export async function runAiPlan(
   });
 
   for (;;) {
-    // Hard token budget (design §5): spent so far is this rung's own output
-    // tokens plus whatever prior ladder rungs already spent. Below the reserve,
-    // stop asking for another round — ship the best plan already produced, or
-    // (nothing produced yet) fail in a way runLadder can recover from.
-    if (budget && !hasRoundBudget(budget.tokens, budget.spentBefore + outputTokens)) {
+    // Hard token budget (design §5). The meter already holds every prior
+    // round's AND every prior ladder rung's output tokens, so there is nothing
+    // to add here. Below the reserve, stop asking for another round — ship the
+    // best plan already produced, or (nothing produced yet) fail in a way
+    // runLadder can recover from.
+    if (!meter.canStartRound()) {
       if (best !== null) return finalizeFrom(best);
       throw new HttpError(
         422,
@@ -1077,9 +1082,7 @@ export async function runAiPlan(
         { usage: usageNow() },
       );
     }
-    const roundMaxTokens = budget
-      ? clampRoundTokens(MAX_TOKENS, budget.tokens, budget.spentBefore + outputTokens)
-      : MAX_TOKENS;
+    const roundMaxTokens = meter.clampRound(MAX_TOKENS);
 
     let response: Awaited<ReturnType<typeof callModel>>;
     try {
@@ -1097,6 +1100,11 @@ export async function runAiPlan(
     const roundOutput = response?.usage?.outputTokens ?? 0;
     inputTokens += roundInput;
     outputTokens += roundOutput;
+    // Charge the run's meter the moment usage is known — BEFORE any of the
+    // throw paths below. A round that spent tokens and then refused/failed to
+    // parse must still count against the budget, or a run could loop past its
+    // cap on failures alone.
+    meter.add(roundOutput);
     // Prefer the cost the provider reports; fall back to a derived estimate
     // only when the round produced no reported cost. Never a guess.
     const roundCost =
@@ -1397,15 +1405,20 @@ function isRecoverable(err: unknown): boolean {
  * Generic over the result so both phases reuse it — schedule (AiPlanResult) and
  * officials (OfficialsPlanResult) both carry a `usage` with the same shape.
  *
- * `attempt` also receives the output tokens spent by every PRIOR rung (0 on
- * the first) — a budget-aware caller can hand this on to the per-rung runner
- * so a hard token budget (design ai-rung.ts) is enforced across the whole
- * ladder, not reset per rung.
+ * The hard token budget (lib/ai-rung.ts) needs NOTHING from this function: the
+ * caller closes over one `TokenMeter` and hands the same instance to every
+ * rung's runner, which charges it per round. Cross-rung accounting therefore
+ * cannot drift from the ladder's own `acc`, and a rung that throws without
+ * riding its usage on the error still has its tokens counted.
  */
 export async function runLadder<T extends { usage: Usage }>(
   rungs: LadderRung[],
-  attempt: (rung: LadderRung, spentOutputTokensSoFar: number) => Promise<T>,
+  attempt: (rung: LadderRung) => Promise<T>,
   acceptable: (result: T) => boolean,
+  /** Asked BEFORE each rung after the first. Returning false stops escalation
+   *  without recording the rung — a budget-exhausted run must not list models
+   *  it never actually asked in `rungs_tried`. */
+  canEscalate?: () => boolean,
 ): Promise<T & { served_model: string; escalated_from?: string; rungs_tried: string[] }> {
   let acc: Usage = { input_tokens: 0, output_tokens: 0, repair_rounds: 0, cost_usd: 0 };
   const tried: string[] = [];
@@ -1427,12 +1440,37 @@ export async function runLadder<T extends { usage: Usage }>(
     rungs_tried: tried,
     ...(tried.length > 1 ? { escalated_from: tried[0] } : {}),
   });
+  // Exhausted (the ladder ran out of rungs, or escalation was stopped early).
+  // A usable (if degraded) plan beats any failure — ship it. Otherwise throw the
+  // last MEANINGFUL failure over a trailing unconfigured skip, carrying the
+  // accumulated spend + the model that raised it. HttpError.extra is read-only
+  // → rebuild it; provider errors take loose fields.
+  const exhaust = (err: unknown, model: string): never => {
+    const chosen = meaningful ?? { err, model };
+    if (chosen.err instanceof HttpError) {
+      throw new HttpError(chosen.err.status, chosen.err.message, chosen.err.code, {
+        ...(chosen.err.extra ?? {}),
+        usage: acc,
+        model: chosen.model,
+      });
+    }
+    (chosen.err as { usage?: Usage; model?: string }).usage = acc;
+    (chosen.err as { model?: string }).model = chosen.model;
+    throw chosen.err;
+  };
   for (let i = 0; i < rungs.length; i++) {
     const rung = rungs[i]!;
     const last = i === rungs.length - 1;
+    if (i > 0 && canEscalate && !canEscalate()) {
+      if (bestEffort) return finalize(bestEffort.result, bestEffort.model);
+      exhaust(
+        meaningful?.err ?? new HttpError(422, "AI planning stopped before a usable plan", "AI_PLAN_FAILED"),
+        tried[tried.length - 1] ?? rung.model,
+      );
+    }
     tried.push(rung.model);
     try {
-      const result = await attempt(rung, acc.output_tokens);
+      const result = await attempt(rung);
       acc = addUsage(acc, result.usage);
       if (acceptable(result)) return finalize(result, rung.model); // clean win — stop
       bestEffort = { result, model: rung.model }; // usable but degraded — remember
@@ -1443,23 +1481,8 @@ export async function runLadder<T extends { usage: Usage }>(
       const unconfigured = err instanceof HttpError && err.code === "AI_PROVIDER_NOT_CONFIGURED";
       if (!unconfigured) meaningful = { err, model: rung.model };
       if (last) {
-        // Exhausted. A usable (if degraded) plan beats any failure — ship it.
         if (bestEffort) return finalize(bestEffort.result, bestEffort.model);
-        // No plan at all: throw the last MEANINGFUL failure over a trailing
-        // unconfigured skip, carrying the accumulated spend + the model that
-        // raised it. HttpError.extra is read-only → rebuild it; provider errors
-        // take loose fields.
-        const chosen = meaningful ?? { err, model: rung.model };
-        if (chosen.err instanceof HttpError) {
-          throw new HttpError(chosen.err.status, chosen.err.message, chosen.err.code, {
-            ...(chosen.err.extra ?? {}),
-            usage: acc,
-            model: chosen.model,
-          });
-        }
-        (chosen.err as { usage?: Usage; model?: string }).usage = acc;
-        (chosen.err as { model?: string }).model = chosen.model;
-        throw chosen.err;
+        exhaust(err, rung.model);
       }
     }
   }
@@ -1468,26 +1491,24 @@ export async function runLadder<T extends { usage: Usage }>(
 }
 
 /** Wire the ladder to the real architect: each rung runs on its own provider,
- *  and a degraded plan escalates via the existing quality gate. `budgetTokens`
- *  (the rung's hard token budget, design ai-rung.ts) is enforced across every
- *  rung tried, not reset per rung — `runLadder` hands each attempt the output
- *  tokens every prior rung already spent. */
+ *  and a degraded plan escalates via the existing quality gate. The `meter`
+ *  (lib/ai-rung.ts) is the SAME instance for every rung, so the run's hard
+ *  token budget spans the whole ladder rather than resetting per rung.
+ *
+ *  Escalation stops the moment the meter refuses a round: continuing would
+ *  enter each remaining rung only to have it throw before any network call,
+ *  which spends nothing but writes models into `rungs_tried` that were never
+ *  actually asked. */
 async function runAiPlanLadder(
   pack: SchedulePack,
   movableIds: Set<string>,
-  budgetTokens?: number,
+  meter: TokenMeter,
 ): Promise<AiPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] }> {
   return runLadder(
     planRungs(),
-    (rung, spentBefore) =>
-      runAiPlan(
-        pack,
-        movableIds,
-        rung.model,
-        rung.provider,
-        budgetTokens !== undefined ? { tokens: budgetTokens, spentBefore } : undefined,
-      ),
+    (rung) => runAiPlan(pack, movableIds, rung.model, rung.provider, meter),
     (result) => planIsAcceptable(result, movableIds.size),
+    () => !meter.stoppedOnBudget,
   );
 }
 
@@ -1561,27 +1582,40 @@ export async function aiPlanForDivision(
 
   const { pack, movableIds } = await buildSchedulePack(auth, divisionId, input);
 
-  // Token-weighted credit rung (design ai-rung.ts): predict from the pack data
-  // already loaded, let the caller override up or down, and stamp `underfunded`
-  // when they picked below the prediction. The server always recomputes this —
-  // a client's displayed prediction is advisory only.
-  const prediction = predictRung(
-    { movableFixtures: movableIds.size, entrants: pack.entrants.length, courts: pack.settings.courts.length },
+  // Token-weighted credit pricing (lib/ai-rung.ts). One line — a division is
+  // one unit of work — so `credits` is just its rung; #350's joint solve passes
+  // one line per division to the SAME function and gets the batch discount.
+  // The server always recomputes this: a client's displayed prediction, and its
+  // `rung` override, are advisory. A pick below the prediction is honoured and
+  // stamps `underfunded`.
+  const quote = quoteRun(
+    [
+      {
+        key: divisionId,
+        input: {
+          movableFixtures: movableIds.size,
+          entrants: pack.entrants.length,
+          courts: pack.settings.courts.length,
+        },
+        ...(input.rung !== undefined ? { chosen: input.rung } : {}),
+      },
+    ],
     schedulingRungWeights(),
   );
-  const rung: Rung = input.rung ?? prediction.rung;
-  const budget = tokenBudgetForRung(rung);
-  const underfunded = rung < prediction.rung;
+  // One meter for the whole run — every ladder rung and repair round charges it.
+  // Sized by the movable fixtures so the per-round reserve is large enough to
+  // actually emit this pack's assignment list.
+  const meter = createTokenMeter(quote.budget, { units: movableIds.size });
 
   let result: AiPlanResult & { served_model: string; escalated_from?: string; rungs_tried: string[] };
   try {
-    // Reserve `rung` credits → run the architect → settle on success / release
+    // Reserve `quote.credits` → run the architect → settle on success / release
     // on failure (SPEC-2 §5.2). PaymentRequiredError("ai.credits") from an empty
     // wallet falls through the catch below untouched (it matches neither
     // planErr nor providerErr) and rethrows as the 402.
-    result = await spendCredit(walletId, auth.orgId, rung, async () => ({
+    result = await spendCredit(walletId, auth.orgId, quote.credits, async () => ({
       aiRunId: crypto.randomUUID(),
-      result: await runAiPlanLadder(pack, movableIds, budget),
+      result: await runAiPlanLadder(pack, movableIds, meter),
     }));
   } catch (err) {
     // Meter a refused / un-correctable / timed-out run's token spend too —
@@ -1646,17 +1680,13 @@ export async function aiPlanForDivision(
                     // already computed, the same number already reported to
                     // PostHog as `fixtures`.
                     pack_units: movableIds.size,
-                    // Token-weighted credit rung (design ai-rung.ts): what was
-                    // charged, what it bought, what the predictor said, and
-                    // whether the org picked below the prediction — even on a
-                    // failed run the credit was reserved at this rung, so the
-                    // ledger stamps it here too.
-                    rung,
-                    budget,
-                    predicted_rung: prediction.rung,
-                    est_tokens: prediction.estTokens,
-                    spent_tokens: usage.output_tokens ?? 0,
-                    underfunded,
+                    // Token-weighted credit pricing (lib/ai-rung.ts): what was
+                    // charged, what it bought, what the predictor said, how much
+                    // the run actually spent and whether the BUDGET cut it off
+                    // — even on a failed run the credits were reserved, so the
+                    // ledger stamps it here too. One helper builds this fragment
+                    // for every surface so they cannot drift.
+                    ...meterStamp(quote, meter),
                     // Provider diagnostics stay server-side (ops needs the real
                     // status; the tenant gets a bare 503).
                     ...(providerErr
@@ -1711,16 +1741,13 @@ export async function aiPlanForDivision(
                 // correct instrumentation ahead of any size-weighted pricing
                 // decision (deferred, SPEC-2 §5.1).
                 pack_units: movableIds.size,
-                // Token-weighted credit rung (design ai-rung.ts): what was
+                // Token-weighted credit pricing (lib/ai-rung.ts): what was
                 // charged, what token budget it bought, what the predictor
-                // said, how much of the budget this run actually spent, and
-                // whether the org picked below the prediction.
-                rung,
-                budget,
-                predicted_rung: prediction.rung,
-                est_tokens: prediction.estTokens,
-                spent_tokens: result.usage.output_tokens,
-                underfunded,
+                // said, how much of the budget this run actually spent, whether
+                // the org picked below the prediction, and whether the budget
+                // cut the run short — the last is what makes a mispriced rung
+                // visible instead of looking like a merely degraded plan.
+                ...meterStamp(quote, meter),
                 // Ladder telemetry: which model was tried first and rejected,
                 // the full ordered chain of rungs attempted (so a 3-rung fall
                 // gemini→sonnet→grok is auditable — `model` above is only the
@@ -1809,13 +1836,10 @@ export async function aiPlanForDivision(
       repair_rounds: result.usage.repair_rounds,
     },
     officials_coverage,
-    // Token-weighted credit rung (design ai-rung.ts) — what was charged, what
-    // the predictor said, and whether the confirm-card's warning applies, so
-    // the client can reconcile against its own (advisory) prediction.
-    rung,
-    predicted_rung: prediction.rung,
-    budget,
-    spent_tokens: result.usage.output_tokens,
-    underfunded,
+    // Token-weighted credit pricing (lib/ai-rung.ts) — what was charged, what
+    // the predictor said, whether the confirm card's warning applies, and
+    // whether the budget cut the run short, so the client can reconcile against
+    // its own (advisory) prediction.
+    ...meterStamp(quote, meter),
   };
 }

--- a/docs/superpowers/specs/2026-07-28-ai-credit-token-weight-design.md
+++ b/docs/superpowers/specs/2026-07-28-ai-credit-token-weight-design.md
@@ -41,21 +41,39 @@ estTokens = piecewise-linear(sizeScore)   // for helper text only
 ```
 
 - `ENTRANT_W`, `COURT_W`, `S1`, `S2`, and the est-tokens curve are code constants with env override (`AI_RUNG_*`).
-- **Calibration** happens once during implementation: one SQL pass over `competition_events` (`schedule.ai_generated` / `schedule.ai_officials_generated` payloads) bucketing actual `output_tokens` (p50/p90) by `pack_units`. Thresholds chosen so p90 of a rung's bucket fits inside that rung's budget. Recalibration = rerun the query, edit constants. The calibration query ships in the repo under `scripts/`.
+- **Calibration** happens once during implementation: one SQL pass over `competition_events` (`schedule.ai_generated` / `schedule.ai_officials_generated` payloads) bucketing actual `output_tokens` (p50/p90) by `pack_units`. Thresholds chosen so p90 of a rung's bucket fits inside that rung's budget. Recalibration = rerun the query, edit constants. The query ships as `scripts/ai-rung-calibration.sql`. **Constants shipped UNCALIBRATED** — the query has not yet been run against prod; §3 of it reads the `stopped_on_budget` stamp as ground truth once there is history, and every budget/threshold is env-overridable in the meantime.
 - Phase B uses the same function with its own constant set (`AI_RUNG_OFFICIALS_*`) — officials packs are lighter and will land rung 1 almost always.
 - The server **always recomputes** the prediction at run time; the client's displayed prediction is advisory.
 
 ## 5. Budget meter (enforcement)
 
+The budget keys on **credits charged**, not on the rung — issue #350 charges
+`max(1, Σ rungs − 1)`, which reaches 5, 8, 11 credits, and a `Record<Rung, …>`
+table cannot key those. The approved 1/2/3 values are unchanged; the curve
+extends past 3 at a flat step:
+
 ```ts
-TOKEN_BUDGETS = { 1: 32_000, 2: 64_000, 3: 128_000 }  // generation tokens (output incl. thinking), whole run
+tokenBudgetForCredits(n)  // generation tokens (output incl. thinking), whole run
+  n <= 3 ? {1: 32_000, 2: 64_000, 3: 128_000}[n]
+         : 128_000 + 32_000 * (n - 3)
 ```
 
-In the existing ladder loop (both phases):
+Every value is env-overridable (`AI_RUNG_BUDGET_1/2/3`, `AI_RUNG_BUDGET_STEP`)
+so an uncalibrated cliff can be loosened in prod without a deploy.
 
-1. `spent += usage.output_tokens` after every round (the same usage numbers already captured for COGS — reuse, no new plumbing).
-2. Before starting the next round: if `spent + MIN_ROUND_RESERVE > budget` → stop escalating; finalize with best valid result so far, else fail. `MIN_ROUND_RESERVE` default 2_000 (a round smaller than this can't produce a useful plan/repair), env-overridable.
-3. Per-round cap: `max_tokens = min(32_000, budget - spent)`.
+In the existing ladder loop (both phases), via one `TokenMeter` per run shared
+by every rung — so the budget spans the whole ladder and cross-rung accounting
+lives in one object rather than a number each layer must remember to forward:
+
+1. `meter.add(usage.output_tokens)` as soon as a round's usage is known, **before** the refusal/parse-failure throws — a round that spent tokens and then failed still counts, so a run cannot loop past its cap on failures alone.
+2. Before starting the next round: `meter.canStartRound()` → `spent + reserve <= budget`. False stops escalation, finalizes with the best valid result so far, else fails — and flips `stoppedOnBudget`.
+3. Per-round cap: `meter.clampRound(32_000)` = `min(32_000, budget − spent)`.
+
+`MIN_ROUND_RESERVE` is **size-aware**: `max(2_000, movableFixtures × 40)`
+(`AI_RUNG_MIN_ROUND_RESERVE` / `AI_RUNG_RESERVE_PER_UNIT`). A flat 2 000 is
+wrong for a 200-fixture pack — the assignment list alone is several thousand
+output tokens, so a round clamped below that truncates, fails to parse, and
+burns the remaining budget for nothing.
 
 Provider-agnostic: identical on OpenRouter fallback models and direct Anthropic. Input tokens are **not** metered (budget = generation budget; on adaptive-thinking models thinking bills as output, which is exactly the cost we're scaling for).
 
@@ -67,8 +85,10 @@ Provider-agnostic: identical on OpenRouter fallback models and direct Anthropic.
 
 ## 7. Billing / ledger
 
-- `spendCredit(walletId, orgId, rung, ...)` — the amount param exists today (hardcoded 1). Reserve→settle/release flow untouched. Grant-first spend order untouched. **No schema change, no migration.**
-- Settle payload adds: `{ rung, budget, predicted_rung, est_tokens, spent_tokens, underfunded }`.
+- `spendCredit(walletId, orgId, quote.credits, ...)` — the amount param exists today (hardcoded 1). Reserve→settle/release flow untouched. Grant-first spend order untouched. **No schema change, no migration.**
+- Settle payload adds `meterStamp(quote, meter)`: `{ credits, budget, spent_tokens, est_tokens, underfunded, stopped_on_budget, rung, predicted_rung }` — and, for a joint run, `{ discount, divisions: [{id, rung, predicted_rung, underfunded}] }` instead of the flat `rung`/`predicted_rung`.
+- **`stopped_on_budget`** is stamped by the meter itself and is the only signal that separates "the budget cut this run short" from "the plan was merely degraded". `underfunded` records the user's choice, not the outcome; without both, §10's "cheaped-out → failed" analysis cannot be run. It is stamped on the failure event too.
+- **The zero-token path is not priced from the pack.** Phase B's empty-instruction run returns the deterministic solver draft with no model call, so it is quoted flat at 1 credit (`freeDraftQuote()`) — sizing it would charge a large division 2-3 credits for a run that spends nothing.
 - Failure path unchanged: no valid schedule (including budget exhausted with nothing usable) → hold **released, no charge**. COGS eaten; worst case ≈ $2 (128K output × $15/M), acceptable.
 - Margin sanity: rung 3 worst-case COGS ≈ $2–2.5 vs 3 credits ≈ $7 retail-equivalent; rung 1 ≈ $0.50 vs 1 credit.
 

--- a/docs/superpowers/specs/2026-07-28-multi-division-ai-design.md
+++ b/docs/superpowers/specs/2026-07-28-multi-division-ai-design.md
@@ -1,8 +1,58 @@
 # Multi-Division AI Scheduling (Competition Board) — Design
 
 **Date:** 2026-07-28
+**Amended:** 2026-07-29 — §2/§6/§7 budget formula (see "Amendment" below)
 **Status:** Approved by owner (brainstorm session), pending implementation plan
 **Depends on:** Token-weighted AI credits design (`2026-07-28-ai-credit-token-weight-design.md`, issue #348) — this feature builds on its predictor, rung pricing, and budget meter.
+
+## Amendment — 2026-07-29 (owner-approved)
+
+The original §2 budget line, "32K × credits charged (discounted total)", was
+found to conflict with #348 and to make a joint run strictly worse than running
+the same divisions separately. Two corrections, both owner-approved, and both
+already implemented in `apps/web/src/lib/ai-rung.ts` (PR #359):
+
+**1. The budget curve is not linear.** #348 approved 1cr→32K, 2cr→64K,
+3cr→**128K**. `32K × credits` gives 96K at 3 credits — a cut to the largest
+single-division runs that nobody agreed to. The curve now keeps the approved
+values and extends past 3 at a flat step:
+
+```
+tokenBudgetForCredits(n) = n <= 3 ? {1: 32K, 2: 64K, 3: 128K}[n]
+                                  : 128K + 32K * (n - 3)
+```
+
+**2. The budget is sized from the UNDISCOUNTED rung total, not from the credits
+charged.** Under the original wording, two joint rung-1 divisions pay
+`max(1, 2−1) = 1` credit and would have received 32K — half the budget the same
+two divisions get when run separately. The batch discount is a margin gift, not
+a capability cut, so pricing and budget are now decoupled:
+
+```
+rungTotal = Σ chosen rungs                  // sizes the budget
+credits   = max(1, rungTotal − 1)           // what the org pays  (≥2 divisions)
+budget    = tokenBudgetForCredits(rungTotal)
+```
+
+Worked: Div A rung 1 + Div B rung 2 + Div C rung 3 → rungTotal 6 → **charge 5
+credits**, **budget 224K** (`128K + 32K×3`).
+
+The "credits buy a budget" invariant still holds from the buyer's side — what
+they buy is sized by the work they asked for; the discount reduces the price of
+that work, not the work itself.
+
+**Also landed ahead of this issue** (PR #359, so §7/§10 need no further design):
+- `quoteRun(lines, weights)` already takes one line per division and applies the
+  `max(1, Σ−1)` discount — the joint path calls the same function the division
+  path calls, with more lines.
+- `meterStamp()` already emits the joint payload shape §10 asks for
+  (`{credits, discount, budget, spent_tokens, divisions: [{id, rung,
+  predicted_rung, underfunded}]}`), plus `stopped_on_budget` — a stamp §10 did
+  not have, which distinguishes "the budget cut this run short" from "the plan
+  was merely degraded".
+- Every budget value is env-overridable (`AI_RUNG_BUDGET_1/2/3`,
+  `AI_RUNG_BUDGET_STEP`), so a mispriced joint run can be loosened in prod
+  without a deploy.
 
 ## 1. Problem
 
@@ -15,7 +65,7 @@ The competition-level schedule board (`/o/[orgSlug]/c/[compSlug]/schedule`, Pro-
 | Shape | **B — one joint solve.** All selected divisions' movable fixtures in a single AI run (rejected: sequential orchestration, hierarchical meta-pass). |
 | Size ceiling | **Block over cap.** >500 movable fixtures total → refuse with "too large — schedule per division". No silent fallback, no cap raise. |
 | Pricing | **Sum of division rungs − 1, min 1** (batch discount). Each division predicted individually by the #348 predictor; breakdown shown to user. |
-| Budget | **Follows charged credits**: total-run generation budget = 32K × credits charged (discounted total). Keeps the "credits buy budget" invariant; discount justified by shared context. |
+| Budget | ~~Follows charged credits: 32K × credits charged (discounted total).~~ **SUPERSEDED 2026-07-29** — sized from the UNDISCOUNTED rung total on the #348 curve: `tokenBudgetForCredits(Σ rungs)`. See Amendment above. |
 | Officials | Joint officials (Phase B) **out of scope** — stays per-division. |
 
 ## 3. Current state (file:line anchors)
@@ -46,15 +96,16 @@ Extends the existing Phase-A prompt (`schedule-ai-prompt.ts`):
 
 ## 6. Engine
 
-- Same escalation ladder and #348 cumulative token meter. Budget = 32K × credits charged.
+- Same escalation ladder and #348 cumulative token meter — one `TokenMeter` (`lib/ai-rung.ts`) shared by every rung and repair round of the joint run. Budget = `tokenBudgetForCredits(Σ rungs)` (Amendment).
+- The meter's per-round reserve is size-aware (`max(2_000, movableFixtures × 40)`), which matters more here than per-division: a joint pack's assignment list is the sum of every selected division's.
 - Repair-round validation runs `validateAssignments` over ALL selected divisions' assignments jointly, so cross-division double-booking is caught in-run, not at apply.
 
 ## 7. Pricing
 
-- Per-division rung via the #348 predictor (`ai-rung.ts`), then `credits = max(1, Σ rungs − 1)`.
-- Breakdown UI: "Div A 1 + Div B 2 + Div C 3 − 1 batch discount = 5 credits". Per-division rung chips adjustable 1-3 (same semantics as single-division; below-predicted picks stamp `underfunded` per division).
-- One `spendCredit(walletId, orgId, N)` reserve; one settle/release, atomic with the run. Grant-first order, wallet-only gating unchanged.
-- Margin note: discount gives back ≈ one credit per joint run; worst-case COGS remains well under the retail sum of the rungs.
+- Per-division rung via the #348 predictor, then `credits = max(1, Σ rungs − 1)`. **Already implemented**: `quoteRun(lines, schedulingRungWeights())` in `lib/ai-rung.ts` takes one `{key: divisionId, input, chosen?}` line per division and returns `{lines, rungTotal, credits, discount, budget, estTokens, underfunded}`. The division path calls the same function with one line — there is no second pricing code path to keep in sync.
+- Breakdown UI: "Div A 1 + Div B 2 + Div C 3 − 1 batch discount = 5 credits" — read straight off `quote.lines` / `quote.discount` / `quote.credits`. Per-division rung chips adjustable 1-3 (same semantics as single-division; below-predicted picks stamp `underfunded` per division, and `quote.underfunded` is the any-line roll-up).
+- One `spendCredit(walletId, orgId, quote.credits)` reserve; one settle/release, atomic with the run. Grant-first order, wallet-only gating unchanged.
+- Margin note: discount gives back ≈ one credit per joint run; worst-case COGS remains well under the retail sum of the rungs. Note the budget is NOT discounted (Amendment), so the COGS ceiling of a joint run is the undiscounted `tokenBudgetForCredits(Σ rungs)` — still bounded, and bounded by the same 500-fixture cap.
 
 ## 8. API
 

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -49226,6 +49226,22 @@
                       "assignments"
                     ],
                     "additionalProperties": false
+                  },
+                  "rung": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 1
+                      },
+                      {
+                        "type": "number",
+                        "const": 2
+                      },
+                      {
+                        "type": "number",
+                        "const": 3
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -49465,6 +49481,122 @@
                             "repair_rounds"
                           ],
                           "additionalProperties": false
+                        },
+                        "credits": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "budget": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "spent_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "est_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "underfunded": {
+                          "type": "boolean"
+                        },
+                        "stopped_on_budget": {
+                          "type": "boolean"
+                        },
+                        "rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "predicted_rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "discount": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "divisions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "predicted_rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "underfunded": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "rung",
+                              "predicted_rung",
+                              "underfunded"
+                            ],
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -54089,6 +54221,22 @@
                       "blockGapMinutes"
                     ],
                     "additionalProperties": false
+                  },
+                  "rung": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 1
+                      },
+                      {
+                        "type": "number",
+                        "const": 2
+                      },
+                      {
+                        "type": "number",
+                        "const": 3
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -54463,6 +54611,122 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "credits": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "budget": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "spent_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "est_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "underfunded": {
+                          "type": "boolean"
+                        },
+                        "stopped_on_budget": {
+                          "type": "boolean"
+                        },
+                        "rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "predicted_rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "discount": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "divisions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "predicted_rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "underfunded": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "rung",
+                              "predicted_rung",
+                              "underfunded"
+                            ],
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -35067,6 +35067,22 @@
                       "assignments"
                     ],
                     "additionalProperties": false
+                  },
+                  "rung": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 1
+                      },
+                      {
+                        "type": "number",
+                        "const": 2
+                      },
+                      {
+                        "type": "number",
+                        "const": 3
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -35306,6 +35322,122 @@
                             "repair_rounds"
                           ],
                           "additionalProperties": false
+                        },
+                        "credits": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "budget": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "spent_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "est_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "underfunded": {
+                          "type": "boolean"
+                        },
+                        "stopped_on_budget": {
+                          "type": "boolean"
+                        },
+                        "rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "predicted_rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "discount": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "divisions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "predicted_rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "underfunded": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "rung",
+                              "predicted_rung",
+                              "underfunded"
+                            ],
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -39930,6 +40062,22 @@
                       "blockGapMinutes"
                     ],
                     "additionalProperties": false
+                  },
+                  "rung": {
+                    "anyOf": [
+                      {
+                        "type": "number",
+                        "const": 1
+                      },
+                      {
+                        "type": "number",
+                        "const": 2
+                      },
+                      {
+                        "type": "number",
+                        "const": 3
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -40304,6 +40452,122 @@
                               "type": "null"
                             }
                           ]
+                        },
+                        "credits": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "budget": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "spent_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "est_tokens": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "underfunded": {
+                          "type": "boolean"
+                        },
+                        "stopped_on_budget": {
+                          "type": "boolean"
+                        },
+                        "rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "predicted_rung": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 1
+                            },
+                            {
+                              "type": "number",
+                              "const": 2
+                            },
+                            {
+                              "type": "number",
+                              "const": 3
+                            }
+                          ]
+                        },
+                        "discount": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
+                        "divisions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "predicted_rung": {
+                                "anyOf": [
+                                  {
+                                    "type": "number",
+                                    "const": 1
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 2
+                                  },
+                                  {
+                                    "type": "number",
+                                    "const": 3
+                                  }
+                                ]
+                              },
+                              "underfunded": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "rung",
+                              "predicted_rung",
+                              "underfunded"
+                            ],
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [

--- a/scripts/ai-rung-calibration.sql
+++ b/scripts/ai-rung-calibration.sql
@@ -1,0 +1,152 @@
+-- Token-weighted AI credit rungs — calibration pass.
+--
+-- Design: docs/superpowers/specs/2026-07-28-ai-credit-token-weight-design.md §4.
+-- Code:   apps/web/src/lib/ai-rung.ts (the constants this query exists to set).
+--
+-- WHY THIS FILE EXISTS
+-- The predictor's thresholds (AI_RUNG_S1 / S2), its weights, and the est-token
+-- anchors shipped UNCALIBRATED — chosen by inspection, not from data. The hard
+-- token budget is enforced regardless, so a threshold set too low shows up as
+-- runs cut short. Run this against production `competition_events` and set the
+-- constants from what it reports.
+--
+-- HOW TO RUN
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/ai-rung-calibration.sql
+-- Read-only. Safe on prod. Set the search_path first if your role does not
+-- already resolve to the app schema:
+--   SET search_path TO seazn_club;
+--
+-- HOW TO READ IT
+-- Section 1 buckets real runs by pack size and reports the p50/p90 of the
+-- generation tokens they actually spent. Pick S1 so that p90 of everything at
+-- or below it fits inside rung 1's budget (32K by default), and S2 likewise for
+-- rung 2's (64K). Section 2 shows how the CURRENT constants would have priced
+-- the same history — the "would have been cut short" column is the number that
+-- matters. Section 3 reports what actually happened once this shipped.
+--
+-- Recalibration is: rerun this, edit the constants in ai-rung.ts (or set the
+-- AI_RUNG_* env overrides for an immediate change), redeploy.
+
+\echo ''
+\echo '=== 1. Observed generation tokens by pack size ==================='
+\echo '   Set S1 where p90 first exceeds rung 1'\''s budget (default 32,000),'
+\echo '   and S2 where p90 first exceeds rung 2'\''s (default 64,000).'
+\echo ''
+
+with runs as (
+  select
+    (payload ->> 'pack_units')::int                     as pack_units,
+    (payload -> 'usage' ->> 'output_tokens')::int       as output_tokens,
+    (payload ->> 'cost_usd')::numeric                   as cost_usd,
+    type
+  from competition_events
+  where type in ('schedule.ai_generated', 'schedule.ai_officials_generated')
+    and payload ? 'pack_units'
+    and payload -> 'usage' ? 'output_tokens'
+)
+select
+  case
+    when pack_units <=  25 then '  0- 25'
+    when pack_units <=  50 then ' 26- 50'
+    when pack_units <= 100 then ' 51-100'
+    when pack_units <= 150 then '101-150'
+    when pack_units <= 200 then '151-200'
+    when pack_units <= 300 then '201-300'
+    when pack_units <= 400 then '301-400'
+    else                        '   400+'
+  end                                                                  as pack_bucket,
+  type                                                                 as phase,
+  count(*)                                                             as runs,
+  round(avg(pack_units))                                               as avg_units,
+  percentile_disc(0.5) within group (order by output_tokens)           as p50_output_tokens,
+  percentile_disc(0.9) within group (order by output_tokens)           as p90_output_tokens,
+  max(output_tokens)                                                   as max_output_tokens,
+  round(avg(cost_usd)::numeric, 4)                                     as avg_cost_usd
+from runs
+group by pack_bucket, phase
+order by phase, pack_bucket;
+
+\echo ''
+\echo '=== 2. How the CURRENT constants would have priced that history =='
+\echo '   `would_exceed_budget` is the count this pricing would have cut'
+\echo '   short. Anything above a few percent means the rung is too cheap'
+\echo '   for its bucket — raise the budget or lower the threshold.'
+\echo ''
+
+-- Keep these four literals in sync with ai-rung.ts (schedulingRungWeights /
+-- TOKEN budgets). They are repeated here, not read, because this query runs in
+-- psql against prod with no access to the app's env.
+with const as (
+  select
+    0.5::numeric   as entrant_weight,
+    2.0::numeric   as court_weight,
+    60::numeric    as s1,
+    200::numeric   as s2,
+    32000::int     as budget_1,
+    64000::int     as budget_2,
+    128000::int    as budget_3
+),
+runs as (
+  select
+    (payload ->> 'pack_units')::int               as pack_units,
+    (payload -> 'usage' ->> 'output_tokens')::int as output_tokens
+  from competition_events
+  where type = 'schedule.ai_generated'
+    and payload ? 'pack_units'
+    and payload -> 'usage' ? 'output_tokens'
+),
+-- NOTE: entrants/courts are not on the historical payload, so this approximates
+-- sizeScore by pack_units alone. It therefore UNDER-estimates the score, which
+-- makes this section a lower bound on how often the budget would bite.
+priced as (
+  select
+    r.output_tokens,
+    case
+      when r.pack_units <= c.s1 then 1
+      when r.pack_units <= c.s2 then 2
+      else 3
+    end as rung,
+    case
+      when r.pack_units <= c.s1 then c.budget_1
+      when r.pack_units <= c.s2 then c.budget_2
+      else c.budget_3
+    end as budget
+  from runs r cross join const c
+)
+select
+  rung,
+  count(*)                                                             as runs,
+  budget,
+  percentile_disc(0.9) within group (order by output_tokens)           as p90_output_tokens,
+  count(*) filter (where output_tokens > budget)                       as would_exceed_budget,
+  round(100.0 * count(*) filter (where output_tokens > budget) / nullif(count(*), 0), 1)
+                                                                       as pct_cut_short
+from priced
+group by rung, budget
+order by rung;
+
+\echo ''
+\echo '=== 3. What actually happened since rung pricing shipped ========='
+\echo '   `stopped_on_budget` is ground truth — it is stamped by the meter'
+\echo '   itself, not inferred. `underfunded` is the user picking below the'
+\echo '   prediction; the two together separate "we mispriced it" from'
+\echo '   "they chose to cheap out".'
+\echo ''
+
+select
+  type                                                                 as event,
+  (payload ->> 'rung')::int                                            as rung,
+  count(*)                                                             as runs,
+  count(*) filter (where (payload ->> 'stopped_on_budget')::bool)      as stopped_on_budget,
+  count(*) filter (where (payload ->> 'underfunded')::bool)            as underfunded,
+  count(*) filter (
+    where (payload ->> 'stopped_on_budget')::bool
+      and not coalesce((payload ->> 'underfunded')::bool, false)
+  )                                                                    as cut_short_at_predicted_rung,
+  percentile_disc(0.9) within group (order by (payload ->> 'spent_tokens')::int)
+                                                                       as p90_spent_tokens
+from competition_events
+where type in ('schedule.ai_generated', 'schedule.ai_officials_generated', 'schedule.ai_failed')
+  and payload ? 'rung'
+group by event, rung
+order by event, rung;


### PR DESCRIPTION
Implements the backend for the AI credit token-weight design (`docs/superpowers/specs/2026-07-28-ai-credit-token-weight-design.md`, #348), and reshapes it so the multi-division joint solve (#350) can reuse it instead of copying it.

Fixes #348. Amends the #350 design (see below).

## What it does

A pure predictor (`apps/web/src/lib/ai-rung.ts`) maps movable fixtures, entrants and courts to a 1/2/3 credit **rung**; the rung sets a hard per-run generation-token **budget** enforced across both AI ladders (`schedule-ai.ts`, `officials-ai.ts`); `spendCredit` charges the quoted credits instead of a hardcoded 1. The ladder stops escalating once the budget cannot fit another round and ships the best plan produced so far rather than failing outright. Ledger events and API responses carry what was charged, what it bought, and what actually happened.

## The seam (why this is shaped the way it is)

The first cut keyed the token budget off the **rung**. #350 charges `max(1, Σ rungs − 1)` — 5, 8, 11 credits — which a `Record<1|2|3, number>` cannot key at all. Three concerns are now separate:

| | input | output | function |
|---|---|---|---|
| **Sizing** | pack shape | `Rung` (1\|2\|3) | `predictRung()` |
| **Pricing** | chosen rungs | credits charged | `quoteRun()` |
| **Budget** | credits | hard token cap | `tokenBudgetForCredits()` |

`quoteRun()` takes **one line per unit of work**. One line is today's division path; two or more applies #350's batch discount — same function, already unit-tested. `meterStamp()` already emits #350 §10's joint payload shape.

## Owner decisions encoded (2026-07-29)

1. **Budget curve** — `1→32K, 2→64K, 3→128K` (as #348 approved), then `+32K` per credit past 3. #350 §2's "32K × credits" is **superseded**: it would have cut rung 3 from 128K to 96K.
2. **Joint budget** — sized from the **undiscounted** `Σ rungs`, not the discounted credits. Two joint rung-1 divisions pay 1 credit and still get 64K; otherwise a joint run would be strictly worse than running the divisions apart. The discount cuts the price of the work, not the work.
3. **Rollout** — enforce now, with every budget env-overridable (`AI_RUNG_BUDGET_*`) and a `stopped_on_budget` stamp, so an uncalibrated cliff is visible immediately and loosenable without a deploy.

Both spec docs are amended in this PR.

## Two behaviour bugs fixed

**Officials free-draft overcharge.** `AiOfficialsPlanRequest.instruction` defaults to `""`; that path returns the deterministic solver draft with **zero model calls**. Pricing it from the pack charged a large division 2-3 credits for a run that spends nothing. `freeDraftQuote()` pins it at 1 — what it cost before rung pricing existed.

**No cut-short signal.** `underfunded` only records what the user picked. It could not distinguish a run the budget cut short from one that merely returned a degraded plan — which is exactly the signal §10's "cheaped-out → failed" analysis needs. `stopped_on_budget` is stamped by the meter itself, on the failure event too.

Each ships a test that fails without it (both verified red against a reverted fix).

## Robustness

- **`TokenMeter`** replaces `{tokens, spentBefore}` threaded positionally through `runLadder` → `runAiPlan`/`runOfficialsAiPlan` → `callModel`. One instance per run, shared by every rung: cross-rung accounting cannot drift, and a rung that throws *without* riding usage on its error still has its tokens counted (that was a leak). `runLadder` loses the leaky parameter and gains an optional `canEscalate()`.
- **Size-aware round reserve** — `max(2_000, movableFixtures × 40)`. A flat 2 000 tokens cannot emit a 200-fixture assignment list; a round clamped there truncates, fails to parse, and burns the rest of the budget for nothing.
- **No phantom rungs** — a budget-exhausted run stops escalating instead of entering each remaining rung only to throw, which listed models in `rungs_tried` that were never asked.
- **One stamp builder** — `meterStamp()` replaces four hand-maintained copies of the ledger/response fragment.
- `scripts/ai-rung-calibration.sql` — the calibration pass design §4 requires. Section 3 reads `stopped_on_budget` as ground truth.
- `openapi/v1.json` + `v1.public.json` regenerated. These were stale on the first push and failed the drift gate **before the unit-test step ran**, so nothing in the original PR had been verified by CI.

## Out of scope (follow-ups)

Confirm-card UI (rung picker, prediction helper text, warnings), the en/es/fr/nl copy, `scripts/smoke.ts`, e2e coverage, and running the calibration query against prod.

## Verification

Run locally against an ephemeral Postgres (`db:apply` + `sync:sports` on a fresh schema):

- `npm run typecheck --workspace apps/web` — clean
- `npm run lint --workspace apps/web` — 0 errors
- `npm run openapi:gen` — no drift, deterministic across repeated runs
- Full `apps/web` suite — **515 files, 4270 tests passing**, 14 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)
