### PR TITLE
fix(billing): W10 add-on, pass and money leaks — capacity dies with the money that rented it (#304 #329 #330 #331 #347 #353)

### DIFF
--- a/apps/web/content/help/billing/credits.md
+++ b/apps/web/content/help/billing/credits.md
@@ -30,7 +30,7 @@ Billing is group-level: one subscription can pay for several organisations. When
 
 What happens to the credits you already hold depends on whether they are yours alone. If your organisation is **billed on its own**, they **move with you**: joining a group merges your unspent balance straight into the shared pool — monthly-grant credits stay monthly-grant credits, purchased and earned credits stay in their own never-expiring pool, exactly as before. If you are **already sharing a wallet** with other organisations, that balance **stays with them** — it is the whole group's pool, not your share of it — and you join the new group with a fresh wallet.
 
-Leaving a group works the same way: you take **no share** of the pool with you. Your organisation goes back to its own bill and starts with a fresh, empty wallet, and the credits you were sharing stay with the group.
+Leaving a group depends on whether anyone is left to hold the pool. If **other organisations remain** on the group, you take **no share** with you — it is their pool, not your part of it — and your organisation goes back to its own bill with a fresh, empty wallet. If you are the **last organisation to leave**, the balance **comes with you**, bucket for bucket: there would be no group left to hold it otherwise.
 
 ## Run history and export
 

--- a/apps/web/content/help/billing/event-pass.md
+++ b/apps/web/content/help/billing/event-pass.md
@@ -54,6 +54,8 @@ Nothing is deleted, and nothing is taken back. The competition stays fully reada
 
 The app says so everywhere it mentions the pass: the **Event Pass M active** (or **L active**) marker becomes **Event Pass ended**, names which of the two reasons above applied, and offers the two things that are actually still available — **Create next year's edition**, and **Go Pro** if you are running events often enough that the monthly plan fits better. The pass is never offered for sale again on that competition, because it cannot be bought twice.
 
+**The same line decides when a pass can be BOUGHT.** You can buy a pass while its competition is still running, or during the 7-day grace after its end date; once a competition has passed that line the purchase is refused rather than sold, so you can never pay for a pass that would apply to nothing.
+
 **Renaming a competition does not need a new pass** — the pass is bound to the competition itself, not its name, so you can rename this year's event freely and its pass rides along. A **brand-new competition needs its own pass, even if it has the same name**: finishing this year's championship and creating next year's is a new event, so it is a new purchase. Creating a fresh competition never copies last year's pass onto it — starting from scratch is exactly that.
 
 ## When it fits

--- a/apps/web/src/app/api/billing/pass-checkout/route.ts
+++ b/apps/web/src/app/api/billing/pass-checkout/route.ts
@@ -9,7 +9,7 @@ import { buildPassCheckoutParams, competitionHasRefusedPassPayment } from "@/lib
 import { preferredCurrency } from "@/lib/currency-server";
 import { PASS_KEYS } from "@/lib/currency";
 import { routes } from "@/lib/routes";
-import { isPaidPlan, orgPlanKey } from "@/lib/entitlements";
+import { isPaidPlan, orgPlanKey, passLockReason } from "@/lib/entitlements";
 
 const schema = z
   .object({
@@ -36,8 +36,23 @@ export async function POST(req: Request) {
 
     // `name` is the Stripe invoice line description — without it an org that
     // buys three passes sees three identical rows on its billing page.
-    const [comp] = await sql<{ slug: string; name: string; org_id: string }[]>`
-      select slug, name, org_id from competitions where id = ${competition_id}`;
+    //
+    // `status`/`ends_on` ride along for the #353 gate below. Read HERE, with the
+    // row the rest of the route already needs, so the ownership check and the
+    // "is this competition still running" verdict cannot come from two different
+    // moments — and so a sale costs no extra query.
+    const [comp] = await sql<
+      {
+        slug: string;
+        name: string;
+        org_id: string;
+        status: string;
+        // `Date | string | null`, matching the five other sites that feed this
+        // predicate: `ends_on` is a `date` column and the driver hands back a
+        // Date, which is why `passLockReason`'s NaN arm is unreachable here.
+        ends_on: Date | string | null;
+      }[]
+    >`select slug, name, org_id, status, ends_on from competitions where id = ${competition_id}`;
     if (!comp || comp.org_id !== orgId) throw new HttpError(404, "competition not found");
 
     // A paid org is refused a pass (v3/07 §3 interplay).
@@ -122,6 +137,43 @@ export async function POST(req: Request) {
     // pass checkout, not only refused ones. Migration first.
     if (await competitionHasRefusedPassPayment(competition_id)) {
       throw new HttpError(409, "A payment for this competition is under review.");
+    }
+
+    // v17 gap #353 — the competition is already OVER, so the pass would not
+    // apply to a single thing the buyer is about to pay for.
+    //
+    // Until this the route read `slug, name, org_id` and never asked: a FIRST
+    // purchase for a finished or long-past competition was taken in full, the
+    // pass minted, and every surface in the product said "Event Pass ended" the
+    // same second. On the terminal arm the buyer could not even retry, because
+    // one pass per competition is forever (#248 Q4, enforced by the
+    // `competition_passes` PK) — so they lost the money AND their one chance.
+    //
+    // THE ROUTE IS THE AUTHORITY, even though the offer surfaces now suppress
+    // this. The surfaces have been wrong about the lock before — #301 is a whole
+    // wave of them saying a locked pass was active — and `/upgrade` is a direct
+    // link an organiser can hold in a bookmark or an email long after the event.
+    // A suppressed button is a nicety; refusing to take the money is the rule.
+    //
+    // Judged by `passLockReason`, never by a status list of its own: the SQL
+    // (`pass_applies`, V343) and this function are already the two authorised
+    // copies of the rule and a third is how they drift (#301's actual cause).
+    //
+    // 410 Gone, and its own arm in `passCheckoutErrorKey`: the generic 4xx copy
+    // says "the page may be out of date, reload and try again", which is a lie
+    // to this reader — reloading changes nothing, and on the terminal arm
+    // nothing the buyer can do changes anything.
+    //
+    // AFTER the two refusals above, deliberately. Both are more specific and
+    // more actionable than "it ended": an org that already holds a pass is owed
+    // the one-pass-forever sentence (#301 pinned that BOTH lock states get that
+    // identical refusal), and an org whose money is sitting in a mint refusal is
+    // owed news about the money before news about the calendar.
+    if (passLockReason(comp.status, comp.ends_on)) {
+      throw new HttpError(
+        410,
+        "This competition has already ended, so an Event Pass would not apply to it.",
+      );
     }
 
     // Priced by RUNG. Each rung's one-time price id is written back by

--- a/apps/web/src/app/o/[orgSlug]/__tests__/org-home-pass-menu.test.tsx
+++ b/apps/web/src/app/o/[orgSlug]/__tests__/org-home-pass-menu.test.tsx
@@ -1,0 +1,173 @@
+// The dashboard card menu's Event Pass offer, rendered (v17 gap #353).
+//
+// The menu offered "Event Pass — from $29" on EVERY un-passed competition an
+// editor could see, including ones that were finished, archived, or a week past
+// their end date. The checkout route now refuses those with a 410 — but a live
+// button that leads to a refusal is still a promise the product cannot keep, and
+// before the route gate it led to a completed sale for a pass that applied to
+// nothing.
+//
+// Rendered rather than source-scanned, deliberately. `pass-entry-points.test.ts`
+// is a source scan and it says so: a scan pins syntax rather than meaning, and
+// the task 6 review found `passLock.get(c.id) === "terminal"` satisfying every
+// assertion in that file while re-shipping #301 for the whole `past_ends_on`
+// arm. The specific hole this file exists to close is a suppression built on a
+// column the query never selected: `isPassLocked(undefined, undefined)` answers
+// "not locked" for every competition on the page, and a source scan cannot tell
+// that apart from a working gate.
+//
+// Rendered through react-dom/server — vitest runs `environment: "node"` and this
+// workspace has no jsdom (same pattern as the upgrade page's own suite).
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const h = vi.hoisted(() => ({
+  planKey: "community" as string,
+  canEdit: true,
+  competitions: [] as Array<{
+    id: string;
+    name: string;
+    slug: string;
+    status: string;
+    ends_on: string | null;
+  }>,
+}));
+
+vi.mock("@/server/page-auth", () => ({
+  requireOrgPage: async () => ({
+    // `userId: null` keeps the onboarding write out of the way — it is a
+    // dynamic import of a module that talks to Postgres, and this page renders
+    // it before anything else.
+    auth: { orgId: "org-1", via: "session", userId: null, role: "owner", keyId: null },
+    user: { id: "u-1" },
+    org: { id: "org-1", name: "Riverside CC", slug: "riverside", role: "owner" },
+    canEdit: h.canEdit,
+  }),
+}));
+
+vi.mock("@/server/usecases/competitions", () => ({
+  listCompetitions: async () => ({ items: h.competitions, next_cursor: null }),
+}));
+vi.mock("@/server/usecases/card-stats", () => ({
+  listCompetitionCardStats: async () => new Map(),
+  nextLine: () => null,
+}));
+
+// The only query the page issues itself is the held-pass read. Nothing here
+// holds a pass — a held pass suppresses the offer on its own and would make
+// every case below pass for the wrong reason.
+vi.mock("@/lib/db", () => ({
+  sql: (strings: TemplateStringsArray | unknown[], ...vals: unknown[]) => {
+    void vals;
+    if (!Array.isArray(strings) || !("raw" in strings)) return { __fragment: strings };
+    return Promise.resolve([]);
+  },
+}));
+
+// PARTIAL: `isPassLocked` stays REAL. Replacing it would make this file assert
+// that the page calls a stub, which is precisely the vacuity it exists to avoid.
+vi.mock("@/lib/entitlements", async (orig) => ({
+  ...(await orig<typeof import("@/lib/entitlements")>()),
+  orgPlanKey: async () => h.planKey,
+}));
+vi.mock("@/lib/currency-server", () => ({ preferredCurrency: async () => "usd" }));
+vi.mock("@/lib/resolve-locale", () => ({ resolveLocale: async () => "en" }));
+vi.mock("@/components/billing-banner", () => ({ BillingBanner: () => null }));
+
+// The card chrome, stubbed down to the one thing under test. <CardMenu> renders
+// its items only once OPENED (it is a client popover), so against the real
+// component every assertion below would read "absent" forever — a green suite
+// pinning nothing at all.
+vi.mock("@/components/ui/entity-card", () => ({
+  EntityCard: (p: { name: string; menu?: React.ReactNode }) => (
+    <div data-card={p.name}>{p.menu}</div>
+  ),
+}));
+vi.mock("@/components/ui/card-menu", () => ({
+  CardMenu: (p: { items: Array<{ label: string; href: string }> }) => (
+    <ul data-card-menu>
+      {p.items.map((i) => (
+        <li key={i.href} data-menu-href={i.href}>
+          {i.label}
+        </li>
+      ))}
+    </ul>
+  ),
+}));
+vi.mock("@/components/ui/view-toggle", () => ({
+  ViewToggleContainer: (p: { children?: React.ReactNode }) => <div>{p.children}</div>,
+}));
+
+import Page from "../page";
+import { PASS_END_GRACE_DAYS } from "@/lib/entitlements";
+
+/** The UTC calendar date `offsetDays` from today, as 'YYYY-MM-DD'. The lock
+ *  boundary is a date-only comparison against the UTC day; a local-midnight
+ *  `new Date(...)` sits hours off it, exactly where `<` and `<=` stop being
+ *  distinguishable. */
+const utcDay = (offsetDays: number): string => {
+  const now = new Date();
+  const dayMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return new Date(dayMs + offsetDays * 86_400_000).toISOString().slice(0, 10);
+};
+
+const comp = (over: Partial<(typeof h.competitions)[number]> = {}) => ({
+  id: "comp-1",
+  name: "Summer League",
+  slug: "summer-league",
+  status: "live",
+  ends_on: null as string | null,
+  ...over,
+});
+
+const render = async (): Promise<string> =>
+  renderToStaticMarkup(await Page({ params: Promise.resolve({ orgSlug: "riverside" }) }));
+
+/** Does the card menu invite a pass purchase? Keyed on the HREF rather than on
+ *  the price string: the label is derived from the ladder floor and moves with
+ *  a price change, while the upgrade route is what the offer actually is. */
+const offersPass = (html: string) => html.includes('data-menu-href="/o/riverside/c/summer-league/upgrade"');
+
+beforeEach(() => {
+  h.planKey = "community";
+  h.canEdit = true;
+  h.competitions = [comp()];
+});
+
+describe("the dashboard card menu offers the pass only while it could apply", () => {
+  it("offers it on a running competition — the positive this whole file rests on", async () => {
+    // Without this every absence below is satisfied by a page that offers the
+    // pass to nobody, which is a different bug wearing this fix's clothes.
+    const html = await render();
+    expect(offersPass(html)).toBe(true);
+    expect(html).toContain("Event Pass");
+  });
+
+  it("drops it on a COMPLETED competition", async () => {
+    h.competitions = [comp({ status: "completed" })];
+    const html = await render();
+    expect(offersPass(html)).toBe(false);
+    // The rest of the menu is untouched — this suppresses one item, not the card.
+    expect(html).toContain('data-menu-href="/o/riverside/c/summer-league/schedule"');
+  });
+
+  it("drops it on an ARCHIVED competition", async () => {
+    h.competitions = [comp({ status: "archived" })];
+    expect(offersPass(await render())).toBe(false);
+  });
+
+  it("drops it on a still-LIVE competition whose end date is past the grace week", async () => {
+    // The arm a status filter alone misses entirely, and the common one: nobody
+    // goes back to mark last season 'completed'.
+    h.competitions = [comp({ ends_on: utcDay(-(PASS_END_GRACE_DAYS + 1)) })];
+    expect(offersPass(await render())).toBe(false);
+  });
+
+  it("KEEPS it for a competition sitting exactly on the grace boundary", async () => {
+    // ends_on + grace landing ON today is still applying. The discriminator for
+    // the case above: a gate that refused any past `ends_on` would pass it and
+    // would silently stop selling passes during every competition's final week.
+    h.competitions = [comp({ ends_on: utcDay(-PASS_END_GRACE_DAYS) })];
+    expect(offersPass(await render())).toBe(true);
+  });
+});

--- a/apps/web/src/app/o/[orgSlug]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/page.tsx
@@ -14,7 +14,7 @@ import { CardMenu } from "@/components/ui/card-menu";
 import { ViewToggleContainer } from "@/components/ui/view-toggle";
 import { StatusChip, competitionChipState, CHIP_SORT } from "@/components/ui/status-chip";
 import { sql } from "@/lib/db";
-import { isPaidPlan, orgPlanKey, passLockReason } from "@/lib/entitlements";
+import { isPaidPlan, isPassLocked, orgPlanKey, passLockReason } from "@/lib/entitlements";
 import { formatMinor, isPassKey } from "@/lib/currency";
 import { lowestPassRung } from "@/lib/pass-ladder";
 import { PassSeal } from "@/components/pass-seal";
@@ -221,7 +221,18 @@ export default async function OrgHomePage({
                         // on a paid plan (`passed` is empty and `paidPlan`
                         // suppresses the offer) — never re-sold, never a
                         // downgrade. Editors only: the buy itself is owner-only.
-                        ...(!paidPlan && !heldRung && canEdit
+                        //
+                        // ...and absent once the COMPETITION is over (v17 gap
+                        // #353). The menu offered a purchase for a competition
+                        // that had finished or run a week past its end date —
+                        // money for a pass that would apply to nothing, and on
+                        // the terminal arm unrecoverable (#248 Q4: one pass per
+                        // competition, forever). `isPassLocked` is the same
+                        // predicate the seal above uses, from the row's own
+                        // columns — `listCompetitions` already selects `status`
+                        // and `ends_on` (COLS), so nothing here is undefined and
+                        // silently answering "not locked" for everything.
+                        ...(!paidPlan && !heldRung && canEdit && !isPassLocked(c.status, c.ends_on)
                           ? [
                               {
                                 label: t(dict, "pass.menu.buy", { price: passLabel }),

--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -220,12 +220,20 @@ export default async function BillingPage({
   // already passed. `not exists` is presence-only — a staff-granted pass has a
   // null `stripe_payment_intent` and is fully active, so filtering on payment
   // would re-offer a pass the org already holds.
+  //
+  // `pass_applies` (V343) is the DATE half, and without it this list offered a
+  // $29/$59 purchase the checkout route now refuses outright (v17 gap #353): the
+  // status filter alone leaves a competition that is still 'live' but whose end
+  // date passed months ago — the arm nobody marks completed. The SQL predicate
+  // rather than a second WHERE clause spelling out the grace week, so this list
+  // and the resolver cannot answer the question differently.
   const passCandidates = passOfferable
     ? await sql<PassCandidate[]>`
         select c.id, c.name, c.slug
         from competitions c
         where c.org_id = ${orgId}
           and c.status in ('draft','published','live')
+          and pass_applies(c.status, c.ends_on, (now() at time zone 'utc')::date)
           and not exists (
             select 1 from competition_passes cp where cp.competition_id = c.id)
         order by c.created_at desc

--- a/apps/web/src/components/__tests__/competition-pass-entry.test.tsx
+++ b/apps/web/src/components/__tests__/competition-pass-entry.test.tsx
@@ -303,8 +303,25 @@ describe("CompetitionPassEntry — ended", () => {
   it("still OFFERS the pass when a lock reason arrives with no pass row", () => {
     // Precedence lives in usePassGateState (passKey before lockReason) and this
     // is the surface half of it: an archived competition that never held a pass
-    // must read "none", not invent an ended one. Offering it is right —
-    // competitions.ts still lets a pass be bought for it.
+    // must read "none", not invent an ended one.
+    //
+    // STILL DELIBERATE AFTER v17 gap #353, which is why this test is kept rather
+    // than flipped. #353 made the checkout route the authority: it now 410s an
+    // ended competition, and `passCheckoutErrorKey(410)` gives the buyer
+    // `upgrade.buyError.ended` — the true sentence, not "reload and try again".
+    // The two LIST surfaces (the dashboard card menu, the billing page's offer)
+    // suppress the offer so the refusal is rarely reached; the two surfaces this
+    // component serves — the competition header and competition settings — do
+    // not, and that is the decision.
+    //
+    // The reason they differ: those two are reached by a DIRECT LINK to a
+    // specific competition, often a bookmark or an old email, and the reader is
+    // already standing on the event. Hiding the control there answers nothing —
+    // it leaves an organiser who expected an Event Pass with a page that never
+    // mentions one. Clicking through to a stated "this competition has already
+    // ended, so an Event Pass wouldn't apply to it" tells them why, and no money
+    // moves either way. A list, by contrast, has no reader question to answer:
+    // it is an inventory of things to buy, and an unbuyable line on it is noise.
     const html = render({ lockReason: "terminal" });
     expect(html).toContain(BUY);
     expect(html).not.toContain("data-pass-ended");

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -836,6 +836,7 @@
   "upgrade.buyError.rung": "This pass size isn’t on sale right now. Try the other size, or contact support.",
   "upgrade.buyError.underReview": "We've already taken a payment for this competition and it needs checking before the pass can be issued. We're on it — please don't pay again, and contact support if you haven't heard from us.",
   "upgrade.passUnderReview": "Your payment for this competition went through, but it didn't match the pass size we recorded, so we've held the pass rather than issue the wrong one. Our team has been alerted and will refund you or issue the right pass. Please don't pay again.",
+  "upgrade.buyError.ended": "This competition has already ended, so an Event Pass wouldn’t apply to it.",
   "upgrade.buyError.stale": "This purchase can’t go ahead — the page may be out of date. Reload and try again.",
   "upgrade.buyError.generic": "Checkout is unavailable right now. Please try again.",
   "upgrade.slotNote": "A competition with a pass stops counting against your free competition slots.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -836,6 +836,7 @@
   "upgrade.buyError.rung": "Este tamaño de pase no está a la venta ahora mismo. Prueba con el otro tamaño o escribe a soporte.",
   "upgrade.buyError.underReview": "Ya hemos recibido un pago por esta competición y hay que revisarlo antes de emitir el pase. Estamos en ello: no vuelvas a pagar y contacta con soporte si no tienes noticias nuestras.",
   "upgrade.passUnderReview": "Tu pago por esta competición se completó, pero no coincidía con el tamaño de pase que registramos, así que hemos retenido el pase en lugar de emitir el incorrecto. Nuestro equipo ya está avisado y te devolverá el dinero o emitirá el pase correcto. No vuelvas a pagar.",
+  "upgrade.buyError.ended": "Esta competición ya ha terminado, así que un Event Pass no se aplicaría a ella.",
   "upgrade.buyError.stale": "Esta compra no puede continuar: puede que la página esté desactualizada. Recarga e inténtalo de nuevo.",
   "upgrade.buyError.generic": "El pago no está disponible ahora mismo. Inténtalo de nuevo.",
   "upgrade.slotNote": "Una competición con pase deja de contar en tus plazas de competición gratuitas.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -836,6 +836,7 @@
   "upgrade.buyError.rung": "Cette taille de pass n’est pas en vente pour le moment. Essayez l’autre taille ou contactez le support.",
   "upgrade.buyError.underReview": "Un paiement pour cette compétition a déjà été encaissé et doit être vérifié avant que le pass puisse être émis. Nous nous en occupons : ne payez pas une seconde fois et contactez le support si vous restez sans nouvelles.",
   "upgrade.passUnderReview": "Votre paiement pour cette compétition a bien été encaissé, mais il ne correspondait pas à la taille de pass enregistrée : nous avons donc suspendu le pass plutôt que d'émettre le mauvais. Notre équipe est prévenue et vous remboursera ou émettra le bon pass. Ne payez pas une seconde fois.",
+  "upgrade.buyError.ended": "Cette compétition est déjà terminée : un Event Pass ne s’y appliquerait pas.",
   "upgrade.buyError.stale": "Cet achat ne peut pas aboutir — la page n’est peut-être plus à jour. Rechargez et réessayez.",
   "upgrade.buyError.generic": "Le paiement est indisponible pour le moment. Veuillez réessayer.",
   "upgrade.slotNote": "Une compétition dotée d’un pass ne compte plus dans vos créneaux de compétition gratuits.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -836,6 +836,7 @@
   "upgrade.buyError.rung": "Dit passformaat is nu niet te koop. Probeer het andere formaat of neem contact op met support.",
   "upgrade.buyError.underReview": "We hebben al een betaling voor deze competitie ontvangen en die moet gecontroleerd worden voordat de pass kan worden uitgegeven. We zijn ermee bezig — betaal niet opnieuw en neem contact op met support als je niets hoort.",
   "upgrade.passUnderReview": "Je betaling voor deze competitie is gelukt, maar kwam niet overeen met de pass-grootte die wij hadden vastgelegd. Daarom houden we de pass vast in plaats van de verkeerde uit te geven. Ons team is gewaarschuwd en zal je terugbetalen of de juiste pass uitgeven. Betaal niet opnieuw.",
+  "upgrade.buyError.ended": "Deze competitie is al afgelopen, dus een Event Pass zou er niet op van toepassing zijn.",
   "upgrade.buyError.stale": "Deze aankoop kan niet doorgaan — de pagina is mogelijk verouderd. Herlaad en probeer het opnieuw.",
   "upgrade.buyError.generic": "Afrekenen is nu niet beschikbaar. Probeer het opnieuw.",
   "upgrade.slotNote": "Een competitie met een pass telt niet meer mee voor je gratis competitieplekken.",

--- a/apps/web/src/lib/__tests__/_approved-copy.ts
+++ b/apps/web/src/lib/__tests__/_approved-copy.ts
@@ -120,6 +120,23 @@ export const APPROVED_EVENT_PASS_INVENTORY: string[] = [
   "665584fd0671d579",
   "3f3be96ac6e6be4e",
   "a28f1eacfd464458",
+  // Approved 2026-07-29 (v17 gap #353). ONE new paragraph, inserted here: "The
+  // same line decides when a pass can be BOUGHT. You can buy a pass while its
+  // competition is still running, or during the 7-day grace after its end date;
+  // once a competition has passed that line the purchase is refused rather than
+  // sold, so you can never pay for a pass that would apply to nothing."
+  //
+  // Read against the code before recording, per this file's own rule. The claim
+  // is "the buy window is the same window as the apply window", and the code it
+  // describes is `lib/entitlements.ts`'s `passLockReason` — status in
+  // {completed, archived}, or ends_on + PASS_END_GRACE_DAYS (7) < today (UTC) —
+  // which is now what `api/billing/pass-checkout/route.ts` gates the purchase
+  // on, and what `pass_applies` (V343) gates the billing page's offer list on.
+  // So the two windows are literally the same predicate, and "7 days" is that
+  // constant rather than a number written down twice. "Refused rather than sold"
+  // is the 410, which is raised BEFORE any Stripe session is created — no money
+  // moves, which is the part of the sentence a reader is relying on.
+  "3b3bc011debe7da5",
   "9a68888ef2d9aa1a",
   "c42978cab6965d56",
   "331525dbff809017",

--- a/apps/web/src/lib/__tests__/billing-sync-plan-item.test.ts
+++ b/apps/web/src/lib/__tests__/billing-sync-plan-item.test.ts
@@ -1,0 +1,134 @@
+// #329, the money half: what syncSubscriptionForGroup PERSISTS off a
+// multi-item subscription.
+//
+// A group with an extra-organisation rider carries two subscription items and
+// Stripe does not promise which comes first. The two items report different
+// `current_period_end` — measured at 2027-07-27 (annual plan) against
+// 2026-08-27 (monthly rider) on one live test-mode subscription. While
+// billing.ts read `items.data[0]`, an add-on landing first stamped the group's
+// `current_period_end` eleven months early: an annual customer who paid through
+// 2027 reads as lapsing in 2026, and every renewal/entitlement decision that
+// hangs off that column follows it.
+//
+// Its own file rather than an `it` bolted onto billing-sync-trial-credits.ts:
+// that suite's `stripeSub()` builder is single-item BY CONSTRUCTION (the point
+// it pins is grant ORDER), and widening it to carry add-ons would put the
+// two-item fixture underneath assertions that have nothing to do with it.
+//
+// Real Postgres required; skipped without DATABASE_URL. Seeds are run-unique.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
+import { sql } from "@/lib/db";
+import { syncSubscriptionForGroup } from "@/lib/billing";
+import { ORG_ADDON_FEATURE_KEY } from "@/lib/org-addons";
+import { setOrgPlan } from "./_billing-group";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+const tempPlanKeys: string[] = [];
+
+/** The two period ends measured on the live test-mode subscription that this
+ *  issue was reproduced against: an ANNUAL plan item and a MONTHLY rider. */
+const PLAN_PERIOD_END = Math.floor(Date.UTC(2027, 6, 27) / 1000); // annual plan
+const ADDON_PERIOD_END = Math.floor(Date.UTC(2026, 7, 27) / 1000); // monthly rider
+
+/** A temp plan with a known Stripe price, so the same fixture also pins the
+ *  price→plan_key resolution (billing.ts's other `items.data[0]` read): if that
+ *  one picks the add-on, the price is unknown and the plan key never lands. */
+async function seedPlanWithPrice(): Promise<{ key: string; priceId: string }> {
+  const key = `tmp_plan_${uniq()}`;
+  const priceId = `price_known_${uniq()}`;
+  await sql`insert into plans (key, name, stripe_price_id_annual)
+            values (${key}, ${"Temp " + key}, ${priceId})`;
+  tempPlanKeys.push(key);
+  return { key, priceId };
+}
+
+async function seedOrg(): Promise<string> {
+  const suffix = uniq();
+  const [owner] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`plan-item-${suffix}@test.local`}, 'Plan Item Owner', true) returning id`;
+  const [org] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"Plan Item Org " + suffix}, ${"plan-item-org-" + suffix}, ${owner!.id}) returning id`;
+  return org!.id;
+}
+
+/** The shape the webhook actually hands us for a group that bought an extra
+ *  organisation: TWO items, the RIDER first. Stripe's ordering is not a
+ *  contract, so "first" here is not a contrivance — it is one of the two
+ *  orderings production sees, and the one nothing was defending against. */
+function twoItemSub(planPriceId: string): Stripe.Subscription {
+  return {
+    id: `sub_${uniq()}`,
+    status: "active",
+    trial_end: null,
+    cancel_at_period_end: false,
+    currency: "usd",
+    items: {
+      data: [
+        {
+          id: "si_rider",
+          price: { id: `price_rider_${uniq()}` },
+          current_period_end: ADDON_PERIOD_END,
+          metadata: { feature_key: ORG_ADDON_FEATURE_KEY },
+        },
+        {
+          id: "si_plan",
+          price: { id: planPriceId },
+          current_period_end: PLAN_PERIOD_END,
+          metadata: {},
+        },
+      ],
+    },
+  } as unknown as Stripe.Subscription;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  if (tempPlanKeys.length) {
+    // Same teardown order as billing-sync-trial-credits.test.ts: orgs let go of
+    // the group (organizations_subscription_fk) before the subscriptions row
+    // referencing the temp plan can go, before plan_entitlements/plans.
+    await sql`
+      update organizations set subscription_id = null
+       where subscription_id in (select id from subscriptions
+                                  where plan_key = any(${tempPlanKeys}))`;
+    await sql`delete from subscriptions where plan_key = any(${tempPlanKeys})`;
+    await sql`delete from plan_entitlements where plan_key = any(${tempPlanKeys})`;
+    await sql`delete from plans where key = any(${tempPlanKeys})`;
+  }
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("syncSubscriptionForGroup with an add-on item present (#329)", () => {
+  it("stamps current_period_end from the PLAN item, not from whichever item is first", async () => {
+    const { key, priceId } = await seedPlanWithPrice();
+    const orgId = await seedOrg();
+    const groupId = await setOrgPlan(orgId, "pro", "active");
+
+    await syncSubscriptionForGroup(groupId, twoItemSub(priceId));
+
+    const [row] = await sql<{ current_period_end: string | null; plan_key: string }[]>`
+      select current_period_end, plan_key from subscriptions where id = ${groupId}`;
+
+    expect(row?.current_period_end).not.toBeNull();
+    expect(new Date(row!.current_period_end!).toISOString()).toBe(
+      new Date(PLAN_PERIOD_END * 1000).toISOString(),
+    );
+    // The rider's own end must never be what we stored — that is the eleven
+    // months, spelled out so a regression reads as the bug and not as an
+    // off-by-something.
+    expect(new Date(row!.current_period_end!).toISOString()).not.toBe(
+      new Date(ADDON_PERIOD_END * 1000).toISOString(),
+    );
+    // Same read, other consumer: the price we resolve the plan from is the
+    // plan item's, so the group actually lands on the purchased plan.
+    expect(row?.plan_key).toBe(key);
+  });
+});

--- a/apps/web/src/lib/__tests__/entitlements-canceled-plan.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-canceled-plan.test.ts
@@ -18,7 +18,7 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
 import { sql } from "@/lib/db";
-import { getLimit, hasFeature, orgPlanKey } from "@/lib/entitlements";
+import { addonBonusForWallet, getLimit, hasFeature, orgPlanKey } from "@/lib/entitlements";
 import { groupOrgLimit } from "@/lib/billing-group";
 import { processStripeEvent } from "@/server/usecases/billing-events";
 import type Stripe from "stripe";
@@ -147,9 +147,11 @@ describe.skipIf(!HAS_DB)("a cancelled subscription does not convey its plan", ()
 // webhook handler.
 const COMMUNITY_MAX_OWNED = 1;
 
-/** A group with a Stripe subscription id, one org, and add-on rows on three
- *  distinct axes: a PURCHASED extra-org rider, an ADMIN comp of the same cap,
- *  and a purchased SEAT rider. Only the first may die with the subscription. */
+/** A group with a Stripe subscription id, one org, and add-on rows on four
+ *  distinct axes: a PURCHASED extra-org rider, an ADMIN comp of that cap, a
+ *  purchased SEAT rider and an ADMIN comp of THAT cap. Churn cancels the two
+ *  PURCHASED rows (#293 for orgs, #330 for seats) and neither comp: the split
+ *  is what Stripe was billing, not which cap the row lifts. */
 async function seedChurnGroup(): Promise<{
   orgId: string;
   subId: string;
@@ -177,7 +179,8 @@ async function seedChurnGroup(): Promise<{
     values
       (${subId}, null, 'orgs.max_owned', 1, 2, ${`si_org_${suffix}`}, 'active'),
       (${subId}, null, 'orgs.max_owned', 1, 1, null, 'granted'),
-      (${subId}, null, 'members.max', 1, 3, ${`si_seat_${suffix}`}, 'active')`;
+      (${subId}, null, 'members.max', 1, 3, ${`si_seat_${suffix}`}, 'active'),
+      (${subId}, null, 'members.max', 1, 1, null, 'granted')`;
   return { orgId, subId, stripeSubId };
 }
 
@@ -243,22 +246,36 @@ describe.skipIf(!HAS_DB)("churn cancels the recurring add-ons it was renting", (
     expect(granted!.status).toBe("granted");
   });
 
-  // PINNED BUG, not an invariant. Seats have the same churn hole this describe
-  // block closes for orgs.max_owned: a `members.max` rider outlives the
-  // subscription that paid for it. That is INHERITED, not introduced by v17 gap
-  // #293, and is tracked as issue #330. This test records TODAY's behaviour so
-  // the #293 cancel is proven not to reach across feature keys; when #330 is
-  // fixed, THIS is the test that should go red, and flipping it to 'canceled'
-  // is the expected edit.
-  it("PINNED BUG #330: the seat rider survives churn — it must go red when #330 is fixed", async () => {
-    const { subId, stripeSubId } = await seedChurnGroup();
+  // #330, the seat half of the same hole. This test was the PINNED BUG left
+  // behind by #293 — it asserted `active`, recording that the churn cancel did
+  // not reach across feature keys — and flipping it to 'canceled' is exactly
+  // the edit that issue predicted. syncSeatAddonsForSubscription runs only on
+  // `customer.subscription.updated` and a DELETED subscription still reports
+  // its items, so nothing else ever cancelled these rows: a churned group kept
+  // `community base + 3` seats for ever, unpaid.
+  it("REGRESSION (#330): a deleted subscription cancels the SEAT rider too", async () => {
+    const { orgId, subId, stripeSubId } = await seedChurnGroup();
+    // purchased 3 + admin comp 1, on top of whatever the plan grants.
+    expect(await addonBonusForWallet(subId, "members.max", orgId)).toBe(4);
 
     await processStripeEvent(deletedEvent(stripeSubId, subId));
 
-    const [seat] = await sql<{ status: string }[]>`
-      select status from org_addons
-       where wallet_id = ${subId} and feature_key = 'members.max'`;
-    expect(seat!.status).toBe("active");
+    // The purchased rider FREEZES (V323/V324 — row and qty kept for history and
+    // for a re-buy); the admin comp is untouched, because a grant is capacity
+    // the group was GIVEN, not something Stripe was billing.
+    const rows = await sql<{ stripe_item_id: string | null; qty: number; status: string }[]>`
+      select stripe_item_id, qty, status from org_addons
+       where wallet_id = ${subId} and feature_key = 'members.max'
+       order by stripe_item_id nulls last`;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.stripe_item_id).not.toBeNull();
+    expect(rows[0]!.status).toBe("canceled");
+    expect(rows[0]!.qty).toBe(3);
+    expect(rows[1]!.stripe_item_id).toBeNull();
+    expect(rows[1]!.status).toBe("granted");
+
+    // …so the seat cap falls back to the plan base plus the comp alone.
+    expect(await addonBonusForWallet(subId, "members.max", orgId)).toBe(1);
   });
 
   it("refuses to cancel another group's rows when the delete may not write", async () => {
@@ -271,5 +288,8 @@ describe.skipIf(!HAS_DB)("churn cancels the recurring add-ons it was renting", (
 
     expect(await orgPlanKey(orgId)).toBe("pro");
     expect(await getLimit(orgId, "orgs.max_owned")).toBe(8);
+    // Both families, not just the one #293 added: the seat cancel (#330) sits
+    // after the same return, so a replayed delete must not strip seats either.
+    expect(await addonBonusForWallet(subId, "members.max", orgId)).toBe(4);
   });
 });

--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -263,6 +263,43 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     });
   }
 
+  // v17 #347: V343 lifted the pass arm's predicate out of org_has_feature into
+  // `pass_applies(status, ends_on, today)`, so the two TS ENFORCEMENT sites
+  // (competitions.ts's active-comp quota, entitlement-freeze.ts's candidate
+  // loader + count) could ask the lock question instead of "does a pass row
+  // exist". That makes pass_applies a THIRD public copy of SPEC-4 §7's rule,
+  // and this suite is where copies get tied together: assert it against
+  // passLockReason directly, arm by arm, rather than only through
+  // org_has_feature — the enforcement sites call the function, not the resolver,
+  // so a drift there would not show up in any case above.
+  //
+  // `today` is passed explicitly as the UTC calendar date, the same basis
+  // passLockReason computes on (V334). Dates are UTC-midnight STRINGS: a
+  // `new Date()`-derived value carries a time of day and lands ~20h off the
+  // boundary, where the rule's strict `<` and a buggy `<=` are
+  // indistinguishable (#346).
+  it("pass_applies (V343) answers exactly what passLockReason answers", async () => {
+    const shapes: [label: string, status: string, endsOn: string | null][] = [
+      ["archived (terminal)", "archived", null],
+      ["completed (terminal)", "completed", null],
+      // Terminal wins even with a perfectly current ends_on — the arms are
+      // OR'd, and a completed competition inside its grace must still lock.
+      ["archived with a live ends_on", "archived", utcDayString(0)],
+      ["live, exactly ON the grace boundary", "live", utcDayString(-PASS_END_GRACE_DAYS)],
+      ["live, one day PAST the grace boundary", "live", utcDayString(-PASS_END_GRACE_DAYS - 1)],
+      ["live, no ends_on at all", "live", null],
+    ];
+    for (const [label, status, endsOn] of shapes) {
+      const [row] = await sql<{ v: boolean }[]>`
+        select pass_applies(${status}, ${endsOn}::date,
+                            (now() at time zone 'utc')::date) as v`;
+      const tsApplies = passLockReason(status, endsOn) === null;
+      expect(`${label}: sql=${row.v} ts=${tsApplies}`).toBe(
+        `${label}: sql=${tsApplies} ts=${tsApplies}`,
+      );
+    }
+  });
+
   it("coalesces a null-bool Event Pass row THROUGH to the plan, not into a deny", async () => {
     // A pass row whose bool_value is null is NO answer, not a deny: it must fall
     // through to the plan row, exactly as org_has_feature's coalesce does.

--- a/apps/web/src/lib/__tests__/pass-checkout-plan-gate.test.ts
+++ b/apps/web/src/lib/__tests__/pass-checkout-plan-gate.test.ts
@@ -85,6 +85,7 @@ import { sql } from "@/lib/db";
 import { POST as passCheckoutPOST } from "@/app/api/billing/pass-checkout/route";
 import { maybeAlertPassRungMismatch, reconcilePassCheckout } from "@/lib/billing";
 import { passCheckoutErrorKey } from "@/lib/pass-ladder";
+import { PASS_END_GRACE_DAYS } from "@/lib/entitlements";
 import { processStripeEvent } from "@/server/usecases/billing-events";
 import { balance, walletIdFor } from "@/lib/credits";
 import { PASS_CREDIT_GRANT } from "@/lib/pricing-cards";
@@ -99,6 +100,28 @@ async function seedOrgWithComp(): Promise<{ orgId: string; compId: string }> {
   const [{ id: compId }] = await sql<{ id: string }[]>`
     insert into competitions (org_id, name, slug)
     values (${orgId}, ${"Gate Cup " + suffix}, ${"gate-cup-" + suffix}) returning id`;
+  return { orgId, compId };
+}
+
+/** `seedOrgWithComp` plus the `subscriptions` row every org gets at creation,
+ *  on the free plan — an org that is genuinely eligible to buy a pass, with
+ *  `authState` already pointed at it. Module-scope (it was local to the #301
+ *  describe) so the #353 suite below buys from the same fixture: a refusal is
+ *  only meaningful against an org that could otherwise have bought. */
+async function seedCommunityOrgWithComp(): Promise<{ orgId: string; compId: string }> {
+  const { orgId, compId } = await seedOrgWithComp();
+  await sql`with _owner as (
+    insert into users (email, display_name, email_verified)
+    values ('seedowner-' || gen_random_uuid() || '@test.local', 'Seed Owner', true)
+    returning id
+  ),
+  _seed_sub as (
+    insert into subscriptions (owner_user_id, plan_key, status, currency)
+    select coalesce(o.created_by, (select id from _owner)), 'community', 'active', 'usd' from organizations o where o.id = ${orgId}
+    returning id
+  )
+  update organizations set subscription_id = (select id from _seed_sub) where id = ${orgId}`;
+  authState.orgId = orgId;
   return { orgId, compId };
 }
 
@@ -990,22 +1013,8 @@ describe.skipIf(!HAS_DB)("pass-checkout refuses a re-buy truthfully, locked or n
   // two. The rule itself never changes (decision #248 Q4: one pass per
   // competition, forever), so the sentence is now true in BOTH states rather
   // than branching — and these two cases pin exactly that.
-  async function seedCommunityOrgWithComp() {
-    const { orgId, compId } = await seedOrgWithComp();
-    await sql`with _owner as (
-      insert into users (email, display_name, email_verified)
-      values ('seedowner-' || gen_random_uuid() || '@test.local', 'Seed Owner', true)
-      returning id
-    ),
-    _seed_sub as (
-      insert into subscriptions (owner_user_id, plan_key, status, currency)
-      select coalesce(o.created_by, (select id from _owner)), 'community', 'active', 'usd' from organizations o where o.id = ${orgId}
-      returning id
-    )
-    update organizations set subscription_id = (select id from _seed_sub) where id = ${orgId}`;
-    authState.orgId = orgId;
-    return { orgId, compId };
-  }
+  //
+  // The fixture moved to module scope so the #353 suite below shares it.
 
   it("refuses a re-buy on an ACTIVE pass, without claiming present-tense possession", async () => {
     const { compId, orgId } = await seedCommunityOrgWithComp();
@@ -1050,5 +1059,82 @@ describe.skipIf(!HAS_DB)("pass-checkout refuses a re-buy truthfully, locked or n
     const endedBody = await (await passCheckoutPOST(req(ended.compId))).json();
 
     expect(endedBody.error).toBe(liveBody.error);
+  });
+});
+
+// v17 gap #353 — an Event Pass could be SOLD for a competition the lock rule
+// had already ended.
+//
+// The route read `slug, name, org_id` and nothing else, so a FIRST purchase was
+// never judged against `status`/`ends_on`. The money landed, the pass minted,
+// and every surface in the product said "Event Pass ended" the same second —
+// and on the terminal arm the buyer could not even try again, because decision
+// #248 Q4 (one pass per competition, forever, enforced by the
+// `competition_passes` PK) means there is no second purchase to make. They lost
+// the $29/$59 AND their one chance at it.
+//
+// Dates are written as explicit UTC CALENDAR strings, derived from the UTC
+// getters rather than from a local-midnight `new Date(...)`: the grace boundary
+// is a date-only comparison against the UTC day, and a local-midnight date sits
+// hours off it — exactly where `<` and `<=` become indistinguishable.
+describe.skipIf(!HAS_DB)("pass-checkout refuses a competition that has already ended (#353)", () => {
+  /** The UTC calendar date `offsetDays` from today, as 'YYYY-MM-DD'. */
+  const utcDay = (offsetDays: number): string => {
+    const now = new Date();
+    const dayMs = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+    return new Date(dayMs + offsetDays * 86_400_000).toISOString().slice(0, 10);
+  };
+
+  /** Did the route mint anything? A refusal that still wrote the row would be
+   *  the same defect with a different status code. */
+  const passExists = async (compId: string): Promise<boolean> => {
+    const rows = await sql<{ competition_id: string }[]>`
+      select competition_id from competition_passes where competition_id = ${compId}`;
+    return rows.length > 0;
+  };
+
+  it("410s a LIVE competition whose end date is past the grace window", async () => {
+    // Still 'live' — the organiser never marked it completed. Only the date has
+    // moved, which is the arm a status-only filter misses entirely, and the one
+    // that is RECOVERABLE (moving the end date makes the pass buyable again).
+    const { compId } = await seedCommunityOrgWithComp();
+    await givePrice();
+    await sql`update competitions set ends_on = ${utcDay(-(PASS_END_GRACE_DAYS + 1))}
+               where id = ${compId}`;
+
+    const res = await passCheckoutPOST(req(compId));
+    expect(res.status).toBe(410);
+    expect(stripeMock.checkoutCreate).not.toHaveBeenCalled();
+    expect(await passExists(compId)).toBe(false);
+    // The buyer reads a localised sentence, never the server's English. 410 is
+    // its OWN arm and not the generic 4xx "reload and try again", which would be
+    // a confident lie: reloading an ended competition changes nothing.
+    expect(passCheckoutErrorKey(410)).toBe("upgrade.buyError.ended");
+    expect(passCheckoutErrorKey(410)).not.toBe(passCheckoutErrorKey(400));
+  });
+
+  it("410s an ARCHIVED competition — the arm the buyer can never recover from", async () => {
+    const { compId } = await seedCommunityOrgWithComp();
+    await givePrice();
+    await sql`update competitions set status = 'archived' where id = ${compId}`;
+
+    const res = await passCheckoutPOST(req(compId));
+    expect(res.status).toBe(410);
+    expect(stripeMock.checkoutCreate).not.toHaveBeenCalled();
+    expect(await passExists(compId)).toBe(false);
+  });
+
+  it("still SELLS a competition sitting exactly on the grace boundary", async () => {
+    // ends_on + grace landing ON today is still applying (`passLockReason`'s
+    // strictly-less `<`). The discriminator for both refusals above: a gate that
+    // simply refused anything with an `ends_on` in the past would pass them and
+    // would stop selling passes for every competition in its final week.
+    const { compId } = await seedCommunityOrgWithComp();
+    await givePrice();
+    await sql`update competitions set ends_on = ${utcDay(-PASS_END_GRACE_DAYS)}
+               where id = ${compId}`;
+
+    expect((await passCheckoutPOST(req(compId))).status).toBe(200);
+    expect(stripeMock.checkoutCreate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/__tests__/pass-ladder.test.ts
+++ b/apps/web/src/lib/__tests__/pass-ladder.test.ts
@@ -192,9 +192,23 @@ describe("passCheckoutErrorKey", () => {
     // and 401/404 add two more. They differ in cause and NOT in remedy.
     //
     // 409 is deliberately NOT in this list any more (v17 gap #326): see below.
+    // Neither is 410 (v17 gap #353) — same reason, different remedy.
     for (const status of [400, 401, 402, 404, 429]) {
       expect(passCheckoutErrorKey(status)).toBe("upgrade.buyError.stale");
     }
+  });
+
+  it("does NOT tell a buyer to reload a competition that is over (410)", () => {
+    // v17 gap #353. The route refuses a purchase for a completed, archived or
+    // past-grace competition, because the pass would apply to nothing. 410 sits
+    // INSIDE the 4xx range, so only the arm ordering keeps it out of the stale
+    // bucket — and "the page may be out of date, reload and try again" is a lie
+    // to this reader twice over: reloading changes nothing, and on the terminal
+    // arm nothing the buyer can do changes anything (#248 Q4 — one pass per
+    // competition, forever, and this one was never bought).
+    expect(passCheckoutErrorKey(410)).toBe("upgrade.buyError.ended");
+    expect(passCheckoutErrorKey(410)).not.toBe(passCheckoutErrorKey(400));
+    expect(passCheckoutErrorKey(410)).not.toBe(passCheckoutErrorKey(409));
   });
 
   it("does NOT tell an already-charged buyer to reload and try again (409)", () => {

--- a/apps/web/src/lib/__tests__/pass-quota-freeze-lock.test.ts
+++ b/apps/web/src/lib/__tests__/pass-quota-freeze-lock.test.ts
@@ -1,0 +1,158 @@
+// v17 gap #347 — the two ENFORCEMENT sites must ask the same question the
+// RESOLVER asks: "is this competition's Event Pass still applying?", not "does
+// a competition_passes row exist?".
+//
+// `competitions.ts`'s assertActiveQuota and `entitlement-freeze.ts`'s candidate
+// loader + count both exempted a competition on bare row existence. Both also
+// filter on ACTIVE_COMPETITION_STATUSES (draft/published/live), which
+// incidentally covers the lock rule's `terminal` arm — an archived/completed
+// competition is excluded anyway — but covers NOTHING of the `past_ends_on`
+// arm. Nothing retires a `live` competition past its end date, so a competition
+// still marked `live` whose ends_on passed more than PASS_END_GRACE_DAYS ago
+// kept its exemption FOR EVER: permanently outside `competitions.max_active`
+// and permanently immune to freezing, on a pass `passLockReason` (TS) and V338
+// (SQL) had both already stopped honouring. One $29 pass bought a free active
+// slot in perpetuity.
+//
+// Real Postgres required; skipped without DATABASE_URL. Seeds are run-unique.
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { getLimit, invalidateOrgEntitlements, PASS_END_GRACE_DAYS } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition } from "@/server/usecases/competitions";
+import { frozenCompetitionIds } from "@/server/usecases/entitlement-freeze";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+/** A UTC-midnight 'YYYY-MM-DD' STRING `offsetDays` from today.
+ *
+ *  A STRING, never a `new Date()`-derived Date: a Date carries a time of day,
+ *  so "N days ago" lands ~20h off the boundary the rule compares against, and
+ *  the strict `<` the rule is built on becomes indistinguishable from a buggy
+ *  `<=`. That is exactly how a mutation shipped green in #346. */
+const utcDayString = (offsetDays: number): string => {
+  const now = new Date();
+  const ms = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return new Date(ms + offsetDays * 86_400_000).toISOString().slice(0, 10);
+};
+
+/** Community org with an explicit subscriptions row. A raw
+ *  `insert into organizations` does NOT create one (only lib/auth.ts does), and
+ *  the pass arm only fires while the resolved plan is 'community'. */
+async function seedCommunityOrg(): Promise<{ orgId: string; auth: AuthCtx }> {
+  const s = uniq();
+  const [{ id: ownerId }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`quota-${s}@test.local`}, 'Quota Owner', true) returning id`;
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, created_by)
+    values (${"Quota Org " + s}, ${"quota-org-" + s}, ${ownerId}) returning id`;
+  await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
+  await sql`
+    with _owner as (
+      insert into users (email, display_name, email_verified)
+      values ('seedowner-' || gen_random_uuid() || '@test.local', 'Seed Owner', true)
+      returning id
+    ),
+    _seed_sub as (
+      insert into subscriptions (owner_user_id, plan_key, status)
+      select coalesce(o.created_by, (select id from _owner)), 'community', 'active'
+      from organizations o where o.id = ${orgId}
+      returning id
+    )
+    update organizations set subscription_id = (select id from _seed_sub) where id = ${orgId}`;
+  await invalidateOrgEntitlements(orgId);
+  return { orgId, auth: { orgId, via: "session", userId: ownerId, role: "owner", keyId: null } };
+}
+
+/** `n` plain ACTIVE (live) competitions, no pass, created just now — so they
+ *  are all more recently active than the passed competition below, and the
+ *  freeze selector picks the passed one when the org is one over quota. */
+async function seedPlainActive(orgId: string, n: number): Promise<void> {
+  if (n <= 0) return;
+  const s = uniq();
+  await sql`
+    insert into competitions (org_id, name, slug, status)
+    select ${orgId}, 'Plain ' || g || ' ' || ${s}, ${"plain-" + s + "-"} || g, 'live'
+    from generate_series(1, ${n}) g`;
+}
+
+/** One `live` competition carrying an Event Pass, with an explicit ends_on.
+ *  created_at is pinned in the past so it is the LEAST recently active
+ *  candidate — the one the freeze selector must pick first. */
+async function seedPassedCompetition(orgId: string, endsOn: string): Promise<string> {
+  const s = uniq();
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug, status, ends_on, created_at)
+    values (${orgId}, ${"Passed " + s}, ${"passed-" + s}, 'live', ${endsOn}::date,
+            timestamptz '2020-01-01 00:00:00+00')
+    returning id`;
+  await sql`insert into competition_passes (competition_id, org_id) values (${id}, ${orgId})`;
+  await invalidateOrgEntitlements(orgId);
+  return id;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("an Event Pass exempts its competition only while the pass APPLIES (#347)", () => {
+  let orgId: string;
+  let auth: AuthCtx;
+  let limit: number;
+
+  beforeEach(async () => {
+    ({ orgId, auth } = await seedCommunityOrg());
+    // Read the ceiling rather than hard-coding it — the community cap has moved
+    // three times (V112 2, V270 1, V311 5, V319 10) and this suite is about the
+    // predicate, not the number.
+    const resolved = await getLimit(orgId, "competitions.max_active");
+    expect(resolved).not.toBeNull();
+    limit = resolved as number;
+  });
+
+  const create = (name: string) =>
+    createCompetition(auth, { name: `${name} ${uniq()}`, visibility: "private", branding: {} });
+
+  it("REGRESSION (#347): a pass on a LONG-ENDED live competition stops buying it out of the quota", async () => {
+    await seedPlainActive(orgId, limit - 1);
+    await seedPassedCompetition(orgId, utcDayString(-(PASS_END_GRACE_DAYS + 1)));
+    // The org now holds exactly `limit` active competitions, one of them a
+    // `live` row whose pass the resolver stopped honouring a day ago. It must
+    // COUNT, so the next create is one too many.
+    await expect(create("one too many")).rejects.toMatchObject({ status: 402 });
+  });
+
+  it("a pass EXACTLY on the grace boundary still buys the competition out (strict <)", async () => {
+    await seedPlainActive(orgId, limit - 1);
+    await seedPassedCompetition(orgId, utcDayString(-PASS_END_GRACE_DAYS));
+    // ends_on + grace lands exactly ON today: still applying, so the passed
+    // competition is exempt and the org is one under its ceiling. This is the
+    // guard against "fix" it by counting every passed competition.
+    await expect(create("still fine")).resolves.toBeTruthy();
+  });
+
+  it("REGRESSION (#347): a locked pass no longer makes its competition unfreezable", async () => {
+    await seedPlainActive(orgId, limit);
+    const compId = await seedPassedCompetition(orgId, utcDayString(-(PASS_END_GRACE_DAYS + 1)));
+    // limit + 1 active competitions: exactly one must freeze, and the passed
+    // one is the least recently active, so it is that one.
+    expect([...(await frozenCompetitionIds(orgId))]).toContain(compId);
+  });
+
+  it("a pass ON the boundary still keeps its competition out of the freeze set", async () => {
+    await seedPlainActive(orgId, limit);
+    const compId = await seedPassedCompetition(orgId, utcDayString(-PASS_END_GRACE_DAYS));
+    // Still applying ⇒ neither counted nor a freeze candidate: the org sits at
+    // exactly `limit` countable competitions, so nothing freezes at all.
+    const frozen = [...(await frozenCompetitionIds(orgId))];
+    expect(frozen).not.toContain(compId);
+    expect(frozen).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/__tests__/subscription-items.test.ts
+++ b/apps/web/src/lib/__tests__/subscription-items.test.ts
@@ -1,0 +1,60 @@
+// #329: `items.data[0]` is not "the single item" any more. A group with an
+// extra-organisation rider or extra seats carries TWO items, Stripe does not
+// promise which comes first, and the two report DIFFERENT `current_period_end`
+// — measured at 2027-07-27 (annual plan) against 2026-08-27 (monthly rider) on
+// one live test-mode subscription. Pure unit test: no DB, no Stripe.
+import { describe, expect, it } from "vitest";
+import type Stripe from "stripe";
+import { planItem } from "@/lib/subscription-items";
+import { ORG_ADDON_FEATURE_KEY } from "@/lib/org-addons";
+import { SEAT_ADDON } from "@/lib/seat-addons";
+
+const item = (
+  id: string,
+  periodEnd: number,
+  metadata: Record<string, string> = {},
+): Stripe.SubscriptionItem =>
+  ({
+    id,
+    current_period_end: periodEnd,
+    metadata,
+    // No `lookup_key`: the unexpanded-price shape, which is what forces both
+    // isSeatAddonItem and isOrgAddonItem onto their metadata fallbacks — the
+    // weaker of the two identifications, so the one worth pinning.
+    price: { id: `price_${id}` },
+  }) as unknown as Stripe.SubscriptionItem;
+
+const sub = (items: Stripe.SubscriptionItem[]): Stripe.Subscription =>
+  ({ items: { data: items } }) as unknown as Stripe.Subscription;
+
+describe("planItem", () => {
+  it("picks the plan item even when an add-on is FIRST in items.data (#329)", () => {
+    const addon = item("si_addon", 1_787_000_000, { feature_key: ORG_ADDON_FEATURE_KEY });
+    const plan = item("si_plan", 1_816_000_000);
+    // Stripe does not guarantee order; the add-on landing first is what stamped
+    // an annual group with the monthly rider's period end, eleven months early.
+    expect(planItem(sub([addon, plan]))?.id).toBe("si_plan");
+    expect(planItem(sub([addon, plan]))?.current_period_end).toBe(1_816_000_000);
+  });
+
+  it("ignores a seat add-on item (target_org_id + members.max, as extra-seats.ts stamps it)", () => {
+    const seat = item("si_seat", 1_787_000_000, {
+      target_org_id: "11111111-1111-1111-1111-111111111111",
+      feature_key: SEAT_ADDON.featureKey,
+    });
+    const plan = item("si_plan", 1_816_000_000);
+    expect(planItem(sub([seat, plan]))?.id).toBe("si_plan");
+  });
+
+  it("returns null rather than guessing when every item is an add-on", () => {
+    const seat = item("si_seat", 1, {
+      target_org_id: "11111111-1111-1111-1111-111111111111",
+      feature_key: SEAT_ADDON.featureKey,
+    });
+    expect(planItem(sub([seat]))).toBeNull();
+  });
+
+  it("returns null on an empty subscription", () => {
+    expect(planItem(sub([]))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -14,6 +14,7 @@ import { grantTrialForRow, recordPassGrant, recordPassRefund, walletIdFor } from
 import { PASS_KEYS, isPassKey, type PassKey } from "@/lib/currency";
 import stripePlans from "@/config/stripe-plans.json";
 import { PASS_CREDIT_GRANT } from "@/lib/pricing-cards";
+import { planItem } from "@/lib/subscription-items";
 import { creditPassTowardSubscription } from "@/server/usecases/pass-credit";
 import { sendPassRungMismatchAlertEmail } from "@/lib/email";
 
@@ -730,7 +731,10 @@ export async function syncSubscriptionForGroup(
   subscriptionId: string,
   stripeSub: Stripe.Subscription,
 ): Promise<void> {
-  const priceId = stripeSub.items.data[0]?.price?.id ?? null;
+  // The PLAN item's price, not `data[0]`'s: an add-on's price maps to no `plans`
+  // row, so picking it by position resolved "unknown price" and left the group
+  // on whatever plan_key it already had (#329).
+  const priceId = planItem(stripeSub)?.price?.id ?? null;
   const knownPlanKey = priceId ? await planKeyForPrice(priceId) : null;
   // Unknown price (grandfathered/migrated in Stripe but not synced into `plans`):
   // keep the org's current plan instead of silently downgrading every affected
@@ -763,8 +767,11 @@ export async function syncSubscriptionForGroup(
   // that lands here corrects itself on the next webhook once the status is
   // mapped; the reverse mistake bills nobody and entitles everybody.
   const status = mapped ?? "incomplete";
-  // In Stripe v22, current_period_end lives on each subscription item.
-  const periodEnd = stripeSub.items.data[0]?.current_period_end ?? null;
+  // In Stripe v22, current_period_end lives on each subscription ITEM — and a
+  // group with an add-on has more than one, on different cycles. Reading
+  // `data[0]` stamped an annual group with a monthly rider's period end,
+  // eleven months early, whenever Stripe returned the rider first (#329).
+  const periodEnd = planItem(stripeSub)?.current_period_end ?? null;
   // null = this object cannot answer; see paymentMethodFromStripeSubscription.
   const hasPm = paymentMethodFromStripeSubscription(stripeSub);
 

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -3327,6 +3327,7 @@ export type DictionaryKey =
   | "upgrade.active.title"
   | "upgrade.backToCompetition"
   | "upgrade.buyCta"
+  | "upgrade.buyError.ended"
   | "upgrade.buyError.generic"
   | "upgrade.buyError.rung"
   | "upgrade.buyError.stale"

--- a/apps/web/src/lib/pass-ladder.ts
+++ b/apps/web/src/lib/pass-ladder.ts
@@ -226,7 +226,7 @@ export const PASS_RUNG_MARKETING_KEY: Record<PassKey, DictionaryKey> = {
  * is one unhandled throw away from being rendered to a buyer as purchase
  * advice. Mapping on status makes that structurally impossible.
  *
- * Four buckets, and the 4xx one is deliberately NOT narrowed to "bad rung":
+ * Five buckets, and the 4xx one is deliberately NOT narrowed to "bad rung":
  *
  *   409  a previous payment for this competition was taken and then REFUSED by
  *        the mint guard (v17 gap #326), so the sale is frozen until staff
@@ -236,6 +236,16 @@ export const PASS_RUNG_MARKETING_KEY: Record<PassKey, DictionaryKey> = {
  *        it has already been charged. It is the one refusal on this route the
  *        buyer cannot clear by any action at all, so the copy says what
  *        happened to their money instead of asking them to retry.
+ *   410  the competition itself is over — completed, archived, or more than the
+ *        grace week past its end date — so the pass would apply to nothing
+ *        (v17 gap #353). Split out of the 4xx bucket for the same reason 409 is,
+ *        and it is worth being precise about how it differs from `stale`: a
+ *        stale page is a page RELOADING fixes, and reloading fixes nothing here.
+ *        On the recoverable arm the remedy is off this page entirely — move the
+ *        competition's end date, or reopen it — and on the terminal arm there is
+ *        no remedy at all, because a pass cannot be bought twice for one
+ *        competition (#248 Q4) and this one was never bought once. So the copy
+ *        states the fact rather than issuing an instruction that cannot work.
  *   503  the only thing this route 503s for is a rung whose one-time price has
  *        not been `stripe:sync`'d in this environment. Unambiguous as a CAUSE,
  *        so the copy names the rung — but it says "try the other size" rather
@@ -253,6 +263,9 @@ export const PASS_RUNG_MARKETING_KEY: Record<PassKey, DictionaryKey> = {
  */
 export function passCheckoutErrorKey(status: number | null): DictionaryKey {
   if (status === 409) return "upgrade.buyError.underReview";
+  // Ahead of the 4xx arm below, which would otherwise swallow it: 410 is inside
+  // that range, and order is the only thing keeping these two apart.
+  if (status === 410) return "upgrade.buyError.ended";
   if (status === 503) return "upgrade.buyError.rung";
   if (status !== null && status >= 400 && status < 500) return "upgrade.buyError.stale";
   return "upgrade.buyError.generic";

--- a/apps/web/src/lib/subscription-items.ts
+++ b/apps/web/src/lib/subscription-items.ts
@@ -1,0 +1,34 @@
+import type Stripe from "stripe";
+import { isSeatAddonItem } from "@/lib/seat-addons";
+import { isOrgAddonItem } from "@/lib/org-addons";
+
+/**
+ * The PLAN item on a group's Stripe subscription.
+ *
+ * `items.data[0]` used to be an acceptable shorthand for this and is not any
+ * more (#329). A group with an extra-organisation rider carries two items,
+ * Stripe does not promise which comes first, and the two report DIFFERENT
+ * `current_period_end` values — measured at 2027-07-27 (annual plan) against
+ * 2026-08-27 (monthly rider) on one live test-mode subscription. Persisting
+ * the wrong one dates an annual group eleven months early.
+ *
+ * Identified by ELIMINATION, because that is the direction that stays correct
+ * as add-on families are added: every add-on family carries a metadata marker
+ * (`target_org_id` + `members.max` for seats, `feature_key` for org riders) and
+ * the plan item carries neither. A new add-on family that forgets to teach its
+ * predicate here shows up as a plan item — loudly wrong at the first period
+ * end — rather than as a silently mis-picked one.
+ *
+ * Returns null rather than falling back to `data[0]`. A subscription with no
+ * identifiable plan item is a state we do not understand, and guessing there
+ * is how the wrong period end got written in the first place — callers decide
+ * whether that is a 500 or a skip, visibly.
+ */
+export function planItem(sub: Stripe.Subscription): Stripe.SubscriptionItem | null {
+  for (const item of sub.items?.data ?? []) {
+    if (isSeatAddonItem(item)) continue;
+    if (isOrgAddonItem(item)) continue;
+    return item;
+  }
+  return null;
+}

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -172,6 +172,7 @@ vi.mock("@/lib/stripe", () => ({ getStripe: () => stripeMock.stripe }));
 import { sql } from "@/lib/db";
 import { hasFeature } from "@/lib/entitlements";
 import { billedQuantity } from "@/lib/billing-group";
+import { balance, grantBalance, packBalance, walletIdFor } from "@/lib/credits";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
 import {
   acceptGroupTransfer,
@@ -1140,6 +1141,120 @@ describe.skipIf(!HAS_DB)("detach leaves an audit trail for the wallet it does no
     // The same action name is written by the attach-side forfeit, so the row
     // has to say which path it came from.
     expect(audit?.detail?.via).toBe("detach");
+  });
+});
+
+describe.skipIf(!HAS_DB)("detach of the LAST org carries the wallet out (#304)", () => {
+  it("hands the shared pool to the leaver when it empties the group", async () => {
+    // The shape #285's default cannot cover. A payer's group holds exactly ONE
+    // org, owned by somebody else (a club owner in a federation's group), so the
+    // "you already have your own billing group" refusal — which only fires when
+    // the leaver's owner IS the payer — lets this through. The org leaves, the
+    // group is left with no orgs at all, and "the credits stay with the group"
+    // means "they stay with a group nobody is in and nobody can reach": no org
+    // resolves to it, and `ai_credit_ledger.wallet_id` has no foreign key to
+    // keep the row alive on its behalf.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const group = await makeGroup(payer, {
+      plan: "pro",
+      stripeSubId: null,
+      stripeCustomerId: null,
+      periodEndDays: 30,
+    });
+    const orgId = await makeOrg(group, clubOwner);
+    // Both buckets, so a merge that pooled them into one row would show.
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 25, 'monthly_grant', 'grant', 25, ${"seed-" + uniq()})`;
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 10, 'pack_purchase', 'pack', 35, ${"seed-" + uniq()})`;
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId, mode: "release" });
+
+    // The move really happened, and to a NEW group (otherwise the balances below
+    // would be reading the same wallet twice and pass for nothing).
+    expect(res.subscription_id).not.toBe(group);
+    expect(await orgGroup(orgId)).toBe(res.subscription_id);
+
+    // The whole pool followed the org out, bucket-preserving: pack credits never
+    // expire, so pooling them into the resetting grant bucket would destroy them
+    // on the 1st.
+    expect(await grantBalance(res.subscription_id)).toBe(25);
+    expect(await packBalance(res.subscription_id)).toBe(10);
+    // And nothing is left behind on the emptied group.
+    expect(await balance(group)).toBe(0);
+  });
+
+  it("still takes NO share when sibling orgs stay behind (#285 default, unchanged)", async () => {
+    // The #304 branch must be exactly one case wide. With a sibling remaining,
+    // the wallet is a live shared pool that org is still spending from, and the
+    // leaver carries nothing — the decided default.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const group = await makeGroup(payer, { stripeSubId: "sub_304_kept_" + uniq() });
+    const staysBehind = await makeOrg(group, payer);
+    const orgId = await makeOrg(group, clubOwner);
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 40, 'monthly_grant', 'grant', 40, ${"seed-" + uniq()})`;
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 15, 'pack_purchase', 'pack', 55, ${"seed-" + uniq()})`;
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId, mode: "release" });
+
+    expect(await orgGroup(orgId)).toBe(res.subscription_id);
+    expect(await orgGroup(staysBehind)).toBe(group);
+    // The remaining org keeps every credit it relies on.
+    expect(await grantBalance(group)).toBe(40);
+    expect(await packBalance(group)).toBe(15);
+    // The leaver starts empty, and the forfeit is still audited.
+    expect(await balance(res.subscription_id)).toBe(0);
+    const [audit] = await sql<{ detail: { via?: string } }[]>`
+      select detail from staff_audit_log
+       where target_id = ${orgId} and action = 'billing_group.detach_wallet_not_carried'
+       order by created_at desc limit 1`;
+    expect(audit?.detail?.via).toBe("detach");
+  });
+
+  it("leaves the pool REACHABLE, not merely moved", async () => {
+    // A balance that reads right while the ledger still points at a wallet
+    // nothing resolves to is the same bug one layer down. Two things have to
+    // hold: the org's own wallet resolution (coalesce(subscription_id, id) —
+    // what every spend path actually reads) must find the credits, and no row
+    // may be left naming a subscription id that no longer exists, since
+    // `ai_credit_ledger.wallet_id` carries no foreign key to stop that.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const group = await makeGroup(payer, {
+      plan: "pro",
+      stripeSubId: null,
+      stripeCustomerId: null,
+      periodEndDays: 30,
+    });
+    const orgId = await makeOrg(group, clubOwner);
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 25, 'monthly_grant', 'grant', 25, ${"seed-" + uniq()})`;
+    await sql`insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${group}, 10, 'pack_purchase', 'pack', 35, ${"seed-" + uniq()})`;
+
+    await detachOrgFromGroup({ actorUserId: clubOwner, orgId, mode: "release" });
+
+    // Reached the way a real AI run reaches it, not by the id detach returned.
+    const wallet = await walletIdFor(orgId);
+    expect(wallet).not.toBe(group);
+    expect(await balance(wallet)).toBe(35);
+
+    // Nothing on the old wallet is orphaned. The merge is double-entry, so the
+    // compensating debits stay on the old wallet by design (net 0) — what must
+    // NOT happen is those rows surviving a `dropEmptyGroup`/`cancelGroupIfEmpty`
+    // that removed the subscription row they name, leaving history pointing into
+    // nothing. Either the row is still there or no rows are.
+    const [orphans] = await sql<{ n: string }[]>`
+      select count(*)::text as n
+        from ai_credit_ledger l
+       where l.wallet_id = ${group}
+         and not exists (select 1 from subscriptions s where s.id::text = l.wallet_id)`;
+    expect(Number(orphans.n)).toBe(0);
+    expect(await balance(group)).toBe(0);
   });
 });
 

--- a/apps/web/src/server/usecases/__tests__/extra-org-addon.test.ts
+++ b/apps/web/src/server/usecases/__tests__/extra-org-addon.test.ts
@@ -357,6 +357,11 @@ describe.skipIf(!HAS_DB)("extra-org add-on — webhook sync -> resolver", () => 
 });
 
 describe.skipIf(!HAS_DB)("extra-org add-on — never sweeps another add-on family", () => {
+  // Still correct after #330, which is a different path: the CHURN cancel
+  // (handleSubscriptionDeleted) now takes both families down together, but this
+  // RECONCILE sweep stays scoped to orgs.max_owned — a subscription that no
+  // longer reports an org item says nothing about its seat items, which
+  // syncSeatAddonsForSubscription reconciles on its own.
   it("removing every org add-on leaves the SEAT rows on the same wallet untouched", async () => {
     const { orgId, walletId } = await makeGroupOrg("pro");
     const membersBase = (await getLimit(orgId, "members.max"))!;

--- a/apps/web/src/server/usecases/__tests__/platform-dispute.test.ts
+++ b/apps/web/src/server/usecases/__tests__/platform-dispute.test.ts
@@ -68,6 +68,43 @@ async function seedSubOrg(plan = "pro"): Promise<{ orgId: string; customer: stri
   return { orgId, customer };
 }
 
+/** The group's wallet — org_addons.wallet_id IS the subscription id. */
+async function walletFor(orgId: string): Promise<string> {
+  const [{ subscription_id }] = await sql<{ subscription_id: string }[]>`
+    select subscription_id from organizations where id = ${orgId}`;
+  return subscription_id;
+}
+
+/** A PURCHASED extra-org rider (+1 orgs.max_owned), billed as a Stripe item. */
+async function seedRiderAddon(walletId: string, itemId: string) {
+  await sql`
+    insert into org_addons (wallet_id, target_org_id, feature_key, delta_each, qty, status, stripe_item_id)
+    values (${walletId}, null, 'orgs.max_owned', 1, 1, 'active', ${itemId})`;
+}
+
+/** A PURCHASED extra seat (+1 members.max on one org), billed as a Stripe item. */
+async function seedSeatAddon(walletId: string, orgId: string, itemId: string) {
+  await sql`
+    insert into org_addons (wallet_id, target_org_id, feature_key, delta_each, qty, status, stripe_item_id)
+    values (${walletId}, ${orgId}, 'members.max', 1, 1, 'active', ${itemId})`;
+}
+
+/** An ADMIN-granted comp of the same cap (SPEC-3): no Stripe item, so nothing
+ *  Stripe-shaped may ever cancel it. */
+async function seedGrantedAddon(walletId: string) {
+  await sql`
+    insert into org_addons (wallet_id, target_org_id, feature_key, delta_each, qty, status)
+    values (${walletId}, null, 'orgs.max_owned', 1, 2, 'granted')`;
+}
+
+/** Every add-on row on the wallet, keyed by its Stripe item id ('granted' for
+ *  the comp row) — so an assertion names WHICH row moved, not just a count. */
+async function addonStatuses(walletId: string): Promise<Record<string, string>> {
+  const rows = await sql<{ stripe_item_id: string | null; status: string }[]>`
+    select stripe_item_id, status from org_addons where wallet_id = ${walletId}`;
+  return Object.fromEntries(rows.map((r) => [r.stripe_item_id ?? "granted", r.status]));
+}
+
 // A community org that bought an Event Pass for one competition. `passKey`
 // selects the rung (v17 #294) — the staff alert has to name the RIGHT product,
 // or a disputed $59 L purchase reads to staff as the $29 M one.
@@ -286,6 +323,58 @@ describe.skipIf(!HAS_DB)("platform-charge disputes — subscription", () => {
       select disputed_at, dispute_id from subscriptions where id = (select subscription_id from organizations where id = ${orgId})`;
     expect(cleared.disputed_at).toBeNull();
     expect(cleared.dispute_id).toBeNull();
+  });
+
+  // v17 gap #331: the plan is only ONE of the two axes the resolver adds up.
+  // Recurring add-ons sit on TOP of the plan base, and the loss branch was not
+  // touching them — syncOrgAddonsForSubscription only ever runs on
+  // `customer.subscription.updated`, which a dispute never emits. A group that
+  // lost a chargeback therefore kept `community base + N` on BOTH orgs.max_owned
+  // and members.max, indefinitely, having stopped paying.
+  it("closed lost cancels the Stripe-billed add-ons too, sparing an admin grant", async () => {
+    const { orgId, customer } = await seedSubOrg("pro");
+    const walletId = await walletFor(orgId);
+    const riderItem = `si_rider_${uniq()}`;
+    const seatItem = `si_seat_${uniq()}`;
+    await seedRiderAddon(walletId, riderItem);
+    await seedSeatAddon(walletId, orgId, seatItem);
+    await seedGrantedAddon(walletId); // comp: null stripe_item_id, status 'granted'
+
+    const did = "dp_" + uniq();
+    await processStripeEvent(subDisputeEvent("created", customer, did));
+    await processStripeEvent(subDisputeEvent("closed", customer, did, "lost"));
+
+    expect(await addonStatuses(walletId)).toEqual({
+      [riderItem]: "canceled", // the extra-org rider stops lifting orgs.max_owned
+      [seatItem]: "canceled", // and the seat row stops lifting members.max
+      granted: "granted", // capacity the group was GIVEN survives — Stripe never billed it
+    });
+  });
+
+  // The `exists` guard on the add-on cancel is not decoration: without it a
+  // stale loss that the plan update correctly ignored would still strip the
+  // capacity off a group that has since re-bought.
+  it("a stale loss (dispute_id mismatch) leaves plan AND add-ons untouched", async () => {
+    const { orgId, customer } = await seedSubOrg("pro");
+    const walletId = await walletFor(orgId);
+    const riderItem = `si_rider_${uniq()}`;
+    const seatItem = `si_seat_${uniq()}`;
+    await seedRiderAddon(walletId, riderItem);
+    await seedSeatAddon(walletId, orgId, seatItem);
+    const flagged = "dp_old_" + uniq();
+    await sql`update subscriptions set dispute_id = ${flagged}, disputed_at = now()
+              where id = ${walletId}`;
+
+    await processStripeEvent(subDisputeEvent("closed", customer, "dp_new_" + uniq(), "lost"));
+
+    const [s] = await sql<{ plan_key: string; status: string }[]>`
+      select plan_key, status from subscriptions where id = ${walletId}`;
+    expect(s.plan_key).toBe("pro");
+    expect(s.status).toBe("active");
+    expect(await addonStatuses(walletId)).toEqual({
+      [riderItem]: "active",
+      [seatItem]: "active",
+    });
   });
 
   it("real webhook charge id string resolves the customer via charges.retrieve", async () => {

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -1658,6 +1658,25 @@ async function handlePlatformDispute(
     // customer has since renewed/re-bought under a different (or no) dispute.
     await sql`update subscriptions set plan_key = 'community', status = 'canceled',
               updated_at = now() where id = ${subscriptionId} and dispute_id = ${dispute.id}`;
+    // The plan is one axis; recurring add-ons sit on TOP of it (#331). Losing a
+    // dispute is churn by another route — nothing else cancels these rows on
+    // this path, because syncOrgAddonsForSubscription runs only on
+    // `customer.subscription.updated`, which a dispute never emits — so the
+    // group kept `community base + N` on orgs.max_owned AND members.max, for
+    // ever and unpaid. Scoped exactly like the churn cancel: these two
+    // Stripe-billed families only, `stripe_item_id is not null` so an
+    // ADMIN-granted comp (SPEC-3, status='granted', null item id) survives, and
+    // FROZEN rather than deleted so the qty stays for history and a re-buy.
+    // Guarded on dispute_id like the update above — via `exists`, since the
+    // update may have to fire on a group whose plan row was already community —
+    // so a stale loss that clobbered no plan strips no capacity either.
+    await sql`
+      update org_addons set status = 'canceled'
+       where wallet_id = ${subscriptionId}
+         and feature_key in ${sql([ORG_ADDON_FEATURE_KEY, SEAT_ADDON.featureKey])}
+         and stripe_item_id is not null and status = 'active'
+         and exists (select 1 from subscriptions s
+                      where s.id = ${subscriptionId} and s.dispute_id = ${dispute.id})`;
     // A lost dispute cancels the plan for every org in the group.
     await invalidateGroupEntitlements(subscriptionId);
   }

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -1233,31 +1233,20 @@ async function handleSubscriptionDeleted(stripeSub: Stripe.Subscription) {
   // strictly bigger hole than the self-serve reduction setExtraOrgs guards,
   // which churn bypasses entirely.
   //
-  // Scoped exactly like that sweep: this feature key only, and
-  // `stripe_item_id is not null`, so an ADMIN-granted comp of the same cap
-  // (SPEC-3, status='granted', null item id) and every seat / size-pack row on
-  // the same wallet survive. FROZEN, never deleted (V323/V324) — the qty stays
-  // for history and for a re-buy.
+  // BOTH Stripe-billed add-on families, not just the extra-org rider: the seat
+  // (`members.max`) rows had the identical hole, for the identical reason, and
+  // closing it is issue #330.
   //
-  // Seats have the same hole (`members.max` add-ons also outlive a cancel).
-  // That is INHERITED, not introduced here, and is tracked as issue #330.
-  //
-  // The reason recorded here previously — "closing it means deciding what a
-  // re-buy inherits" — was WRONG, and is corrected rather than deleted so the
-  // fix is never weighed against a cost that does not exist. `quantity_paid`
-  // above is the PLAN item's quantity (how many organisations the group bills
-  // for, maintained by syncGroupQuantity); it has nothing to do with the
-  // `members.max` rows in org_addons, so resetting it decides nothing about
-  // seats. And syncSeatAddonsForSubscription is cancel-what-I-do-not-see, so a
-  // stale seat row is swept by the first `subscription.updated` after a re-buy
-  // in any case.
-  //
-  // What actually keeps it out is SCOPE: this change is #293's extra-org
-  // rider, the seat family has its own sweep and its own issue, and widening a
-  // cancel across add-on families is not something to do in passing.
+  // Scoped exactly like that sweep in every other respect: these feature keys
+  // only, so a size-pack or any future family on the same wallet survives, and
+  // `stripe_item_id is not null`, so an ADMIN-granted comp of either cap
+  // (SPEC-3, status='granted', null item id) survives — a grant is capacity the
+  // group was GIVEN, never something Stripe was billing. FROZEN, never deleted
+  // (V323/V324) — the qty stays for history and for a re-buy.
   await sql`
     update org_addons set status = 'canceled'
-     where wallet_id = ${subscriptionId} and feature_key = ${ORG_ADDON_FEATURE_KEY}
+     where wallet_id = ${subscriptionId}
+       and feature_key in ${sql([ORG_ADDON_FEATURE_KEY, SEAT_ADDON.featureKey])}
        and stripe_item_id is not null and status = 'active'`;
   // A cancel drops EVERY org in the group to Community at once.
   await invalidateGroupEntitlements(subscriptionId);

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -988,10 +988,33 @@ export async function detachOrgFromGroup(args: {
               ${compedUntil}, ${group.trial_used_at}, now())
       returning id`;
     await tx`update organizations set subscription_id = ${fresh.id} where id = ${orgId}`;
-    // #285: no wallet merge on detach (the departing org takes no share of
-    // the group's pool — decided default) — just an audit trail of what was
-    // left behind, for accountability.
-    await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, group.id, fresh.id, "detach");
+    // #285 decided the default: a departing org takes no share of the group's
+    // pool, because a shared wallet has no per-org share to split off — just an
+    // audit trail of what was left behind, for accountability.
+    //
+    // #304 is the ONE case that default cannot cover. When `others` is empty the
+    // org is the last one out, and "the credits stay with the group" means "they
+    // stay with a group that is about to be dropped": the lines after this
+    // transaction hand `result.from` to cancelGroupIfEmpty/dropEmptyGroup, and
+    // `ai_credit_ledger.wallet_id` carries NO foreign key, so nothing keeps that
+    // row alive on the ledger's behalf. There is no remaining org to be
+    // "the group's pool" for either — nobody resolves to that wallet any more
+    // (walletIdFor is coalesce(subscription_id, id)), so the balance is not
+    // somebody else's, it is nobody's.
+    //
+    // The refusal above ("already has its own billing group") does NOT prevent
+    // this: it only fires when the leaving org's owner IS the group payer. A
+    // club owner leaving a federation payer's group reaches exactly this state.
+    //
+    // mergeWalletOnAttach is direction-agnostic despite the name — (from, to),
+    // bucket-preserving, locks both wallets in sorted order, and its only guard
+    // is from === to. Attach reaches the same fork for the same reason (the
+    // sole-live-org merge at the top of attachOrgToGroup); this is the mirror.
+    if (others.length === 0) {
+      await mergeWalletOnAttach(tx, group.id, fresh.id);
+    } else {
+      await auditWalletForfeitedOnDetach(tx, actorUserId, orgId, group.id, fresh.id, "detach");
+    }
     // `comped` drives the seat spend below: a seat is only consumed when a comp
     // was actually handed out (ride_out on a paying group), never on a release.
     return {

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -26,6 +26,7 @@ import {
 } from "@/lib/entitlements";
 import { activeOrgCount, assertWithinGroupCap, groupOrgLimit } from "@/lib/billing-group";
 import { orgAddonForPlan } from "@/lib/org-addons";
+import { planItem } from "@/lib/subscription-items";
 import { hasLiveSubscription } from "@/lib/subscription-status";
 import { intervalForPrice } from "@/lib/billing-manage";
 import { toLocale, type Locale } from "@/lib/i18n-constants";
@@ -83,13 +84,16 @@ export interface QuantitySync {
   orphaned?: boolean;
 }
 
-/** The single item on a group's live Stripe subscription. */
+/** The PLAN item on a group's live Stripe subscription — never `data[0]`,
+ *  which is an add-on half the time now (#329). Everything below prices,
+ *  previews and syncs the QUANTITY (the group's org count) off this item; a
+ *  rider picked by position would move the wrong subscription line. */
 async function subscriptionItem(
   stripeSubscriptionId: string,
 ): Promise<{ live: Stripe.Subscription; item: Stripe.SubscriptionItem }> {
   const live = await getStripe().subscriptions.retrieve(stripeSubscriptionId);
-  const item = live.items.data[0];
-  if (!item) throw new HttpError(500, "Subscription has no items.");
+  const item = planItem(live);
+  if (!item) throw new HttpError(500, "Subscription has no plan item.");
   return { live, item };
 }
 

--- a/apps/web/src/server/usecases/billing-manage.ts
+++ b/apps/web/src/server/usecases/billing-manage.ts
@@ -12,6 +12,7 @@ import {
 import { invalidateEntitlementsForOrgGroup, isPassLocked } from "@/lib/entitlements";
 import { isPassKey, type PassKey } from "@/lib/currency";
 import { subscriptionIdForOrg } from "@/lib/billing-group";
+import { planItem } from "@/lib/subscription-items";
 import { logStaffAction } from "@/lib/admin";
 import {
   buildAddressUpdateParams,
@@ -244,7 +245,10 @@ export async function getBillingOverview(orgId: string): Promise<BillingOverview
     >`
       select stripe_price_id_monthly, stripe_price_id_annual
       from plans where key = ${sub.plan_key}`;
-    const priceId = stripeSub?.items.data[0]?.price?.id ?? null;
+    // The PLAN item's price — `intervalForPrice` below asks "is this group
+    // billed monthly or yearly", and an add-on rider is always monthly, so
+    // `data[0]` mislabelled an annual group's interval (#329).
+    const priceId = (stripeSub ? planItem(stripeSub) : null)?.price?.id ?? null;
     // Scope invoices to the current payer's own tenure(s) (#privacy): the group
     // is one customer whose invoice PDFs snapshot the payer-of-record's name and
     // address, so a new payer must not see a predecessor's. The viewer here is
@@ -599,8 +603,15 @@ async function resolvePriceChange(
     throw new HttpError(503, "Billing is not yet configured. Please contact support.");
 
   const stripeSub = await getStripe().subscriptions.retrieve(sub.stripe_subscription_id);
-  const item = stripeSub.items.data[0];
-  if (!item) throw new HttpError(500, "Subscription has no items.");
+  // The PLAN item — the caller puts `itemId` straight into a price SWAP, so
+  // `data[0]` picking an add-on rider would move the RIDER onto the plan price
+  // and leave the plan itself untouched (#329). Unresolvable is a 500 for the
+  // same reason the empty case already was: this function's entire output is
+  // "which item to reprice", and there is no safe answer to invent. The
+  // pre-existing throw is retargeted rather than added — a null here must not
+  // reach `item.price.id` below and refuse the change as "already on this plan".
+  const item = planItem(stripeSub);
+  if (!item) throw new HttpError(500, "Subscription has no plan item.");
   if (item.price.id === priceId) throw new HttpError(400, alreadyMessage);
 
   return {

--- a/apps/web/src/server/usecases/competitions.ts
+++ b/apps/web/src/server/usecases/competitions.ts
@@ -78,14 +78,21 @@ export async function listCompetitions(
 
 // Doc 10 §1: `competitions.max_active` — draft/published/live competitions
 // count; completed/archived don't, and neither do Event-Passed comps (a pass
-// buys its competition out of the quota, v3/07 §3). Enforced at the write
-// (doc 10 §2 rule 1).
+// buys its competition out of the quota, v3/07 §3) — for as long as the pass
+// APPLIES, which is what this used to get wrong (#347). "A pass row exists" is
+// not the rule: SPEC-4 §7 ends the pass at the grace boundary, and a live
+// competition past that boundary was keeping a free slot for ever. Same
+// predicate the resolver uses (V343's pass_applies), so the three sites cannot
+// drift apart again. Enforced at the write (doc 10 §2 rule 1).
 async function assertActiveQuota(auth: AuthCtx): Promise<void> {
   const count = await withTenant(auth.orgId, async (tx) => {
     const [{ n }] = await tx<{ n: number }[]>`
       select count(*)::int as n from competitions c
       where c.status in ${tx([...ACTIVE_COMPETITION_STATUSES])}
-        and not exists (select 1 from competition_passes cp where cp.competition_id = c.id)`;
+        and not exists (
+          select 1 from competition_passes cp
+           where cp.competition_id = c.id
+             and pass_applies(c.status, c.ends_on, (now() at time zone 'utc')::date))`;
     return n;
   });
   const { ok } = await withinLimit(auth.orgId, "competitions.max_active", count + 1);
@@ -421,6 +428,12 @@ export async function deleteCompetition(auth: AuthCtx, id: string): Promise<void
     // Money guards (payments-hardening spec P0-1): a delete would CASCADE
     // paid registrations, the Event Pass, and comp-scoped sponsorship —
     // erasing the app's only record of live money. Archive is always allowed.
+    //
+    // Deliberately bare row-existence, NOT V343's pass_applies (#347): this
+    // asks "was a pass ever bought" — money history, like pass-credit.ts:138 —
+    // not "is a pass applying". Adding the lock predicate here would INVERT the
+    // guard on exactly the competitions most likely to be deleted (long-ended
+    // ones), letting the cascade erase the record of a real $29/$59 charge.
     const [pass] = await tx`
       select 1 from competition_passes where competition_id = ${id} limit 1`;
     if (pass) {

--- a/apps/web/src/server/usecases/entitlement-freeze.ts
+++ b/apps/web/src/server/usecases/entitlement-freeze.ts
@@ -40,7 +40,10 @@ export function selectFrozen(
 // Activity = latest score event anywhere in the competition, else created_at.
 // Passed competitions (v3/07 §3) are excluded here AND from the count below:
 // an Event Pass buys that competition out of the active-comp quota for its
-// lifetime, so it neither freezes nor occupies a free slot.
+// lifetime — which ENDS at the grace boundary (SPEC-4 §7). This used to read
+// "a pass row exists", so the exemption never ended (#347): a `live`
+// competition past its ends_on + grace was immune to freezing for ever.
+// V343's pass_applies is the same predicate the resolver uses.
 async function loadCandidates(tx: Tx): Promise<FreezeCandidate[]> {
   const rows = await tx<{ id: string; last_active: string }[]>`
     select c.id,
@@ -50,7 +53,10 @@ async function loadCandidates(tx: Tx): Promise<FreezeCandidate[]> {
     left join fixtures f on f.division_id = d.id
     left join score_events e on e.fixture_id = f.id
     where c.status in ${tx([...ACTIVE_COMPETITION_STATUSES])}
-      and not exists (select 1 from competition_passes cp where cp.competition_id = c.id)
+      and not exists (
+        select 1 from competition_passes cp
+         where cp.competition_id = c.id
+           and pass_applies(c.status, c.ends_on, (now() at time zone 'utc')::date))
     group by c.id, c.created_at`;
   return rows.map((r) => ({ id: r.id, lastActiveAt: r.last_active }));
 }
@@ -67,7 +73,10 @@ export async function frozenCompetitionIds(orgId: string, tx?: Tx): Promise<Set<
     const [{ n }] = await t<{ n: number }[]>`
       select count(*)::int as n from competitions c
       where c.status in ${t([...ACTIVE_COMPETITION_STATUSES])}
-        and not exists (select 1 from competition_passes cp where cp.competition_id = c.id)`;
+        and not exists (
+          select 1 from competition_passes cp
+           where cp.competition_id = c.id
+             and pass_applies(c.status, c.ends_on, (now() at time zone 'utc')::date))`;
     if (n <= limit) return new Set();
     return selectFrozen(await loadCandidates(t), limit);
   };

--- a/db/migration/deltas/V343__pass_applies_predicate.sql
+++ b/db/migration/deltas/V343__pass_applies_predicate.sql
@@ -1,0 +1,118 @@
+-- V343 — ONE definition of "this competition's Event Pass still applies".
+--
+-- The rule (SPEC-4 §7) had three copies: lib/entitlements.ts's passLockReason,
+-- V338's pass arm inside org_has_feature, and — implicitly, and WRONGLY — the
+-- two enforcement sites in server/usecases/{competitions,entitlement-freeze}.ts,
+-- which asked only whether a competition_passes ROW EXISTS.
+--
+-- That third copy was the leak (#347). Those sites filter on the ACTIVE
+-- statuses (draft/published/live), which incidentally covers the rule's
+-- terminal arm — an archived or completed competition is excluded anyway — but
+-- covers NOTHING of the past_ends_on arm. A competition still marked `live`
+-- whose ends_on passed more than the grace ago kept its pass exemption for
+-- ever: permanently outside competitions.max_active, permanently immune to
+-- freezing, on a pass the resolver had already stopped honouring. Nothing
+-- retires a live competition past its end date, so nothing ended it.
+--
+-- The boundary is the UTC CALENDAR DATE, not session-TZ `current_date` (V334),
+-- and the comparison is STRICTLY less: ends_on + grace landing exactly on today
+-- is still applying.
+--
+-- IMMUTABLE is correct here despite `now()` NOT appearing in it: the function
+-- takes the comparison date from the caller-supplied ends_on only, and the
+-- "today" side is passed in by the caller (org_has_feature is STABLE, which is
+-- where the clock read belongs). Callers that pass a literal date therefore get
+-- a genuinely immutable answer, which is what lets this be inlined and indexed.
+
+create or replace function pass_applies(
+  p_status text,
+  p_ends_on date,
+  p_today date
+) returns boolean
+  language sql immutable as $$
+    select not (
+      p_status in ('archived', 'completed')
+      or (p_ends_on is not null and p_ends_on + interval '7 days' < p_today)
+    )
+  $$;
+
+-- org_has_feature re-issued so the resolver calls the function rather than
+-- carrying its own copy of the predicate. The body is copied FORWARD from V338;
+-- the ONLY change is the pass arm's `and not (...)` clause becoming
+-- `and pass_applies(c.status, c.ends_on, (now() at time zone 'utc')::date)`.
+-- Every other arm is byte-for-byte V338 — including its comments, so the diff
+-- against V338 is exactly one hunk. Signature, security-definer and the pinned
+-- search_path are unchanged; the public_* views call the FUNCTION, so no view
+-- is reissued here.
+
+create or replace function org_has_feature(
+  p_org_id uuid,
+  p_feature_key text,
+  p_competition_id uuid
+) returns boolean
+  language sql stable security definer
+  set search_path = ${flyway:defaultSchema}, pg_temp as $$
+    with plan as (
+      select case
+        -- MODERATION, not billing (mirrors entitlements.ts): a suspended ORG
+        -- resolves community whatever its group pays for, scoped to that one org
+        -- so a moderator cannot degrade siblings that merely share a payer.
+        when o.status = 'suspended' then 'community'
+        when s.comped_until is not null and s.comped_until <= now()
+             and (s.stripe_subscription_id is null
+                  or coalesce(s.status, '') not in
+                     ('trialing', 'active', 'past_due'))
+             then 'community'
+        when s.status = 'past_due'
+             and coalesce(s.status_changed_at, s.updated_at) <= now() - interval '14 days'
+             then 'community'
+        -- Trial-end backstop: a trialing sub whose trial ended over a day ago is a
+        -- MISSED transition webhook (Stripe moves trialing→active/past_due/canceled at
+        -- trial_end). The resolver stops trusting the stale status, cron-free, the same
+        -- way the past_due arm above does. 1-day grace absorbs Stripe's transition lag.
+        -- trial_end IS null on a never-trialed sub → guard it so those stay on plan.
+        when s.status = 'trialing'
+             and s.trial_end is not null
+             and s.trial_end <= now() - interval '1 day'
+             then 'community'
+        -- v17 #287/#288: a never-paid first invoice conveys NO plan (mirrors
+        -- entitlements.ts's orgPlanKey — the arm this migration adds). Must NOT
+        -- inherit the past_due grace above, which is for a renewal that failed on
+        -- a subscription that WAS active; 'incomplete' never was.
+        when s.status = 'incomplete' then 'community'
+        -- A CANCELLED subscription does not convey its plan (V313). The
+        -- comped_at guard keeps an INDEFINITE staff comp alive; a lapsed comp is
+        -- already community via the comped_until arm above.
+        when s.status = 'canceled' and s.comped_at is null
+             then 'community'
+        else coalesce(s.plan_key, 'community')
+      end as plan_key
+      from organizations o
+      left join subscriptions s on s.id = o.subscription_id
+      where o.id = p_org_id
+    )
+    select coalesce(
+      (select bool_value from org_entitlement_overrides
+        where org_id = p_org_id and feature_key = p_feature_key
+          and (expires_at is null or expires_at > now())),
+      -- Event Pass: community orgs only, competition in scope. A key absent from
+      -- the pass matrix falls through to the plan row rather than denying. v17
+      -- SPEC-4 §7: the pass stops applying once its competition is archived or
+      -- long-ended (mirrors isPassLocked in lib/entitlements.ts). The grace
+      -- boundary is the UTC calendar date (V334), matching isPassLocked's
+      -- Date.UTC(getUTC*) — NOT the session-TZ `current_date`.
+      (select pe.bool_value
+         from competition_passes cp
+         join competitions c on c.id = cp.competition_id
+         join plan_entitlements pe
+           on pe.plan_key = cp.pass_key and pe.feature_key = p_feature_key
+        where p_competition_id is not null
+          and cp.competition_id = p_competition_id
+          and cp.org_id = p_org_id
+          and (select plan_key from plan) = 'community'
+          and pass_applies(c.status, c.ends_on, (now() at time zone 'utc')::date)),
+      (select pe.bool_value from plan_entitlements pe
+        where pe.feature_key = p_feature_key
+          and pe.plan_key = (select plan_key from plan)),
+      false)
+  $$;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -784,6 +784,21 @@ async function main() {
   // owner and a NON-PAYER inside that same group are refused the same way and
   // offered nothing. Own fresh group; keyless-safe.
   await extraOrgAddonSuite();
+
+  // --- v17 gap W10: the Event Pass lock's `past_ends_on` arm, which the
+  // resolver honoured and the ENFORCEMENT sites did not. A pass one day past
+  // the grace stops buying its competition out of competitions.max_active
+  // (#347), and the checkout route refuses to sell a pass for a competition
+  // that is already over (#353) — each paired with the same competition ON the
+  // boundary, which must still be honoured. Own fresh orgs; keyless-safe.
+  await passLockEnforcementSuite();
+
+  // --- v17 gap W10: purchased add-on capacity dies with the money that rented
+  // it. A churned subscription (#330) and a lost dispute (#331) each cancel the
+  // extra-org rider AND the seat block while sparing an admin-granted comp,
+  // driven through the real signed-webhook route. Own fresh groups; needs
+  // STRIPE_WEBHOOK_SECRET and skips cleanly without it.
+  await addonChurnWebhookSuite();
 }
 
 /** design/v9 PROMPT-55: the chargeback-liability copy is live on the public
@@ -2743,6 +2758,278 @@ async function extraOrgAddonSuite(): Promise<void> {
     check(
       "extra-org: a CANCELED rider stops counting — the cap falls straight back to the plan base (6 → 5)",
       (await orgCap(payer, auth.org_id)) === PRO_ORG_CAP,
+    );
+  } finally {
+    await db.end();
+  }
+}
+
+/**
+ * v17 gap W10 — purchased add-on capacity dies with the money that rented it.
+ *
+ * Two ways a group stops paying, both driven through the app's REAL webhook
+ * route rather than by calling the handler: a `customer.subscription.deleted`
+ * (#330) and a lost dispute (#331). Before this wave the plan collapsed to
+ * community on both and the recurring add-on rows stayed `active`, so a
+ * churned group kept `community base + N` organisations and seats for ever,
+ * unpaid — and nothing else swept them, because the reconciling sweep only
+ * runs on `customer.subscription.updated`, which neither path emits.
+ *
+ * Every leg asserts THREE rows, not one: the extra-org rider and the seat
+ * rider must both freeze, and an ADMIN-granted comp (`stripe_item_id` null)
+ * must survive untouched. The grant is the half that makes this a scoped
+ * cancel rather than a truncate — a fix that cancelled everything on the
+ * wallet would pass a one-row assertion.
+ *
+ * Needs the server's `STRIPE_WEBHOOK_SECRET` to sign a payload it will accept;
+ * skips cleanly without one, the same convention `paymentMethodSuite` uses.
+ * No Stripe key and no network call: the dispute legs carry an EXPANDED charge
+ * object, which `disputeCustomerId` reads inline instead of retrieving.
+ */
+async function addonChurnWebhookSuite(): Promise<void> {
+  if (!process.env.STRIPE_WEBHOOK_SECRET) {
+    check(
+      "addon churn: skipped (no STRIPE_WEBHOOK_SECRET — cannot sign a webhook this server will accept); the DB-backed vitest suites cover both paths",
+      true,
+    );
+    return;
+  }
+
+  const db = smokeDb();
+  try {
+    /** A fresh paid group carrying all three add-on rows, with Stripe ids the
+     *  handlers can match on. Returns the wallet (= subscription) id. */
+    const seedGroup = async (label: string, plan: string) => {
+      const s = newSession();
+      const email = `addonchurn_${label}_${tag}@example.com`;
+      const orgId = (await signIn(s, email)).org_id;
+      await setPlan(orgId, plan, s);
+      const [row] = await db<{ wallet_id: string }[]>`
+        select coalesce(subscription_id::text, id::text) as wallet_id
+          from organizations where id = ${orgId}`;
+      const walletId = row!.wallet_id;
+      await db`
+        update subscriptions
+           set stripe_subscription_id = ${`sub_smoke_${label}_${tag}`},
+               stripe_customer_id = ${`cus_smoke_${label}_${tag}`}
+         where id = ${walletId}`;
+      await db`
+        insert into org_addons (wallet_id, target_org_id, feature_key, delta_each, qty,
+                                stripe_item_id, status)
+        values (${walletId}, null, 'orgs.max_owned', 1, 1,
+                ${`si_smoke_${label}_rider_${tag}`}, 'active'),
+               (${walletId}, null, 'members.max', 1, 3,
+                ${`si_smoke_${label}_seat_${tag}`}, 'active'),
+               (${walletId}, null, 'members.max', 1, 1, null, 'granted')`;
+      return { orgId, walletId };
+    };
+
+    /** The three rows' statuses, keyed so a check reads as a sentence. */
+    const statuses = async (walletId: string) => {
+      const rows = await db<{ feature_key: string; stripe_item_id: string | null; status: string }[]>`
+        select feature_key, stripe_item_id, status from org_addons
+         where wallet_id = ${walletId} order by stripe_item_id nulls last`;
+      return {
+        rider: rows.find((r) => r.feature_key === "orgs.max_owned")?.status,
+        seat: rows.find((r) => r.feature_key === "members.max" && r.stripe_item_id)?.status,
+        granted: rows.find((r) => !r.stripe_item_id)?.status,
+      };
+    };
+
+    // === #330 — churn. The subscription is gone; so is the capacity it billed.
+    const churn = await seedGroup("churn", "pro_plus");
+    const before = await statuses(churn.walletId);
+    check(
+      "addon churn: fixture built — a paid group carrying a purchased rider, a purchased seat block and an admin comp, all live",
+      before.rider === "active" && before.seat === "active" && before.granted === "granted",
+    );
+    const churnStatus = await postSignedStripeWebhook("customer.subscription.deleted", {
+      id: `sub_smoke_churn_${tag}`,
+      object: "subscription",
+      customer: `cus_smoke_churn_${tag}`,
+      status: "canceled",
+      items: { object: "list", data: [] },
+    });
+    check("addon churn: the app accepts the signed deletion webhook (200)", churnStatus === 200);
+    const afterChurn = await statuses(churn.walletId);
+    check(
+      "addon churn: a deleted subscription cancels BOTH Stripe-billed families — the extra-org rider and the seat block (#330)",
+      afterChurn.rider === "canceled" && afterChurn.seat === "canceled",
+    );
+    check(
+      "addon churn: ...and leaves the ADMIN-granted comp alone — a grant is capacity the group was given, never something Stripe was billing",
+      afterChurn.granted === "granted",
+    );
+
+    // === #331 — a lost dispute. Same outcome by a different route, and the
+    // `created` event first because the loss is guarded on the dispute_id it
+    // stamps: a loss that matches no stored dispute must strip nothing.
+    const disputed = await seedGroup("disp", "pro");
+    const disputeId = `dp_smoke_${tag}`;
+    const charge = { id: `ch_smoke_${tag}`, object: "charge", customer: `cus_smoke_disp_${tag}` };
+    const createdStatus = await postSignedStripeWebhook("charge.dispute.created", {
+      id: disputeId,
+      object: "dispute",
+      charge,
+      status: "warning_needs_response",
+      payment_intent: null,
+    });
+    check("addon churn/dispute: the app accepts the signed dispute-opened webhook (200)", createdStatus === 200);
+
+    // A loss under a DIFFERENT dispute id — the stale-loss case. It must move
+    // nothing, which is the only thing that makes the guard on the real loss
+    // below meaningful rather than decorative.
+    await postSignedStripeWebhook("charge.dispute.closed", {
+      id: `${disputeId}_other`,
+      object: "dispute",
+      charge,
+      status: "lost",
+      payment_intent: null,
+    });
+    const afterStale = await statuses(disputed.walletId);
+    check(
+      "addon churn/dispute: a loss whose dispute id matches nothing strips no capacity (#331 guard)",
+      afterStale.rider === "active" && afterStale.seat === "active",
+    );
+
+    const lostStatus = await postSignedStripeWebhook("charge.dispute.closed", {
+      id: disputeId,
+      object: "dispute",
+      charge,
+      status: "lost",
+      payment_intent: null,
+    });
+    check("addon churn/dispute: the app accepts the signed dispute-lost webhook (200)", lostStatus === 200);
+    const afterLost = await statuses(disputed.walletId);
+    check(
+      "addon churn/dispute: losing a dispute cancels the purchased rider and seat block, not just the plan (#331)",
+      afterLost.rider === "canceled" && afterLost.seat === "canceled",
+    );
+    check(
+      "addon churn/dispute: ...and the admin comp survives here too",
+      afterLost.granted === "granted",
+    );
+    const [plan] = await db<{ plan_key: string; status: string }[]>`
+      select plan_key, status from subscriptions where id = ${disputed.walletId}`;
+    check(
+      "addon churn/dispute: the plan itself still drops to community/canceled — the add-on cancel is in ADDITION to it, not instead of it",
+      plan?.plan_key === "community" && plan?.status === "canceled",
+    );
+  } finally {
+    await db.end();
+  }
+}
+
+/**
+ * v17 gap W10 — the `past_ends_on` arm of the Event Pass lock, over real HTTP.
+ *
+ * `passGrantsSuite` already covers the lock's TERMINAL arm (archived and
+ * completed) against the entitlement resolver. It covers nothing of the other
+ * arm, and `ends_on` appears nowhere else in this file — which is exactly how
+ * #347 and #353 survived: the lock was correct in `entitlements.ts` and two
+ * enforcement sites plus the checkout route never asked it.
+ *
+ * Both legs are PAIRS. A competition one day past the grace must be refused
+ * AND the same competition sitting exactly ON the boundary must still be
+ * honoured, because "refuses everything" passes the first half on its own —
+ * and a grace boundary that is off by a day is the likeliest way this breaks.
+ *
+ * Keyless: the quota leg is pure app SQL, and the checkout leg asserts the
+ * refusal STATUS rather than a completed purchase, so it never needs Stripe.
+ */
+async function passLockEnforcementSuite(): Promise<void> {
+  // V319: community carries 10 concurrent competitions.
+  const COMMUNITY_COMP_CAP = 10;
+  const featureKey = (r: V1Res) =>
+    (r.json.error as { feature_key?: string } | undefined)?.feature_key;
+  // A UTC calendar date `n` days from today, as a string. Written as a string
+  // and computed in UTC on purpose: the rule's boundary is the UTC calendar
+  // date (V334), so a local-midnight Date races it for part of every day.
+  const utcDay = (offsetDays: number) =>
+    new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10);
+
+  const s = newSession();
+  const orgId = (await signIn(s, `passlock_${tag}@example.com`)).org_id;
+  const mkComp = async (name: string) =>
+    v1data<{ id: string }>(
+      await v1(s, "/api/v1/competitions", "POST", { name: `${name} ${tag}`, visibility: "unlisted" }),
+    );
+
+  const db = smokeDb();
+  try {
+    // Fill the org to its cap: ten competitions, the tenth carrying a pass.
+    // Creating the tenth is itself legal (nine active + this one = the cap).
+    const ids: string[] = [];
+    for (let i = 0; i < COMMUNITY_COMP_CAP; i++) ids.push((await mkComp(`Lock Quota ${i}`)).id);
+    const passed = ids[COMMUNITY_COMP_CAP - 1]!;
+    await grantPass(orgId, passed, "event_pass");
+    check(
+      `pass lock/quota: fixture built — ${COMMUNITY_COMP_CAP} live competitions on a community org, the last one passed`,
+      ids.length === COMMUNITY_COMP_CAP,
+    );
+
+    // === PAST the grace: the pass has stopped applying, so the competition it
+    // covers is back inside the quota and the org is genuinely full. Nothing
+    // retires a `live` competition past its end date, which is what made this
+    // state permanent rather than transient.
+    await db`update competitions set ends_on = ${utcDay(-(7 + 1))} where id = ${passed}`;
+    const overCap = await v1(s, "/api/v1/competitions", "POST", {
+      name: `Lock Quota Over ${tag}`,
+      visibility: "unlisted",
+    });
+    check(
+      "pass lock/quota: a pass one day past the grace stops buying its competition out of competitions.max_active — the next create 402s (#347)",
+      overCap.status === 402 && featureKey(overCap) === "competitions.max_active",
+    );
+
+    // === ON the grace boundary: still applying (the comparison is strictly
+    // less), so the passed competition is still exempt and there is room. This
+    // is the half that fails if anyone "fixes" the boundary to `<=`.
+    await db`update competitions set ends_on = ${utcDay(-7)} where id = ${passed}`;
+    const atBoundary = await v1(s, "/api/v1/competitions", "POST", {
+      name: `Lock Quota Boundary ${tag}`,
+      visibility: "unlisted",
+    });
+    check(
+      "pass lock/quota: a pass EXACTLY on the grace boundary still buys its competition out — the same create succeeds (201)",
+      atBoundary.status === 201,
+    );
+
+    // === #353 — the checkout route refuses to SELL a pass for a competition
+    // the lock rule has already ended. Its own org and its own competition: an
+    // org that already holds a pass is refused for a different reason, and a
+    // refusal that fires for the wrong reason proves nothing.
+    const buyer = newSession();
+    await signIn(buyer, `passsell_${tag}@example.com`);
+    const buyComp = v1data<{ id: string }>(
+      await v1(buyer, "/api/v1/competitions", "POST", {
+        name: `Lock Sell ${tag}`,
+        visibility: "unlisted",
+      }),
+    );
+    await db`update competitions set ends_on = ${utcDay(-(7 + 1))} where id = ${buyComp.id}`;
+    const sellEnded = await raw(buyer, "/api/billing/pass-checkout", "POST", {
+      competition_id: buyComp.id,
+    });
+    check(
+      "pass lock/sell: buying a pass for a competition past the grace is REFUSED with 410 (#353) — the money never lands on a pass that would read 'ended'",
+      sellEnded.status === 410,
+    );
+    const [minted] = await db<{ n: number }[]>`
+      select count(*)::int as n from competition_passes where competition_id = ${buyComp.id}`;
+    check("pass lock/sell: ...and nothing was minted", minted?.n === 0);
+
+    // The boundary pair again, and deliberately NOT asserted as 200: with no
+    // Stripe key this route cannot reach a session, so what is asserted is that
+    // it does not reach the LOCK refusal. A gate that 410s everything passes
+    // the case above on its own.
+    await db`update competitions set ends_on = ${utcDay(-7)} where id = ${buyComp.id}`;
+    const sellBoundary = await raw(buyer, "/api/billing/pass-checkout", "POST", {
+      competition_id: buyComp.id,
+    });
+    check(
+      "pass lock/sell: a competition exactly on the grace boundary is still sellable — whatever else happens, it is not the 410",
+      sellBoundary.status !== 410,
     );
   } finally {
     await db.end();


### PR DESCRIPTION
Wave 10 of the v17-gap remediation (#283). Six defects, each one a way the platform kept giving away paid capacity — or took money for capacity it had already stopped giving.

## What was leaking

| # | Defect | Cost |
| --- | --- | --- |
| **#329** | `items.data[0]` read as "the single item" — false since groups gained a rider | An annual group stamped with its monthly rider's period end: **eleven months early** |
| **#330** | Churn cancelled the org rider, not the seat rider | A cancelled group kept `community base + N` seats **for ever, unpaid** |
| **#331** | A lost dispute dropped the plan and left `org_addons` alone | Same, by a second route |
| **#347** | The pass lock never reached the quota or the freeze sweep | One $29 pass bought a **permanent free competition slot** |
| **#353** | Pass checkout never asked whether the competition was over | A buyer pays $29/$59 for a pass that reads "ended" the second it lands — and on the terminal arm **cannot retry**, because one pass per competition is forever |
| **#304** | Detach of the last org stranded the shared credit pool | The wallet became reachable by nobody |

## How each was proved

Every task shipped a test demonstrated failing before its fix, and I re-ran each mutation myself rather than accepting the implementer's report:

| commit | mutation applied | result |
| --- | --- | --- |
| `70efc0be` #329 | revert `planItem` → `data[0]` | 4 of 5 red |
| `a936602a` #347 | strip `pass_applies` back to bare row-existence | 2 of 4 red |
| `ac79915f` #330 | narrow the cancel to the org key alone | regression red |
| `15e4380f` #331 | drop the `exists` guard / narrow the key | 1 red each |
| `b6661231` #304 | unconditional forfeit / invert the branch | 2 red / 1 red |
| `3dd6e463` #353 | remove the 410 gate / flip `<` to `<=` | 2 red / 2 red |

## One rule, one definition

`pass_applies(status, ends_on, today)` (**V343**) replaces the third, implicit copy of the Event Pass lock rule that lived in the enforcement sites as "does a pass row exist". `org_has_feature` is re-issued to call it; the body is copied forward from V338 mechanically, and **the diff against V338 is exactly one hunk** — verified, not asserted.

`IMMUTABLE` with the clock read left in the STABLE caller, which is what makes that honest and lets the parity test pin a literal date instead of racing the boundary.

## Deliberately not done

- The **delete guard** on a passed competition stays bare row-existence. It asks "was a pass ever bought" — money history — not "is a pass applying". Converting it would invert the guard on exactly the competitions most likely to be deleted and let the cascade erase the record of a real charge.
- **Read-time dunning** (#331): two arms degrade the plan while `addonBonus` stays unconditional, so a group 15 days into dunning still reads `community base + N`. Transient, recoverable, and `canceled` is deliberately terminal — un-cancelling on recovery is a product decision. Recorded on #331.
- **Nothing retires a `live` competition past its `ends_on`.** #347 is closed at the enforcement layer; that missing sweep is what makes the `past_ends_on` arm reachable at all, and it survives this wave.

## Verification

- Full suite: **518 files, 504 passed / 14 skipped, exit 0**
- `tsc` clean (app + scripts), `lint` **0 errors**, i18n parity **3541 keys** across es/fr/nl
- Smoke against a prod build on a freshly migrated database: **619 passed, 0 failed** — including 16 new checks. `ends_on` appeared nowhere in `smoke.ts` before this wave.
- V343 applied cleanly, schema at head

## Known gap

375px was **not** screenshot-verified for #353. The diff carries no markup or CSS change — the dashboard loses one link from a popover that keeps three unconditional items, and the billing offer list can reach zero rows, a state that already ships for every paid org. That is an argument, not a screenshot, and it is being closed before merge.

Closes #329
Closes #330
Closes #331
Closes #347
Closes #353
Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)