### PR TITLE
fix(billing): W11 — wrong-bill writes, locked-out payers, and checks that could not fail (#303 #305 #306 #307 #309 #312 #314 #315 #316 #318 #319 #332 #333 #334 #336 #338 #354 #363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,15 @@ jobs:
         env:
           REDIS_URL: redis://localhost:6379
 
+      # #336: platform-settings.ts's cached fee is namespaced by DB_SCHEMA now,
+      # but the regression that catches it going back to a single global key
+      # needs a real Redis actually holding a warm, cross-schema entry — same
+      # REDIS_URL-scoping reason as the two steps above.
+      - name: Platform fee cache isolation tests (real Redis)
+        run: npm test --workspace apps/web -- run src/lib/__tests__/platform-fee-cache-isolation.redis.test.ts
+        env:
+          REDIS_URL: redis://localhost:6379
+
       # Live-Stripe against real test-mode Stripe (sk_test, already in the job env)
       # on the real Postgres this job runs. Sync prices first, then run ONLY the
       # CI-safe live suites: billing-tiers (self-contained) + billing-proration

--- a/apps/web/content/help/billing/credits.md
+++ b/apps/web/content/help/billing/credits.md
@@ -18,6 +18,10 @@ Every plan comes with a monthly grant that **resets on the 1st of each month** �
 
 The grant meter on the Credits tab shows how much of this month's grant you've used and when it resets. Unused grant credits don't roll over — the pool is topped back up to the full amount each month.
 
+If a run fails before it finishes, its credits are refunded — the meter gives them back, so a failed run never counts against your grant.
+
+If a subscription lapses — a payment more than 14 days overdue, a comp that has ended, or a cancelled plan — the monthly grant falls back to the Community 10 a month until it is back in good standing, and the Credits tab shows that lower figure.
+
 ## Packs and Event Pass credits never expire
 
 When your monthly grant runs low, you can **buy a credit pack**. Pack credits — and the **one-time credits an Event Pass adds** — go into a separate pool that **never expires**. AI runs always spend your monthly grant first, so a pack is only touched once the grant is gone. That way a pack you buy is never wasted while free grant credits remain.

--- a/apps/web/content/help/billing/downgrade.md
+++ b/apps/web/content/help/billing/downgrade.md
@@ -25,9 +25,9 @@ Pro-only features (your brand colour, branded exports, sponsor tiers and package
 
 One thing that does **not** switch off: **card entry fees keep working on Community.** Your Stripe connection stays linked, existing paid entries are untouched, and divisions collecting **Card at sign-up** keep taking new registrations exactly as before — a downgrade never closes a register panel for money reasons.
 
-What changes is the platform fee: back on Community the rate returns to **8%**, where Pro is 2% and Pro Plus 1%. See [the fee ladder](/help/billing/plans#the-platform-fee-on-entry-fees).
+What changes is the platform fee, for a competition that never took a paid card entry: on Community that's **8%**, where Pro is 2% and Pro Plus 1%. See [the fee ladder](/help/billing/plans#the-platform-fee-on-entry-fees).
 
-**Passed competitions keep their own rate.** A competition covered by an [Event Pass](/help/billing/event-pass) stays at **5%** after the downgrade, and keeps everything else the pass grants — bigger limits, branded exports, sponsor tiers and packages — while the rest of the org sits on Community.
+A competition that has already taken a paid card entry keeps that platform fee **locked** at the rate it was first charged, for every entry after it, whatever your plan does next — including a downgrade to Community. A competition that takes its **first paid entry** while covered by an [Event Pass](/help/billing/event-pass) **locks in** the pass's **5%** rate the same way, and keeps it after the downgrade along with everything else the pass grants — bigger limits, branded exports, sponsor tiers and packages — while the rest of the org sits on Community.
 
 ## Moving to a cheaper plan gives you credit, not a bill
 

--- a/apps/web/content/help/billing/groups.md
+++ b/apps/web/content/help/billing/groups.md
@@ -28,6 +28,8 @@ So adding a free club to a Pro Plus group takes that club from 8% to 1% the mome
 
 A group has exactly **one payer** — one card, one invoice, one billing address, one VAT number. The payer manages the plan, the card and cancellation for the whole group.
 
+**The payer can open that bill from any organisation on it**, whether or not they are a member of one — **Settings → Billing**, **Credits** and **Add-ons** are theirs on every organisation the group funds. What they reach there is the bill and nothing else: no competitions, no members, nothing about the club itself to change.
+
 An organisation inside a group **cannot pay for itself, or pay a share.** There is no way to split a single invoice between several people; that's a payments product, not a setting. An organisation that wants its own bill has to leave the group first — see below. That's also the answer for two clubs that are two separate registered charities: two legal entities need two VAT numbers and two invoices, so they need two groups.
 
 Ownership of an organisation and payment for it are separate things. If an organisation changes owner, its billing stays with the group; the new owner sees who is paying for them, and can leave.

--- a/apps/web/content/help/scheduling/ai-scheduling.md
+++ b/apps/web/content/help/scheduling/ai-scheduling.md
@@ -10,8 +10,8 @@ order: 5
 
 Scheduling runs in two passes, and you can stop after the first:
 
-1. **Schedule** — the architect places every movable fixture on a court and time. This phase runs on **every plan** (within the run quota below).
-2. **Officials** — once you're happy with the times, the architect can staff the matches, assigning referees and other officials around their roles, blackout dates and other bookings. The officials pass is part of **automatic officials assignment**, a **Pro Plus** feature.
+1. **Schedule** — the architect places every movable fixture on a court and time. This phase runs on **every plan** (within the credits and rate limit below).
+2. **Officials** — once you're happy with the times, the architect can staff the matches, assigning referees and other officials around their roles, blackout dates and other bookings. Like the schedule pass, it runs on **every plan** too — see [AI Officials](/help/scheduling/ai-officials).
 
 You can apply the schedule on its own, or apply both together.
 
@@ -37,18 +37,11 @@ Your data stays yours: the brief is sent to one of our AI providers — Anthropi
 
 Every proposal is checked by the same engine that powers the drag-and-drop board. Blocking clashes (a double-booked court, a final before its feeder finishes) are repaired automatically for up to two rounds; anything left over is shown to you rather than hidden. Rest gaps, session windows and soft warnings are surfaced, never silently ignored.
 
-## Run quotas
+## Credits and rate limits
 
-AI Schedule needs no upgrade — it runs on **every plan, Community included**. What your plan sets is how many times you can run it: each **schedule generation** counts against a per-division quota.
+AI Schedule needs no upgrade — it runs on **every plan, Community included**. There is no per-division run cap any more: every run is metered by your organisation's shared **AI credit wallet** instead. Generate, refine and repair each spend **one AI credit**, and the officials pass spends one too — including its no-instruction default spread, which makes no model call but still draws from the wallet. A run that fails or times out is **refunded**, so it never costs you a credit. See [AI credits](/help/billing/credits) for the monthly grant, buying packs, and how a billing group shares one wallet.
 
-| Plan | AI schedule generations per division |
-| --- | --- |
-| Community | 5 |
-| Event Pass | 10 |
-| Pro | 20 |
-| Pro Plus | 50 |
-
-The quota is a **lifetime total per division** — it doesn't reset weekly or monthly, and a new division starts a fresh count. Refine and repair each use one generation. A run that fails or times out **does not** count. Separately, every plan has a burst brake of **5 AI runs per hour per division**. **Officials AI runs are not metered** — once you have automatic officials assignment, you can restaff as often as you like.
+Separately, every plan has a burst brake of **5 AI runs an hour per division** for scheduling, and its own **5 an hour** for officials — independent counters, so a busy hour staffing matches doesn't use up your scheduling budget or the other way round.
 
 ## Applying and undo
 

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -231,7 +231,7 @@ async function withDb<T>(
  * Every fixture below writes the GROUP, so a missing link has to throw rather
  * than update zero rows. A no-op fixture is the worst kind: the spec runs
  * against whatever state the row already held and reports on the wrong thing,
- * which is how the pre-V310 version of these helpers survived a schema change
+ * which is how the pre-V314 version of these helpers survived a schema change
  * that had already made them impossible.
  */
 async function requireGroupId(sql: import("postgres").Sql, orgId: string): Promise<string> {
@@ -275,10 +275,10 @@ export async function communityLimit(featureKey: string): Promise<number> {
  * Set an org's plan directly in the DB (same trick auth.setup.ts uses for the
  * Pro account). Targets by org id or by owner email.
  *
- * Writes the org's billing GROUP, because V310 moved the plan there and dropped
+ * Writes the org's billing GROUP, because V314 moved the plan there and dropped
  * `subscriptions.org_id`. Two consequences worth knowing before you call it:
  *
- *  - It UPDATES, never inserts. Post-V310 every org points at a group from the
+ *  - It UPDATES, never inserts. Post-V314 every org points at a group from the
  *    moment it is created (lib/auth.ts createOrgForUser), so an insert here
  *    would mint a second, orphaned group that nothing reads.
  *  - The plan is a property of the group, so on a SHARED group this moves every
@@ -509,7 +509,7 @@ export async function setOrgSubscriptionSql(
   const used = fields.trial_used_at ?? null;
   const setId = "stripe_subscription_id" in fields;
   await withDb(async (sql) => {
-    // The org's billing GROUP — V310 moved every one of these columns onto it
+    // The org's billing GROUP — V314 moved every one of these columns onto it
     // and dropped subscriptions.org_id. See setOrgPlanBySql for why this
     // updates rather than inserts, and for the shared-group blast radius.
     const groupId = await requireGroupId(sql, orgId);

--- a/apps/web/e2e/pro-plus-tier.spec.ts
+++ b/apps/web/e2e/pro-plus-tier.spec.ts
@@ -104,7 +104,7 @@ async function seedOrg(opts: {
       returning id`;
     await sql`insert into org_members (org_id, user_id, role) values (${orgId}, ${ownerId}, 'owner')`;
     if (opts.plan) {
-      // V310: org -> subscription, and this seeder writes raw SQL rather than
+      // V314: org -> subscription, and this seeder writes raw SQL rather than
       // going through createOrgForUser, so it owns both halves of the link.
       const [group] = await sql<{ id: string }[]>`
         insert into subscriptions (owner_user_id, plan_key, status)

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -22,6 +22,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
           <Link href="/admin/entitlements" className="hover:text-white">Entitlements</Link>
           <Link href="/admin/revenue" className="hover:text-white">Revenue</Link>
           <Link href="/admin/billing-events" className="hover:text-white">Stripe</Link>
+          <Link href="/admin/pass-credit-reversals" className="hover:text-white">Pass credits</Link>
           <Link href="/admin/ai-runs" className="hover:text-white">AI runs</Link>
           <Link href="/admin/settings" className="hover:text-white">Settings</Link>
           <Link href="/admin/audit" className="hover:text-white">Audit</Link>

--- a/apps/web/src/app/admin/orgs/page.tsx
+++ b/apps/web/src/app/admin/orgs/page.tsx
@@ -4,7 +4,7 @@ import { sql } from "@/lib/db";
 export const dynamic = "force-dynamic";
 
 export default async function AdminOrgsPage() {
-  // Joined through organizations.subscription_id. V310 dropped
+  // Joined through organizations.subscription_id. V314 dropped
   // subscriptions.org_id and reversed the direction of the relationship — this
   // page was still joining on the old column, so it was a hard 500.
   //

--- a/apps/web/src/app/admin/pass-credit-reversals/page.tsx
+++ b/apps/web/src/app/admin/pass-credit-reversals/page.tsx
@@ -1,0 +1,142 @@
+import Link from "@/components/ui/console-link";
+import { requireStaff } from "@/lib/admin";
+import { listUndeterminedPassCreditReversals } from "@/server/usecases/pass-credit";
+import { ResolveUndeterminedForm } from "./resolve-form";
+
+export const dynamic = "force-dynamic";
+
+const STATUS_LABEL: Record<string, string> = {
+  open: "Needs a decision",
+  kept: "Reviewed — customer keeps it",
+  clawed_back: "Resolved — clawed back",
+};
+
+const STATUS_CLS: Record<string, string> = {
+  open: "bg-amber-900 text-amber-200",
+  kept: "bg-slate-700 text-slate-300",
+  clawed_back: "bg-emerald-900 text-emerald-300",
+};
+
+/**
+ * #305 (#286 phase 2) — the worklist for pass-credit redemptions whose refund
+ * reversal could not be decided automatically, and the one place a human can
+ * close one.
+ *
+ * An `open` row is holding its group's ONE lifetime Event Pass credit and will
+ * go on doing so until somebody decides here; that is deliberate (the customer
+ * provably still holds the money) but it is not a state to leave unattended.
+ */
+export default async function AdminPassCreditReversalsPage() {
+  const staff = await requireStaff();
+  const rows = await listUndeterminedPassCreditReversals();
+  const open = rows.filter((r) => r.status === "open").length;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="mb-1 text-xs text-slate-500">
+          <Link href="/admin" className="hover:text-white">
+            Admin
+          </Link>{" "}
+          / Pass credit reversals
+        </p>
+        <h1 className="text-xl font-bold text-white">Undetermined pass credit reversals</h1>
+        <p className="mt-2 max-w-3xl text-sm text-slate-400">
+          An Event Pass was refunded but the customer&rsquo;s Stripe balance could not be attributed
+          to that pass, so nothing was clawed back automatically and the group&rsquo;s one lifetime
+          pass credit stays held. Settle the balance in the Stripe dashboard FIRST, then record what
+          you did here — this page never moves money.
+        </p>
+        <p className="mt-2 text-xs text-slate-500">
+          {open} awaiting a decision · {rows.length} total
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border border-slate-800">
+        <table className="w-full min-w-[64rem] text-sm">
+          <thead className="bg-slate-800 text-xs text-slate-400">
+            <tr>
+              <th className="px-3 py-2 text-left">Org</th>
+              <th className="px-3 py-2 text-left">Competition</th>
+              <th className="px-3 py-2 text-left">Payment intent</th>
+              <th className="px-3 py-2 text-left">Granted / reversed</th>
+              <th className="px-3 py-2 text-left">Undetermined</th>
+              <th className="px-3 py-2 text-left">Status</th>
+              <th className="px-3 py-2 text-left">Decided by</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {rows.map((r) => (
+              <tr key={r.id} className="align-top hover:bg-slate-800/50">
+                <td className="px-3 py-2 text-slate-300">
+                  {r.orgName ?? "—"}
+                  <div className="font-mono text-[10px] text-slate-600">{r.orgId}</div>
+                </td>
+                <td className="px-3 py-2 text-slate-400">{r.competitionName ?? "—"}</td>
+                <td className="px-3 py-2 font-mono text-xs text-purple-300">{r.paymentIntent}</td>
+                <td className="px-3 py-2 text-slate-400">
+                  {r.amountMinor} / {r.reversedMinor ?? 0}{" "}
+                  <span className="uppercase text-slate-600">{r.currency}</span>
+                  <div className="text-[10px] text-slate-600">minor units</div>
+                </td>
+                <td className="px-3 py-2 text-xs text-slate-500">
+                  {r.undeterminedAt ? new Date(r.undeterminedAt).toLocaleString() : "—"}
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs ${STATUS_CLS[r.status] ?? "bg-slate-700 text-slate-300"}`}
+                  >
+                    {STATUS_LABEL[r.status] ?? r.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs text-slate-400">
+                  {r.resolvedBy ? (
+                    <>
+                      {r.resolvedByName ?? r.resolvedBy}
+                      <div className="text-[10px] text-slate-600">
+                        {r.resolvedAt ? new Date(r.resolvedAt).toLocaleString() : ""}
+                      </div>
+                      {r.reason && <div className="mt-1 text-slate-500">{r.reason}</div>}
+                    </>
+                  ) : (
+                    "—"
+                  )}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-3 py-4 text-center text-slate-500">
+                  Nothing undetermined — every pass credit reversal settled itself.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* The controls live outside the table so a 375px screen scrolls the wide
+          row data horizontally without trapping the form inputs inside it. */}
+      {rows
+        .filter((r) => r.undeterminedAt !== null)
+        .map((r) => (
+          <div key={r.id} className="rounded-lg border border-slate-800 bg-slate-900 p-3">
+            {/* break-all: a Stripe payment intent is one unbreakable token and
+                would otherwise be the thing that scrolls the page at 375px. */}
+            <p className="mb-2 break-all text-xs text-slate-400">
+              <span className="font-semibold text-slate-200">{r.orgName ?? r.orgId}</span> ·{" "}
+              <span className="font-mono text-purple-300">{r.paymentIntent}</span> ·{" "}
+              {r.amountMinor} minor <span className="uppercase">{r.currency}</span> granted
+              {r.status === "kept" && " · already reviewed as kept"}
+            </p>
+            <ResolveUndeterminedForm
+              redemptionId={r.id}
+              grantedMinor={r.amountMinor}
+              currency={r.currency}
+              canClawBack={staff.staff_role === "superadmin"}
+            />
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/pass-credit-reversals/resolve-form.tsx
+++ b/apps/web/src/app/admin/pass-credit-reversals/resolve-form.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+/**
+ * Record a staff decision about ONE undetermined pass-credit reversal
+ * (#305, #286 phase 2).
+ *
+ * The two decisions are deliberately not symmetric in the UI either:
+ * `clawed_back` releases the group's lifetime pass-credit cap and so demands
+ * the amount actually removed in Stripe, and is only offered to a superadmin
+ * (the route enforces it — this just avoids showing support staff a control
+ * that would 403). `kept` moves nothing.
+ */
+export function ResolveUndeterminedForm({
+  redemptionId,
+  grantedMinor,
+  currency,
+  canClawBack,
+}: {
+  redemptionId: string;
+  grantedMinor: number;
+  currency: string;
+  canClawBack: boolean;
+}) {
+  const router = useRouter();
+  const [resolution, setResolution] = useState<"clawed_back" | "kept">(
+    canClawBack ? "clawed_back" : "kept",
+  );
+  const [reversedMinor, setReversedMinor] = useState(String(grantedMinor));
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const inputCls =
+    "rounded border border-slate-600 bg-slate-700 px-2 py-1 text-xs text-white placeholder:text-slate-500";
+
+  async function submit() {
+    setLoading(true);
+    setError("");
+    try {
+      const body: Record<string, unknown> = { redemption_id: redemptionId, resolution, reason };
+      if (resolution === "clawed_back") body.reversed_minor = Number(reversedMinor);
+      const res = await fetch("/api/admin/pass-credit-reversals", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const d = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(d.error ?? `Failed (${res.status})`);
+      }
+      setReason("");
+      router.refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {/* max-w-full: a <select> is sized by its widest OPTION, which at 375px
+          would otherwise push the card wider than the viewport. */}
+      <select
+        aria-label="Resolution"
+        className={`${inputCls} max-w-full`}
+        value={resolution}
+        onChange={(e) => setResolution(e.target.value as "clawed_back" | "kept")}
+      >
+        {canClawBack && <option value="clawed_back">Clawed back — free the cap</option>}
+        <option value="kept">Kept — cap stays held</option>
+      </select>
+      {resolution === "clawed_back" && (
+        <input
+          aria-label={`Minor units removed (${currency})`}
+          className={`${inputCls} w-28`}
+          inputMode="numeric"
+          value={reversedMinor}
+          onChange={(e) => setReversedMinor(e.target.value)}
+          placeholder={`minor ${currency}`}
+        />
+      )}
+      <input
+        aria-label="Reason"
+        className={`${inputCls} min-w-0 flex-1`}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        placeholder="What you checked, and where"
+      />
+      <button
+        type="button"
+        disabled={loading || reason.trim().length === 0}
+        onClick={submit}
+        className="rounded bg-purple-700 px-3 py-1 text-xs font-semibold text-white disabled:opacity-50"
+      >
+        {loading ? "Saving…" : "Record"}
+      </button>
+      {error && <span className="text-xs text-red-400">{error}</span>}
+    </div>
+  );
+}

--- a/apps/web/src/app/api/admin/pass-credit-reversals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/pass-credit-reversals/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+// POST /api/admin/pass-credit-reversals — the staff resolution endpoint for a
+// pass-credit redemption stuck on `reversal_undetermined_at` (#305, #286 phase
+// 2). Mirrors the admin-route test idiom (api/admin/entitlements): the guard
+// and the usecase are mocked so this asserts the ROUTE's contract only — who
+// may record which decision, and that the decision reaches the usecase intact.
+//
+// The privilege split is the point. `clawed_back` RELEASES the group's lifetime
+// pass-credit cap, so a wrong one is a second Event Pass credit handed out;
+// `kept` frees nothing. Support staff may record the second, not the first.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthError } from "@/lib/errors";
+
+const requireStaffMock = vi.fn<() => Promise<{ id: string; staff_role: string | null }>>();
+vi.mock("@/lib/admin", () => ({
+  requireStaff: () => requireStaffMock(),
+}));
+
+const resolveMock = vi.fn<(...args: unknown[]) => Promise<{ resolved: boolean }>>();
+const listMock = vi.fn<() => Promise<unknown[]>>();
+vi.mock("@/server/usecases/pass-credit", () => ({
+  resolveUndeterminedPassCreditReversal: (...args: unknown[]) => resolveMock(...args),
+  listUndeterminedPassCreditReversals: () => listMock(),
+}));
+
+import { GET, POST } from "../route";
+
+// A real v4 uuid: zod's .uuid() checks the version and variant nibbles, so a
+// made-up "1111-2222-3333-4444" string 400s before the guard is ever reached.
+const REDEMPTION = "11111111-2222-4333-8444-555555555555";
+
+const post = (body: unknown) =>
+  POST(
+    new Request("http://test/api/admin/pass-credit-reversals", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+
+beforeEach(() => {
+  requireStaffMock.mockReset().mockResolvedValue({ id: "staff-1", staff_role: "superadmin" });
+  resolveMock.mockReset().mockResolvedValue({ resolved: true });
+  listMock.mockReset().mockResolvedValue([]);
+});
+
+describe("POST /api/admin/pass-credit-reversals", () => {
+  it("records a superadmin claw-back with the amount actually removed in Stripe", async () => {
+    const res = await post({
+      redemption_id: REDEMPTION,
+      resolution: "clawed_back",
+      reversed_minor: 2500,
+      reason: "removed by hand, cbtxn_x",
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, data: { resolved: true } });
+    expect(resolveMock).toHaveBeenCalledWith("staff-1", REDEMPTION, {
+      resolution: "clawed_back",
+      reversedMinor: 2500,
+      reason: "removed by hand, cbtxn_x",
+    });
+  });
+
+  it("lets support staff record 'kept' — it frees nothing", async () => {
+    requireStaffMock.mockResolvedValue({ id: "staff-2", staff_role: "support" });
+
+    const res = await post({
+      redemption_id: REDEMPTION,
+      resolution: "kept",
+      reason: "customer keeps it",
+    });
+
+    expect(res.status).toBe(200);
+    expect(resolveMock).toHaveBeenCalledWith("staff-2", REDEMPTION, {
+      resolution: "kept",
+      reversedMinor: undefined,
+      reason: "customer keeps it",
+    });
+  });
+
+  it("refuses a claw-back from support staff — that one releases the cap", async () => {
+    requireStaffMock.mockResolvedValue({ id: "staff-2", staff_role: "support" });
+
+    const res = await post({
+      redemption_id: REDEMPTION,
+      resolution: "clawed_back",
+      reversed_minor: 2500,
+      reason: "nope",
+    });
+
+    expect(res.status).toBe(403);
+    expect(resolveMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-staff caller before any write", async () => {
+    requireStaffMock.mockRejectedValue(new AuthError("Staff access required"));
+
+    const res = await post({ redemption_id: REDEMPTION, resolution: "kept", reason: "x" });
+
+    expect(res.status).toBe(401);
+    expect(resolveMock).not.toHaveBeenCalled();
+  });
+
+  it("400s a malformed body before any write", async () => {
+    const res = await post({ redemption_id: "not-a-uuid", resolution: "maybe", reason: "" });
+
+    expect(res.status).toBe(400);
+    expect(resolveMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a usecase refusal through with its own status", async () => {
+    resolveMock.mockRejectedValue(
+      Object.assign(new Error("nothing to resolve"), { status: 409, name: "HttpError" }),
+    );
+    const res = await post({ redemption_id: REDEMPTION, resolution: "kept", reason: "x" });
+    // Not a 200 dressed up as success — the operator must see the refusal.
+    expect(res.status).not.toBe(200);
+  });
+});
+
+describe("GET /api/admin/pass-credit-reversals", () => {
+  it("returns the worklist to staff", async () => {
+    listMock.mockResolvedValue([{ id: REDEMPTION, status: "open" }]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      data: { rows: [{ id: REDEMPTION, status: "open" }] },
+    });
+  });
+
+  it("rejects a non-staff caller", async () => {
+    requireStaffMock.mockRejectedValue(new AuthError("Staff access required"));
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/admin/pass-credit-reversals/route.ts
+++ b/apps/web/src/app/api/admin/pass-credit-reversals/route.ts
@@ -1,0 +1,65 @@
+import { requireStaff } from "@/lib/admin";
+import { handler, HttpError } from "@/lib/http";
+import {
+  listUndeterminedPassCreditReversals,
+  resolveUndeterminedPassCreditReversal,
+} from "@/server/usecases/pass-credit";
+import { z } from "zod";
+
+const resolveSchema = z
+  .object({
+    redemption_id: z.string().uuid(),
+    resolution: z.enum(["clawed_back", "kept"]),
+    /** Minor units staff actually removed in Stripe. Required for a claw-back;
+     *  the usecase bounds it by the grant and 422s outside 0..grant. */
+    reversed_minor: z.number().int().nonnegative().optional(),
+    reason: z.string().min(1).max(500),
+  })
+  .strict();
+
+/** The staff worklist: every pass-credit redemption whose refund reversal could
+ *  not be decided automatically (#286 / V337), plus the decision each has since
+ *  been given. Read-only, so plain staff. */
+export async function GET() {
+  return handler(async () => {
+    await requireStaff();
+    return { rows: await listUndeterminedPassCreditReversals() };
+  });
+}
+
+/**
+ * Record a staff decision about one undetermined reversal (#305, #286 phase 2).
+ *
+ * `clawed_back` is SUPERADMIN-only: it releases the group's lifetime pass-credit
+ * cap, so getting it wrong hands the group a second Event Pass credit it never
+ * earned — the same bar `entitlement-override` and `addon_grant` sit behind.
+ * `kept` moves no money and frees nothing (the cap goes on holding), so support
+ * staff may record it.
+ *
+ * This endpoint NEVER touches Stripe. The claw-back it records already happened,
+ * by hand, in the Stripe dashboard — that is the whole reason a human is in the
+ * loop. See the §6 header in server/usecases/pass-credit.ts.
+ */
+export async function POST(req: Request) {
+  return handler(async () => {
+    const staff = await requireStaff();
+    const { redemption_id, resolution, reversed_minor, reason } = resolveSchema.parse(
+      await req.json(),
+    );
+
+    // Inline rather than a second `requireSuperadmin()` call: the privilege
+    // depends on WHICH decision is being recorded, which is only known after
+    // the body parses, and re-querying the staff row to learn what we already
+    // hold would just be a second round trip.
+    if (resolution === "clawed_back" && staff.staff_role !== "superadmin") {
+      throw new HttpError(403, "Releasing a pass-credit cap requires superadmin.");
+    }
+
+    const { resolved } = await resolveUndeterminedPassCreditReversal(staff.id, redemption_id, {
+      resolution,
+      reversedMinor: reversed_minor,
+      reason,
+    });
+    return { resolved };
+  });
+}

--- a/apps/web/src/app/api/billing/extra-orgs/__tests__/group-scope.test.ts
+++ b/apps/web/src/app/api/billing/extra-orgs/__tests__/group-scope.test.ts
@@ -1,0 +1,244 @@
+// v17 gap #334 — a group-scoped billing WRITE must act on the group the
+// REQUEST names, not on the one the `seazn_org` cookie happens to still hold.
+//
+// The window is real and narrow: `ActiveOrgSync` re-points the cookie from a
+// client effect that runs AFTER the destination page has painted, so a payer
+// who lands on group B's Add-ons tab and saves early is authorised (they own
+// both groups, `requireBillingOwner` has nothing to refuse) while the route
+// resolves group A. And `count` is a TOTAL, not a delta — so choosing 1 for B
+// rewrites A's total to 1 and CANCELS the riders A was standing on.
+//
+// These tests therefore assert the money, not a status code: group A's rider
+// quantity in Stripe must be untouched. A 4xx would prove a refusal; only an
+// unchanged quantity proves the write landed on the right bill.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { User } from "@/lib/types";
+
+// The entitlement/slug caches would otherwise answer a stale org row between
+// tests in this file; every read here must see the row it just wrote.
+vi.mock("@/lib/cache", () => ({
+  cacheEnabled: () => false,
+  cacheGet: async () => null,
+  cacheSet: async () => {},
+  cacheDelPattern: async () => {},
+  incrWindow: async () => 1,
+}));
+
+/** A miniature Stripe: one item list per subscription id, mutated in place, so
+ *  "what is group A billed for now" is a real observation rather than a spy
+ *  argument. */
+const stripeState = vi.hoisted(() => {
+  const subs = new Map<
+    string,
+    { id: string; items: { id: string; quantity: number; price: { lookup_key: string | null } }[] }
+  >();
+  return { subs };
+});
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    subscriptions: {
+      retrieve: async (id: string) => {
+        const sub = stripeState.subs.get(id);
+        if (!sub) throw new Error(`test stripe: no subscription ${id}`);
+        return { id: sub.id, items: { data: sub.items } };
+      },
+    },
+    subscriptionItems: {
+      update: async (itemId: string, params: { quantity?: number }) => {
+        for (const sub of stripeState.subs.values()) {
+          const item = sub.items.find((i) => i.id === itemId);
+          if (item && params.quantity !== undefined) item.quantity = params.quantity;
+        }
+        return {};
+      },
+      create: async (params: { subscription: string; quantity: number }) => {
+        const sub = stripeState.subs.get(params.subscription);
+        if (!sub) throw new Error(`test stripe: no subscription ${params.subscription}`);
+        sub.items.push({
+          id: `si_${randomUUID().slice(0, 8)}`,
+          quantity: params.quantity,
+          price: { lookup_key: ORG_ADDON_LOOKUP_KEY },
+        });
+        return {};
+      },
+      del: async (itemId: string) => {
+        for (const sub of stripeState.subs.values()) {
+          const at = sub.items.findIndex((i) => i.id === itemId);
+          if (at >= 0) sub.items.splice(at, 1);
+        }
+        return {};
+      },
+    },
+    prices: { list: async () => ({ data: [{ id: "price_org_addon_test" }] }) },
+  }),
+}));
+
+/** The session. `cookieOrgId` IS the `seazn_org` cookie — the value that lags
+ *  the URL — and `requireUser` is the signed-in payer. */
+const authState = vi.hoisted(() => ({ userId: "", cookieOrgId: null as string | null }));
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    requireUser: async () => ({ id: authState.userId }) as unknown as User,
+    getCurrentUser: async () => ({ id: authState.userId }) as unknown as User,
+    getActiveOrgId: async () => authState.cookieOrgId,
+  };
+});
+
+/** The request's own headers. `orgScope` is what the page the payer is
+ *  actually looking at puts on the request. */
+const headerState = vi.hoisted(() => ({ orgScope: null as string | null }));
+vi.mock("next/headers", () => ({
+  headers: async () =>
+    new Headers(headerState.orgScope ? { "x-seazn-org": headerState.orgScope } : {}),
+  cookies: async () => ({ get: () => undefined, set: () => {}, delete: () => {} }),
+}));
+
+import { sql } from "@/lib/db";
+import { createOrgForUser } from "@/lib/auth";
+import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+import { orgAddonForPlan } from "@/lib/org-addons";
+import { POST } from "@/app/api/billing/extra-orgs/route";
+
+const ORG_ADDON_LOOKUP_KEY = orgAddonForPlan("pro")?.lookupKey ?? "extra_org_pro";
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function makeUser(): Promise<string> {
+  const [row] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`group-scope-${uniq()}@test.local`}, 'Group Scope Payer', true) returning id`;
+  return row!.id;
+}
+
+/** A billed Pro group of one org, holding `riders` extra-organisation units in
+ *  Stripe. Returns everything a caller needs to point a request at it. */
+async function makeBilledGroup(
+  payerId: string,
+  riders: number,
+): Promise<{ orgId: string; orgSlug: string; groupId: string; stripeSubId: string }> {
+  const org = await createOrgForUser(payerId, `Group Scope ${uniq()}`);
+  const groupId = await setOrgPlan(org.id, "pro");
+  const stripeSubId = `sub_${uniq()}`;
+  await sql`
+    update subscriptions
+       set stripe_subscription_id = ${stripeSubId}, owner_user_id = ${payerId}
+     where id = ${groupId}`;
+  stripeState.subs.set(stripeSubId, {
+    id: stripeSubId,
+    items:
+      riders > 0
+        ? [{ id: `si_${uniq()}`, quantity: riders, price: { lookup_key: ORG_ADDON_LOOKUP_KEY } }]
+        : [],
+  });
+  const [row] = await sql<{ slug: string }[]>`
+    select slug from organizations where id = ${org.id}`;
+  return { orgId: org.id, orgSlug: row!.slug, groupId, stripeSubId };
+}
+
+/** Extra-org units Stripe is billing this subscription for. */
+function ridersOn(stripeSubId: string): number {
+  const sub = stripeState.subs.get(stripeSubId);
+  return (sub?.items ?? []).reduce((n, i) => n + i.quantity, 0);
+}
+
+function postExtraOrgs(count: number): Promise<Response> {
+  return POST(
+    new Request("http://test.local/api/billing/extra-orgs", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ count }),
+    }),
+  );
+}
+
+describe.skipIf(!HAS_DB)("group-scoped billing writes follow the request, not the cookie", () => {
+  beforeEach(() => {
+    stripeState.subs.clear();
+    authState.userId = "";
+    authState.cookieOrgId = null;
+    headerState.orgScope = null;
+  });
+
+  // Fixtures are left in place, as every other DB-backed suite here does: the
+  // rows are unique per run and the test database is throwaway. Unpicking them
+  // means organizations -> subscriptions -> users in FK order, which is more
+  // teardown than a disposable schema is worth.
+
+  it("saves group B's total onto group B while the cookie still names group A", async () => {
+    const payer = await makeUser();
+    // The group the payer just navigated AWAY from. Three riders it is
+    // standing on and paying for.
+    const a = await makeBilledGroup(payer, 3);
+    // The group whose Add-ons tab is on screen. No riders yet.
+    const b = await makeBilledGroup(payer, 0);
+
+    // The race, exactly: the URL (and so the page) is B's; ActiveOrgSync has
+    // not yet re-pointed the cookie, which still says A.
+    authState.userId = payer;
+    authState.cookieOrgId = a.orgId;
+    headerState.orgScope = b.orgSlug;
+
+    const res = await postExtraOrgs(1);
+
+    // Not a refusal — the payer owns both groups and this is a legitimate
+    // purchase. It simply has to land on B.
+    expect(res.status).toBe(200);
+    // THE MONEY, asserted FIRST: A never asked for anything. The two riders it
+    // is standing on must not be cancelled by a save meant for another bill.
+    expect(ridersOn(a.stripeSubId)).toBe(3);
+    expect(ridersOn(b.stripeSubId)).toBe(1);
+  });
+
+  it("still uses the cookie when the request names no group", async () => {
+    const payer = await makeUser();
+    const a = await makeBilledGroup(payer, 0);
+
+    authState.userId = payer;
+    authState.cookieOrgId = a.orgId;
+    headerState.orgScope = null;
+
+    const res = await postExtraOrgs(2);
+
+    expect(res.status).toBe(200);
+    expect(ridersOn(a.stripeSubId)).toBe(2);
+  });
+
+  it("refuses a request naming a group its caller does not pay for", async () => {
+    const payer = await makeUser();
+    const stranger = await makeUser();
+    const mine = await makeBilledGroup(payer, 0);
+    const theirs = await makeBilledGroup(stranger, 4);
+
+    authState.userId = payer;
+    authState.cookieOrgId = mine.orgId;
+    headerState.orgScope = theirs.orgSlug;
+
+    const res = await postExtraOrgs(1);
+
+    expect(res.status).toBe(403);
+    expect(ridersOn(theirs.stripeSubId)).toBe(4);
+    expect(ridersOn(mine.stripeSubId)).toBe(0);
+  });
+
+  it("refuses a request naming an organisation that does not exist", async () => {
+    const payer = await makeUser();
+    const a = await makeBilledGroup(payer, 3);
+
+    authState.userId = payer;
+    authState.cookieOrgId = a.orgId;
+    headerState.orgScope = "no-such-organisation-slug";
+
+    const res = await postExtraOrgs(1);
+
+    // 400 — the same class, and the same remedy ("pick an organisation
+    // again"), as a stale cookie. Never a silent fall back to the cookie:
+    // that is the bug this closes.
+    expect(res.status).toBe(400);
+    expect(ridersOn(a.stripeSubId)).toBe(3);
+  });
+});

--- a/apps/web/src/app/api/billing/groups/route.test.ts
+++ b/apps/web/src/app/api/billing/groups/route.test.ts
@@ -107,7 +107,7 @@ describe.skipIf(!HAS_DB)("GET /api/billing/groups", () => {
     expect(mine).toBeDefined();
     expect(mine!.plan_key).toBe("pro");
     expect(mine!.orgs.map((o) => o.id).sort()).toEqual([...g.orgIds].sort());
-    // Pro holds 5 (V310). The cap is what the UI needs to say "2 slots left"
+    // Pro holds 5 (V314). The cap is what the UI needs to say "2 slots left"
     // without inventing the number itself.
     expect(mine!.max_orgs).toBe(5);
   });

--- a/apps/web/src/app/api/cron/billing-quantity/route.test.ts
+++ b/apps/web/src/app/api/cron/billing-quantity/route.test.ts
@@ -1,0 +1,92 @@
+// Cron route for the daily billing reconciliation: same x-cron-secret /
+// CRON_SECRET contract as /api/cron/billing-events. next/headers is mocked so
+// the route runs without a request scope, and the three usecases are mocked so
+// this stays DB-free and Stripe-free — their logic is covered in their own
+// suites (billing-groups, billing-events-sweep, org-addon-price-sweep).
+//
+// The third assertion is the point of this file. #332's sweep shipped with NO
+// CALLER: the function existed, was tested, and could never run in production.
+// A backstop nothing invokes is indistinguishable from an absent backstop, and
+// nothing in the sweep's own suite could notice. This is the test that fails if
+// it is ever unwired again.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const hdrs = vi.hoisted(() => ({ store: new Headers() }));
+vi.mock("next/headers", () => ({ headers: async () => hdrs.store }));
+
+const mocks = vi.hoisted(() => ({
+  reconcile: vi.fn(),
+  orphans: vi.fn(),
+  addonPrices: vi.fn(),
+}));
+vi.mock("@/server/usecases/billing-groups", () => ({
+  reconcileGroupQuantities: mocks.reconcile,
+  countOrgsWithoutGroup: mocks.orphans,
+}));
+vi.mock("@/server/usecases/billing-events", () => ({
+  sweepStaleOrgAddonPrices: mocks.addonPrices,
+}));
+
+import { POST } from "./route";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  hdrs.store = new Headers();
+  for (const m of Object.values(mocks)) m.mockReset();
+});
+
+const authorize = () => {
+  vi.stubEnv("CRON_SECRET", "s3cret");
+  hdrs.store = new Headers({ "x-cron-secret": "s3cret" });
+  mocks.reconcile.mockResolvedValue({ checked: 3, corrected: 1 });
+  mocks.orphans.mockResolvedValue(0);
+  mocks.addonPrices.mockResolvedValue({
+    total: 2,
+    checked: 2,
+    mismatched: 0,
+    unresolved: 0,
+    vanished: 0,
+    unreadable: 0,
+    alerted: 0,
+    mismatches: [],
+  });
+};
+
+describe("POST /api/cron/billing-quantity", () => {
+  it("401s on a missing or wrong x-cron-secret, running nothing", async () => {
+    vi.stubEnv("CRON_SECRET", "s3cret");
+    expect((await POST()).status).toBe(401); // no header at all
+    hdrs.store = new Headers({ "x-cron-secret": "wrong" });
+    expect((await POST()).status).toBe(401);
+    // Asserted for all three, not just the first: an unauthenticated caller
+    // must not be able to make the platform spend Stripe reads either.
+    for (const m of Object.values(mocks)) expect(m).not.toHaveBeenCalled();
+  });
+
+  it("503s when CRON_SECRET is not configured", async () => {
+    vi.stubEnv("CRON_SECRET", "");
+    expect((await POST()).status).toBe(503);
+  });
+
+  it("REGRESSION (#332): runs the stale-price sweep and returns its counts", async () => {
+    authorize();
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(mocks.addonPrices).toHaveBeenCalledTimes(1);
+    const body = (await res.json()) as { data: { addonPrices?: { checked: number } } };
+    // Present in the RESPONSE, not merely invoked: whoever reads this schedule's
+    // output is the only audience the sweep has, so a run whose result is
+    // dropped on the floor is the same as no run.
+    expect(body.data.addonPrices?.checked).toBe(2);
+  });
+
+  it("still reports the quantity reconcile and the orphan-org guard alongside it", async () => {
+    authorize();
+    const body = (await (await POST()).json()) as {
+      data: { checked: number; corrected: number; orphanOrgs: number };
+    };
+    expect(body.data).toMatchObject({ checked: 3, corrected: 1, orphanOrgs: 0 });
+    expect(mocks.reconcile).toHaveBeenCalledTimes(1);
+    expect(mocks.orphans).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/cron/billing-quantity/route.ts
+++ b/apps/web/src/app/api/cron/billing-quantity/route.ts
@@ -2,6 +2,7 @@ import { headers } from "next/headers";
 import { handler } from "@/lib/http";
 import { HttpError } from "@/lib/errors";
 import { countOrgsWithoutGroup, reconcileGroupQuantities } from "@/server/usecases/billing-groups";
+import { sweepStaleOrgAddonPrices } from "@/server/usecases/billing-events";
 
 /** POST /api/cron/billing-quantity — daily: for every live billing group whose
  *  paid-for seat count disagrees with its organisation count, put the Stripe
@@ -21,10 +22,23 @@ export async function POST() {
     if (given !== secret) throw new HttpError(401, "Bad cron secret");
     // orphanOrgs is the #232 P2 invariant guard: 0 in a healthy database. The
     // schedule warns when reconcile corrects drift or an orphan appears.
-    const [reconcile, orphanOrgs] = await Promise.all([
+    //
+    // addonPrices rides this schedule rather than the hourly billing-events one
+    // (#332). Same subscription ITEMS as reconcileGroupQuantities above, one
+    // field over: that call puts the item's QUANTITY back on the truth, this one
+    // reports items whose PRICE no longer matches the plan's rider. Daily is
+    // also the honest cadence for its cost — it reads one Stripe price per
+    // active rider, so hourly would multiply that by 24 to re-derive an answer
+    // that changes only when a price does.
+    //
+    // Report-only, deliberately: a repairing sweep would be an unattended bulk
+    // billing mutation, and whatever left a group on a stale price is likely
+    // still there to do it again. `mismatched > 0` is the signal to look.
+    const [reconcile, orphanOrgs, addonPrices] = await Promise.all([
       reconcileGroupQuantities(),
       countOrgsWithoutGroup(),
+      sweepStaleOrgAddonPrices(),
     ]);
-    return { ...reconcile, orphanOrgs };
+    return { ...reconcile, orphanOrgs, addonPrices };
   });
 }

--- a/apps/web/src/app/api/orgs/[id]/subscription/route.ts
+++ b/apps/web/src/app/api/orgs/[id]/subscription/route.ts
@@ -12,7 +12,7 @@ export async function GET(
     const { id: orgId } = await params;
     await requireOrgRole(orgId, ORG_ROLES);
 
-    // Reached through organizations.subscription_id (V310). `org_id` is no
+    // Reached through organizations.subscription_id (V314). `org_id` is no
     // longer a column on subscriptions — it is projected from the org we were
     // asked about, because many orgs may share the row behind it.
     //

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -105,7 +105,7 @@ export async function DELETE(req: Request) {
     // Hand on (or shut down) every billing group this user PAYS for, before
     // org_members is emptied below — the heir is found through it.
     //
-    // Since V310 billing gates on subscriptions.owner_user_id, so a group left
+    // Since V314 billing gates on subscriptions.owner_user_id, so a group left
     // pointing at a deleted user is unmanageable by anyone: every billing route
     // 403s, nobody can cancel, and the card keeps being charged for ever. The
     // sole-owner 409 above does not cover this — an association can pay for

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/__tests__/competition-header-trial-promise.test.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/__tests__/competition-header-trial-promise.test.tsx
@@ -1,0 +1,113 @@
+// The competition header's Event Pass entry point (task 19) passes
+// `goProLabel={t(dict, "upgrade.proCard.cta")}` straight to
+// `<CompetitionPassEntry>`, which renders it verbatim inside the "ended" pass
+// card (v17 gap #354). That string reads "Go Pro — 14-day free trial" and
+// must not be shown to an org that has already spent its one trial
+// (`subscriptions.trial_used_at`, V304/#190) — the checkout will not grant a
+// second one (`checkoutTrialDays` in lib/billing.ts).
+//
+// Rendered through react-dom/server (no jsdom in this workspace, same pattern
+// as upgrade-page.test.tsx). The page is called directly to get its resolved
+// element, then wrapped in the REAL <CompetitionPassProvider> the competition
+// layout would mount in production — the "ended" gate branch that carries
+// `goProLabel` cannot render at all without it, so this is the smallest render
+// that actually exercises the code path the fix touches.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const h = vi.hoisted(() => ({
+  // v17 gap #354: null means this org has not spent its one trial.
+  trialUsedAt: null as string | null,
+}));
+
+vi.mock("@/server/page-auth", () => ({
+  requireCompetitionPage: async () => ({
+    auth: { orgId: "org-1" },
+    org: { id: "org-1", name: "Riverside CC", slug: "riverside" },
+    competition: { id: "comp-1", name: "Summer League", slug: "summer-league" },
+    canEdit: true,
+  }),
+}));
+
+vi.mock("@/server/usecases/competitions", () => ({
+  getCompetition: async () => ({
+    id: "comp-1",
+    org_id: "org-1",
+    name: "Summer League",
+    slug: "summer-league",
+    description: null,
+    starts_on: null,
+    ends_on: null,
+    visibility: "private",
+    branding: null,
+    status: "live",
+    created_at: new Date().toISOString(),
+    discoverable: false,
+    discovery: null,
+    frozen: false,
+  }),
+}));
+vi.mock("@/server/usecases/divisions", () => ({ listDivisions: async () => [] }));
+vi.mock("@/server/usecases/card-stats", () => ({
+  listDivisionCardStats: async () => new Map(),
+  nextLine: () => null,
+  formatLabel: () => null,
+}));
+vi.mock("@/server/public-site/data", () => ({ resolveLogoUrl: () => null }));
+vi.mock("@/lib/currency-server", () => ({ preferredCurrency: async () => "usd" }));
+vi.mock("@/lib/resolve-locale", () => ({ resolveLocale: async () => "en" }));
+
+// The trial read the page adds (v17 gap #354) — same org→subscription join
+// shape as upgrade/page.tsx, mocked here rather than hit against a real DB.
+vi.mock("@/lib/db", () => ({
+  sql: (strings: TemplateStringsArray | unknown[]) => {
+    if (!Array.isArray(strings) || !("raw" in strings)) return { __fragment: strings };
+    return Promise.resolve([{ trial_used_at: h.trialUsedAt }]);
+  },
+}));
+// Fully mocked like upgrade-page.test.tsx's own `@/lib/billing` double —
+// reproducing the real predicate's exact shape rather than importing the
+// real module (which drags in Stripe/db/email at import time).
+vi.mock("@/lib/billing", () => ({
+  checkoutTrialDays: (sub?: { trial_used_at: string | null }) => (sub?.trial_used_at ? 0 : 14),
+}));
+
+import Page from "../page";
+import { CompetitionPassProvider } from "@/components/competition-pass-provider";
+import { t } from "@/lib/i18n-runtime";
+import uiEn from "@/dictionaries/en/ui.json";
+
+beforeEach(() => {
+  h.trialUsedAt = null;
+});
+
+/**
+ * Renders the page wrapped in the real provider, forced into the "ended" gate
+ * — the only branch of `<CompetitionPassEntry>` that shows `goProLabel` — so
+ * the assertions are about the actual prop the page computed, not a stand-in.
+ */
+async function renderEnded(): Promise<string> {
+  const el = await Page({ params: Promise.resolve({ orgSlug: "riverside", compSlug: "summer-league" }) });
+  return renderToStaticMarkup(
+    <CompetitionPassProvider passKey="event_pass" paidPlan={false} lockReason="terminal">
+      {el}
+    </CompetitionPassProvider>,
+  );
+}
+
+describe("competition header — the Go Pro trial promise (v17 gap #354)", () => {
+  it("still promises the trial for an org that has not spent it", async () => {
+    const html = await renderEnded();
+    expect(html).toContain("data-pass-ended-pro");
+    expect(html).toContain(t(uiEn, "upgrade.proCard.cta"));
+  });
+
+  it("drops the trial clause once trial_used_at is set", async () => {
+    h.trialUsedAt = "2026-01-01T00:00:00.000Z";
+    const html = await renderEnded();
+    expect(html).toContain("data-pass-ended-pro");
+    expect(html).not.toContain(t(uiEn, "upgrade.proCard.cta"));
+    expect(html).toContain(t(uiEn, "upgrade.proCard.ctaNoTrial"));
+    expect(html).not.toContain("free trial");
+  });
+});

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/page.tsx
@@ -20,6 +20,8 @@ import { preferredCurrency } from "@/lib/currency-server";
 import { routes } from "@/lib/routes";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary, t, plural } from "@/lib/i18n";
+import { sql } from "@/lib/db";
+import { checkoutTrialDays } from "@/lib/billing";
 
 export default async function CompetitionPage({
   params,
@@ -32,14 +34,22 @@ export default async function CompetitionPage({
   const id = page.competition.id;
   const locale = await resolveLocale();
   const dict = await getDictionary(locale, "ui");
-  const [competition, divisions, stats, currency] = await Promise.all([
+  const [competition, divisions, stats, currency, [subRow]] = await Promise.all([
     getCompetition(auth, id),
     listDivisions(auth, id),
     listDivisionCardStats(auth, id),
     // The pass price is currency-switcher-dependent, and the entry point is a
     // client island — so it is formatted here and crosses as a finished string.
     preferredCurrency(page.org.id),
+    // v17 gap #354 — the "ended" pass card below offers a Go Pro link whose
+    // label must not promise a trial the checkout won't grant. Same read
+    // `checkoutTrialDays` (lib/billing.ts) itself consults.
+    sql<{ trial_used_at: string | null }[]>`
+      select s.trial_used_at from organizations o
+      join subscriptions s on s.id = o.subscription_id
+      where o.id = ${page.org.id}`,
   ]);
+  const trialAvailable = checkoutTrialDays(subRow) > 0;
   const publicPath =
     competition.visibility !== "private" ? routes.shared(orgSlug, competition.slug) : null;
 
@@ -67,7 +77,7 @@ export default async function CompetitionPage({
               nextEditionHref={routes.competitionNew(orgSlug)}
               nextEditionLabel={t(dict, "pass.entry.ended.nextEdition")}
               goProHref={routes.billing(orgSlug)}
-              goProLabel={t(dict, "upgrade.proCard.cta")}
+              goProLabel={t(dict, trialAvailable ? "upgrade.proCard.cta" : "upgrade.proCard.ctaNoTrial")}
               canBuy={canEdit}
             />
             <h1 className="page-title mt-1 truncate">

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/settings/__tests__/settings-header-trial-promise.test.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/settings/__tests__/settings-header-trial-promise.test.tsx
@@ -1,0 +1,112 @@
+// Competition settings mounts the SAME Event Pass entry point as the
+// competition header (task 19), with its own copy of
+// `goProLabel={t(dict, "upgrade.proCard.cta")}` — "Go Pro — 14-day free
+// trial", unconditionally, in the "ended" pass card (v17 gap #354). An org
+// that already spent its one trial (`subscriptions.trial_used_at`, V304/#190)
+// must not be shown that clause: the checkout will not grant a second one
+// (`checkoutTrialDays` in lib/billing.ts).
+//
+// Same technique as competition-header-trial-promise.test.tsx: call the page
+// directly to get its resolved element, then wrap it in the REAL
+// <CompetitionPassProvider> the competition layout mounts in production,
+// forced into the "ended" gate — the only branch that renders `goProLabel`.
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const h = vi.hoisted(() => ({
+  trialUsedAt: null as string | null,
+}));
+
+vi.mock("@/server/page-auth", () => ({
+  requireCompetitionPage: async () => ({
+    auth: { orgId: "org-1" },
+    org: { id: "org-1", name: "Riverside CC", slug: "riverside", branding: null },
+    competition: { id: "comp-1", name: "Summer League", slug: "summer-league" },
+    canEdit: true,
+  }),
+}));
+
+vi.mock("@/server/usecases/competitions", () => ({
+  getCompetition: async () => ({
+    id: "comp-1",
+    org_id: "org-1",
+    name: "Summer League",
+    slug: "summer-league",
+    description: null,
+    starts_on: null,
+    ends_on: null,
+    visibility: "private",
+    branding: null,
+    status: "live",
+    created_at: new Date().toISOString(),
+    discoverable: false,
+    discovery: null,
+    frozen: false,
+  }),
+}));
+vi.mock("@/server/usecases/divisions", () => ({ listDivisions: async () => [] }));
+vi.mock("@/lib/entitlements", () => ({ hasFeature: async () => false }));
+vi.mock("@/lib/currency-server", () => ({ preferredCurrency: async () => "usd" }));
+vi.mock("@/lib/resolve-locale", () => ({ resolveLocale: async () => "en" }));
+// The client form itself is not what this fix touches — stubbed so its own
+// dependencies (a DictProvider context this render never mounts) cannot make
+// an unrelated part of the tree the reason this test fails.
+vi.mock("@/components/v2/competition-settings", () => ({
+  CompetitionSettings: () => <div data-competition-settings-stub />,
+}));
+vi.mock("@/components/v2/archived-divisions", () => ({
+  ArchivedDivisions: () => <div data-archived-divisions-stub />,
+}));
+
+// `withTenant`'s callback receives a tagged-template tx; the youth and
+// fixture-aggregate queries this page also issues are answered generically so
+// only the org→subscription trial read (v17 gap #354) needs a real branch.
+vi.mock("@/lib/db", () => {
+  const sql = (strings: TemplateStringsArray | unknown[]) => {
+    if (!Array.isArray(strings) || !("raw" in strings)) return { __fragment: strings };
+    const text = (strings as TemplateStringsArray).join(" ");
+    if (text.includes("organizations"))
+      return Promise.resolve([{ trial_used_at: h.trialUsedAt }]);
+    if (text.includes("eligibility")) return Promise.resolve([{ youth: false }]);
+    return Promise.resolve([{ total: 0, underway: 0, done: 0, scheduled: 0 }]);
+  };
+  return { sql, withTenant: async (_orgId: string, cb: (tx: typeof sql) => unknown) => cb(sql) };
+});
+vi.mock("@/lib/billing", () => ({
+  checkoutTrialDays: (sub?: { trial_used_at: string | null }) => (sub?.trial_used_at ? 0 : 14),
+}));
+
+import Page from "../page";
+import { CompetitionPassProvider } from "@/components/competition-pass-provider";
+import { t } from "@/lib/i18n-runtime";
+import uiEn from "@/dictionaries/en/ui.json";
+
+beforeEach(() => {
+  h.trialUsedAt = null;
+});
+
+async function renderEnded(): Promise<string> {
+  const el = await Page({ params: Promise.resolve({ orgSlug: "riverside", compSlug: "summer-league" }) });
+  return renderToStaticMarkup(
+    <CompetitionPassProvider passKey="event_pass" paidPlan={false} lockReason="terminal">
+      {el}
+    </CompetitionPassProvider>,
+  );
+}
+
+describe("competition settings — the Go Pro trial promise (v17 gap #354)", () => {
+  it("still promises the trial for an org that has not spent it", async () => {
+    const html = await renderEnded();
+    expect(html).toContain("data-pass-ended-pro");
+    expect(html).toContain(t(uiEn, "upgrade.proCard.cta"));
+  });
+
+  it("drops the trial clause once trial_used_at is set", async () => {
+    h.trialUsedAt = "2026-01-01T00:00:00.000Z";
+    const html = await renderEnded();
+    expect(html).toContain("data-pass-ended-pro");
+    expect(html).not.toContain(t(uiEn, "upgrade.proCard.cta"));
+    expect(html).toContain(t(uiEn, "upgrade.proCard.ctaNoTrial"));
+    expect(html).not.toContain("free trial");
+  });
+});

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/settings/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/settings/page.tsx
@@ -11,7 +11,8 @@ import { formatMinor } from "@/lib/currency";
 import { lowestPassRung, passActiveLabels, passEndedReasons } from "@/lib/pass-ladder";
 import { preferredCurrency } from "@/lib/currency-server";
 import { hasFeature } from "@/lib/entitlements";
-import { withTenant } from "@/lib/db";
+import { sql, withTenant } from "@/lib/db";
+import { checkoutTrialDays } from "@/lib/billing";
 import { resolveLocale } from "@/lib/resolve-locale";
 import { getDictionary, t } from "@/lib/i18n";
 
@@ -38,15 +39,23 @@ export default async function CompetitionSettingsPage({
   const id = page.competition.id;
   const locale = await resolveLocale();
   const dict = await getDictionary(locale, "ui");
-  const [competition, discoveryBranding, themeBranding, allDivisions, currency] =
+  const [competition, discoveryBranding, themeBranding, allDivisions, currency, [subRow]] =
     await Promise.all([
       getCompetition(auth, id),
       hasFeature(auth.orgId, "discovery.branding"),
       hasFeature(auth.orgId, "dashboard.branding"),
       listDivisions(auth, id, { includeArchived: true }),
       preferredCurrency(org.id),
+      // v17 gap #354 — the "ended" pass card below offers a Go Pro link whose
+      // label must not promise a trial the checkout won't grant. Same read
+      // `checkoutTrialDays` (lib/billing.ts) itself consults.
+      sql<{ trial_used_at: string | null }[]>`
+        select s.trial_used_at from organizations o
+        join subscriptions s on s.id = o.subscription_id
+        where o.id = ${org.id}`,
     ]);
   const archivedDivisions = allDivisions.filter((d) => d.archived_at !== null);
+  const trialAvailable = checkoutTrialDays(subRow) > 0;
 
   // Youth flag (v3/11 gap 8): any live division with a U-age eligibility rule
   // raises the guardian-consent interstitial before the competition leaves
@@ -95,7 +104,7 @@ export default async function CompetitionSettingsPage({
             nextEditionHref={routes.competitionNew(orgSlug)}
             nextEditionLabel={t(dict, "pass.entry.ended.nextEdition")}
             goProHref={routes.billing(orgSlug)}
-            goProLabel={t(dict, "upgrade.proCard.cta")}
+            goProLabel={t(dict, trialAvailable ? "upgrade.proCard.cta" : "upgrade.proCard.ctaNoTrial")}
             canBuy={canEdit}
           />
           <h1 className="mt-1 text-xl font-semibold tracking-tight text-slate-900">

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/upgrade/__tests__/upgrade-page.test.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/upgrade/__tests__/upgrade-page.test.tsx
@@ -40,6 +40,10 @@ const h = vi.hoisted(() => ({
   // to a real group with no redemption, so every pre-existing "credit shown"
   // case keeps meaning what it meant.
   subscriptionId: "sub-1" as string | null,
+  // v17 gap #354: null means the org has not spent its one trial yet — the
+  // same column `checkoutTrialDays` reads to decide the checkout's own
+  // `trial_period_days`.
+  trialUsedAt: null as string | null,
   groupRedeemed: false as boolean,
   // v17 gap #326: an unresolved `pass_mint_refusals` row for this competition.
   passUnderReview: false as boolean,
@@ -89,7 +93,9 @@ vi.mock("@/lib/db", () => {
     if (text.includes("pass_credit_redemptions"))
       return Promise.resolve(h.groupRedeemed ? [{ one: 1 }] : []);
     if (text.includes("organizations"))
-      return Promise.resolve(h.subscriptionId ? [{ id: h.subscriptionId }] : []);
+      return Promise.resolve(
+        h.subscriptionId ? [{ id: h.subscriptionId, trial_used_at: h.trialUsedAt }] : [],
+      );
     void vals;
     return Promise.resolve([]);
   };
@@ -120,6 +126,12 @@ vi.mock("@/lib/billing", () => ({
     if (h.passUnderReviewThrows) throw new Error("relation \"pass_mint_refusals\" does not exist");
     return h.passUnderReview;
   },
+  // The real predicate (lib/billing.ts) — reproduced rather than imported so
+  // this module stays fully mocked like every other export here, but matching
+  // its exact shape: `sub?.trial_used_at ? 0 : 14`. v17 gap #354's fix reads
+  // this SAME function, so a test that faked the answer a different way could
+  // pass while the page called something else entirely.
+  checkoutTrialDays: (sub?: { trial_used_at: string | null }) => (sub?.trial_used_at ? 0 : 14),
 }));
 vi.mock("@/server/usecases/billing-manage", () => ({ getPassPurchases: async () => h.purchases }));
 // The picker is NOT mocked. Since v17 #294 it owns both prices, the buy
@@ -168,6 +180,7 @@ beforeEach(() => {
   h.purchases = [];
   h.reconciled = [];
   h.subscriptionId = "sub-1";
+  h.trialUsedAt = null;
   h.groupRedeemed = false;
   h.passUnderReview = false;
   h.passUnderReviewThrows = false;
@@ -707,5 +720,43 @@ describe("ended — the pass is on the record but has stopped applying", () => {
     const html = await render();
     expect(html).toContain("data-pass-active");
     expect(html).not.toContain("data-pass-ended");
+  });
+});
+
+describe("the Go Pro trial promise (v17 gap #354)", () => {
+  // `upgrade.proCard.cta` reads "Go Pro — 14-day free trial" and is rendered
+  // regardless of pass state (offer, owned, ceiling, ended) — every one of
+  // them renders <ProNext>. An org that already spent its one trial
+  // (`trial_used_at`, V304/#190) must never see that clause: the checkout
+  // itself decides via `checkoutTrialDays(sub)`, and this is the SAME read,
+  // not a second guess at it. Exercised on the "ended" state because that is
+  // the one W8 mounted onto orgs with a payment history — raising the odds
+  // the trial is already spent well above the baseline — but the CTA is the
+  // same element regardless of which pass state put it on screen.
+  function endedPass() {
+    h.passRow = {
+      purchased_at: new Date(Date.now() - 20 * 86_400_000).toISOString(),
+      stripe_payment_intent: "pi_live_1",
+      pass_key: "event_pass",
+      status: "completed",
+      ends_on: null,
+    };
+    h.purchases = [RECEIPT];
+  }
+
+  it("still promises the trial for an org that has not spent it", async () => {
+    endedPass();
+    h.trialUsedAt = null;
+    const html = await render();
+    expect(html).toContain(t(uiEn, "upgrade.proCard.cta"));
+  });
+
+  it("drops the trial clause once trial_used_at is set", async () => {
+    endedPass();
+    h.trialUsedAt = "2026-01-01T00:00:00.000Z";
+    const html = await render();
+    expect(html).not.toContain(t(uiEn, "upgrade.proCard.cta"));
+    expect(html).toContain(`${t(uiEn, "upgrade.proCard.ctaNoTrial")} →`);
+    expect(html).not.toContain("free trial");
   });
 });

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/upgrade/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/upgrade/page.tsx
@@ -44,7 +44,7 @@ export const dynamic = "force-dynamic";
 // time. See lib/pass-comparison.ts for why nothing is written down.
 import Link from "@/components/ui/console-link";
 import { sql } from "@/lib/db";
-import { competitionHasRefusedPassPayment, reconcilePassCheckout } from "@/lib/billing";
+import { checkoutTrialDays, competitionHasRefusedPassPayment, reconcilePassCheckout } from "@/lib/billing";
 import { captureError } from "@/lib/sentry";
 import { requireCompetitionPage } from "@/server/page-auth";
 import { routes } from "@/lib/routes";
@@ -147,9 +147,12 @@ export default async function CompetitionUpgradePage({
     // orgPlanKey() does the same org→subscription join internally but doesn't
     // expose the id, and `groupAlreadyRedeemed` below needs the group's
     // `subscriptions.id` directly (same join `creditPassTowardSubscription`
-    // itself does in pass-credit.ts).
-    sql<{ id: string }[]>`
-      select s.id from organizations o join subscriptions s on s.id = o.subscription_id
+    // itself does in pass-credit.ts). `trial_used_at` rides along (v17 gap
+    // #354): the Go Pro CTA below must ask the SAME question the checkout
+    // does — `checkoutTrialDays` — rather than promise a trial a second,
+    // independent read might disagree with.
+    sql<{ id: string; trial_used_at: string | null }[]>`
+      select s.id, s.trial_used_at from organizations o join subscriptions s on s.id = o.subscription_id
       where o.id = ${orgId}`,
     // A payment for THIS competition was taken and then refused by the mint
     // guard (v17 gap #326, V342). Read here rather than inferred from the
@@ -276,6 +279,10 @@ export default async function CompetitionUpgradePage({
   // a missing row is treated as ineligible rather than assumed, matching this
   // page's existing defensive style.
   const subscriptionId = subRow?.id ?? null;
+  // v17 gap #354 — the SAME predicate the embedded checkout builds its
+  // `trial_period_days` from (lib/billing.ts): an org whose `trial_used_at`
+  // is already set must not be promised a trial the checkout will not grant.
+  const trialAvailable = checkoutTrialDays(subRow) > 0;
   const creditEligible =
     !!pass?.stripe_payment_intent &&
     !!purchasedAt &&
@@ -373,6 +380,7 @@ export default async function CompetitionUpgradePage({
           orgSlug={orgSlug}
           orgName={page.org.name}
           creditEligible={creditEligible}
+          trialAvailable={trialAvailable}
         />
       )}
 
@@ -805,6 +813,7 @@ function ProNext({
   orgSlug,
   orgName,
   creditEligible,
+  trialAvailable,
 }: {
   dict: Dict;
   state: UpgradePageState;
@@ -812,6 +821,10 @@ function ProNext({
   orgSlug: string;
   orgName: string;
   creditEligible: boolean;
+  /** v17 gap #354 — `checkoutTrialDays(sub) > 0`, read where the page fetches
+   *  the org's subscription. The CTA below drops its trial clause once this
+   *  is false, whatever pass state put the card on screen. */
+  trialAvailable: boolean;
 }) {
   const held = state.kind === "owned" || state.kind === "ceiling";
   // An ended pass reads as "already bought something here" for this panel's
@@ -854,7 +867,7 @@ function ProNext({
           first rather than shrinking both. */}
       <div className="mt-5 flex flex-wrap gap-3">
         <Link href={routes.billing(orgSlug)} className="btn btn-primary inline-block px-5 py-2.5">
-          {t(dict, "upgrade.proCard.cta")} →
+          {t(dict, trialAvailable ? "upgrade.proCard.cta" : "upgrade.proCard.ctaNoTrial")} →
         </Link>
         {/* The honest alternative to a re-buy. The pass cannot be bought again
             for THIS competition (decision #248 Q4), but next season's edition

--- a/apps/web/src/app/o/[orgSlug]/settings/__tests__/payer-billing-access.test.ts
+++ b/apps/web/src/app/o/[orgSlug]/settings/__tests__/payer-billing-access.test.ts
@@ -1,0 +1,212 @@
+// v17 gap #333 — a billing group's PAYER must be able to open the billing UI
+// for the bill they fund, even when they are not a member of any organisation
+// on it.
+//
+// That state is reachable by design, not by accident: `transferGroup` moves
+// `subscriptions.owner_user_id` ALONE and leaves memberships untouched, and an
+// org owner may remove the payer from the org at any time. Gated on membership
+// — which is what every organiser page under `/o/[orgSlug]` is, and rightly —
+// the payer keeps paying for a group whose Billing, Credits and Add-ons tabs
+// all 404 on them. Not even cancelling is reachable.
+//
+// The relaxation is ONE sentence wide and these tests bound it on every side:
+// a stranger is still refused, a scorer still bounces, and a member is admitted
+// on exactly the terms they had before.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import type { User } from "@/lib/types";
+
+// The membership list is read through this cache; a stale answer would make a
+// just-removed member look admitted.
+vi.mock("@/lib/cache", () => ({
+  cacheEnabled: () => false,
+  cacheGet: async () => null,
+  cacheSet: async () => {},
+  cacheDelPattern: async () => {},
+  incrWindow: async () => 1,
+}));
+
+// `notFound()` / `redirect()` throw control-flow errors that Next unwraps. Make
+// each one a distinguishable exception so a test can tell "refused" from
+// "bounced to My matches" — a refusal that silently became a redirect would
+// otherwise read as a pass.
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("NOT_FOUND");
+  },
+  redirect: (to: string) => {
+    throw new Error(`REDIRECT:${to}`);
+  },
+  permanentRedirect: (to: string) => {
+    throw new Error(`PERMANENT_REDIRECT:${to}`);
+  },
+}));
+
+const authState = vi.hoisted(() => ({ userId: "" }));
+vi.mock("@/lib/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/auth")>();
+  return {
+    ...actual,
+    getCurrentUser: async () => (authState.userId ? ({ id: authState.userId } as User) : null),
+    getActiveOrgId: async () => null,
+  };
+});
+
+import { sql } from "@/lib/db";
+import { createOrgForUser } from "@/lib/auth";
+import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+import { requireBillingPage, requireOrgPage } from "@/server/page-auth";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+async function makeUser(label: string): Promise<string> {
+  const [row] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`payer-access-${label}-${uniq()}@test.local`}, ${label}, true) returning id`;
+  return row!.id;
+}
+
+/**
+ * The shape the issue describes: a club (`orgSlug`) whose owner is `ownerId`,
+ * billed by a group whose payer is `payerId` — and the payer is NOT a member of
+ * the club. Built the way production reaches it: the club keeps its own
+ * memberships, only its `subscription_id` moves onto the payer's group.
+ */
+async function makeFundedClub(): Promise<{
+  payerId: string;
+  ownerId: string;
+  orgId: string;
+  orgSlug: string;
+}> {
+  const payerId = await makeUser("Payer");
+  const ownerId = await makeUser("ClubOwner");
+  // The payer's own organisation carries the group they pay for.
+  const payerOrg = await createOrgForUser(payerId, `Payer Org ${uniq()}`);
+  const groupId = await setOrgPlan(payerOrg.id, "pro");
+  await sql`update subscriptions set owner_user_id = ${payerId} where id = ${groupId}`;
+
+  const club = await createOrgForUser(ownerId, `Funded Club ${uniq()}`);
+  await sql`update organizations set subscription_id = ${groupId} where id = ${club.id}`;
+  const [row] = await sql<{ slug: string }[]>`
+    select slug from organizations where id = ${club.id}`;
+  return { payerId, ownerId, orgId: club.id, orgSlug: row!.slug };
+}
+
+async function setRole(orgId: string, userId: string, role: string): Promise<void> {
+  await sql`
+    insert into org_members (org_id, user_id, role) values (${orgId}, ${userId}, ${role})
+    on conflict (org_id, user_id) do update set role = ${role}`;
+}
+
+describe.skipIf(!HAS_DB)("a group's payer can open the billing UI for the bill they fund", () => {
+  beforeEach(() => {
+    authState.userId = "";
+  });
+
+  it("admits the payer of an organisation's group even with no membership in it", async () => {
+    const club = await makeFundedClub();
+    authState.userId = club.payerId;
+
+    // The state the issue is about: they fund it and are not in it.
+    const [membership] = await sql`
+      select 1 from org_members where org_id = ${club.orgId} and user_id = ${club.payerId}`;
+    expect(membership).toBeUndefined();
+
+    const page = await requireBillingPage(club.orgSlug, { tail: "/settings/billing" });
+
+    expect(page.org.id).toBe(club.orgId);
+    expect(page.user.id).toBe(club.payerId);
+    // Admitted to the BILL, not to the club: no role, and nothing editable.
+    expect(page.viaPayer).toBe(true);
+    expect(page.canEdit).toBe(false);
+    expect(page.org.role).toBeNull();
+  });
+
+  it("still refuses a non-member who does not pay for the organisation's group", async () => {
+    const club = await makeFundedClub();
+    const stranger = await makeUser("Stranger");
+    authState.userId = stranger;
+
+    await expect(requireBillingPage(club.orgSlug, { tail: "/settings/billing" })).rejects.toThrow(
+      "NOT_FOUND",
+    );
+  });
+
+  it("still refuses a payer of a DIFFERENT group", async () => {
+    const club = await makeFundedClub();
+    const other = await makeFundedClub();
+    // Pays for their own bill, and only for their own.
+    authState.userId = other.payerId;
+
+    await expect(requireBillingPage(club.orgSlug, { tail: "/settings/billing" })).rejects.toThrow(
+      "NOT_FOUND",
+    );
+  });
+
+  it("admits a member on exactly the terms requireOrgPage gives them", async () => {
+    const club = await makeFundedClub();
+    authState.userId = club.ownerId;
+
+    const viaBilling = await requireBillingPage(club.orgSlug, { tail: "/settings/billing" });
+    const viaOrg = await requireOrgPage(club.orgSlug, { tail: "/settings/billing" });
+
+    expect(viaBilling.org.role).toBe("owner");
+    expect(viaBilling.org.role).toBe(viaOrg.org.role);
+    expect(viaBilling.canEdit).toBe(viaOrg.canEdit);
+    expect(viaBilling.auth).toEqual(viaOrg.auth);
+    expect(viaBilling.viaPayer).toBe(false);
+  });
+
+  it("still bounces a scorer who does not pay for the group", async () => {
+    const club = await makeFundedClub();
+    const scorer = await makeUser("Scorer");
+    await setRole(club.orgId, scorer, "scorer");
+    authState.userId = scorer;
+
+    await expect(requireBillingPage(club.orgSlug, { tail: "/settings/billing" })).rejects.toThrow(
+      "REDIRECT:/my-matches",
+    );
+  });
+
+  it("admits a viewer, as the billing tabs have always been member-visible", async () => {
+    const club = await makeFundedClub();
+    const viewer = await makeUser("Viewer");
+    await setRole(club.orgId, viewer, "viewer");
+    authState.userId = viewer;
+
+    const page = await requireBillingPage(club.orgSlug, { tail: "/settings/billing" });
+    expect(page.org.role).toBe("viewer");
+    expect(page.viaPayer).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+/**
+ * The wiring, which is half of what #333 asks for: "the Add-ons, Billing and
+ * Credits tabs should reach it together — solving it for one leaves the same
+ * dead end on the other two." A payer-aware gate that only one tab calls closes
+ * nothing, and no behavioural test of a single page would notice.
+ */
+describe("all three billing tabs reach the same gate", () => {
+  const dir = path.resolve(__dirname, "..");
+  const surfaces = [
+    "billing/page.tsx",
+    "credits/page.tsx",
+    "add-ons/page.tsx",
+    // The Credits tab's own Export button. A payer who can open the tab and
+    // then 404s on its download is the same dead end one door further in.
+    "billing/credits.csv/route.ts",
+  ] as const;
+
+  it.each(surfaces)("%s gates on requireBillingPage, not requireOrgPage", (surface) => {
+    const src = readFileSync(path.join(dir, surface), "utf8");
+    expect(src).toContain("requireBillingPage(");
+    expect(src).not.toContain("requireOrgPage(");
+  });
+});

--- a/apps/web/src/app/o/[orgSlug]/settings/add-ons/__tests__/add-ons-page.test.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/add-ons/__tests__/add-ons-page.test.tsx
@@ -16,17 +16,23 @@
 // tree, so it can simply be awaited and walked. Its dependencies are mocked at
 // the module boundary; the DICTIONARY is real, so a key that was never added to
 // en/ui.json renders as itself and fails these assertions.
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { walk, propsOf, textOf } from "@/components/__tests__/_hook-harness";
 import { ExtraOrgsControl } from "@/components/extra-orgs-control";
+import { BackLink } from "@/components/back-link";
 import type { AddOnsTabView } from "@/server/usecases/add-ons-tab";
 
+// `requireBillingPage`, not `requireOrgPage`: the billing tabs admit the
+// group's PAYER alongside the org's members (v17 gap #333), and `viaPayer` is
+// what tells the page which of the two it is rendering for.
+const pageAuthState = vi.hoisted(() => ({ viaPayer: false }));
 vi.mock("@/server/page-auth", () => ({
-  requireOrgPage: vi.fn(async () => ({
-    org: { id: "org-1", slug: "acme", role: "owner" },
+  requireBillingPage: vi.fn(async () => ({
+    org: { id: "org-1", slug: "acme", role: pageAuthState.viaPayer ? null : "owner" },
     user: { id: "user-1" },
     auth: { orgId: "org-1", userId: "user-1" },
-    canEdit: true,
+    canEdit: !pageAuthState.viaPayer,
+    viaPayer: pageAuthState.viaPayer,
   })),
 }));
 vi.mock("@/server/usecases/add-ons-tab", () => ({ getAddOnsTab: vi.fn() }));
@@ -299,5 +305,32 @@ describe("Add-ons page — the numbers it hands the control", () => {
     const { text } = await render({ orgCap: null, liveOrgCount: 4 });
     expect(text).toContain("Using 4 organisations on this bill");
     expect(text).not.toContain("null");
+  });
+});
+
+describe("Add-ons page — a payer who is not a member of this club (v17 gap #333)", () => {
+  beforeEach(() => {
+    pageAuthState.viaPayer = true;
+  });
+  afterEach(() => {
+    pageAuthState.viaPayer = false;
+  });
+
+  it("still gets the purchase control — it is their bill", async () => {
+    const { control } = await render();
+    expect(control).toBeDefined();
+  });
+
+  it("is not offered a back link into a Settings index that would 404 on them", async () => {
+    view.mockResolvedValue(makeView());
+    const tree = await AddOnsSettingsPage({ params: Promise.resolve({ orgSlug: "acme" }) });
+    expect(walk(tree).some((el) => el.type === BackLink)).toBe(false);
+  });
+
+  it("keeps that back link for a member, who can open it", async () => {
+    pageAuthState.viaPayer = false;
+    view.mockResolvedValue(makeView());
+    const tree = await AddOnsSettingsPage({ params: Promise.resolve({ orgSlug: "acme" }) });
+    expect(walk(tree).some((el) => el.type === BackLink)).toBe(true);
   });
 });

--- a/apps/web/src/app/o/[orgSlug]/settings/add-ons/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/add-ons/page.tsx
@@ -12,7 +12,7 @@ export const dynamic = "force-dynamic";
 // itself payer-only. `lib/feature-copy.ts`'s 402 offer points customers here by
 // name — "Settings → Add-ons" — so routes.addOns and that sentence move
 // together.
-import { requireOrgPage } from "@/server/page-auth";
+import { requireBillingPage } from "@/server/page-auth";
 import { routes } from "@/lib/routes";
 import { BackLink } from "@/components/back-link";
 import { getAddOnsTab } from "@/server/usecases/add-ons-tab";
@@ -28,7 +28,9 @@ export default async function AddOnsSettingsPage({
   params: Promise<{ orgSlug: string }>;
 }) {
   const { orgSlug } = await params;
-  const { org, user } = await requireOrgPage(orgSlug, { tail: "/settings/add-ons" });
+  const { org, user, viaPayer } = await requireBillingPage(orgSlug, {
+    tail: "/settings/add-ons",
+  });
   const locale = await resolveLocale();
   const dict = await getDictionary(locale, "ui");
   const currency = await preferredCurrency(org.id);
@@ -45,11 +47,17 @@ export default async function AddOnsSettingsPage({
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-8">
-      <BackLink
-        href={routes.orgSettings(orgSlug)}
-        label={t(dict, "action.settings")}
-        emphasis="button"
-      />
+      {/* The org's own Settings index is member-gated, so a payer who is not a
+          member of this club would only 404 on it (v17 gap #333). They arrived
+          from the bill, not from the club, and have nothing to go back to
+          here. */}
+      {!viaPayer && (
+        <BackLink
+          href={routes.orgSettings(orgSlug)}
+          label={t(dict, "action.settings")}
+          emphasis="button"
+        />
+      )}
       <div className="mb-1 flex items-center gap-2">
         <h1 className="page-title">{t(dict, "settings.nav.addOns")}</h1>
         <Tip id="billing.addons.extra-org" small />

--- a/apps/web/src/app/o/[orgSlug]/settings/billing/credits.csv/route.ts
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/credits.csv/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireOrgPage } from "@/server/page-auth";
+import { requireBillingPage } from "@/server/page-auth";
 import { walletIdFor } from "@/lib/credits";
 import { creditHistory } from "@/server/usecases/credits-tab";
 
@@ -22,13 +22,18 @@ function csvEscape(v: string | number): string {
 
 /**
  * GET /o/[orgSlug]/settings/billing/credits.csv — the org's AI-credit run
- * history as CSV (SPEC-6 §A3 export). Session-authed via requireOrgPage (org
- * members only, non-members 404); reads the same wallet the Credits tab shows,
- * so a grouped org exports the shared pool it spends from.
+ * history as CSV (SPEC-6 §A3 export). Reads the same wallet the Credits tab
+ * shows, so a grouped org exports the shared pool it spends from.
+ *
+ * Session-authed via `requireBillingPage` — the SAME gate as the Credits tab
+ * that renders this link (v17 gap #333), so members and the group's payer get
+ * the file and everyone else 404s. On `requireOrgPage` the payer could open the
+ * tab and then 404 on its own Export button, which is the "solved it for one
+ * surface" failure the issue names.
  */
 export async function GET(_req: Request, { params }: { params: Promise<{ orgSlug: string }> }) {
   const { orgSlug } = await params;
-  const { org } = await requireOrgPage(orgSlug, { tail: "/settings/billing" });
+  const { org } = await requireBillingPage(orgSlug, { tail: "/settings/billing" });
   const walletId = await walletIdFor(org.id);
   const rows = await creditHistory(walletId, 1000);
 

--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 import { sql } from "@/lib/db";
 import { reconcileCheckout, billingCtaLabel, hasLiveSubscription } from "@/lib/billing";
-import { requireOrgPage } from "@/server/page-auth";
+import { requireBillingPage } from "@/server/page-auth";
 import { BillingBanner } from "@/components/billing-banner";
 import { UpgradeButton, DowngradeButton } from "@/components/billing-actions";
 import {
@@ -73,7 +73,9 @@ export default async function BillingPage({
   searchParams: Promise<{ checkout?: string; session_id?: string }>;
 }) {
   const { orgSlug } = await params;
-  const { org, user } = await requireOrgPage(orgSlug, { tail: "/settings/billing" });
+  const { org, user, viaPayer } = await requireBillingPage(orgSlug, {
+    tail: "/settings/billing",
+  });
   const orgId = org.id;
   const locale = await resolveLocale();
   const dict = await getDictionary(locale, "ui");
@@ -251,11 +253,16 @@ export default async function BillingPage({
         {/* The apron chevron alone was not found: 16px at 70% opacity on the
             dark bar, label hidden until hover. #190 removed the labelled link
             as duplication; reported twice as missing, so it is back. */}
-        <BackLink
-          href={routes.orgSettings(orgSlug)}
-          label={t(dict, "action.settings")}
-          emphasis="button"
-        />
+        {/* …and not at all for a payer who is not a member of this club: the
+            Settings index it points at is member-gated and would 404 on them
+            (v17 gap #333). */}
+        {!viaPayer && (
+          <BackLink
+            href={routes.orgSettings(orgSlug)}
+            label={t(dict, "action.settings")}
+            emphasis="button"
+          />
+        )}
         <div className="mb-6">
           <h1 className="page-title">
             {t(dict, "billing.title")}

--- a/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/billing/page.tsx
@@ -88,7 +88,7 @@ export default async function BillingPage({
     await reconcileCheckout(orgId, sp.session_id);
   }
 
-  // WHO PAYS, not who owns this org (V310). A billing group can fund many orgs,
+  // WHO PAYS, not who owns this org (V314). A billing group can fund many orgs,
   // each with its own owner, and everything below the plan summary —
   // invoices, billing address, tax ids, cards, the credit balance, and every
   // mutating control — belongs to the PAYER. Gating those on `org.role` would
@@ -125,7 +125,7 @@ export default async function BillingPage({
     isPayer ? [] : getFormerPayerInvoices(orgId, user.id),
   ]);
 
-  // The billing GROUP behind this org (V310). `org_id` is projected from the
+  // The billing GROUP behind this org (V314). `org_id` is projected from the
   // org, not read from subscriptions — the column is gone, and the row may be
   // shared with sibling orgs.
   const [sub] = await sql<Subscription[]>`

--- a/apps/web/src/app/o/[orgSlug]/settings/credits/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/settings/credits/page.tsx
@@ -4,7 +4,7 @@ export const dynamic = "force-dynamic";
 // billing group they don't pay for must still see the pool they spend from, so
 // this page is member-visible and NOT payer-gated. The credit-pack purchase +
 // CSV export it mounts are session-authed inside their own handlers.
-import { requireOrgPage } from "@/server/page-auth";
+import { requireBillingPage } from "@/server/page-auth";
 import { routes } from "@/lib/routes";
 import { BackLink } from "@/components/back-link";
 import { BillingCredits } from "@/components/billing-credits";
@@ -20,7 +20,7 @@ export default async function CreditsSettingsPage({
   params: Promise<{ orgSlug: string }>;
 }) {
   const { orgSlug } = await params;
-  const { org } = await requireOrgPage(orgSlug, { tail: "/settings/credits" });
+  const { org, viaPayer } = await requireBillingPage(orgSlug, { tail: "/settings/credits" });
   const orgId = org.id;
   const locale = await resolveLocale();
   const dict = await getDictionary(locale, "ui");
@@ -33,11 +33,17 @@ export default async function CreditsSettingsPage({
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-8">
-      <BackLink
-        href={routes.orgSettings(orgSlug)}
-        label={t(dict, "action.settings")}
-        emphasis="button"
-      />
+      {/* The org's own Settings index is member-gated, so a payer who is not a
+          member of this club would only 404 on it (v17 gap #333). They arrived
+          from the bill, not from the club, and have nothing to go back to
+          here. */}
+      {!viaPayer && (
+        <BackLink
+          href={routes.orgSettings(orgSlug)}
+          label={t(dict, "action.settings")}
+          emphasis="button"
+        />
+      )}
       <div className="mb-6">
         <h1 className="page-title">{t(dict, "settings.nav.credits")}</h1>
       </div>

--- a/apps/web/src/components/__tests__/admin-plan-panel.test.tsx
+++ b/apps/web/src/components/__tests__/admin-plan-panel.test.tsx
@@ -269,7 +269,7 @@ describe("AdminPlanPanel — Payment methods (Task 6C staff-only card removal)",
     expect(html).not.toContain("No cards on file — or Stripe could not be reached.");
   });
 
-  // Blast radius (V310). Every control on this panel writes the SHARED
+  // Blast radius (V314). Every control on this panel writes the SHARED
   // subscriptions row, so a comp applied from one org's page moves the plan for
   // every org on that bill. The usecases were always group-wide; the panel was
   // not, so staff had no way to see how many orgs they were about to change.

--- a/apps/web/src/components/billing-actions.tsx
+++ b/apps/web/src/components/billing-actions.tsx
@@ -5,6 +5,7 @@ import { EmbeddedCheckoutProvider, EmbeddedCheckout } from "@stripe/react-stripe
 import { track, EVENTS } from "@/lib/analytics";
 import { fetchCheckoutClientSecret } from "@/lib/billing-checkout-client";
 import { stripePromise } from "@/lib/stripe-browser";
+import { orgScopeHeaders } from "@/lib/org-scope";
 import { useConfirm } from "@/components/ui/confirm-provider";
 import { useMsg } from "@/components/i18n/dict-provider";
 import { Modal } from "@/components/modal";
@@ -90,7 +91,15 @@ export function DowngradeButton() {
     setError(null);
     const res = await fetch("/api/billing/downgrade", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        // WHICH organisation this write is for, from the console URL on
+        // screen rather than the `seazn_org` cookie the route would otherwise
+        // read — that cookie lags a navigation by one client effect, so a save
+        // made inside the window landed on the PREVIOUS billing group (v17 gap
+        // #334).
+        ...orgScopeHeaders(),
+      },
       body: "{}",
     });
     const data = await res.json();

--- a/apps/web/src/components/billing-banner.tsx
+++ b/apps/web/src/components/billing-banner.tsx
@@ -20,7 +20,7 @@ export async function BillingBanner({ orgId }: Props) {
   // stay a single indexed read: the banner renders on org home, a hot path, and
   // a live Stripe call per page view is not acceptable.
   //
-  // The row is reached through organizations.subscription_id (V310) and may be
+  // The row is reached through organizations.subscription_id (V314) and may be
   // shared with sibling orgs; org_status comes from the ORG, because suspension
   // is per-org moderation and no longer touches the shared subscription.
   //

--- a/apps/web/src/components/billing-manage.tsx
+++ b/apps/web/src/components/billing-manage.tsx
@@ -14,6 +14,7 @@ import { useConfirm } from "@/components/ui/confirm-provider";
 import { useMsg } from "@/components/i18n/dict-provider";
 import { asCurrency, formatMinor } from "@/lib/currency";
 import { planLabel } from "@/lib/plan-label";
+import { orgScopeHeaders } from "@/lib/org-scope";
 import {
   TAX_ID_TYPES,
   type DiscountSummary,
@@ -32,7 +33,15 @@ import {
 async function post(path: string, body?: unknown) {
   const res = await fetch(path, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // WHICH organisation this write is for, from the console URL on
+      // screen rather than the `seazn_org` cookie the route would otherwise
+      // read — that cookie lags a navigation by one client effect, so a save
+      // made inside the window landed on the PREVIOUS billing group (v17 gap
+      // #334).
+      ...orgScopeHeaders(),
+    },
     body: JSON.stringify(body ?? {}),
   });
   return res.json();

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -820,6 +820,7 @@
   "upgrade.perMonth": "/month",
   "upgrade.proCard.body": "Pro raises every competition in {org}, not just this one — and adds the schedule board, player stats, officials and API access the pass never covers.",
   "upgrade.proCard.cta": "Go Pro — 14-day free trial",
+  "upgrade.proCard.ctaNoTrial": "Go Pro",
   "upgrade.titleOwned": "Event Pass — “{name}”",
   "upgrade.titlePlan": "“{name}” on your plan",
   "upgrade.buyCta": "Buy the pass — {rung}",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -820,6 +820,7 @@
   "upgrade.perMonth": "/mes",
   "upgrade.proCard.body": "Pro mejora todas las competiciones de {org}, no solo esta — y añade el tablero de planificación, las estadísticas de jugadores, los oficiales y el acceso a la API que el pase nunca cubre.",
   "upgrade.proCard.cta": "Pasar a Pro — prueba gratuita de 14 días",
+  "upgrade.proCard.ctaNoTrial": "Hazte Pro",
   "upgrade.titleOwned": "Event Pass — «{name}»",
   "upgrade.titlePlan": "«{name}» con tu plan",
   "upgrade.buyCta": "Comprar el pase — {rung}",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -820,6 +820,7 @@
   "upgrade.perMonth": "/mois",
   "upgrade.proCard.body": "Pro améliore toutes les compétitions de {org}, pas seulement celle-ci — et ajoute le tableau de planification, les statistiques des joueurs, les officiels et l’accès API que le pass ne couvre jamais.",
   "upgrade.proCard.cta": "Passer à Pro — essai gratuit de 14 jours",
+  "upgrade.proCard.ctaNoTrial": "Passer à Pro",
   "upgrade.titleOwned": "Event Pass — « {name} »",
   "upgrade.titlePlan": "« {name} » avec votre formule",
   "upgrade.buyCta": "Acheter le pass — {rung}",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -820,6 +820,7 @@
   "upgrade.perMonth": "/maand",
   "upgrade.proCard.body": "Pro upgradet elke competitie in {org}, niet alleen deze — en voegt het planningsbord, spelersstatistieken, officials en API-toegang toe die de pass nooit dekt.",
   "upgrade.proCard.cta": "Neem Pro — 14 dagen gratis proberen",
+  "upgrade.proCard.ctaNoTrial": "Word Pro",
   "upgrade.titleOwned": "Event Pass — “{name}”",
   "upgrade.titlePlan": "“{name}” met je abonnement",
   "upgrade.buyCta": "Koop de pass — {rung}",

--- a/apps/web/src/lib/__tests__/_approved-copy.ts
+++ b/apps/web/src/lib/__tests__/_approved-copy.ts
@@ -505,6 +505,14 @@ export const APPROVED_GROUPS_INVENTORY: string[] = [
   "a09dc0137f8e8527",
   "e12f4df63f6cc9ea",
   "03db06a1af2d3405",
+  // v17 gap #333, position 17. Read against `server/page-auth.ts`
+  // requireBillingPage: the payer branch is entered only on
+  // `subscriptions.owner_user_id` of the org's OWN group ("any organisation on
+  // it"), and hands back role null / canEdit false while every other page in
+  // the /o tree stays on requireOrgPage — which is what makes "the bill and
+  // nothing else" true. The three tabs named are exactly the three that call
+  // it: settings/{billing,credits,add-ons}/page.tsx.
+  "8cca87480a6deb54",
   "696c2fcc2ecfec40",
   "a052c3f07ce2508c",
   "0efcbcbfd21cd2d3",

--- a/apps/web/src/lib/__tests__/_billing-group.ts
+++ b/apps/web/src/lib/__tests__/_billing-group.ts
@@ -1,4 +1,4 @@
-// Fixture helper for billing groups (V310).
+// Fixture helper for billing groups (V314).
 //
 // Billing moved off the org: `subscriptions` is now the GROUP (its own id,
 // its own owner_user_id payer) and `organizations.subscription_id` points at

--- a/apps/web/src/lib/__tests__/billing-group-view.test.ts
+++ b/apps/web/src/lib/__tests__/billing-group-view.test.ts
@@ -1,4 +1,4 @@
-// The billing-group panel's decisions (V310). This is the copy and the
+// The billing-group panel's decisions (V314). This is the copy and the
 // arithmetic a payer reads immediately before spending money or giving a
 // subscription away, so every branch is pinned here rather than left to a
 // screenshot someone remembers to look at.

--- a/apps/web/src/lib/__tests__/billing-groups.test.ts
+++ b/apps/web/src/lib/__tests__/billing-groups.test.ts
@@ -1,4 +1,4 @@
-// Billing groups (V310) with MORE THAN ONE ORG IN THE GROUP.
+// Billing groups (V314) with MORE THAN ONE ORG IN THE GROUP.
 //
 // Every other suite seeds a group of one, which is the one shape that cannot
 // fail: a group of one resolves like the old org-keyed subscription did, its cap

--- a/apps/web/src/lib/__tests__/billing-reconcile-invalidate.test.ts
+++ b/apps/web/src/lib/__tests__/billing-reconcile-invalidate.test.ts
@@ -12,7 +12,7 @@ import type Stripe from "stripe";
 // Spy on the invalidation without touching the rest of the resolver — this is
 // the exact call the regression guards. (Sibling convention: billing-pass-revoke
 // mocks @/lib/email the same way.)
-// V310: the reconcile path drops the cache for the whole billing GROUP, so the
+// V314: the reconcile path drops the cache for the whole billing GROUP, so the
 // call it makes is invalidateEntitlementsForOrgGroup — still keyed by the org.
 const entMock = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
@@ -92,7 +92,7 @@ afterAll(async () => {
   if (tempPlanKeys.length) {
     // Subscriptions seeded onto the temp plans must go first — plans.key is
     // referenced by subscriptions_plan_key_fkey. Their orgs must let go of the
-    // group first, or organizations_subscription_fk (V310) blocks the delete.
+    // group first, or organizations_subscription_fk (V314) blocks the delete.
     await sql`
       update organizations set subscription_id = null
        where subscription_id in (select id from subscriptions

--- a/apps/web/src/lib/__tests__/billing-reconcile-pass-credit.test.ts
+++ b/apps/web/src/lib/__tests__/billing-reconcile-pass-credit.test.ts
@@ -74,7 +74,7 @@ async function seedOrgAwaitingReconcile(): Promise<{ orgId: string; priceId: str
 /** A completed subscription checkout session as reconcileCheckout retrieves
  *  it — same shape as billing-reconcile-invalidate.test.ts's
  *  subscriptionSession, except the customer id is unique PER CALL: the
- *  partial unique index on subscriptions.stripe_customer_id (V310) means two
+ *  partial unique index on subscriptions.stripe_customer_id (V314) means two
  *  different groups sharing one literal customer id in the same test run
  *  throws on the second linkStripeCustomer, which would otherwise mask this
  *  file's own assertions behind an unrelated 23505. */

--- a/apps/web/src/lib/__tests__/billing-sync-guards.test.ts
+++ b/apps/web/src/lib/__tests__/billing-sync-guards.test.ts
@@ -113,7 +113,7 @@ afterAll(async () => {
   if (tempPlanKeys.length) {
     // Subscriptions seeded onto the temp plans must go first — plans.key is
     // referenced by subscriptions_plan_key_fkey. Their orgs must let go of the
-    // group first, or organizations_subscription_fk (V310) blocks the delete.
+    // group first, or organizations_subscription_fk (V314) blocks the delete.
     await sql`
       update organizations set subscription_id = null
        where subscription_id in (select id from subscriptions
@@ -194,7 +194,7 @@ describe.skipIf(!HAS_DB)("syncSubscription — unknown-price guard (P1-5)", () =
     expect(s.plan_key).toBe("pro_plus");
   });
 
-  // V310: an org ALWAYS has a group (createOrgForUser mints one, the migration
+  // V314: an org ALWAYS has a group (createOrgForUser mints one, the migration
   // backfilled the rest), so "no row yet" is now "a never-synced community
   // group" — the shape a first checkout syncs onto.
   it("a never-synced community group with an unknown price still lands community", async () => {

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -48,16 +48,28 @@ afterEach(() => {
 
 // grantMonthlyForAllWallets full-table-scans every subscription row with a
 // live org in the schema on each call, plus one resolver read per row. Run in
-// isolation that's instant, but inside the FULL vitest run (thousands of
-// fixture rows accumulated by every other suite in the same session) it can
-// comfortably exceed vitest's default 5s per-test timeout — not a regression
-// in the code path itself, just the cost of "every wallet" scaling with the
-// whole test session's row count. Every test here bumps its timeout
-// accordingly.
-const CRON_TEST_TIMEOUT = 20000;
+// isolation that's instant (the whole file is ~6.5s for all 12 tests), but
+// inside the FULL vitest run (thousands of fixture rows accumulated by every
+// other suite in the same session) it can comfortably exceed vitest's default
+// 5s per-test timeout — not a regression in the code path itself, just the
+// cost of "every wallet" scaling with the whole test session's row count.
+//
+// (#363) This USED TO be handled by pinning a per-test `{ timeout: N }` on
+// every `it(...)` here — which is exactly the wrong tool: a per-test timeout
+// OVERRIDES `--testTimeout` on the CLI, it does not merely raise the floor.
+// The repo-wide convention for slow-DB suites is the CLI flag (every gate/CI
+// invocation runs `vitest ... --testTimeout=30000`), so a 20000ms inline pin
+// here silently CAPPED this file below what every other suite in the same
+// run was given — under real load the CLI's 30s margin never took effect,
+// and the failure read as a hang ("Test timed out in 20000ms") rather than
+// what it was: quiet slack the file had denied itself. No test in this file
+// is individually slow enough to need its own bound (see the ~6.5s total
+// above) — the CLI flag alone is sufficient, so none is pinned inline.
+// Anyone tempted to re-add one: it will silently defeat `--testTimeout`
+// again, whatever value that flag is given.
 
 describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () => {
-  it("grants a paid wallet the scaled amount (monthly(plan) * quantity_paid)", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("grants a paid wallet the scaled amount (monthly(plan) * quantity_paid)", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro");
     await sql`update subscriptions set quantity_paid = 3 where id = ${subId}`;
@@ -73,7 +85,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(60 * 3);
   });
 
-  it("grants a community wallet the FLAT 10, ignoring quantity_paid", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("grants a community wallet the FLAT 10, ignoring quantity_paid", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "community");
     // Even if quantity_paid were ever non-1 on a community group-of-one,
@@ -85,7 +97,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(10);
   });
 
-  it("is a no-op on a second run in the same calendar month (idempotent per period)", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("is a no-op on a second run in the same calendar month (idempotent per period)", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro_plus");
 
@@ -96,7 +108,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(200);
   });
 
-  it("REGRESSION (#290): grants the resolved Community rate for a canceled (churned) subscription, not zero", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("REGRESSION (#290): grants the resolved Community rate for a canceled (churned) subscription, not zero", async () => {
     const orgId = await seedOrg();
     // comped_at stays null (setOrgPlan's default) — orgPlanKey's `canceled`
     // arm degrades this to community, exactly like any other entitlement
@@ -112,7 +124,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(10);
   });
 
-  it("REGRESSION (#290): grants the resolved Community rate for an incomplete (never-paid) subscription", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("REGRESSION (#290): grants the resolved Community rate for an incomplete (never-paid) subscription", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro", "incomplete");
 
@@ -121,7 +133,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(10);
   });
 
-  it("expires the prior period's unspent grant balance before granting the new period (D1)", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("expires the prior period's unspent grant balance before granting the new period (D1)", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro");
     // Leftover from a prior period the wallet never spent.
@@ -137,7 +149,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(60);
   });
 
-  it("a paid wallet's period is the calendar month, never current_period_end — a Stripe cycle change within the same month is a no-op", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("a paid wallet's period is the calendar month, never current_period_end — a Stripe cycle change within the same month is a no-op", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro");
     const cycle1 = new Date("2026-07-05T00:00:00Z");
@@ -163,7 +175,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(60);
   });
 
-  it("Community wallets grant on plain calendar month (no Stripe period at all)", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("Community wallets grant on plain calendar month (no Stripe period at all)", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "community");
     const [row] = await sql<{ current_period_end: string | null }[]>`
@@ -177,7 +189,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(10); // still idempotent via the calendar-month key
   });
 
-  it("REGRESSION (SPEC-2 §5.4 Cadence): an annual (yearly-renewing) Pro subscription still grants 12x/year, not a single lump", { timeout: 30000 }, async () => {
+  it("REGRESSION (SPEC-2 §5.4 Cadence): an annual (yearly-renewing) Pro subscription still grants 12x/year, not a single lump", async () => {
     // grantMonthlyForAllWallets scans every LIVE subscription row in the
     // schema each call; this test calls it across simulated months, which —
     // on a long-running local schema with many accumulated fixture rows —
@@ -229,7 +241,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(60);
   });
 
-  it("REGRESSION (#291): a trialing group grants for the LIVE org count when quantity_paid is frozen below it", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("REGRESSION (#291): a trialing group grants for the LIVE org count when quantity_paid is frozen below it", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro", "trialing");
     // #279 (syncGroupQuantity) freezes quantity_paid at its pre-trial
@@ -248,7 +260,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(subId)).toBe(60 * 2);
   });
 
-  it("can be scoped to named wallets, so a parallel suite's wallets cannot move the answer (#351)", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("can be scoped to named wallets, so a parallel suite's wallets cannot move the answer (#351)", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro");
     await sql`update subscriptions set quantity_paid = 2 where id = ${subId}`;
@@ -262,7 +274,7 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(await balance(otherSub)).toBe(0); // untouched: not in scope
   });
 
-  it("REGRESSION (#291): a trialing group still grants for quantity_paid when it sits ABOVE the live org count", { timeout: CRON_TEST_TIMEOUT }, async () => {
+  it("REGRESSION (#291): a trialing group still grants for quantity_paid when it sits ABOVE the live org count", async () => {
     const orgId = await seedOrg();
     const subId = await setOrgPlan(orgId, "pro", "trialing");
     // The other direction of the max(): this customer PAID for 3 seats before

--- a/apps/web/src/lib/__tests__/dictionary-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/dictionary-copy-truth.test.ts
@@ -600,6 +600,15 @@ const KNOWN_POSITIVES: string[] = [
   "two schedule runs",
   "AI scheduling is limited to 5 attempts per division",
   "Each division may be scheduled by AI up to 20 times.",
+  // ── AI runs claimed unmetered/free (#303) ──
+  "Officials AI runs are not metered.",
+  "The schedule pass is unmetered.",
+  "You can restaff as often as you like.",
+  "Just run it as often as you like.",
+  "Run it as often as you like, at no cost.",
+  "Officials AI runs are free.",
+  "It costs nothing to restaff.",
+  "AI schedule runs are uncapped.",
   // ── Task 3's APPROVED FORMS (the help-tree allowlist) ──
   // These are positives in the opposite sense to everything else here: they are
   // the shapes the help copy is ALLOWED to use, so each one is a real sentence
@@ -686,6 +695,31 @@ const KNOWN_POSITIVES: string[] = [
   "elke maand credits",
   "iedere maand credits",
   "een terugkerende bijboeking",
+  // #338 item 3 — the same recurring falsehood, yearly/weekly/quarterly, in
+  // es/fr/nl (the English list already had this half; these three did not).
+  "créditos anuales",
+  "créditos al año",
+  "cada año recibes créditos",
+  "por año recibes créditos",
+  "créditos semanales",
+  "cada semana recibes créditos",
+  "créditos trimestrales",
+  "en cada renovación recibes créditos",
+  "des crédits annuels",
+  "des crédits par an",
+  "chaque année vous recevez des crédits",
+  "tous les ans vous recevez des crédits",
+  "des crédits hebdomadaires",
+  "chaque semaine vous recevez des crédits",
+  "des crédits trimestriels",
+  "à chaque renouvellement vous recevez des crédits",
+  "jaarlijkse credits",
+  "credits per jaar",
+  "elk jaar credits",
+  "wekelijkse credits",
+  "elke week credits",
+  "credits per kwartaal",
+  "bij elke verlenging credits",
   // ── The V312 fee lock and its reversion claim (task 3) ──
   "the platform fee returns to your plan's rate",
   "the fee reverts to whatever your plan charges",
@@ -1114,6 +1148,92 @@ describe.skipIf(!HAS_DB)("the four-locale dictionaries say what the resolver enf
       }),
       "a bare half-rate claim in an exempt key must red, in every locale",
     ).toEqual([]);
+  });
+
+  /**
+   * #338 item 2: DISCOVERY BEYOND ONE FILENAME SHAPE.
+   *
+   * Everything above this point discovers a new claim-making key only if it
+   * matches `pricing.faq.*.a` (the FAQ classification) or the `pricing.*`
+   * prefix (`PRICING_KEY_DISPOSITION`). Neither reaches `ui.json`, and neither
+   * reaches a `marketing.json` key outside the `pricing.` namespace — which is
+   * everywhere else: 408 marketing keys and the whole of `ui.json` at the time
+   * this was written. Demonstrated: adding `pricing.pass.note2` and
+   * `upgrade.footnote` in all four locales, carrying "Your pass has no use-by
+   * date and keeps working after the competition ends" (the exact reviewer
+   * probe from #338), shipped 40/40 green before this test existed.
+   *
+   * The fix is not a hand-written classification of every key — that is a list,
+   * and a list is the thing that must be remembered (the same lesson
+   * `describedEntries` recorded for the Stripe seed). Instead this scans EVERY
+   * value in BOTH dictionary files, in all four locales, with the SAME
+   * clause-scoped vocabularies the exempt-key re-scan above already trusts, and
+   * requires a hit to be on a PINNED key. A key nobody pinned that starts
+   * making one of these claims is discovered the moment it does — no filename
+   * shape required. Measured against the two dictionaries as they stand today:
+   * zero hits, so this costs nothing and reds the day either falsehood lands.
+   */
+  /** The scan itself, factored out so the mutation proof below calls the exact
+   *  code under test rather than a re-implementation of it. `extra` injects
+   *  additional {file,key,value} entries per locale, standing in for a key that
+   *  does not exist on disk yet — the only way to prove discovery reaches a key
+   *  nobody has written without actually writing one into the dictionaries. */
+  const scanWholeDictionary = (
+    extra: Array<{ file: "marketing" | "ui"; key: string; value: Record<DictionaryLocale, string> }> = [],
+  ): string[] => {
+    const pinned = new Set(APPROVED_DICTIONARY_COPY.map((e) => e.key));
+    const faults: string[] = [];
+    for (const locale of DICTIONARY_LOCALES) {
+      const claims = LOCALE_CLAIMS[locale];
+      for (const file of ["marketing", "ui"] as const) {
+        const dict = load(locale, file);
+        const entries = [
+          ...Object.entries(dict),
+          ...extra.filter((e) => e.file === file).map((e) => [e.key, e.value[locale]] as const),
+        ];
+        for (const [key, value] of entries) {
+          if (typeof value !== "string" || pinned.has(key)) continue;
+          if (claims.halfClaim.test(value) && !claims.atMostHalf.test(value)) {
+            faults.push(`${locale} ${file}.${key}: quotes half the base rate with no "no more than" qualifier`);
+          }
+          for (const clause of valueClauses(value)) {
+            if (!claims.passSubject.test(clause)) continue;
+            if (!claims.permanence.some((p) => p.test(clause))) continue;
+            faults.push(
+              `${locale} ${file}.${key}: unpinned, but "${clause.slice(0, 60)}" claims the pass has unbounded duration`,
+            );
+            break;
+          }
+          if (/\+\s*\d[\d,]*\s*AI\s+credits?/i.test(value) && claims.recurring.some((p) => p.test(value))) {
+            faults.push(`${locale} ${file}.${key}: unpinned, but sells an AI-credit grant as recurring`);
+          }
+        }
+      }
+    }
+    return faults;
+  };
+
+  it("discovers a new claim-making key ANYWHERE in marketing or ui, not just pricing.faq.*.a", () => {
+    expect(scanWholeDictionary()).toEqual([]);
+
+    // …and the scan FIRES, on the issue's own reviewer probe, injected as BRAND
+    // NEW keys in a shape none of the axes above recognise (not
+    // `pricing.faq.*.a`, not even `pricing.*`, and one of the two is in
+    // `ui.json`).
+    const NEW_KEY_PROBE: Record<DictionaryLocale, string> = {
+      en: "Your pass has no use-by date and keeps working after the competition ends.",
+      es: "Tu pase no tiene fecha de caducidad y sigue funcionando después de que termine la competición.",
+      fr: "Votre pass n'a pas de date limite et continue de fonctionner après la fin de la compétition.",
+      nl: "Je pass heeft geen houdbaarheidsdatum en blijft werken nadat de competitie is afgelopen.",
+    };
+    expect(
+      scanWholeDictionary([{ file: "marketing", key: "pricing.pass.note2", value: NEW_KEY_PROBE }]),
+      "a brand-new pricing.* key must still be caught even though it is not pricing.faq.*.a",
+    ).not.toEqual([]);
+    expect(
+      scanWholeDictionary([{ file: "ui", key: "upgrade.footnote", value: NEW_KEY_PROBE }]),
+      "a brand-new ui.json key must be caught too — this is the axis PRICING_KEY_DISPOSITION cannot reach",
+    ).not.toEqual([]);
   });
 
   /**
@@ -2479,6 +2599,34 @@ describe("the dictionary guards survive a rewording, in every locale", () => {
     }
   });
 
+  /**
+   * #338 item 3: `{es,fr,nl}.recurring` was MONTHLY-ONLY, so a yearly, weekly or
+   * quarterly framing of the same one-time-grant falsehood scored 0/9 — none of
+   * these nine phrasings, one per locale per cadence, tripped anything before
+   * this task widened the three lists. Reusing the issue's own nine examples
+   * rather than inventing new ones: "cada año", "anuales", "en cada renovación"
+   * (es); "chaque année", "annuels", "à chaque renouvellement" (fr); "elk jaar",
+   * "jaarlijks", "bij elke verlenging" (nl).
+   */
+  it("catches the recurring-grant claim beyond monthly, in es/fr/nl", () => {
+    for (const [locale, recurring] of [
+      ["es", "Recibe +25 créditos de IA cada año."],
+      ["es", "Créditos de IA anuales: +25."],
+      ["es", "En cada renovación, +25 créditos de IA."],
+      ["fr", "Recevez +25 crédits IA chaque année."],
+      ["fr", "Crédits IA annuels : +25."],
+      ["fr", "À chaque renouvellement, +25 crédits IA."],
+      ["nl", "Ontvang elk jaar +25 AI-credits."],
+      ["nl", "Jaarlijks +25 AI-credits."],
+      ["nl", "Bij elke verlenging +25 AI-credits."],
+    ] as Array<[DictionaryLocale, string]>) {
+      expect(
+        localeCreditGrantFaults(v(locale, recurring), PASS_CREDIT_GRANT).join(" "),
+        `${locale}: ${recurring}`,
+      ).toContain("sells the one-time grant as recurring");
+    }
+  });
+
   // ── The Pro Plus differentiators ───────────────────────────────────────────
 
   const SHARED = { community: true, pro: true, pro_plus: true };
@@ -2720,6 +2868,41 @@ describe("every pattern in @/lib/copy-truth does something", () => {
   // while the same byte in an exported pattern redded three tests.
   it("exports every top-level pattern, so none is exempt from the checks above", () => {
     expect(unexportedPatternFaults(MODULE_SOURCE)).toEqual([]);
+  });
+
+  /**
+   * #338 item 4 (second vacuity hole), mutation-proven. The OLD `PATTERN_SHAPED`
+   * required the pattern immediately after `=` and missed one wrapped in a
+   * container: `const ZZ_PROBE_LIST: RegExp[] = [/(?!x)x-inert/i];` — a real
+   * inert, unexported RegExp array — shipped clean because the `=` is followed
+   * by `[`, not `/`. Same failure for `new RegExp(...)` and `claim(...)` a
+   * bracket deep. All three must now red; a bare non-pattern const declaration
+   * (a Record of STRINGS, e.g. the module's own `CLAUSE_BREAK`/`SUBJECT_BREAK`
+   * shape) must still pass, or every plain lookup table in the file would need
+   * an unnecessary `export`.
+   */
+  it("catches a pattern hidden inside a container, not just bare after '='", () => {
+    expect(
+      unexportedPatternFaults('const ZZ_PROBE_LIST: RegExp[] = [/(?!x)x-inert/i];'),
+      "an array literal one bracket deep",
+    ).toEqual([
+      "ZZ_PROBE_LIST: a top-level pattern that is not exported — collectPatterns cannot see it, so it is exempt from every anti-vacuity rule below. Add `export`.",
+    ]);
+    expect(
+      unexportedPatternFaults("const ZZ_PROBE_MAP: Record<string, RegExp> = { a: new RegExp('x') };"),
+      "new RegExp(...) inside an object literal",
+    ).not.toEqual([]);
+    expect(
+      unexportedPatternFaults("const ZZ_PROBE_CLAIM: RegExp[] = [claim('x')];"),
+      "claim(...) inside an array literal",
+    ).not.toEqual([]);
+    // …and a plain lookup table of STRINGS — this module's own shape for
+    // CLAUSE_BREAK/SUBJECT_BREAK — must not be swept in: it holds no RegExp at
+    // all, so requiring `export` on it would be busywork, not a fix.
+    expect(
+      unexportedPatternFaults('const ZZ_NOT_A_PATTERN: Record<string, string> = { en: "x" };'),
+      "a plain string lookup table is not pattern-shaped",
+    ).toEqual([]);
   });
 
   // …and the control-character scan run over the RAW SOURCE, which reaches what

--- a/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-sql-parity.test.ts
@@ -11,7 +11,9 @@
 // Real Postgres required; skipped without DATABASE_URL. Seeds are run-unique.
 import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
 import { sql } from "@/lib/db";
+import { syncSubscription } from "@/lib/billing";
 import {
   getLimit,
   hasFeature,
@@ -106,11 +108,69 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     expect(await sqlHasFeature(orgId, "realtime")).toBe(false);
   });
 
+  // #314 (2): the comp-expiry guard is an AND of "comped_until lapsed" with
+  // "the subscription isn't genuinely live" (id null OR status outside
+  // LIVE_SUBSCRIPTION_STATUSES) — the row above only ever exercises the
+  // id-is-null disjunct. A PAYING org that was ALSO comped in the past (a
+  // staff grant layered on top of a real subscription) must keep resolving
+  // its own live plan once the comp lapses, not fall back to community —
+  // otherwise a real subscriber loses their paid plan the moment an old comp
+  // date passes.
+  it("keeps a LIVE paying subscription on plan after its OWN comp lapses", async () => {
+    await sql`
+      update subscriptions
+      set plan_key = 'pro', comped_until = now() - interval '1 day',
+          stripe_subscription_id = 'sub_live', status = 'active'
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime")).toBe(true);
+    expect(await sqlHasFeature(orgId, "realtime")).toBe(true);
+  });
+
   it("degrades past_due beyond the 14-day grace", async () => {
     await sql`
       update subscriptions
       set plan_key = 'pro', status = 'past_due',
           status_changed_at = now() - interval '15 days',
+          stripe_subscription_id = 'sub_test'
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime")).toBe(false);
+    expect(await sqlHasFeature(orgId, "realtime")).toBe(false);
+  });
+
+  // #314 (1): the row above only proves the DEGRADE past 14 days — there was
+  // no positive case proving a past_due row WITHIN the grace still resolves
+  // its paid plan. Without this, an arm widened to degrade every past_due
+  // row (dropping the 14-day guard entirely) would ship green: nothing here
+  // pinned that dunning gets its grace period at all.
+  it("keeps a past_due subscription on plan WITHIN the 14-day grace", async () => {
+    await sql`
+      update subscriptions
+      set plan_key = 'pro', status = 'past_due',
+          status_changed_at = now() - interval '3 days',
+          stripe_subscription_id = 'sub_test'
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime")).toBe(true);
+    expect(await sqlHasFeature(orgId, "realtime")).toBe(true);
+  });
+
+  // #314 (3): both resolvers anchor the past_due grace on
+  // `coalesce(status_changed_at, updated_at)` specifically to cover rows the
+  // V291 backfill never saw (a status_changed_at of null on a row written
+  // before that migration). Every other past_due case in this file has a
+  // real status_changed_at, so the fallback itself has never been exercised
+  // here — a regression that dropped the coalesce (using status_changed_at
+  // bare) would silently stop degrading every pre-backfill row, since
+  // `null <= now() - interval '14 days'` is NULL, not true, in both SQL and
+  // the equivalent TS comparison.
+  it("degrades past_due via the updated_at fallback when status_changed_at is NULL", async () => {
+    await sql`
+      update subscriptions
+      set plan_key = 'pro', status = 'past_due',
+          status_changed_at = null,
+          updated_at = now() - interval '15 days',
           stripe_subscription_id = 'sub_test'
       where id = (select subscription_id from organizations o where o.id = ${orgId})`;
     await invalidateOrgEntitlements(orgId);
@@ -412,6 +472,50 @@ describe.skipIf(!HAS_DB)("org_has_feature parity with lib/entitlements", () => {
     await invalidateOrgEntitlements(orgId);
     expect(await hasFeature(orgId, "realtime")).toBe(false);
     expect(await sqlHasFeature(orgId, "realtime")).toBe(false);
+  });
+
+  // #314 (4): STATUS_MAP (lib/billing.ts) collapses Stripe's 'paused' status
+  // into our 'past_due' at write time, exactly like 'unpaid' (see the
+  // billing-grace-anchor audit) — the literal string 'paused' must never
+  // reach subscriptions.status. Neither resolver needs its own 'paused' arm
+  // BECAUSE of that translation, but nothing in this suite had proven the
+  // write actually happens before asking both resolvers to agree on the
+  // result. Fresh off a real transition, status_changed_at is stamped to
+  // now(), so the row lands WELL within the 14-day grace: both resolvers
+  // must still read the paid plan, not community.
+  it("STATUS_MAP maps a Stripe 'paused' sub to past_due, and both resolvers agree it's within grace", async () => {
+    const subId = `sub_paused_${uniq()}`;
+    // Live 'active' first so the write below is a genuine TRANSITION (the
+    // grace anchor only stamps status_changed_at on a status change).
+    await sql`
+      update subscriptions
+      set plan_key = 'pro', status = 'active', stripe_subscription_id = ${subId}
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    await syncSubscription(orgId, {
+      id: subId,
+      status: "paused",
+      trial_end: null,
+      cancel_at_period_end: false,
+      currency: "usd",
+      items: {
+        data: [
+          {
+            price: { id: "price_unknown" },
+            current_period_end: Math.floor(Date.now() / 1000) + 86_400,
+          },
+        ],
+      },
+    } as unknown as Stripe.Subscription);
+
+    const [row] = await sql<{ status: string }[]>`
+      select status from subscriptions
+      where id = (select subscription_id from organizations o where o.id = ${orgId})`;
+    // The literal string 'paused' must never land in the column.
+    expect(row.status).toBe("past_due");
+
+    await invalidateOrgEntitlements(orgId);
+    expect(await hasFeature(orgId, "realtime")).toBe(true);
+    expect(await sqlHasFeature(orgId, "realtime")).toBe(true);
   });
 
   // Coverage addition, not a regression: both resolvers already agreed a

--- a/apps/web/src/lib/__tests__/help-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/help-copy-truth.test.ts
@@ -49,6 +49,7 @@ import {
   retiredRunCapProseFaults,
   riderRateFaults,
   statesFeeLock,
+  unmeteredAiRunProseFaults,
   unqualifiedFeeReversionFaults,
 } from "@/lib/copy-truth";
 import { HELP_ARTICLE_SLUGS, helpUrl } from "@/lib/help";
@@ -94,16 +95,17 @@ afterAll(async () => {
 /**
  * Articles this task fixed, and therefore scans.
  *
- * NOT a directory walk. `content/help/billing/downgrade.md` carries the SAME
- * unqualified fee-reversion claim these guards now ban, `scheduling/ai-scheduling.md`
- * still documents the retired per-division run cap, and both are out of scope
- * for this wave by decision, tracked on #303. A `readdirSync` here would red the
- * suite on other people's work; naming the gaps keeps them visible and makes
- * closing one a one-line move rather than a rediscovery.
+ * NOT a directory walk. Two siblings this task fixed were `billing/downgrade.md`
+ * (the same unqualified fee-reversion claim these guards ban — see the new
+ * describe block below, `billing/downgrade.md is gated too`) and
+ * `scheduling/ai-scheduling.md` (the retired per-division run-cap table AND the
+ * false "officials AI runs are not metered" claim — see
+ * `scheduling/ai-scheduling.md is gated too`, further down). Both moved out of
+ * this list and into real scans once #303 corrected the copy. What remains
+ * below is a real gap with a real issue, and listing it as data rather than
+ * leaving it silently unscanned is the point.
  */
 const KNOWN_GAPS = [
-  "billing/downgrade.md:28 — 'the rate returns to 8%', same missing V312 qualifier (#303)",
-  "scheduling/ai-scheduling.md — retired per-division run-cap table and hourly brake (#303)",
   "lib/pricing-cards.ts + e2e/pro-plus-tier.spec.ts — card bullets pinned verbatim (#303)",
   "config/tips.ts + dictionaries/*/ui.json — tips.schedule.save-points.body is stale on BOTH sides vs schedule.checkpoints.max (community 2 since V319, pro 5, pro_plus unlimited); documented as the tip-mirror exception in dictionary-copy-truth.test.ts (#303)",
   "content/help/** link TARGETS are invisible to the inventory gate — claimSurfaces reduces [text](/url) to text, so repointing a URL raises 0 faults (sibling of the link-TITLE hole, #338)",
@@ -111,7 +113,7 @@ const KNOWN_GAPS = [
   "app/globals.css .competition-prose table — `display: block` is what gives that scroll box its overflow, and it drops the implicit table role in some assistive tech (row/column relationships stop being announced). Mitigation is an explicit role=\"table\"/rowgroup set, which the same sanitiser strips (#303)",
   // ── Round 4 bookkeeping: the residuals, named rather than left implicit ────
   "THE AXIS IS CIRCULAR. `claiming` is computed by running `en.halfClaim` over the tree, so an article only joins the half-rate axis — and therefore only earns a gate — if that vocabulary already matches it. The vocabulary has been measured at 0/12 and 0/24, so an article stating the rate in an unseen shape is invisible to the axis AND ungated. The axis narrows the ungated set; it does not close it (#303)",
-  "THE FOURTH ARTICLE. `billing/plans.md` states the plan org caps and the fee ladder and is inventory-gated, but `billing/downgrade.md`, `billing/credits.md`, `billing/operator.md` and every non-billing article are ungated and unscanned. They are defended only by the vocabulary above (#303)",
+  "THE FOURTH ARTICLE. `billing/plans.md` states the plan org caps and the fee ladder and is inventory-gated. `billing/downgrade.md` and `scheduling/ai-scheduling.md` now carry the fee-lock/run-cap/unmetered-run vocabulary scans (below), which is real coverage but NOT the word-for-word inventory gate — a reword that stays inside the vocabulary's blind spots is still possible. `billing/credits.md`, `billing/operator.md` and every other non-billing, non-scheduling article remain fully ungated and unscanned, defended only by the vocabulary above (#303)",
   "COMMENTS OWNED BY A CLOSING TOKEN SURVIVE `codeOnly` — NOT just the JSX idiom. `forEachChild` never visits TOKENS, so any comment whose nearest owner is a closing token is never blanked: `{/* … */}`, but equally an end-of-block comment on its own line, a comment in an empty block, the last call argument, the last array element, the last object property, the end of an interface body, a `switch`, or an `if`. Only an end-of-file comment is blanked. Measured tree-wide: 569 comment lines / 32,229 chars across 168 of 1,460 files. Direction is FAIL-SAFE — a negative scan can red on a comment that mentions a banned idiom, but can never miss real code — which is why it is recorded rather than fixed. Recorded as .tsx-only in round 5; that scoping was wrong and would have left the next reader hunting a JSX bug (#338)",
   "LITERAL-FREE SPANS ARE UNAUDITED, AND THIS ONE IS FAIL-OPEN. `blankedInsideLiteralFaults` proves every changed character lies OUTSIDE every string/regex/template-part/JSX literal, which closes the historical family (a `/*` inside a string ate 193 lines of division-settings.tsx) — proven by a length-preserving blank across every file raising 14,857 faults. It does NOT audit a stripper that eats a span containing NO literal at all. Constructed and it PASSES: blanking the largest literal-free span per file ships 79/79 green while destroying 1,061,443 chars across 1,341 of 1,460 files, largest single span 11,831 chars in server/usecases/billing-events.ts — LARGER than the 11,384 the historical bug actually ate. So this is not a corner case, it is most of the tree. THE COST ESTIMATE IN THE TASK 7 REPORT IS WRONG and that is the part that matters: closing this does NOT need a re-parse-and-compare 'doubling the walk'. It is a string check on the CHANGED CHARACTERS ONLY — take each maximal run of changed offsets, extend across neighbouring changed/space chars, require that span's raw text to be comments and whitespace only. O(changed chars), no re-parse, sub-millisecond per file. A wrong cost estimate is what stops a thing ever being closed (#338)",
   "FRONTMATTER PARSER DIVERGENCE, STILL LIVE. `server/help-content.ts`'s parseFrontmatter splits on `indexOf(\":\")` and is last-wins, so an indented `  description:` or a spaced `description :` is still RENDERED as the article's description while `copy-truth.ts`'s claimSurfaces regex (`^([A-Za-z_][\\w-]*):`) does not match it — the field scores 0 gate faults and is invisible to every rule. A falsehood delivered that way ships green (#303)",
@@ -275,6 +277,81 @@ describe("billing help articles say what the resolver enforces", () => {
       qualified.length,
       "no block both states what happens to the rate and qualifies it — the guards above are passing on silence",
     ).toBeGreaterThan(0);
+  });
+});
+
+// The two KNOWN_GAPS entries #303 actually fixed — closed as real scans rather
+// than left as prose that merely LOOKS corrected. "Trust the code, not the
+// drifted line number" applies here too: `helpArticle`/`helpArticleBySlug`
+// throw on a missing/empty file, so a moved or emptied article reds instead of
+// silently scanning nothing.
+describe("billing/downgrade.md is gated too (#303)", () => {
+  const downgrade = helpArticle("downgrade");
+
+  it("never says the entry-fee rate reverts without the first-paid-entry lock", () => {
+    expect(unqualifiedFeeReversionFaults("downgrade.md", downgrade)).toEqual([]);
+  });
+
+  it("states the lock, rather than merely omitting the false claim", () => {
+    expect(feeLockStatedFaults("downgrade.md", downgrade)).toEqual([]);
+
+    // ANTI-VACUITY, same shape as the event-pass/plans check above.
+    const qualified = proseBlocks(downgrade)
+      .flatMap((block) => sentences(block))
+      .filter((sentence) => mentionsRateAfterPass(sentence) && statesFeeLock(sentence));
+    expect(
+      qualified.length,
+      "no block both states what happens to the rate and qualifies it — the guards above are passing on silence",
+    ).toBeGreaterThan(0);
+  });
+
+  it("quotes no retired per-division AI-run cap", () => {
+    expect(retiredRunCapProseFaults("downgrade.md", downgrade)).toEqual([]);
+  });
+
+  // MUTATION PROOF: the exact unqualified sentence #303 found at line 28
+  // ("back on Community the rate returns to 8%", no V312 qualifier) must red
+  // both guards above — this is what "the guard would have caught it" means,
+  // demonstrated rather than asserted.
+  it("reds on the exact unqualified sentence #303 found", () => {
+    const reverted = downgrade.replace(
+      /What changes is the platform fee[\s\S]*?while the rest of the org sits on Community\./,
+      "What changes is the platform fee: back on Community the rate returns to **8%**, where Pro is 2% and Pro Plus 1%. See the fee ladder.\n\n**Passed competitions keep their own rate.** A competition covered by an Event Pass stays at **5%** after the downgrade, and keeps everything else the pass grants — bigger limits, branded exports, sponsor tiers and packages — while the rest of the org sits on Community.",
+    );
+    expect(reverted, "the replacement never matched — the article moved").not.toBe(downgrade);
+    expect(unqualifiedFeeReversionFaults("x", reverted)).not.toEqual([]);
+    expect(feeLockStatedFaults("x", reverted)).not.toEqual([]);
+  });
+});
+
+describe("scheduling/ai-scheduling.md is gated too (#303)", () => {
+  const aiScheduling = helpArticleBySlug("scheduling/ai-scheduling");
+
+  it("quotes no retired per-division AI-run cap", () => {
+    expect(retiredRunCapProseFaults("ai-scheduling.md", aiScheduling)).toEqual([]);
+  });
+
+  it("never claims an AI run — schedule or officials — is unmetered", () => {
+    expect(unmeteredAiRunProseFaults("ai-scheduling.md", aiScheduling)).toEqual([]);
+  });
+
+  // MUTATION PROOF, both halves #303 found: the retired lifetime-quota table,
+  // and "Officials AI runs are not metered".
+  it("reds on the exact retired table and the exact unmetered claim #303 found", () => {
+    const oldTable = `## Run quotas
+
+AI Schedule needs no upgrade — it runs on **every plan, Community included**. What your plan sets is how many times you can run it: each **schedule generation** counts against a per-division quota.
+
+| Plan | AI schedule generations per division |
+| --- | --- |
+| Community | 5 |
+| Event Pass | 10 |
+| Pro | 20 |
+| Pro Plus | 50 |
+
+The quota is a **lifetime total per division** — it doesn't reset weekly or monthly, and a new division starts a fresh count. Refine and repair each use one generation. A run that fails or times out **does not** count. Separately, every plan has a burst brake of **5 AI runs per hour per division**. **Officials AI runs are not metered** — once you have automatic officials assignment, you can restaff as often as you like.`;
+    expect(retiredRunCapProseFaults("x", oldTable)).not.toEqual([]);
+    expect(unmeteredAiRunProseFaults("x", oldTable)).not.toEqual([]);
   });
 });
 
@@ -449,6 +526,23 @@ describe("the help-prose guards survive a rewording, not just a revert", () => {
     ).not.toEqual([]);
     expect(
       retiredRunCapProseFaults("x", "Community gets 5 AI schedule runs per division."),
+    ).not.toEqual([]);
+  });
+
+  // The second exemption (#303): the genuinely live HOURLY burst brake
+  // (`rateLimit('ai-plan:'+divisionId, {max:5, windowSeconds:3600})`,
+  // schedule-ai.ts) is shaped exactly like the retired lifetime table to the
+  // base vocabulary, and must be writable — but ONLY when the sentence actually
+  // names an hourly window. A day/week/month framing names no real mechanism
+  // and must still red, same as any other invented allowance.
+  it("lets prose state the live hourly burst brake, but not a monthly one", () => {
+    expect(
+      retiredRunCapProseFaults("x", "Every plan has a burst brake of 5 AI runs an hour per division."),
+      "the true hourly rate limit",
+    ).toEqual([]);
+    expect(
+      retiredRunCapProseFaults("x", "Community gets 5 AI schedule runs a month per division."),
+      "a monthly per-division allowance is not a real mechanism and must still red",
     ).not.toEqual([]);
   });
 

--- a/apps/web/src/lib/__tests__/migration-header-truth.test.ts
+++ b/apps/web/src/lib/__tests__/migration-header-truth.test.ts
@@ -1,0 +1,117 @@
+// A migration that misnames itself in its own header is the most expensive kind
+// of wrong comment: it is the AUTHORITATIVE file, so every reader who opens it
+// to check a fact copies the wrong version number out of it.
+//
+// That is not hypothetical. #312 corrected 33 citations across 23 files that all
+// said V310 for facts V314 states — and the source was V314's own header
+// (`-- V310 — billing moves off the org...`). One wrong header produced 33 wrong
+// citations, which is the whole argument for this guard costing a test.
+//
+// Scope, deliberately narrow: this checks ONLY the self-naming header — the
+// first non-empty line, in the `-- V### — description` shape this repo uses to
+// title a migration. A migration that legitimately REFERENCES another one in
+// prose ("V283 deliberately withheld DELETE on sponsor_orders...") is not
+// naming itself and must not be flagged; requiring the dash separator is what
+// tells the two apart. 64 of 101 migrations have no self-naming header at all,
+// which is fine — the rule is "if you name yourself, be right", not "name
+// yourself".
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+const DELTAS = path.resolve(__dirname, "../../../../../db/migration/deltas");
+
+/** `-- V314 — billing moves off the org` → "314". Null for anything else,
+ *  including a prose line that merely starts with a version reference. */
+const selfNamed = (line: string): string | null =>
+  /^--\s*V(\d+)\s*[—–-]\s/.exec(line.trim())?.[1] ?? null;
+
+/** The version a migration file's NAME declares. */
+const fileVersion = (name: string): string => /^V(\d+)__/.exec(name)![1]!;
+
+/**
+ * Migrations whose header is known-wrong and which cannot be corrected in place.
+ *
+ * Flyway checksums applied migrations, so editing the body — even one comment
+ * character — fails `flyway migrate` validation on every environment where the
+ * migration has already run. Correcting these costs a coordinated `flyway
+ * repair`, tracked in #366 to ride along with the next migration that already
+ * requires coordination.
+ *
+ * All three are one incident: V314/V315/V316 were renumbered after being
+ * written and their headers never followed, which is exactly the off-by-four
+ * run you would expect from a rebase.
+ *
+ * This list may only ever SHRINK. The test below fails if an entry stops being
+ * wrong, so a fixed header cannot leave a stale exemption behind to hide the
+ * next one.
+ */
+const KNOWN_WRONG_HEADERS: Readonly<Record<string, string>> = {
+  "V314__billing_groups.sql": "310",
+  "V315__billing_group_transfers.sql": "311",
+  "V316__competition_fee_lock.sql": "312",
+};
+
+const migrations = fs
+  .readdirSync(DELTAS)
+  .filter((f) => /^V\d+__.*\.sql$/.test(f))
+  .sort();
+
+describe("migration headers name their own file", () => {
+  it("finds the migration directory and a plausible number of files", () => {
+    // Guards the guard: a wrong path would make every assertion below vacuous
+    // by iterating an empty list, which is the failure mode this whole file
+    // exists to argue against.
+    expect(migrations.length).toBeGreaterThan(50);
+  });
+
+  it("every self-naming header states its own version (#366)", () => {
+    const wrong: string[] = [];
+    for (const file of migrations) {
+      const first = fs
+        .readFileSync(path.join(DELTAS, file), "utf8")
+        .split("\n")
+        .find((l) => l.trim() !== "");
+      const claimed = first ? selfNamed(first) : null;
+      if (claimed === null) continue; // no self-naming header — not this rule's business
+      if (claimed === fileVersion(file)) continue;
+      if (KNOWN_WRONG_HEADERS[file] === claimed) continue; // tracked in #366
+      wrong.push(`${file} names itself V${claimed}`);
+    }
+    expect(wrong).toEqual([]);
+  });
+
+  it("the #366 exemption list holds nothing that has since been fixed", () => {
+    // A stale exemption is worse than none: it silently permits the exact
+    // defect it was written to tolerate temporarily. When #366 lands, this is
+    // the test that tells you to delete the entry rather than leaving it to rot.
+    const stale: string[] = [];
+    for (const [file, claimed] of Object.entries(KNOWN_WRONG_HEADERS)) {
+      const full = path.join(DELTAS, file);
+      if (!fs.existsSync(full)) {
+        stale.push(`${file} no longer exists — drop it from KNOWN_WRONG_HEADERS`);
+        continue;
+      }
+      const first = fs
+        .readFileSync(full, "utf8")
+        .split("\n")
+        .find((l) => l.trim() !== "");
+      const actual = first ? selfNamed(first) : null;
+      if (actual !== claimed) {
+        stale.push(`${file} no longer claims V${claimed} — drop it from KNOWN_WRONG_HEADERS`);
+      }
+    }
+    expect(stale).toEqual([]);
+  });
+
+  it("does not flag a header that merely REFERENCES another migration", () => {
+    // The distinguishing case, pinned so a future tightening of the regex
+    // cannot quietly start failing legitimate prose. V300 opens with
+    // "-- V283 deliberately withheld DELETE on sponsor_orders from app_user"
+    // — a sentence about V283, not a claim to be V283.
+    expect(selfNamed("-- V283 deliberately withheld DELETE on sponsor_orders")).toBeNull();
+    expect(selfNamed("-- V314 — billing moves off the org")).toBe("314");
+    expect(selfNamed("-- V314 - billing moves off the org")).toBe("314");
+    expect(selfNamed("-- Adds a column. See V283 for why.")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/__tests__/org-scope.test.ts
+++ b/apps/web/src/lib/__tests__/org-scope.test.ts
@@ -1,0 +1,131 @@
+// v17 gap #334, the CLIENT half: the seams that write to group-scoped routes
+// must put the org from the URL on the request. The server's preference for
+// that header is proven against the real route in
+// `app/api/billing/extra-orgs/__tests__/group-scope.test.ts`; if nothing ever
+// SENDS it, the whole fix falls back to the cookie it was written to replace
+// and every one of those tests still passes.
+import { afterEach, describe, expect, it } from "vitest";
+import { ORG_SCOPE_HEADER, orgScopeHeaders, orgSlugFromPath } from "@/lib/org-scope";
+import { postJson } from "@/lib/api-post";
+import { api } from "@/lib/client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** The header a call actually went out with, or undefined. */
+function sentScope(init: RequestInit | undefined): string | undefined {
+  return (init?.headers as Record<string, string> | undefined)?.[ORG_SCOPE_HEADER];
+}
+
+describe("orgSlugFromPath", () => {
+  it("reads the org out of a console path, at any depth", () => {
+    expect(orgSlugFromPath("/o/riverside")).toBe("riverside");
+    expect(orgSlugFromPath("/o/riverside/settings/add-ons")).toBe("riverside");
+    expect(orgSlugFromPath("/o/riverside-cc-2/settings/billing")).toBe("riverside-cc-2");
+  });
+
+  it("claims nothing outside the console tree", () => {
+    // `/orgs/new` is the trap: a `/o/` prefix test would read "rgs" as a slug
+    // and stamp a request made from a page that has no org at all.
+    expect(orgSlugFromPath("/orgs/new")).toBeNull();
+    expect(orgSlugFromPath("/admin/billing-events")).toBeNull();
+    expect(orgSlugFromPath("/")).toBeNull();
+    expect(orgSlugFromPath("/o/")).toBeNull();
+    expect(orgSlugFromPath(null)).toBeNull();
+    expect(orgSlugFromPath(undefined)).toBeNull();
+  });
+
+  it("refuses anything that is not slug-shaped", () => {
+    expect(orgSlugFromPath("/o/Not A Slug")).toBeNull();
+    expect(orgSlugFromPath("/o/%ZZ")).toBeNull();
+    expect(orgSlugFromPath("/o/-leading-hyphen")).toBeNull();
+  });
+
+  it("builds no header off the console tree", () => {
+    expect(orgScopeHeaders("/orgs/new")).toEqual({});
+    expect(orgScopeHeaders("/o/acme")).toEqual({ [ORG_SCOPE_HEADER]: "acme" });
+  });
+});
+
+describe("postJson names the org its page is about", () => {
+  it("stamps the slug from the path it was called on", async () => {
+    let seen: RequestInit | undefined;
+    const fetchFn = (async (_url: string, init?: RequestInit) => {
+      seen = init;
+      return jsonResponse({ ok: true, data: { extraOrgs: 1 } });
+    }) as unknown as typeof fetch;
+
+    const result = await postJson(
+      "/api/billing/extra-orgs",
+      { count: 1 },
+      fetchFn,
+      "/o/northside/settings/add-ons",
+    );
+
+    expect(result.ok).toBe(true);
+    expect(sentScope(seen)).toBe("northside");
+  });
+
+  it("sends no scope from a page that has no org in its URL", async () => {
+    let seen: RequestInit | undefined;
+    const fetchFn = (async (_url: string, init?: RequestInit) => {
+      seen = init;
+      return jsonResponse({ ok: true, data: {} });
+    }) as unknown as typeof fetch;
+
+    await postJson("/api/billing/extra-orgs", { count: 1 }, fetchFn, "/orgs/new");
+
+    expect(sentScope(seen)).toBeUndefined();
+  });
+});
+
+describe("api() names the org its page is about", () => {
+  const realFetch = globalThis.fetch;
+  const hadWindow = "window" in globalThis;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (!hadWindow) delete (globalThis as { window?: unknown }).window;
+  });
+
+  it("stamps the slug from the live location", async () => {
+    let seen: RequestInit | undefined;
+    // `api()` has no injection seam — it is the app-wide helper every billing
+    // control on the Billing tab (cancel, plan, interval, promo, address, tax
+    // id, cards) goes through, so the location IS its input.
+    (globalThis as { window?: unknown }).window = {
+      location: { pathname: "/o/riverside/settings/billing" },
+    };
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seen = init;
+      return jsonResponse({ ok: true, data: {} });
+    }) as unknown as typeof fetch;
+
+    await api("/api/billing/cancel", { method: "POST", json: {} });
+
+    expect(sentScope(seen)).toBe("riverside");
+  });
+
+  it("lets an explicit header win, so a caller can still choose", async () => {
+    let seen: RequestInit | undefined;
+    (globalThis as { window?: unknown }).window = {
+      location: { pathname: "/o/riverside/settings/billing" },
+    };
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      seen = init;
+      return jsonResponse({ ok: true, data: {} });
+    }) as unknown as typeof fetch;
+
+    await api("/api/billing/cancel", {
+      method: "POST",
+      json: {},
+      headers: { [ORG_SCOPE_HEADER]: "northside" },
+    });
+
+    expect(sentScope(seen)).toBe("northside");
+  });
+});

--- a/apps/web/src/lib/__tests__/platform-fee-cache-isolation.redis.test.ts
+++ b/apps/web/src/lib/__tests__/platform-fee-cache-isolation.redis.test.ts
@@ -1,0 +1,75 @@
+// #336: platform-settings.ts caches the resolved platform fee under a
+// SINGLE GLOBAL Redis key ("platform:fee_percent") — unlike
+// lib/entitlements.ts's entKey(orgId, featureKey, competitionId), nothing in
+// it is scoped to DB_SCHEMA, tenant, or run. Two callers that are logically
+// different "runs" but share one Redis instance — two migrated test schemas,
+// or a local dev database sitting alongside a test database — therefore
+// share one 300s cache entry: a write meant for one bleeds straight into a
+// read meant for the other.
+//
+// Structurally invisible without a real Redis: with REDIS_URL unset every
+// read hits Postgres fresh (lib/cache.ts is fail-open), so this suite needs
+// a real Redis actually holding a warm, mis-scoped entry. Same reason the
+// rest of the `*.redis.test.ts` family exists. CI runs this in its own
+// REDIS_URL-scoped step, mirroring rate-limit.redis.test.ts and
+// entitlements-cache-invalidation.redis.test.ts.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { cacheSet, cacheDelPattern } from "@/lib/cache";
+import { platformFeeDefault, __platformFeeCacheKeyForTests } from "@/lib/platform-settings";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const HAS_REDIS = !!process.env.REDIS_URL;
+
+describe.skipIf(!HAS_DB || !HAS_REDIS)("platform fee cache isolation (real Redis)", () => {
+  afterAll(async () => {
+    const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+    const dbClient = globalForDb._sql;
+    globalForDb._sql = undefined;
+    await dbClient?.end();
+    const g = globalThis as unknown as { _redis?: { quit?: () => Promise<unknown> } };
+    await g._redis?.quit?.().catch(() => {});
+  });
+
+  it("a value cached for one DB_SCHEMA does not leak into a read under another", async () => {
+    // lib/db.ts's postgres client is a lazily-initialised singleton: the
+    // FIRST query fixes its `search_path` (connectionOptions reads
+    // process.env.DB_SCHEMA once, at that moment) and every later query
+    // reuses that same connection regardless of what DB_SCHEMA becomes
+    // afterwards. Force that initialisation now, against the REAL schema
+    // this test process is actually migrated against, before faking
+    // DB_SCHEMA below purely to vary the CACHE key — otherwise the next
+    // section's fake schema names would be sent to Postgres as a real
+    // search_path and the query would 42P01 on a schema that doesn't exist.
+    await sql`select 1`;
+
+    const prevSchema = process.env.DB_SCHEMA;
+    let keyA = "";
+    let keyB = "";
+    try {
+      // "Suite A" (or a dev DB, or a differently-schema'd test run): its own
+      // resolved fee is cached under whatever key this run computes for its
+      // DB_SCHEMA.
+      process.env.DB_SCHEMA = `w11_iso_a_${randomUUID().slice(0, 6)}`;
+      keyA = __platformFeeCacheKeyForTests();
+      await cacheSet(keyA, { v: 999 }, 60);
+
+      // "Suite B": a DIFFERENT run/schema. Pre-fix, CACHE_KEY is the same
+      // literal string regardless of DB_SCHEMA, so keyB === keyA and this
+      // read would return the 999 "Suite A" just wrote — a real order
+      // dependence, not a hypothetical one. Post-fix the keys differ, so
+      // this read misses A's entry and resolves fresh (the seeded default,
+      // 5 — definitely not 999).
+      process.env.DB_SCHEMA = `w11_iso_b_${randomUUID().slice(0, 6)}`;
+      keyB = __platformFeeCacheKeyForTests();
+      expect(keyB).not.toBe(keyA); // sanity: isolation is only possible if the keys differ
+
+      expect(await platformFeeDefault()).not.toBe(999);
+    } finally {
+      await cacheDelPattern(keyA);
+      await cacheDelPattern(keyB);
+      process.env.DB_SCHEMA = prevSchema;
+    }
+  });
+});

--- a/apps/web/src/lib/__tests__/platform-settings.test.ts
+++ b/apps/web/src/lib/__tests__/platform-settings.test.ts
@@ -1,10 +1,14 @@
 // Platform fee default (spec §1): admin-set platform_settings row → env → 5.
 // Real Postgres required; skipped without DATABASE_URL.
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
 import { sql } from "@/lib/db";
 import { cacheDelPattern } from "@/lib/cache";
-import { platformFeeDefault, setPlatformFeeDefault } from "@/lib/platform-settings";
+import {
+  platformFeeDefault,
+  setPlatformFeeDefault,
+  __platformFeeCacheKeyForTests,
+} from "@/lib/platform-settings";
 
 const HAS_DB = !!process.env.DATABASE_URL;
 
@@ -17,6 +21,15 @@ afterAll(async () => {
 });
 
 describe.skipIf(!HAS_DB)("platform fee default", () => {
+  // #336: defensive hygiene, not the fix — every read/write in this file
+  // already invalidates the key it touches, but a fresh cache at the start
+  // of each test means a future test added here without perfect discipline
+  // fails loudly on its own miss, not silently on a leftover warm entry from
+  // whichever test happened to run first.
+  beforeEach(async () => {
+    await cacheDelPattern(__platformFeeCacheKeyForTests());
+  });
+
   it("reads the seeded default, honours admin writes, validates range", async () => {
     const [{ id: actor }] = await sql<{ id: string }[]>`
       insert into users (email, display_name, email_verified)
@@ -42,12 +55,19 @@ describe.skipIf(!HAS_DB)("platform fee default", () => {
     // Cache is Redis-backed and fail-open — absent REDIS_URL (test env) every
     // read hits Postgres, so garbage → fallback is directly observable.
     await sql`update platform_settings set value = '"nonsense"' where key = 'platform_fee_percent'`;
-    await cacheDelPattern("platform:fee_percent"); // no-op locally, correct in prod
+    await cacheDelPattern(__platformFeeCacheKeyForTests()); // no-op locally, correct in prod
 
     const prev = process.env.PLATFORM_FEE_PERCENT;
     process.env.PLATFORM_FEE_PERCENT = "12";
     expect(await platformFeeDefault()).toBe(12);
+    // #336: that read just cached { v: 12 } for 300s (real Redis, cache-aside).
+    // Without busting it here, the next line is not a fresh read at all — it's
+    // this SAME call's own cache entry, and the assertion below would silently
+    // check 12 against 12 instead of exercising the env-unset fallback. This
+    // is the exact "one read's write leaks into the next read" defect #336
+    // reports, reproduced within a single test rather than across two.
     delete process.env.PLATFORM_FEE_PERCENT;
+    await cacheDelPattern(__platformFeeCacheKeyForTests());
     expect(await platformFeeDefault()).toBe(5);
     if (prev !== undefined) process.env.PLATFORM_FEE_PERCENT = prev;
 

--- a/apps/web/src/lib/__tests__/reconcile-stranded-wallets-manual-review-artifact.test.ts
+++ b/apps/web/src/lib/__tests__/reconcile-stranded-wallets-manual-review-artifact.test.ts
@@ -1,0 +1,63 @@
+// Pure-function coverage for `toManualReviewJsonl`
+// (scripts/reconcile-stranded-wallets.ts, #309).
+//
+// The reconcile script previously routed every unattributable wallet to
+// MANUAL REVIEW via `console.warn` only — on the staging fixture run that was
+// 76 of 81 wallets, and the console log was the only artifact. If staging
+// cleanup is meant to complete, the rows that still need a human decision
+// have to be workable from a file, not scraped from a terminal.
+//
+// JSON Lines (one self-contained JSON object per line) was chosen over CSV
+// and over a single top-level JSON array:
+//   - CSV needs column-escaping for `reason`, which is free text and can
+//     itself contain commas/quotes (see the second test below) — a fragile
+//     format for something meant to be parsed by a script, not eyeballed.
+//   - A single JSON array requires the whole array to close cleanly; a
+//     process that dies mid-run (this script explicitly must survive one bad
+//     wallet without aborting the rest) would leave an unparsable file. Each
+//     JSONL line stands alone, so every COMPLETE line stays usable.
+//
+// Pinned as a pure function, the same way `chooseReconcileTarget` and
+// `classifyBucketAmounts` are pinned in
+// reconcile-stranded-wallets-select-target.test.ts, without touching Postgres.
+import { describe, expect, it } from "vitest";
+import {
+  toManualReviewJsonl,
+  type ManualReviewRow,
+} from "../../../../../scripts/reconcile-stranded-wallets";
+
+describe("toManualReviewJsonl", () => {
+  it("emits one self-contained JSON object per row, newline-terminated", () => {
+    const rows: ManualReviewRow[] = [
+      { wallet_id: "wallet-a", grant: 500, pack: 0, reason: "no_spend_attribution" },
+      { wallet_id: "wallet-b", grant: 0, pack: -10, reason: "no_positive_balance" },
+    ];
+    const out = toManualReviewJsonl(rows);
+    const lines = out.split("\n").filter((line) => line.length > 0);
+
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!)).toEqual(rows[0]);
+    expect(JSON.parse(lines[1]!)).toEqual(rows[1]);
+    // Newline-terminated so the file can be `cat`-appended to safely.
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("keeps a reason containing commas and quotes machine-readable (the CSV failure mode)", () => {
+    const rows: ManualReviewRow[] = [
+      {
+        wallet_id: "wallet-c",
+        grant: 12,
+        pack: 3,
+        reason: 'processing_error: relation "ai_credit_ledger" does not exist, retry',
+      },
+    ];
+    const parsed = JSON.parse(toManualReviewJsonl(rows).trim());
+    expect(parsed.reason).toBe(
+      'processing_error: relation "ai_credit_ledger" does not exist, retry',
+    );
+  });
+
+  it("returns an empty string for no rows — a valid, empty artifact", () => {
+    expect(toManualReviewJsonl([])).toBe("");
+  });
+});

--- a/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
+++ b/apps/web/src/lib/__tests__/redis-suite-ci-wiring.test.ts
@@ -63,6 +63,72 @@ function ciExecutableText(): string {
   return stripComments(readFileSync(CI_YML, "utf8"));
 }
 
+/**
+ * Split comment-stripped ci.yml text into one block per YAML step, across
+ * every job's `steps:` list.
+ *
+ * #316: the guard used to compare two GLOBAL counts (suites found vs.
+ * `REDIS_URL:` occurrences anywhere in the file) — heuristic in both
+ * directions. Two suites consolidated into one properly-wired step would
+ * false-FAIL it (fewer REDIS_URL occurrences than suites, even though the one
+ * step covers both). Worse, a suite wired into a step that never sets
+ * REDIS_URL would false-PASS it, as long as SOME OTHER unrelated step in the
+ * file happens to set REDIS_URL for its own reason — the count never checks
+ * WHICH step. Per-step correlation below fixes both: it asks, for each
+ * suite, "does the step naming it also set REDIS_URL itself?"
+ *
+ * A step is a YAML list item under a `steps:` key: it starts at a line
+ * indented exactly two spaces deeper than `steps:` itself, matching `- `,
+ * and its body is every line after that until the next such line or a
+ * dedent back to (or above) the `steps:` line's own indent. Job-level `env:`
+ * (declared BEFORE `steps:` in every job in this file) is therefore never
+ * inside a step block — a job-wide REDIS_URL would not satisfy the
+ * per-step check below, which is exactly the property the comment at
+ * ci.yml's Redis steps relies on (REDIS_URL deliberately NOT job-wide).
+ */
+function stepBlocks(text: string): string[] {
+  const lines = text.split("\n");
+  const blocks: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const stepsMatch = lines[i].match(/^(\s*)steps:\s*$/);
+    if (!stepsMatch) {
+      i++;
+      continue;
+    }
+    const stepsIndent = stepsMatch[1].length;
+    const itemIndent = stepsIndent + 2;
+    i++;
+    let current: string[] = [];
+    const flush = () => {
+      if (current.length) blocks.push(current.join("\n"));
+      current = [];
+    };
+    while (i < lines.length) {
+      const line = lines[i];
+      if (line.trim() === "") {
+        current.push(line);
+        i++;
+        continue;
+      }
+      const indent = line.match(/^(\s*)/)![1].length;
+      if (indent <= stepsIndent) break; // dedented out of this steps: list
+      const isNewItem = indent === itemIndent && /^-\s/.test(line.slice(itemIndent));
+      if (isNewItem) flush();
+      current.push(line);
+      i++;
+    }
+    flush();
+  }
+  return blocks;
+}
+
+/** Does this step's OWN text set REDIS_URL (as opposed to some other step,
+ *  or the job-level env: block, which stepBlocks already excludes)? */
+function stepSetsRedisUrl(block: string): boolean {
+  return /(^|\n)\s*REDIS_URL:/.test(block);
+}
+
 describe("Redis-gated suites are wired into CI", () => {
   it("finds the ci.yml this guard reads", () => {
     // Cheap, but it is what stops the whole guard passing vacuously if the
@@ -124,19 +190,72 @@ describe("Redis-gated suites are wired into CI", () => {
     expect(unwired, `not run by any ci.yml step: ${unwired.join(", ")}`).toEqual([]);
   });
 
-  it("gives each Redis-gated suite a step that actually owns REDIS_URL", () => {
+  it("gives each Redis-gated suite a step that BOTH names it and sets its own REDIS_URL", () => {
     // Naming the file is not enough. These suites gate on
     // `!HAS_DB || !HAS_REDIS`, so a suite wired into a step WITHOUT REDIS_URL
     // self-skips and reports green — the same silent no-op as never wiring it
     // at all, and harder to spot because the filename is right there in the
-    // workflow. REDIS_URL is deliberately step-scoped (job-wide breaks the
-    // src/server suites), so there must be at least one step-scoped occurrence
-    // per suite.
-    const exec = ciExecutableText();
-    const withRedisUrl = exec.split("REDIS_URL:").length - 1;
+    // workflow. #316 strengthened this from a global-count comparison (see the
+    // fixture test below for exactly what that missed) to per-step
+    // correlation: for each suite, is there a step whose OWN body names it
+    // AND sets REDIS_URL?
+    const blocks = stepBlocks(ciExecutableText());
+    const uncorrelated = redisSuites().filter((p) => {
+      const name = basename(p);
+      return !blocks.some((b) => b.includes(name) && stepSetsRedisUrl(b));
+    });
     expect(
-      withRedisUrl,
-      `${redisSuites().length} Redis-gated suite(s) but only ${withRedisUrl} step(s) set REDIS_URL`,
-    ).toBeGreaterThanOrEqual(redisSuites().length);
+      uncorrelated,
+      `no step both names and sets REDIS_URL for: ${uncorrelated.join(", ")}`,
+    ).toEqual([]);
+  });
+
+  it("catches what a global REDIS_URL count would miss: a suite named in a step with no REDIS_URL of its own", () => {
+    // #316's exact false-negative, reproduced on a literal fixture rather than
+    // real ci.yml — real ci.yml is expected to stay correctly wired, so this
+    // asserts the RULE, not today's file. Two suites; the file sets REDIS_URL
+    // twice — enough to satisfy "global count >= suite count" — but the
+    // second suite's own step never sets it. The old heuristic (kept here
+    // only as `globalCount`, not as a guard) would have called this fixture
+    // clean.
+    const fixture = [
+      "jobs:",
+      "  smoke:",
+      "    env:",
+      "      REDIS_URL: redis://job-level-decoy:6379", // job-level env — NOT step-scoped
+      "    steps:",
+      "      - name: Rate limiter",
+      "        run: npm test -- run src/lib/__tests__/rate-limit.redis.test.ts",
+      "        env:",
+      "          REDIS_URL: redis://localhost:6379",
+      "      - name: Entitlement cache invalidation",
+      "        run: npm test -- run src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts",
+      // No REDIS_URL in THIS step. A step further down the file setting it
+      // for an unrelated reason is what the global count could not tell apart
+      // from this step setting it itself.
+      "      - name: unrelated step that also happens to set REDIS_URL",
+      "        run: echo hi",
+      "        env:",
+      "          REDIS_URL: redis://localhost:6379",
+    ].join("\n");
+
+    const suites = [
+      "src/lib/__tests__/rate-limit.redis.test.ts",
+      "src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts",
+    ];
+
+    // The OLD heuristic on this fixture: 2 suites, 3 `REDIS_URL:` occurrences
+    // (including the job-level one) — "enough", and wrongly green.
+    const globalCount = (fixture.match(/REDIS_URL:/g) ?? []).length;
+    expect(globalCount).toBeGreaterThanOrEqual(suites.length);
+
+    // The NEW per-step correlation catches it: the second suite's own step
+    // block never sets REDIS_URL, so it comes back uncorrelated.
+    const blocks = stepBlocks(fixture);
+    const uncorrelated = suites.filter((s) => {
+      const name = basename(s);
+      return !blocks.some((b) => b.includes(name) && stepSetsRedisUrl(b));
+    });
+    expect(uncorrelated).toEqual(["src/lib/__tests__/entitlements-cache-invalidation.redis.test.ts"]);
   });
 });

--- a/apps/web/src/lib/api-post.ts
+++ b/apps/web/src/lib/api-post.ts
@@ -21,11 +21,14 @@
 // `error`; changing that under all of them to serve one page is how a small
 // billing fix becomes an unrelated regression.
 //
-// No React, no `server-only`, no imports at all — so it unit-tests under the
-// node vitest env with a hand-rolled `fetch`, and a "use client" island can
-// import it. No `"use client"` directive, deliberately — same as
+// No React and no `server-only` — so it unit-tests under the node vitest env
+// with a hand-rolled `fetch`, and a "use client" island can import it. Its one
+// import (`lib/org-scope`) holds to the same rule for the same reason. No
+// `"use client"` directive, deliberately — same as
 // lib/billing-checkout-client.ts: the importing island already establishes the
 // boundary, and leaving it off keeps the module usable from either side.
+
+import { orgScopeHeaders } from "@/lib/org-scope";
 
 /** A POST that either produced `data` or did not, with everything a caller
  *  needs to CHOOSE ITS OWN COPY on the failure branch. */
@@ -58,17 +61,28 @@ const FALLBACK_ERROR = "Request failed.";
  * A body with `ok: false` is a failure even on a 2xx, matching `api()`.
  *
  * @param fetchFn injectable so the seam is testable without a DOM or a network.
+ * @param pathname likewise: the console path this write is being made from.
+ *   Defaults to the live location, which is what a browser caller wants.
  */
 export async function postJson<T = unknown>(
   url: string,
   json: unknown,
   fetchFn: typeof fetch = fetch,
+  pathname?: string | null,
 ): Promise<PostResult<T>> {
   let res: Response;
   try {
     res = await fetchFn(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        // WHICH organisation this write is for, taken from the URL the user is
+        // looking at rather than from the `seazn_org` cookie the server would
+        // otherwise read: that cookie is re-pointed by an effect running after
+        // the destination page paints, so a save inside the window was applied
+        // to the PREVIOUS billing group (v17 gap #334).
+        ...orgScopeHeaders(pathname),
+      },
       body: JSON.stringify(json),
     });
   } catch {

--- a/apps/web/src/lib/billing-checkout-client.ts
+++ b/apps/web/src/lib/billing-checkout-client.ts
@@ -6,6 +6,7 @@
 // Stripe's embedded spinner loading forever with nothing to render.
 
 import type { PassKey } from "@/lib/currency";
+import { orgScopeHeaders } from "@/lib/org-scope";
 
 export type CheckoutSecretResult =
   | { ok: true; clientSecret: string }
@@ -30,7 +31,15 @@ async function fetchClientSecret(
   try {
     const res = await fetchFn(path, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        // WHICH organisation this write is for, from the console URL on
+        // screen rather than the `seazn_org` cookie the route would otherwise
+        // read — that cookie lags a navigation by one client effect, so a save
+        // made inside the window landed on the PREVIOUS billing group (v17 gap
+        // #334).
+        ...orgScopeHeaders(),
+      },
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => null);

--- a/apps/web/src/lib/billing-group.ts
+++ b/apps/web/src/lib/billing-group.ts
@@ -27,7 +27,7 @@ export async function subscriptionIdForOrg(orgId: string): Promise<string | null
 
 /**
  * The group an org bills through. Throws rather than returning null: every org
- * gets a group at creation (V310 backfilled the rest), so a missing one is a
+ * gets a group at creation (V314 backfilled the rest), so a missing one is a
  * broken invariant, not a state a caller should branch on.
  */
 export async function requireSubscriptionIdForOrg(orgId: string): Promise<string> {
@@ -106,7 +106,7 @@ export async function groupIdsOwnedBy(userId: string): Promise<string[]> {
 
 /**
  * Refuse to put another org into a group that is already at its plan's
- * `orgs.max_owned` — community 1, Pro 5, Pro Plus 10 (V310).
+ * `orgs.max_owned` — community 1, Pro 5, Pro Plus 10 (V314).
  *
  * The limit is resolved through a member org because entitlements are
  * org-addressed; every org in the group resolves the same plan, so any of them

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -603,7 +603,7 @@ export async function linkStripeCustomer(orgId: string, customerId: string): Pro
  * checkout that created this customer paid for ONE group, and by the time its
  * webhook arrives the org named in the metadata may bill through another one —
  * at which point writing through the org stamps the payer's customer id onto a
- * different customer's row. V310's partial unique index on stripe_customer_id
+ * different customer's row. V314's partial unique index on stripe_customer_id
  * turns that into a raised error rather than silent corruption, which is a
  * safety net, not a licence to keep resolving through the org.
  */
@@ -706,7 +706,7 @@ export async function planKeyForPrice(priceId: string): Promise<string | null> {
  * the webhook handler and the reconcile-on-return path so both stay in sync.
  *
  * Formerly an `insert … on conflict (org_id)` upsert. There is nothing to
- * insert any more: every org is created pointing at a group and V310 backfilled
+ * insert any more: every org is created pointing at a group and V314 backfilled
  * the rest, so the row always exists and this is a plain UPDATE by group id. The
  * old ON CONFLICT clause is preserved verbatim as the SET list — in Postgres an
  * UPDATE's right-hand side reads the OLD row, so each `case when <col> is

--- a/apps/web/src/lib/client.ts
+++ b/apps/web/src/lib/client.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { orgScopeHeaders } from "@/lib/org-scope";
+
 /** Minimal JSON fetch helper for client components. */
 export async function api<T = unknown>(
   url: string,
@@ -10,6 +12,13 @@ export async function api<T = unknown>(
     ...rest,
     headers: {
       "Content-Type": "application/json",
+      // WHICH organisation this call is for, read from the console URL on
+      // screen. The billing routes would otherwise resolve it from the
+      // `seazn_org` cookie, which lags a navigation by one client effect and so
+      // answers with the PREVIOUS billing group (v17 gap #334). Empty off the
+      // `/o/[orgSlug]` tree, and placed BEFORE the caller's own headers so an
+      // explicit override still wins.
+      ...orgScopeHeaders(),
       ...(rest.headers ?? {}),
     },
     body: json !== undefined ? JSON.stringify(json) : rest.body,

--- a/apps/web/src/lib/copy-truth.ts
+++ b/apps/web/src/lib/copy-truth.ts
@@ -1215,8 +1215,9 @@ export function feeLockStatedFaults(label: string, markdown: string): string[] {
 }
 
 /**
- * The retired-cap scan, sentence by sentence, with one exemption the seed does
- * not need: prose is allowed to say the cap is GONE.
+ * The retired-cap scan, sentence by sentence, with two exemptions the seed does
+ * not need: prose is allowed to say the cap is GONE, and prose is allowed to
+ * state the genuinely live HOURLY rate limit.
  *
  * `retiredRunCapFaults` bans the vocabulary outright, which is right for a
  * product description — nothing there ever needs to mention a dead feature. An
@@ -1224,20 +1225,84 @@ export function feeLockStatedFaults(label: string, markdown: string): string[] {
  * useful sentence for a reader who remembers the old limits, and round 1 forced
  * it out of `plans.md`. A guard that bans true sentences gets worked around.
  *
- * The exemption is deliberately narrow: the denial must be in the SAME sentence
- * and the sentence must quote NO NUMBER. "There is no per-division run cap; each
- * division gets 5" is two sentences and reds on the second, and "no cap beyond
- * 20 runs a division" reds on its own digit.
+ * The first exemption is deliberately narrow: the denial must be in the SAME
+ * sentence and the sentence must quote NO NUMBER. "There is no per-division run
+ * cap; each division gets 5" is two sentences and reds on the second, and "no
+ * cap beyond 20 runs a division" reds on its own digit.
+ *
+ * The second exemption (#303) is for the OTHER live number:
+ * `rateLimit('ai-plan:'+divisionId, {max:5, windowSeconds:3600})` in
+ * `schedule-ai.ts` (and its officials twin in `officials-ai.ts`) is a genuine,
+ * still-enforced BURST BRAKE — "5 AI runs an hour per division" — and its shape
+ * ("<n> runs … per division") is indistinguishable from the retired LIFETIME
+ * cap to `RETIRED_AI_RUN_CAP_PATTERNS`, which was written before this rate
+ * limit existed as a separate, undocumented mechanism. Scoped to "hour" only
+ * (not day/week/month, which name no real mechanism): a sentence naming an
+ * hourly window is describing the rate limit, not the retired lifetime table.
+ * This is narrow enough that a compound sentence asserting BOTH a true hourly
+ * window AND a fictitious lifetime count in the same breath could still slip
+ * through — accepted, because splitting that hybrid claim into one sentence
+ * each is the far more natural way to write it, and the anti-vacuity corpus
+ * below still requires the base pattern to fire on a true positive.
  */
 export function retiredRunCapProseFaults(label: string, markdown: string): string[] {
   const faults: string[] = [];
   const denial = /\b(no|not|never|without|isn'?t|aren'?t|dropped|retired|removed|gone|scrapped)\b/i;
+  const hourlyRateLimit = /\b(?:an?|per|every)\s+hour\b|\bhourly\b/i;
   for (const block of claimTexts(markdown)) {
     for (const sentence of sentences(block)) {
       const hits = retiredRunCapFaults(sentence);
       if (hits.length === 0) continue;
       if (denial.test(sentence) && !/\d/.test(sentence)) continue;
+      if (hourlyRateLimit.test(sentence)) continue;
       faults.push(...hits.map((h) => `${label}: "${sentence.slice(0, 72)}…" ${h}`));
+    }
+  }
+  return faults;
+}
+
+/**
+ * v17 gap #303: `content/help/scheduling/ai-scheduling.md` said "Officials AI
+ * runs are not metered — once you have automatic officials assignment, you can
+ * restaff as often as you like." That is false on every tier: both AI phases
+ * spend the SAME shared credit wallet, one credit per run, reserved-then-settled
+ * by the identical `spendCredit(walletId, orgId, 1, …)` call in
+ * `schedule-ai.ts:aiPlanForDivision` and `officials-ai.ts:officialsAiPlanForDivision`
+ * (SPEC-2 §5.2) — including the no-instruction default spread, which makes no
+ * model call but still runs through `spendCredit` and is settled on success.
+ *
+ * The claim family is "an AI run costs nothing / has no limit", independent of
+ * which phase it names — a reworded falsehood about schedule runs would be
+ * exactly as false. Denial-of-the-CAP prose ("there is no per-division cap any
+ * more") is a different, TRUE claim and must not trip this: the vocabulary here
+ * is scoped to UNMETERED/FREE/UNCAPPED, not to the retired count itself (that is
+ * `RETIRED_AI_RUN_CAP_PATTERNS`, a sibling rule).
+ */
+export const AI_RUN_UNMETERED_PATTERNS = [
+  /\bnot\s+metered\b/i,
+  /\bunmetered\b/i,
+  /\brestaff\s+as\s+often\s+as\s+you\s+like\b/i,
+  /\brun\s+it\s+as\s+often\s+as\s+you\s+like\b/i,
+  /\b(?:as\s+often\s+as\s+you\s+(?:like|want|wish))\b[^.;]{0,20}\bno\s+(?:cost|charge)\b/i,
+  /\b(?:officials?|schedul\w*)\s+(?:AI\s+)?(?:runs?|generations?|passes?)\s+(?:are|is)\s+free\b/i,
+  /\bcosts?\s+nothing\s+to\s+(?:run|restaff|regenerate)\b/i,
+  /\buncapped\b[^.;]{0,20}\b(?:runs?|generations?|passes?)\b|\b(?:runs?|generations?|passes?)\b[^.;]{0,20}\buncapped\b/i,
+];
+
+/** The positive pairing: an article that raises this claim family must also
+ *  SAY the run is metered by the credit wallet — deleting the whole paragraph
+ *  would otherwise satisfy the negative half for free. */
+export function unmeteredAiRunProseFaults(label: string, markdown: string): string[] {
+  const faults: string[] = [];
+  for (const block of claimTexts(markdown)) {
+    for (const sentence of sentences(block)) {
+      for (const pattern of AI_RUN_UNMETERED_PATTERNS) {
+        if (pattern.test(sentence)) {
+          faults.push(
+            `${label}: "${sentence.slice(0, 72)}…" claims an AI run is unmetered/free — every run, schedule or officials, on any plan, spends one AI credit (SPEC-2 §5.2)`,
+          );
+        }
+      }
     }
   }
   return faults;
@@ -1636,6 +1701,19 @@ export const LOCALE_CLAIMS: Record<DictionaryLocale, LocaleClaims> = {
       String.raw`\bcada\s+mes\b`,
       String.raw`\bpor\s+mes\b`,
       String.raw`\brecurrente\b`,
+      // #338 item 3: this list was MONTHLY-ONLY, so a yearly or weekly framing
+      // of the same one-time-grant falsehood — "cada año", "anuales", "en cada
+      // renovación" — scored 0/9 across all four locales. Same claim, other
+      // cadence; the family, not the month, is what has to be false.
+      String.raw`\banual(es|mente)?\b`,
+      String.raw`\bal\s+año\b`,
+      String.raw`\bcada\s+año\b`,
+      String.raw`\bpor\s+año\b`,
+      String.raw`\bsemanal(es|mente)?\b`,
+      String.raw`\bcada\s+semana\b`,
+      String.raw`\btrimestral(es|mente)?\b`,
+      String.raw`\brenovaci\w*\b`,
+      String.raw`\ben\s+cada\s+renovaci\w*\b`,
     ].map(claim),
     plusClaims: [
       [
@@ -1714,6 +1792,17 @@ export const LOCALE_CLAIMS: Record<DictionaryLocale, LocaleClaims> = {
       String.raw`\bpar\s+mois\b`,
       String.raw`\bchaque\s+mois\b`,
       String.raw`\brécurrent(e|s)?\b`,
+      // #338 item 3 — the yearly/weekly twin of the same falsehood: "chaque
+      // année", "annuels", "à chaque renouvellement" all scored 0/9.
+      String.raw`\bannuel(le|s|les)?\b`,
+      String.raw`\bpar\s+an\b`,
+      String.raw`\bchaque\s+année\b`,
+      String.raw`\btous\s+les\s+ans\b`,
+      String.raw`\bhebdomadaire(s)?\b`,
+      String.raw`\bchaque\s+semaine\b`,
+      String.raw`\btrimestriel(le|s|les)?\b`,
+      String.raw`\brenouvellement(s)?\b`,
+      String.raw`\bà\s+chaque\s+renouvellement\b`,
     ].map(claim),
     plusClaims: [
       [
@@ -1790,6 +1879,16 @@ export const LOCALE_CLAIMS: Record<DictionaryLocale, LocaleClaims> = {
       String.raw`\bper\s+maand\b`,
       String.raw`\b(elke|iedere)\s+maand\b`,
       String.raw`\bterugkerend(e)?\b`,
+      // #338 item 3 — the yearly/weekly twin of the same falsehood: "elk jaar",
+      // "jaarlijks", "bij elke verlenging" all scored 0/9.
+      String.raw`\bjaarlijks(e)?\b`,
+      String.raw`\bper\s+jaar\b`,
+      String.raw`\b(elk|ieder)\s+jaar\b`,
+      String.raw`\bwekelijks(e)?\b`,
+      String.raw`\b(elke|iedere)\s+week\b`,
+      String.raw`\bper\s+kwartaal\b`,
+      String.raw`\bverlenging(en)?\b`,
+      String.raw`\bbij\s+elke\s+verlenging\b`,
     ].map(claim),
     plusClaims: [
       [
@@ -2372,8 +2471,25 @@ export function controlCharacterFaults(patterns: LocatedPattern[]): string[] {
  * nothing downstream can see it. `CONTROL_CHARACTER` is the one legitimate
  * exception — it is the checker, not a claim, and demanding it match a
  * known-positive fixture would mean putting a control character in the corpus.
+ *
+ * #338 item 4 (second vacuity hole): this was LINE-SHAPED — `=\s*(\/|new
+ * RegExp\b|claim\()` requires the pattern to sit immediately after the `=`,
+ * so it sees `const NAME = /…/` but not a pattern one token further in, inside
+ * a CONTAINER. `const ZZ_PROBE_LIST: RegExp[] = [/(?!x)x-inert/i]` shipped
+ * green: the `=` is followed by `[`, not `/`, so the line never matched at
+ * all — invisible to `collectPatterns` (it only walks exports) AND to this
+ * check (it only recognised the pattern immediately after `=`). Now it looks
+ * for a regex literal, `new RegExp(`, or `claim(` ANYWHERE after the `=` on
+ * the same line, so it does not matter how many array or object brackets sit
+ * between them.
+ *
+ * Deliberately NOT exported-container-transparent across MULTIPLE lines: a
+ * declaration whose regex literal is on a later line than `const NAME =` is
+ * still invisible to this check, the same residual limit the line-based scan
+ * always had. Recorded rather than fixed — closing it needs a token walk of
+ * the whole declaration, not a per-line regex.
  */
-const PATTERN_SHAPED = /=\s*(\/|new RegExp\b|claim\()/;
+const PATTERN_SHAPED = /=[^\n]*?(?:\/(?:[^/\\\n]|\\.)+\/[a-z]*\b|new\s+RegExp\s*\(|claim\s*\()/;
 export const UNEXPORTED_PATTERN_ALLOWLIST = ["CONTROL_CHARACTER", "PATTERN_SHAPED"];
 
 export function unexportedPatternFaults(moduleSource: string): string[] {

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -3379,6 +3379,7 @@ export type DictionaryKey =
   | "upgrade.pro.title"
   | "upgrade.proCard.body"
   | "upgrade.proCard.cta"
+  | "upgrade.proCard.ctaNoTrial"
   | "upgrade.proCard.title"
   | "upgrade.rung.l"
   | "upgrade.rung.m"

--- a/apps/web/src/lib/org-scope.ts
+++ b/apps/web/src/lib/org-scope.ts
@@ -1,0 +1,76 @@
+// Which organisation a request is FOR (v17 gap #334).
+//
+// The console tree is `/o/[orgSlug]/...` and every page under it already
+// authorises from that slug (`requireOrgPage`, PROMPT-30). The API routes those
+// pages POST to did not: they resolved the org from the `seazn_org` cookie,
+// which `ActiveOrgSync` re-points from a client effect that runs AFTER the
+// destination page has painted. A payer who owns two billing groups and saves
+// inside that window is fully authorised — `requireBillingOwner` has nothing to
+// refuse — and the write lands on the group they navigated AWAY from. For a
+// control whose payload is a TOTAL rather than a delta (extra organisations,
+// extra seats) that silently cancels riders on the other bill.
+//
+// The fix is not a faster cookie. Next 16 Server Components cannot set cookies,
+// so the correction can never be hoisted into the render that already knows the
+// right org — the window is structural. So the org travels WITH the request:
+// the client seams stamp the slug from the URL the user is actually looking at,
+// and the server prefers it over the cookie.
+//
+// This module is deliberately dependency-free (no React, no `server-only`, no
+// imports) so both a "use client" island and a route handler can use it.
+
+/** Request header carrying the org slug the caller's page is scoped to.
+ *  Named like `x-seazn-locale` (the proxy's Accept-Language negotiation), the
+ *  established convention for "this request's own context, decided upstream". */
+export const ORG_SCOPE_HEADER = "x-seazn-org";
+
+/** Org slugs are `slugify` output: lower-case alphanumerics and hyphens. The
+ *  pattern is a SANITISER, not a security check — the slug is looked up and the
+ *  payer gate still runs — but it keeps junk (and anything header-shaped) from
+ *  reaching a query, and it means a non-console path can never be mistaken for
+ *  an org. */
+const SLUG = /^[a-z0-9][a-z0-9-]{0,127}$/;
+
+/**
+ * The org slug a console path is about, or null for any other path.
+ *
+ * `/o/riverside/settings/add-ons` -> `riverside`
+ * `/orgs/new`, `/admin/...`, `/` -> null
+ *
+ * Pure, so the rule is testable without a DOM: the caller supplies the
+ * pathname.
+ */
+export function orgSlugFromPath(pathname: string | null | undefined): string | null {
+  if (!pathname) return null;
+  // Only the console tree. `/orgs/...` must not match `/o/...`, which is why
+  // this splits on segments rather than testing a `/o/` prefix.
+  const [, first, second] = pathname.split("/");
+  if (first !== "o" || !second) return null;
+  let slug: string;
+  try {
+    slug = decodeURIComponent(second);
+  } catch {
+    // A malformed percent-escape is not a slug; it is not this module's job to
+    // guess what was meant.
+    return null;
+  }
+  return SLUG.test(slug) ? slug : null;
+}
+
+/**
+ * Headers to merge into a same-origin request so it names its own org. Empty
+ * when the caller is not on a console page — the server then falls back to the
+ * cookie, which is the pre-#334 behaviour and still correct for surfaces that
+ * genuinely have no org in their URL (e.g. `/orgs/new`).
+ *
+ * @param pathname defaults to the live location. Injectable so the seams that
+ *   use it stay unit-testable outside a browser.
+ */
+export function orgScopeHeaders(
+  pathname: string | null | undefined = typeof window === "undefined"
+    ? null
+    : window.location.pathname,
+): Record<string, string> {
+  const slug = orgSlugFromPath(pathname);
+  return slug ? { [ORG_SCOPE_HEADER]: slug } : {};
+}

--- a/apps/web/src/lib/platform-settings.ts
+++ b/apps/web/src/lib/platform-settings.ts
@@ -8,8 +8,29 @@ import { HttpError } from "@/lib/errors";
 import { cacheGet, cacheSet, cacheDelPattern } from "@/lib/cache";
 
 const FEE_KEY = "platform_fee_percent";
-const CACHE_KEY = "platform:fee_percent";
+const CACHE_KEY_PREFIX = "platform:fee_percent";
 const TTL_SECONDS = 300;
+
+/**
+ * Cache key, namespaced by DB_SCHEMA — the same env var lib/db.ts's
+ * connection options use to pick a schema (db.ts:49). A function, not a
+ * module-load-time const: entKey() in entitlements.ts already does this
+ * per-org, and computing it lazily (rather than freezing it at import time)
+ * is what lets a test flip DB_SCHEMA mid-run and observe a different key.
+ *
+ * #336: the old un-namespaced key meant every schema — every migrated test
+ * database, and a local dev database sitting alongside one — shared a single
+ * 300s Redis entry. A write under one schema's platform_settings row leaked
+ * straight into a read for another's.
+ */
+function cacheKey(): string {
+  return `${CACHE_KEY_PREFIX}:${process.env.DB_SCHEMA ?? "seazn_club"}`;
+}
+
+/** @internal — exported for tests (#336 cache-isolation regression). */
+export function __platformFeeCacheKeyForTests(): string {
+  return cacheKey();
+}
 
 function envFallback(): number {
   const raw = Number(process.env.PLATFORM_FEE_PERCENT ?? "5");
@@ -20,13 +41,13 @@ function envFallback(): number {
  *  platform_settings row → PLATFORM_FEE_PERCENT env → 5. Plans and per-org
  *  overrides sit ABOVE this default (see feePercentFor in registrations). */
 export async function platformFeeDefault(): Promise<number> {
-  const cached = await cacheGet<{ v: number }>(CACHE_KEY);
+  const cached = await cacheGet<{ v: number }>(cacheKey());
   if (cached) return cached.v;
   const [row] = await sql<{ value: unknown }[]>`
     select value from platform_settings where key = ${FEE_KEY}`;
   const parsed = Number(row?.value);
   const v = Number.isFinite(parsed) && parsed >= 0 && parsed <= 100 ? parsed : envFallback();
-  await cacheSet(CACHE_KEY, { v }, TTL_SECONDS);
+  await cacheSet(cacheKey(), { v }, TTL_SECONDS);
   return v;
 }
 
@@ -40,5 +61,5 @@ export async function setPlatformFeeDefault(pct: number, actorId: string): Promi
     values (${FEE_KEY}, ${sql.json(pct)}, ${actorId})
     on conflict (key) do update
       set value = excluded.value, updated_at = now(), updated_by = excluded.updated_by`;
-  await cacheDelPattern(CACHE_KEY);
+  await cacheDelPattern(cacheKey());
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -203,7 +203,7 @@ export interface Plan {
 }
 
 export interface Subscription {
-  /** The BILLING GROUP's own id (V310). The row stopped being keyed by org and
+  /** The BILLING GROUP's own id (V314). The row stopped being keyed by org and
    *  gained an identity of its own; `org_id` below is now projected from
    *  whichever org was asked about, because several may share this row. */
   id: string;

--- a/apps/web/src/server/page-auth.ts
+++ b/apps/web/src/server/page-auth.ts
@@ -8,6 +8,7 @@ import "server-only";
 // two orgs can't corrupt each other. Renamed slugs permanent-redirect.
 import { notFound, permanentRedirect, redirect } from "next/navigation";
 import { getCurrentUser, getUserOrgs, getActiveOrgId } from "@/lib/auth";
+import { sql } from "@/lib/db";
 import { EDITOR_ROLES, type OrgMembership, type User } from "@/lib/types";
 import { resourceOrg, type AuthCtx, type ResourceKind } from "@/server/api-v1/auth";
 import { HttpError } from "@/lib/errors";
@@ -86,6 +87,103 @@ export async function requireOrgPage(
     user,
     org,
     canEdit: (EDITOR_ROLES as readonly string[]).includes(org.role),
+  };
+}
+
+/**
+ * Session auth for the BILLING tabs under `/o/[orgSlug]/settings`
+ * (Billing, Credits, Add-ons) — v17 gap #333.
+ *
+ * `requireOrgPage`'s rule is membership, and that is right for every organiser
+ * surface: those pages are about the club. Billing is not about the club, it is
+ * about the GROUP — `subscriptions` is its own row with its own
+ * `owner_user_id`, one bill may fund many clubs, and `transferGroup` moves that
+ * column ALONE, leaving memberships untouched. So a payer can end up funding a
+ * bill they are not a member of (by transfer, or by an org owner removing them)
+ * and, gated on membership, has no route to any of the pages that manage it —
+ * not even to cancel.
+ *
+ * THE ONE RELAXATION, stated exactly: membership is no longer the only way in.
+ * The group's payer is admitted as well. Nothing else moves —
+ *
+ *   - a member is admitted on exactly the terms `requireOrgPage` gives them,
+ *     with the same role and the same `canEdit`;
+ *   - a non-member who does NOT pay for this org's group still 404s, so
+ *     existence is never leaked to a stranger;
+ *   - a scorer who does not pay still bounces to "My matches" (doc 13 §4);
+ *   - the payer is admitted READ-ONLY as far as the org goes: `role` is null
+ *     and `canEdit` is false, so nothing here becomes a way to edit a club.
+ *     What they get is the bill, which is theirs already.
+ *
+ * `requireOrgPage` itself is deliberately UNCHANGED. Putting the exception
+ * inside it would relax the membership rule for every organiser page in the
+ * tree to serve three tabs; a separate gate keeps the widening where it is
+ * legible and where a reviewer can see its whole audience.
+ *
+ * `viaPayer` tells the page which of the two it is looking at. Chrome that
+ * assumes membership — the back link into the org's own Settings index, which
+ * IS member-gated — must not be rendered for a payer who would only 404 on it.
+ */
+export async function requireBillingPage(
+  orgSlug: string,
+  opts: { tail?: string } = {},
+): Promise<PageAuth & { viaPayer: boolean }> {
+  const user = await getCurrentUser();
+  if (!user) redirect("/login");
+  const resolved = await orgBySlug(orgSlug);
+  if (resolved && "renamedTo" in resolved) {
+    permanentRedirect(routes.orgHome(resolved.renamedTo) + (opts.tail ?? ""));
+  }
+  if (!resolved) notFound();
+  const orgs = await getUserOrgs(user.id);
+  const org = orgs.find((o) => o.id === resolved.id);
+
+  // Members first, and untouched: whatever `requireOrgPage` would have handed
+  // them, they still get. Only the two arms it REFUSES are reconsidered below,
+  // so no existing visitor's outcome can move.
+  if (org && org.role !== "scorer") {
+    return {
+      auth: { orgId: org.id, via: "session", userId: user.id, role: org.role, keyId: null },
+      user,
+      org,
+      canEdit: (EDITOR_ROLES as readonly string[]).includes(org.role),
+      viaPayer: false,
+    };
+  }
+
+  // Does this person pay for the group this organisation bills through? Read
+  // straight off `subscriptions.owner_user_id` — the same column
+  // `requireBillingOwner` gates the mutating routes on, so the pages a payer
+  // can OPEN and the writes a payer can MAKE cannot answer differently. An org
+  // with no group (`subscription_id` null) simply has no payer, and the join
+  // drops it.
+  const [payer] = await sql<{ owner_user_id: string }[]>`
+    select s.owner_user_id
+      from organizations o
+      join subscriptions s on s.id = o.subscription_id
+     where o.id = ${resolved.id}`;
+  if (!payer || payer.owner_user_id !== user.id) {
+    // Unchanged refusals: a scorer keeps its own bounce (doc 13 §4), and a
+    // non-member gets the 404 that never leaks existence.
+    if (org) redirect("/my-matches");
+    notFound();
+  }
+
+  return {
+    auth: { orgId: resolved.id, via: "session", userId: user.id, role: null, keyId: null },
+    user,
+    // Payer placeholder. They hold no role in this organisation and must not
+    // acquire one here: the pages read `org.id` for the bill and `org.role`
+    // only to decide what a MEMBER may see, and null denies all of it. Same
+    // shape requireFixturePage uses for a non-member official.
+    org: {
+      id: resolved.id,
+      slug: resolved.slug,
+      name: resolved.name,
+      role: null,
+    } as unknown as OrgMembership,
+    canEdit: false,
+    viaPayer: true,
   };
 }
 

--- a/apps/web/src/server/usecases/__tests__/admin-plan.test.ts
+++ b/apps/web/src/server/usecases/__tests__/admin-plan.test.ts
@@ -505,7 +505,7 @@ describe.skipIf(!HAS_DB)("admin plan tools", () => {
     expect(row.trial_used_at).toBeNull();
   });
 
-  // V310 replaced "no subscription row" with "no billing group", and every
+  // V314 replaced "no subscription row" with "no billing group", and every
   // staff path answers 404 for it — not 500. These are operator-supplied org
   // ids, so a 500 would both blame us and page someone for a data condition the
   // operator is looking straight at.
@@ -551,7 +551,7 @@ describe.skipIf(!HAS_DB)("admin plan tools", () => {
     expect(departed.trial_used_at).toEqual(stamped);
   });
 
-  // Blast radius (V310). Every staff action on the plan panel writes the SHARED
+  // Blast radius (V314). Every staff action on the plan panel writes the SHARED
   // subscriptions row, so a comp applied from one org's page moves the plan for
   // every org on that bill. The usecases were group-wide from the start; what
   // was missing was any way for staff to SEE it, and the panel can only warn
@@ -599,7 +599,7 @@ describe.skipIf(!HAS_DB)("admin plan tools", () => {
   // Stripe before this fix); an org with no customer id was never the bug.
   it("planPanel makes no Stripe calls, even for an org with a stripe_customer_id", async () => {
     const { orgId } = await seedOrg();
-    // Unique per run: V310 puts a partial unique index on stripe_customer_id
+    // Unique per run: V314 puts a partial unique index on stripe_customer_id
     // (one Stripe customer belongs to one billing group, which is what makes the
     // webhook's customer-id fallback safe), and this schema is not torn down
     // between runs, so a hardcoded id collides with the previous run's row.

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -1936,6 +1936,33 @@ describe.skipIf(!HAS_DB)("quantity drift", () => {
     // refunds in this design.
     expect(call![1].proration_behavior).toBe("none");
   });
+
+  it("leaves an INCOMPLETE group's drift uncorrected — its status list excludes 'incomplete' (#311)", async () => {
+    // hasLiveSubscription/LIVE_SUBSCRIPTION_STATUSES (subscription-status.ts)
+    // count 'incomplete' as live. reconcileGroupQuantities' own hand-written
+    // `status in ('trialing', 'active', 'past_due')` does not, so a group whose
+    // first invoice never paid is never selected here no matter how far its
+    // quantity_paid drifts from its live org count — unlike the identically
+    // drifted 'active' sibling above, which the same sweep DOES correct. This
+    // pins the CURRENT behaviour; #311 stops short of deriving this list from
+    // the constant because doing so would be a live behaviour change (this
+    // group would start getting corrected) rather than a pure refactor.
+    const payer = await makeUser("payer");
+    const stripeSubId = "sub_incomplete_drift_" + uniq();
+    const group = await makeGroup(payer, { stripeSubId, status: "incomplete", quantityPaid: 5 });
+    await makeOrg(group, payer);
+    await makeOrg(group, payer);
+    await makeOrg(group, payer);
+    stripeMock.state.quantity = 5;
+
+    await reconcileGroupQuantities(2000);
+
+    expect((await readGroup(group)).quantity_paid).toBe(5);
+    const call = stripeMock.subscriptionsUpdate.mock.calls.find(
+      (c) => (c as unknown as [string])[0] === stripeSubId,
+    );
+    expect(call).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -2319,6 +2346,35 @@ describe.skipIf(!HAS_DB)("a live subscription with nothing left to bill", () => 
       select count(*)::text as n from subscriptions
        where id = ${group} and status in ('trialing', 'active', 'past_due')`;
     expect(Number(n)).toBe(1);
+  });
+
+  it("never cancels an INCOMPLETE group whose last org was soft deleted — cancelGroupIfEmpty's status list excludes 'incomplete' (#311)", async () => {
+    // syncGroupQuantity's own gate is hasLiveSubscription, which correctly
+    // treats 'incomplete' as live (LIVE_SUBSCRIPTION_STATUSES), so it reaches
+    // the orphaned branch and calls the private cancelGroupIfEmpty exactly as
+    // it would for an 'active' group. But that function's claiming UPDATE has
+    // its OWN hand-written `status in ('trialing', 'active', 'past_due')`,
+    // which excludes 'incomplete' — so the UPDATE matches zero rows, the
+    // claim silently fails, and the group is left billing Stripe for an org
+    // that no longer exists, with nothing left to ever retry it. This pins
+    // that CURRENT behaviour; #311 stops short of deriving this list from the
+    // constant because doing so (this group would start being cancelled) is a
+    // live behaviour change, not a pure refactor.
+    const payer = await makeUser("payer");
+    const stripeSubId = "sub_incomplete_orphan_" + uniq();
+    const group = await makeGroup(payer, { stripeSubId, status: "incomplete", periodEndDays: 30 });
+    const orgId = await makeOrg(group, payer);
+    await sql`update organizations set deleted_at = now() where id = ${orgId}`;
+
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await syncGroupQuantity(group);
+    } finally {
+      err.mockRestore();
+    }
+
+    expect(stripeMock.subscriptionsCancel).not.toHaveBeenCalled();
+    expect((await readGroup(group)).status).toBe("incomplete");
   });
 });
 

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -260,9 +260,10 @@ const readGroup = async (id: string) =>
         comped_until: Date | null;
         trial_used_at: Date | null;
         has_payment_method: boolean;
+        cancel_at_period_end: boolean;
       }[]
     >`select plan_key, status, owner_user_id, quantity_paid, comped_until, trial_used_at,
-             has_payment_method from subscriptions where id = ${id}`
+             has_payment_method, cancel_at_period_end from subscriptions where id = ${id}`
   )[0];
 
 const orgGroup = async (orgId: string) =>
@@ -1020,6 +1021,55 @@ describe.skipIf(!HAS_DB)("detach", () => {
     // And so is the answer the group serves. This is the assertion the missing
     // invalidate failed.
     expect(await hasFeature(joiner.orgId, "api.access")).toBe(true);
+    err.mockRestore();
+  });
+
+  it("a FAILED Stripe cancel puts cancel_at_period_end back — a lost flag is a subscription nobody cancels", async () => {
+    // #315. The customer already pressed cancel: the group is live and paying
+    // now, and Stripe is scheduled to end it at the period boundary. The claim
+    // clears that flag along with status/plan/comped/qty because the group is
+    // about to be cancelled OUTRIGHT, which makes the schedule moot.
+    //
+    // When Stripe refuses, the outright cancel never happened — so the schedule
+    // is not moot, it is the customer's standing instruction, and the rollback
+    // that restores status/plan/comped/qty but not this one leaves a group that
+    // is live, billable, and no longer scheduled to stop. That is strictly worse
+    // than never having tried: the customer believes they cancelled, nothing in
+    // the product says otherwise, and the renewal invoices keep arriving with
+    // nobody looking for them. Every other rolled-back column is recoverable by
+    // the reconcile sweep; this one is not — no sweep can infer an intent that
+    // was only ever recorded here.
+    //
+    // Driven through the real failure path (the Stripe double throws) rather
+    // than by hand-writing the post-claim row: writing the row and calling the
+    // restore would prove the restore, not that the catch reaches it.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const stripeSubId = "sub_capefail_" + uniq();
+    const group = await makeGroup(payer, {
+      stripeSubId,
+      periodEndDays: 30,
+      cancelAtPeriodEnd: true,
+    });
+    const leaving = await makeOrg(group, clubOwner);
+    expect((await readGroup(group)).cancel_at_period_end).toBe(true);
+
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    stripeMock.subscriptionsCancel.mockImplementationOnce(async () => {
+      throw new Error("stripe refused the cancel");
+    });
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId: leaving });
+
+    expect(stripeMock.subscriptionsCancel).toHaveBeenCalledWith(stripeSubId);
+    expect(res.cancelled_group).toBeNull();
+    const after = await readGroup(group);
+    // Exactly as it was, all five columns.
+    expect(after.status).toBe("active");
+    expect(after.plan_key).toBe("pro");
+    expect(after.quantity_paid).toBe(1);
+    expect(after.comped_until).toBeNull();
+    expect(after.cancel_at_period_end).toBe(true);
     err.mockRestore();
   });
 

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -1144,6 +1144,139 @@ describe.skipIf(!HAS_DB)("detach leaves an audit trail for the wallet it does no
   });
 });
 
+// ---------------------------------------------------------------------------
+// The comp a ride_out hands out (#306)
+// ---------------------------------------------------------------------------
+
+/** The comp-grant audit row for `orgId`, newest first. */
+const compAudit = async (orgId: string) =>
+  (
+    await sql<
+      {
+        actor_id: string;
+        target_type: string;
+        detail: {
+          old_group_id?: string;
+          new_group_id?: string;
+          payer_user_id?: string;
+          plan_key?: string;
+          comped_until?: string;
+          inherited_from?: string;
+          mode?: string;
+        };
+      }[]
+    >`
+      select actor_id, target_type, detail from staff_audit_log
+       where target_id = ${orgId} and action = 'billing_group.detach_comp_granted'
+       order by created_at desc limit 1`
+  )[0];
+
+describe.skipIf(!HAS_DB)("detach audits the comp it hands out (#306)", () => {
+  it("records the ride_out comp, its expiry, and the payer it is charged against", async () => {
+    // A ride_out mints the leaver a free paid-plan period at the OLD payer's
+    // expense. Before #306 the only trace of that grant was a column value on a
+    // brand-new subscriptions row: no actor, no old group, no payer, nothing to
+    // answer "who took a month of Pro Plus off my subscription, and when".
+    // The wallet forfeit beside it has been audited since #285; a comped plan is
+    // the same class of silent, money-adjacent outcome.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const group = await makeGroup(payer, {
+      plan: "pro_plus",
+      stripeSubId: "sub_comp_audit_" + uniq(),
+      quantityPaid: 2,
+      periodEndDays: 30,
+    });
+    stripeMock.state.quantity = 2;
+    await makeOrg(group, payer);
+    const orgId = await makeOrg(group, clubOwner);
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId });
+
+    // The comp really was handed out (otherwise the audit assertions below are
+    // asserting about nothing).
+    const fresh = await readGroup(res.subscription_id);
+    expect(fresh.plan_key).toBe("pro_plus");
+    expect(fresh.comped_until).not.toBeNull();
+
+    const audit = await compAudit(orgId);
+    // An entitlement grant with an actor on it — the whole point of #306.
+    expect(audit?.actor_id).toBe(clubOwner);
+    expect(audit?.target_type).toBe("org");
+    expect(audit?.detail?.old_group_id).toBe(group);
+    expect(audit?.detail?.new_group_id).toBe(res.subscription_id);
+    // Whose subscription paid for it. The actor here is the club owner, NOT the
+    // payer, so a row that recorded only the actor would name the wrong party.
+    expect(audit?.detail?.payer_user_id).toBe(payer);
+    expect(audit?.detail?.plan_key).toBe("pro_plus");
+    // What was granted, and until when — the same instant that landed on the row.
+    expect(audit?.detail?.comped_until).toBe(fresh.comped_until?.toISOString());
+    expect(audit?.detail?.mode).toBe("ride_out");
+    // Which of the two dates it inherited. A staff comp and a paid period end
+    // are very different money, and the coalesce in detach hides which one won.
+    expect(audit?.detail?.inherited_from).toBe("current_period_end");
+  });
+
+  it("names the STAFF comp when that is the date the leaver rode out on", async () => {
+    // A staff-comped group has comped_until set and current_period_end NULL, so
+    // the leaver's free period is being taken off a comp somebody granted by
+    // hand rather than off a period a customer paid for. The trail has to be
+    // able to tell those apart; only this field can.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const comped = await makeGroup(payer, {
+      plan: "pro",
+      stripeSubId: null,
+      periodEndDays: null,
+      compedUntilDays: 20,
+    });
+    await makeOrg(comped, payer);
+    const orgId = await makeOrg(comped, clubOwner);
+
+    const res = await detachOrgFromGroup({ actorUserId: clubOwner, orgId });
+    expect((await readGroup(res.subscription_id)).plan_key).toBe("pro");
+
+    const audit = await compAudit(orgId);
+    expect(audit?.detail?.inherited_from).toBe("comped_until");
+    expect(audit?.detail?.plan_key).toBe("pro");
+  });
+
+  it("writes NOTHING when no comp is handed out — a release, or a past_due group", async () => {
+    // The row must mark an actual grant, not "a detach happened". A trail that
+    // fires on every detach cannot be read as "these orgs got free plan time".
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const live = await makeGroup(payer, {
+      stripeSubId: "sub_comp_none_" + uniq(),
+      quantityPaid: 2,
+      periodEndDays: 30,
+    });
+    stripeMock.state.quantity = 2;
+    await makeOrg(live, payer);
+    const released = await makeOrg(live, clubOwner);
+
+    await detachOrgFromGroup({ actorUserId: clubOwner, orgId: released, mode: "release" });
+    expect((await readGroup((await orgGroup(released)) as string)).comped_until).toBeNull();
+    expect(await compAudit(released)).toBeUndefined();
+
+    // ride_out on a past_due group degrades to release (a dunning group cannot
+    // hand on a period it has not paid for), so there is no comp there either.
+    const dunning = await makeGroup(payer, {
+      status: "past_due",
+      stripeSubId: "sub_comp_dunning_" + uniq(),
+      quantityPaid: 2,
+      periodEndDays: 30,
+    });
+    stripeMock.state.quantity = 2;
+    await makeOrg(dunning, payer);
+    const degraded = await makeOrg(dunning, clubOwner);
+
+    await detachOrgFromGroup({ actorUserId: clubOwner, orgId: degraded });
+    expect((await readGroup((await orgGroup(degraded)) as string)).comped_until).toBeNull();
+    expect(await compAudit(degraded)).toBeUndefined();
+  });
+});
+
 describe.skipIf(!HAS_DB)("detach of the LAST org carries the wallet out (#304)", () => {
   it("hands the shared pool to the leaver when it empties the group", async () => {
     // The shape #285's default cannot cover. A payer's group holds exactly ONE

--- a/apps/web/src/server/usecases/__tests__/billing-manage-plan.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-manage-plan.test.ts
@@ -67,7 +67,7 @@ vi.mock("@/lib/billing", () => ({
   syncSubscription: billingMock.syncSubscription,
 }));
 
-// V310: the plan change lands on the billing GROUP, so the cache drop is
+// V314: the plan change lands on the billing GROUP, so the cache drop is
 // invalidateEntitlementsForOrgGroup — still called with the org id.
 const entitlementsMock = vi.hoisted(() => ({
   invalidateOrgEntitlements: vi.fn(),
@@ -162,7 +162,7 @@ describe("previewPlanChange price-id selection", () => {
         }),
       }),
     );
-    // V310: the renewal quote is Stripe's own recurring preview, NOT
+    // V314: the renewal quote is Stripe's own recurring preview, NOT
     // proPlusPrice(). Prices are tiers_mode: graduated now, so the flat helper
     // under-quotes every multi-org group — 5800 here is base + one extra org,
     // a number the flat lookup cannot produce.

--- a/apps/web/src/server/usecases/__tests__/billing-webhook-group-resolution.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-webhook-group-resolution.test.ts
@@ -1,4 +1,4 @@
-// Which billing GROUP does a customer.subscription.* webhook write to? (V310)
+// Which billing GROUP does a customer.subscription.* webhook write to? (V314)
 //
 // Before billing groups a subscription belonged to exactly one org, so the
 // webhook could resolve through `metadata.org_id → that org's subscription`.

--- a/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
+++ b/apps/web/src/server/usecases/__tests__/credits-tab.test.ts
@@ -8,9 +8,11 @@ import { randomUUID } from "node:crypto";
 import { sql } from "@/lib/db";
 import {
   grantMonthly,
+  grantMonthlyForAllWallets,
   mergeWalletOnAttach,
   recordEarnGrant,
   recordPackPurchase,
+  release,
   reserve,
   settle,
   walletIdFor,
@@ -111,6 +113,61 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     expect(view.sharedOrgCount).toBe(2);
   });
 
+  // v17 gap #318, the PLAN dimension of the same divergence #291 fixed for
+  // quantity: the tab derived its cap from the subscription's RAW `plan_key`
+  // while `grantMonthlyForAllWallets` grants on the plan `orgPlanKey`
+  // RESOLVES — which degrades a suspended / past_due-beyond-grace /
+  // expired-comp wallet to Community. The org was granted 10 and told 60.
+  // `grantUsed` is clamped by `Math.min(grantCap, ...)`, so the lie could
+  // never show up as a meter over 100%: it showed up as a cap the wallet
+  // never had. The sweep is run here rather than assumed, so this asserts a
+  // real disagreement between two live derives.
+  it("REGRESSION (#318): a past_due-beyond-grace Pro wallet shows the Community cap the sweep actually grants", async () => {
+    const { auth } = await seedOrg("pro");
+    const groupId = (await orgGroupId(auth.orgId))!;
+    // A REAL degradation path, not a hand-written inconsistent row: dunning
+    // has run past orgPlanKey's 14-day past_due grace (anchored on the
+    // status TRANSITION), so every resolved read for this wallet — the
+    // sweep's included — is already Community.
+    await sql`
+      update subscriptions
+         set status = 'past_due', status_changed_at = now() - interval '20 days'
+       where id = ${groupId}`;
+
+    const walletId = await walletIdFor(auth.orgId);
+    const swept = await grantMonthlyForAllWallets({ walletIds: [walletId] });
+    expect(swept.granted).toBe(10); // what the wallet ACTUALLY got
+
+    const view = await getCreditsTab(auth.orgId);
+    expect(view.grantCap).toBe(10); // NOT 60 — the raw plan_key still reads 'pro'
+  });
+
+  // The other side of #318, and the reason the fix resolves the plan on the
+  // group's REPRESENTATIVE org rather than on the viewing org: the sweep
+  // picks the oldest live non-suspended org to answer for the whole wallet,
+  // precisely so one moderation-suspended member cannot degrade the pool its
+  // siblings are paying for. Resolving `orgPlanKey(orgId)` on the viewing org
+  // would have swapped #318's overstatement for an equal and opposite
+  // UNDERstatement on this shape. Passes before and after the fix by design —
+  // it is the guard on the fix, not its red.
+  it("#318 guard: a suspended member org still shows the group's Pro cap, resolved on the representative org", async () => {
+    const { auth: payer } = await seedOrg("pro");
+    const groupId = (await orgGroupId(payer.orgId))!;
+
+    const { auth: member } = await seedOrg("community");
+    await sql`
+      update organizations set subscription_id = ${groupId}, status = 'suspended'
+       where id = ${member.orgId}`;
+
+    const walletId = await walletIdFor(member.orgId);
+    const swept = await grantMonthlyForAllWallets({ walletIds: [walletId] });
+    expect(swept.granted).toBe(60); // the group is still Pro; the pool is unharmed
+
+    const view = await getCreditsTab(member.orgId);
+    expect(view.grantCap).toBe(60); // NOT 10 — moderation is per-org, the wallet is the group's
+    expect(view.sharedOrgCount).toBe(2);
+  });
+
   it("REGRESSION (#292): the used-this-month meter excludes a hold recorded 30 minutes before the UTC month boundary", async (ctx) => {
     const [{ tz }] = await sql<{ tz: string }[]>`select current_setting('TimeZone') as tz`;
     // getCreditsTab has no tx to force a TZ on (see this task's Testability
@@ -144,6 +201,29 @@ describe.skipIf(!HAS_DB)("getCreditsTab", () => {
     const view = await getCreditsTab(auth.orgId);
 
     expect(view.grantUsed).toBe(0); // must NOT count toward the current UTC month
+  });
+
+  // v17 gap #319: `release()` writes a compensating `source='refund'` row
+  // linked to the hold by `ref`, and `spentThisPeriodByOrg` (credits.ts) nets
+  // it — so the operator allocation cap correctly gives a failed run's
+  // allowance back. This meter summed GROSS `run_spend` three lines away from
+  // that derive, so the same failed run read as "used this month" here for
+  // the rest of the month. Two derives of one quantity, disagreeing.
+  it("REGRESSION (#319): the used-this-month meter nets a released run's refund, and still counts a settled one", async () => {
+    const { auth } = await seedOrg("pro");
+    const walletId = await walletIdFor(auth.orgId);
+    await grantMonthly(walletId, "pro", 1);
+
+    // A run that genuinely happened — must stay counted.
+    const settled = await reserve(walletId, auth.orgId, 1);
+    await settle(settled, randomUUID());
+    // A run that failed before settling — release() hands the credits back.
+    const failed = await reserve(walletId, auth.orgId, 3);
+    expect(await release(failed)).toBe(3);
+
+    const view = await getCreditsTab(auth.orgId);
+    expect(view.grantUsed).toBe(1); // NOT 4 — the released run was refunded
+    expect(view.balance).toBe(59); // and the ledger already agrees
   });
 
   // v17 gap #285: credits that arrive because the org joined a billing group

--- a/apps/web/src/server/usecases/__tests__/org-addon-price-sweep.test.ts
+++ b/apps/web/src/server/usecases/__tests__/org-addon-price-sweep.test.ts
@@ -1,0 +1,380 @@
+// v17 gap #332: the extra-organisation rider is sold at two rates ($9/mo on
+// pro, $19/mo on pro_plus) and `convergeOrgAddonPrices` deliberately NEVER
+// THROWS, so every one of its failure paths leaves a group billing the wrong
+// rate with nothing scheduled to try again. Convergence only runs when Stripe
+// emits a `customer.subscription.created`/`.updated` for that group, so "a
+// later plan change re-converges it" is worth nothing for a group that never
+// changes plan again.
+//
+// `sweepStaleOrgAddonPrices` is the backstop: a periodic pass that compares
+// every live rider's ACTUAL Stripe price id against its group's current plan
+// rate and REPORTS the disagreements. It never re-prices — see the function's
+// doc comment for why a bulk billing mutation is not what ships first.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+//
+// CONCURRENCY-SAFE BY CONSTRUCTION. The sweep reads every live rider in the
+// database, so sibling suites running against the same DB — and rows left by
+// earlier runs of this file — are inside its working set. Nothing here asserts
+// a total: every count assertion is derived from the entries THIS test seeded
+// (filtered by item id), and the `prices.list`/`subscriptionItems.retrieve`
+// stubs answer for an unknown item with "already converged" so a foreign row
+// can never manufacture a mismatch of its own.
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+const { itemRetrieveSpy, pricesListSpy, repriceAlertSpy } = vi.hoisted(() => ({
+  itemRetrieveSpy: vi.fn(),
+  pricesListSpy:
+    vi.fn<(args: { lookup_keys: string[]; limit?: number }) => Promise<{ data: { id: string }[] }>>(),
+  // Typed with the one field the assertions read, so `mock.calls[n][0]` is a
+  // real argument rather than the empty tuple a zero-arity `vi.fn()` infers.
+  repriceAlertSpy: vi.fn<(opts: { itemId: string | null }) => Promise<boolean>>(async () => true),
+}));
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    subscriptionItems: { retrieve: itemRetrieveSpy },
+    prices: { list: pricesListSpy },
+  }),
+}));
+// Partial mock: billing-events.ts imports a dozen senders from this module, so
+// only the one the sweep raises is replaced.
+vi.mock("@/lib/email", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/email")>()),
+  sendExtraOrgRepriceFailedAlertEmail: repriceAlertSpy,
+}));
+
+import { sql } from "@/lib/db";
+import { createOrgForUser } from "@/lib/auth";
+import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+import {
+  ORG_ADDONS,
+  ORG_ADDON_DELTA_EACH,
+  ORG_ADDON_FEATURE_KEY,
+} from "@/lib/org-addons";
+import { sweepStaleOrgAddonPrices } from "../billing-events";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 8);
+
+/** The live price id this suite pretends `stripe:sync` produced for a plan.
+ *  Derived from the lookup key so pro and pro_plus can never collide. */
+const proEntry = ORG_ADDONS.find((e) => e.planKey === "pro")!;
+const proPlusEntry = ORG_ADDONS.find((e) => e.planKey === "pro_plus")!;
+const livePriceFor = (lookupKey: string) => `price_live_${lookupKey}`;
+
+/** Every item id this file mints carries this prefix, which is how each
+ *  assertion narrows the sweep's whole-database result to its own rows. */
+const ITEM_PREFIX = "si_sweep332_";
+const mine = <T extends { itemId: string }>(rows: T[]) =>
+  rows.filter((r) => r.itemId.startsWith(ITEM_PREFIX));
+
+/** A billed group on `planKey` carrying one ACTIVE extra-org rider row. */
+async function seedRider(
+  planKey: "pro" | "pro_plus" | "community",
+  qty = 1,
+): Promise<{ groupId: string; orgId: string; stripeSubId: string; itemId: string }> {
+  const [user] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`sweep332-${uniq()}@test.local`}, 'Sweep Owner', true) returning id`;
+  const org = await createOrgForUser(user!.id, `Sweep 332 ${uniq()}`);
+  const groupId = await setOrgPlan(org.id, planKey);
+  const stripeSubId = `sub_sweep332_${uniq()}`;
+  await sql`
+    update subscriptions set stripe_subscription_id = ${stripeSubId}, status = 'active'
+     where id = ${groupId}`;
+  const itemId = `${ITEM_PREFIX}${uniq()}`;
+  await sql`
+    insert into org_addons
+      (wallet_id, target_org_id, target_competition_id, feature_key, delta_each, qty,
+       stripe_item_id, status)
+    values (${groupId}, null, null, ${ORG_ADDON_FEATURE_KEY}, ${ORG_ADDON_DELTA_EACH},
+            ${qty}, ${itemId}, 'active')`;
+  return { groupId, orgId: org.id, stripeSubId, itemId };
+}
+
+/** An extra-SEAT add-on row — the OTHER add-on family riding the very same
+ *  subscription, with its own SKU and its own price. It is `active`, it has a
+ *  `stripe_item_id`, and its group is live, so only the feature_key keeps it
+ *  out of this sweep's working set. */
+async function seedSeatRow(groupId: string, orgId: string): Promise<string> {
+  const itemId = `${ITEM_PREFIX}seat_${uniq()}`;
+  await sql`
+    insert into org_addons
+      (wallet_id, target_org_id, target_competition_id, feature_key, delta_each, qty,
+       stripe_item_id, status)
+    values (${groupId}, ${orgId}, null, 'members.max', 5, 1, ${itemId}, 'active')`;
+  return itemId;
+}
+
+/** A Stripe subscription item as `subscriptionItems.retrieve` returns it. */
+const itemOn = (id: string, priceId: string) => ({ id, price: { id: priceId } });
+
+/** Rows THIS FILE seeded — in an earlier run, or in the test that just ran —
+ *  are still `active` and still inside the sweep's whole-database working set,
+ *  so `mine()` would pick up its predecessors' riders as well as its own. Drop
+ *  them before every test. Scoped to this file's own item prefix, so a sibling
+ *  suite's rows are never touched. */
+async function clearOwnRiders(): Promise<void> {
+  await sql`delete from org_addons where stripe_item_id like ${`${ITEM_PREFIX}%`}`;
+}
+
+beforeEach(async () => {
+  itemRetrieveSpy.mockReset();
+  pricesListSpy.mockReset();
+  repriceAlertSpy.mockClear();
+  vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_sweep332");
+  vi.stubEnv("STAFF_ALERT_EMAIL", "ops@seazn.club");
+  // The synced catalog: every lookup key resolves to its own live price id.
+  pricesListSpy.mockImplementation(async (args) => ({
+    data: [{ id: livePriceFor(args.lookup_keys[0]!) }],
+  }));
+  // Default for an item this test did not seed (a sibling suite's row, or a
+  // leftover): report it as ALREADY on whatever price was asked for, so a
+  // foreign row can never contribute a mismatch or consume an alert slot.
+  itemRetrieveSpy.mockImplementation(async (id: string) =>
+    itemOn(id, livePriceFor(proEntry.lookupKey)),
+  );
+  if (HAS_DB) await clearOwnRiders();
+});
+afterEach(() => vi.unstubAllEnvs());
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("sweepStaleOrgAddonPrices (#332)", () => {
+  it("reports a Pro Plus group whose rider is still on the Pro price", async () => {
+    const { groupId, stripeSubId, itemId } = await seedRider("pro_plus", 3);
+    // The exact #332 shape: convergence failed, so the $19 group still rides
+    // the $9 SKU — the arbitrage the two rates exist to close.
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, id === itemId ? livePriceFor(proEntry.lookupKey) : livePriceFor(proPlusEntry.lookupKey)),
+    );
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    const found = mine(res.mismatches);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({
+      subscriptionId: groupId,
+      stripeSubscriptionId: stripeSubId,
+      planKey: "pro_plus",
+      itemId,
+      qty: 3,
+      currentPriceId: livePriceFor(proEntry.lookupKey),
+      expectedPriceId: livePriceFor(proPlusEntry.lookupKey),
+    });
+    expect(res.mismatched).toBeGreaterThanOrEqual(1);
+    expect(res.alerted).toBeGreaterThanOrEqual(1);
+  });
+
+  it("compares against LIVE Stripe state, not the org_addons row", async () => {
+    // The DB knows only the item id — it never records a price. So the sweep
+    // has to ask Stripe what the item is actually on; a sweep that trusted the
+    // row could not detect this class at all.
+    const { itemId } = await seedRider("pro");
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, id === itemId ? "price_something_else_entirely" : livePriceFor(proEntry.lookupKey)),
+    );
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(itemRetrieveSpy).toHaveBeenCalledWith(itemId);
+    expect(mine(res.mismatches)[0]).toMatchObject({
+      itemId,
+      currentPriceId: "price_something_else_entirely",
+      expectedPriceId: livePriceFor(proEntry.lookupKey),
+    });
+  });
+
+  it("stays silent on a converged rider — no mismatch, no alert", async () => {
+    const { itemId } = await seedRider("pro");
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, livePriceFor(proEntry.lookupKey)),
+    );
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(mine(res.mismatches)).toEqual([]);
+    const alertedItems = repriceAlertSpy.mock.calls.map((c) => c[0].itemId);
+    expect(alertedItems).not.toContain(itemId);
+  });
+
+  it("flags an unsynced catalog as unresolved and never guesses a price", async () => {
+    const { itemId } = await seedRider("pro");
+    // resolveOrgAddonPriceId's 503: `stripe:sync` has not run for this account.
+    pricesListSpy.mockResolvedValue({ data: [] });
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    const found = mine(res.mismatches);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ itemId, expectedPriceId: null, currentPriceId: null });
+    expect(res.unresolved).toBeGreaterThanOrEqual(1);
+    // Nothing to compare against, so the item is never even read.
+    expect(itemRetrieveSpy).not.toHaveBeenCalledWith(itemId);
+  });
+
+  it("resolves each plan's price ONCE per pass, not once per rider", async () => {
+    const a = await seedRider("pro");
+    const b = await seedRider("pro");
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, livePriceFor(proEntry.lookupKey)),
+    );
+
+    await sweepStaleOrgAddonPrices();
+
+    const proLookups = pricesListSpy.mock.calls.filter(
+      (c) => c[0]!.lookup_keys[0] === proEntry.lookupKey,
+    );
+    expect(proLookups).toHaveLength(1);
+    expect(a.itemId).not.toBe(b.itemId); // both really were in the working set
+  });
+
+  it("reports a rider on a plan that has no rider SKU at all", async () => {
+    // Community has no org-addon entry, so convergeOrgAddonPrices returns
+    // early and does nothing — which leaves a paid rider riding a plan that
+    // cannot price it. Invisible today; the sweep is what surfaces it.
+    const { itemId } = await seedRider("community");
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    const found = mine(res.mismatches);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.itemId).toBe(itemId);
+    expect(found[0]!.reason).toMatch(/community/);
+    expect(found[0]!.expectedPriceId).toBeNull();
+  });
+
+  it("skips canceled rider rows and groups Stripe no longer bills", async () => {
+    const canceled = await seedRider("pro");
+    await sql`update org_addons set status = 'canceled' where stripe_item_id = ${canceled.itemId}`;
+    const dead = await seedRider("pro");
+    await sql`update subscriptions set status = 'canceled' where id = ${dead.groupId}`;
+    const unbilled = await seedRider("pro");
+    await sql`update subscriptions set stripe_subscription_id = null where id = ${unbilled.groupId}`;
+    // If any of the three WERE swept they would read as mismatched.
+    itemRetrieveSpy.mockImplementation(async (id: string) => itemOn(id, "price_wrong"));
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(mine(res.mismatches)).toEqual([]);
+    for (const id of [canceled.itemId, dead.itemId, unbilled.itemId]) {
+      expect(itemRetrieveSpy).not.toHaveBeenCalledWith(id);
+    }
+  });
+
+  it("ignores the extra-SEAT add-on family entirely", async () => {
+    // Seats ride the same subscription and land in the same table, but they are
+    // a different SKU at a different price. A sweep that selected them would
+    // report every seat item in the estate as an extra-org rider on the wrong
+    // price — a false positive on a scale that would bury the true ones.
+    const { groupId, orgId } = await seedRider("pro");
+    const seatItemId = await seedSeatRow(groupId, orgId);
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, livePriceFor(proEntry.lookupKey)),
+    );
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(itemRetrieveSpy).not.toHaveBeenCalledWith(seatItemId);
+    expect(mine(res.mismatches)).toEqual([]);
+  });
+
+  it("counts a vanished item separately and does not alert on it", async () => {
+    const { itemId } = await seedRider("pro");
+    itemRetrieveSpy.mockImplementation(async (id: string) => {
+      if (id !== itemId) return itemOn(id, livePriceFor(proEntry.lookupKey));
+      throw Object.assign(new Error("No such subscription item"), { code: "resource_missing" });
+    });
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(res.vanished).toBeGreaterThanOrEqual(1);
+    expect(mine(res.mismatches)).toEqual([]);
+    const alertedItems = repriceAlertSpy.mock.calls.map((c) => c[0].itemId);
+    expect(alertedItems).not.toContain(itemId);
+  });
+
+  it("a Stripe read failure is unreadable, not a mismatch — it never invents one", async () => {
+    const { itemId } = await seedRider("pro");
+    itemRetrieveSpy.mockImplementation(async (id: string) => {
+      if (id !== itemId) return itemOn(id, livePriceFor(proEntry.lookupKey));
+      throw new Error("stripe unavailable");
+    });
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(res.unreadable).toBeGreaterThanOrEqual(1);
+    // The whole point: a transient outage must not be reported as "this group
+    // is billing the wrong rate", which is what a responder would act on.
+    expect(mine(res.mismatches)).toEqual([]);
+  });
+
+  it("never re-prices: the sweep reports and mutates nothing", async () => {
+    const { itemId } = await seedRider("pro_plus");
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, id === itemId ? livePriceFor(proEntry.lookupKey) : livePriceFor(proPlusEntry.lookupKey)),
+    );
+
+    await sweepStaleOrgAddonPrices();
+
+    // `subscriptionItems.update` is not even on the stubbed client — a sweep
+    // that tried to repair would throw here rather than silently mutate.
+    const [row] = await sql<{ status: string; qty: number }[]>`
+      select status, qty from org_addons where stripe_item_id = ${itemId}`;
+    expect(row).toMatchObject({ status: "active", qty: 1 });
+  });
+
+  it("reports without alerting when STAFF_ALERT_EMAIL is unset", async () => {
+    vi.stubEnv("STAFF_ALERT_EMAIL", "");
+    const { itemId } = await seedRider("pro_plus");
+    itemRetrieveSpy.mockImplementation(async (id: string) =>
+      itemOn(id, id === itemId ? livePriceFor(proEntry.lookupKey) : livePriceFor(proPlusEntry.lookupKey)),
+    );
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(mine(res.mismatches)).toHaveLength(1);
+    expect(res.alerted).toBe(0);
+    expect(repriceAlertSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all without a Stripe key", async () => {
+    vi.stubEnv("STRIPE_SECRET_KEY", "");
+    await seedRider("pro_plus");
+
+    const res = await sweepStaleOrgAddonPrices();
+
+    expect(res).toEqual({
+      total: 0,
+      checked: 0,
+      mismatched: 0,
+      unresolved: 0,
+      vanished: 0,
+      unreadable: 0,
+      alerted: 0,
+      mismatches: [],
+    });
+    expect(pricesListSpy).not.toHaveBeenCalled();
+  });
+
+  it("reports its own truncation: total counts riders `limit` never reached", async () => {
+    // `limit` truncates a STABLE created_at ordering over a working set that
+    // never drains, so an estate larger than the limit leaves its newest riders
+    // permanently unexamined. A backstop that had silently stopped covering the
+    // estate would be indistinguishable from a clean pass without this.
+    await seedRider("pro");
+    await seedRider("pro");
+
+    const res = await sweepStaleOrgAddonPrices(1);
+
+    expect(res.checked).toBe(1);
+    expect(res.total).toBeGreaterThan(res.checked);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/pass-credit-backfill-precheck.test.ts
+++ b/apps/web/src/server/usecases/__tests__/pass-credit-backfill-precheck.test.ts
@@ -22,7 +22,10 @@ import { afterAll, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
 
 import { sql } from "@/lib/db";
-import { groupAlreadyCapped } from "../../../../../../scripts/backfill-pass-credit-redemptions";
+import {
+  describeCapStatus,
+  groupAlreadyCapped,
+} from "../../../../../../scripts/backfill-pass-credit-redemptions";
 
 const HAS_DB = !!process.env.DATABASE_URL;
 const uniq = () => randomUUID().slice(0, 12);
@@ -141,5 +144,50 @@ describe.skipIf(!HAS_DB)("backfill pre-check: groupAlreadyCapped", () => {
     const { orgId, subscriptionId } = await seedOrgAndSubscription();
     await seedRedemption({ subscriptionId, orgId, reversed: true });
     expect(await groupAlreadyCapped(sql, subscriptionId)).toBe(false);
+  });
+});
+
+// #307: `groupAlreadyCapped` collapses BOTH arms of the widened cap index
+// into one boolean, which is exactly right for "is there anything to
+// backfill" but wrong for a SUMMARY — a healthy live cap and an
+// undetermined-blocked group are opposite operational states (one is fine,
+// the other is money nobody has decided about) and a report that folds them
+// into one "already capped" count cannot be told apart from "the run went
+// well" by whoever reads it. `describeCapStatus` is the function the
+// backfill's main loop uses to keep them separate; this test builds BOTH row
+// shapes side by side and asserts they resolve to distinct, correctly-typed
+// statuses — a test built from only one shape cannot catch a conflation.
+describe.skipIf(!HAS_DB)("backfill summary: describeCapStatus tells healthy and undetermined apart", () => {
+  it("resolves a group with no redemption row as free", async () => {
+    const { subscriptionId } = await seedOrgAndSubscription();
+    expect(await describeCapStatus(sql, subscriptionId)).toBe("free");
+  });
+
+  it("resolves a healthy LIVE redemption as capped_healthy, distinctly from capped_undetermined", async () => {
+    const healthy = await seedOrgAndSubscription();
+    await seedRedemption({ subscriptionId: healthy.subscriptionId, orgId: healthy.orgId });
+
+    const blocked = await seedOrgAndSubscription();
+    await seedRedemption({
+      subscriptionId: blocked.subscriptionId,
+      orgId: blocked.orgId,
+      reversed: true,
+      undetermined: true,
+    });
+
+    const healthyStatus = await describeCapStatus(sql, healthy.subscriptionId);
+    const blockedStatus = await describeCapStatus(sql, blocked.subscriptionId);
+
+    expect(healthyStatus).toBe("capped_healthy");
+    expect(blockedStatus).toBe("capped_undetermined");
+    // The whole defect in one line: these must never collapse to the same
+    // value, or a summary built on top of this function conflates them again.
+    expect(healthyStatus).not.toBe(blockedStatus);
+  });
+
+  it("resolves a cleanly-reversed (determined) redemption as free, not undetermined", async () => {
+    const { orgId, subscriptionId } = await seedOrgAndSubscription();
+    await seedRedemption({ subscriptionId, orgId, reversed: true });
+    expect(await describeCapStatus(sql, subscriptionId)).toBe("free");
   });
 });

--- a/apps/web/src/server/usecases/__tests__/pass-credit-undetermined-resolution.test.ts
+++ b/apps/web/src/server/usecases/__tests__/pass-credit-undetermined-resolution.test.ts
@@ -1,0 +1,464 @@
+// #305 (#286 phase 2) — the STAFF RESOLUTION path for a pass-credit redemption
+// stuck on `reversal_undetermined_at`.
+//
+// Phase 1 (V337) made an undetermined reversal hold the group's one lifetime
+// pass credit PERMANENTLY: `reversed_at` is stamped (webhook idempotency) but
+// nothing was actually clawed back, so the widened
+// `pass_credit_redemptions_group_cap` keeps the row live. That is correct — the
+// customer provably still holds the £/$ credit — but nothing ever cleared it,
+// so a group whose balance staff later settled by hand in Stripe stayed capped
+// forever with no release path.
+//
+// What this suite pins is the two things that make a release path safe rather
+// than a lever that loses money:
+//
+//   1. BOTH outcomes are expressible. "Staff clawed it back in Stripe" frees
+//      the cap; "the customer keeps it" leaves the cap held and is recorded as
+//      REVIEWED. A path that only supports the first is a way to hand out a
+//      second credit; a path that only supports the second is not a resolution
+//      at all.
+//   2. Every resolution is attributable and ATOMIC with its audit row (the
+//      admin-addons.ts / #272 adminAdjust pattern): a crash between the column
+//      clear and the audit insert can never leave a freed cap with nobody's
+//      name on it. The FK-violation test below is the real proof of that — it
+//      forces the audit insert to fail and asserts the cap did NOT move.
+//
+// And, crucially, resolving ONE row must not free ANY other: the
+// "stays blocked" test seeds two independent groups and resolves only one.
+//
+// Real Postgres required; skipped without DATABASE_URL. Stripe is mocked and
+// asserted NEVER to be called — staff settle the balance by hand in the Stripe
+// dashboard BEFORE recording the decision here, so a second automatic claw-back
+// from this path would take the money twice.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+
+const stripeMock = vi.hoisted(() => ({
+  retrieveCustomer: vi.fn(),
+  listBalance: vi.fn(),
+  createBalance: vi.fn(),
+}));
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    customers: {
+      retrieve: stripeMock.retrieveCustomer,
+      listBalanceTransactions: stripeMock.listBalance,
+      createBalanceTransaction: stripeMock.createBalance,
+    },
+  }),
+}));
+
+import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
+import {
+  PASS_CREDIT_RESOLVE_ACTION,
+  creditPassTowardSubscription,
+  groupAlreadyRedeemed,
+  listUndeterminedPassCreditReversals,
+  resolveUndeterminedPassCreditReversal,
+} from "../pass-credit";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const uniq = () => randomUUID().slice(0, 12);
+const orgIds: string[] = [];
+const actorIds: string[] = [];
+
+async function seedActor(): Promise<string> {
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified, is_staff, staff_role)
+    values (${"resolver-" + uniq() + "@test.local"}, 'Resolver', true, true, 'superadmin')
+    returning id`;
+  actorIds.push(id);
+  return id;
+}
+
+/** One group holding one UNDETERMINED redemption — the exact row state
+ *  `reversePassCreditOnRefund`'s unsafe branch leaves behind (reversed_at
+ *  stamped as the idempotency guard, reversed_minor 0, undetermined stamped). */
+async function seedUndeterminedRedemption(opts?: { amountMinor?: number }): Promise<{
+  redemptionId: string;
+  orgId: string;
+  subscriptionId: string;
+  intent: string;
+}> {
+  const suffix = uniq();
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${"Resolve Org " + suffix}, ${"resolve-org-" + suffix}) returning id`;
+  orgIds.push(orgId);
+  await sql`
+    with _owner as (
+      insert into users (email, display_name, email_verified)
+      values ('resolveowner-' || gen_random_uuid() || '@test.local', 'Resolve Owner', true)
+      returning id
+    ),
+    _seed_sub as (
+      insert into subscriptions (owner_user_id, plan_key, status, stripe_customer_id, currency)
+      select coalesce(o.created_by, (select id from _owner)), 'pro', 'active',
+             ${"cus_" + suffix}, 'gbp'
+      from organizations o where o.id = ${orgId}
+      returning id
+    )
+    update organizations set subscription_id = (select id from _seed_sub) where id = ${orgId}`;
+  const [{ subscription_id: subscriptionId }] = await sql<{ subscription_id: string }[]>`
+    select subscription_id from organizations where id = ${orgId}`;
+
+  const [{ id: competitionId }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug)
+    values (${orgId}, ${"Resolve Cup " + suffix}, ${"resolve-cup-" + suffix}) returning id`;
+  const intent = "pi_" + suffix;
+  const [{ id: redemptionId }] = await sql<{ id: string }[]>`
+    insert into pass_credit_redemptions
+      (subscription_id, org_id, competition_id, payment_intent, amount_minor, currency,
+       reversed_at, reversed_minor, reversal_undetermined_at)
+    values (${subscriptionId}, ${orgId}, ${competitionId}, ${intent},
+            ${opts?.amountMinor ?? 2500}, 'gbp', now(), 0, now())
+    returning id`;
+  return { redemptionId, orgId, subscriptionId, intent };
+}
+
+/** A second, different Event Pass on the same org — the thing the cap must go
+ *  on refusing (or start allowing) depending on the resolution. */
+async function seedCompetitionPass(orgId: string): Promise<string> {
+  const suffix = uniq();
+  const [{ id: competitionId }] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug)
+    values (${orgId}, ${"Second Pass " + suffix}, ${"second-pass-" + suffix}) returning id`;
+  const intent = "pi_second_" + suffix;
+  await sql`
+    insert into competition_passes (competition_id, org_id, stripe_payment_intent, purchased_at)
+    values (${competitionId}, ${orgId}, ${intent}, now())`;
+  return intent;
+}
+
+async function redemptionRow(id: string) {
+  const [row] = await sql<
+    {
+      reversed_at: string | null;
+      reversed_minor: number | null;
+      amount_minor: number;
+      reversal_undetermined_at: string | null;
+    }[]
+  >`select reversed_at, reversed_minor, amount_minor, reversal_undetermined_at
+      from pass_credit_redemptions where id = ${id}`;
+  return row;
+}
+
+async function auditRows(redemptionId: string) {
+  return sql<{ actor_id: string; action: string; target_type: string; target_id: string; detail: Record<string, unknown> }[]>`
+    select actor_id, action, target_type, target_id, detail
+      from staff_audit_log
+     where action = ${PASS_CREDIT_RESOLVE_ACTION}
+       and detail->>'redemption_id' = ${redemptionId}
+     order by created_at asc`;
+}
+
+beforeEach(() => {
+  stripeMock.retrieveCustomer.mockReset();
+  stripeMock.listBalance.mockReset();
+  stripeMock.createBalance.mockReset();
+});
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  if (actorIds.length) {
+    await sql`delete from staff_audit_log where actor_id = any(${actorIds})`;
+  }
+  if (orgIds.length) {
+    await sql`delete from competitions where org_id = any(${orgIds})`;
+    const groups = await sql<{ subscription_id: string }[]>`
+      select subscription_id from organizations
+       where id = any(${orgIds}) and subscription_id is not null`;
+    await sql`delete from organizations where id = any(${orgIds})`;
+    if (groups.length)
+      await sql`delete from subscriptions where id = any(${groups.map((g) => g.subscription_id)})`;
+  }
+  if (actorIds.length) await sql`delete from users where id = any(${actorIds})`;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("resolveUndeterminedPassCreditReversal", () => {
+  it("'clawed_back' clears the hold, frees the group cap, and records who decided", async () => {
+    const actorId = await seedActor();
+    const { redemptionId, subscriptionId, orgId } = await seedUndeterminedRedemption();
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(true);
+
+    const res = await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "clawed_back",
+      reversedMinor: 2500,
+      reason: "settled by hand in Stripe, txn cbtxn_x",
+    });
+
+    expect(res.resolved).toBe(true);
+    const row = await redemptionRow(redemptionId);
+    expect(row?.reversal_undetermined_at).toBeNull();
+    expect(row?.reversed_at).not.toBeNull(); // idempotency stamp untouched
+    expect(row?.reversed_minor).toBe(2500); // what staff actually removed
+    // The whole point: the group can mint its next pass credit again.
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(false);
+
+    const audit = await auditRows(redemptionId);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]!.actor_id).toBe(actorId);
+    expect(audit[0]!.target_type).toBe("org");
+    expect(audit[0]!.target_id).toBe(orgId);
+    expect(audit[0]!.detail.resolution).toBe("clawed_back");
+    expect(audit[0]!.detail.reversed_minor).toBe(2500);
+    expect(audit[0]!.detail.reason).toBe("settled by hand in Stripe, txn cbtxn_x");
+  });
+
+  it("'clawed_back' moves NO money — staff already settled it in Stripe by hand", async () => {
+    const actorId = await seedActor();
+    const { redemptionId } = await seedUndeterminedRedemption();
+
+    await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "clawed_back",
+      reversedMinor: 2500,
+      reason: "already reversed in dashboard",
+    });
+
+    // A second automatic claw-back here would debit the customer twice.
+    expect(stripeMock.createBalance).not.toHaveBeenCalled();
+    expect(stripeMock.retrieveCustomer).not.toHaveBeenCalled();
+  });
+
+  it("'kept' leaves the cap HELD and still records who decided", async () => {
+    const actorId = await seedActor();
+    const { redemptionId, subscriptionId, orgId } = await seedUndeterminedRedemption();
+
+    const res = await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "kept",
+      reason: "customer keeps the credit, confirmed with finance",
+    });
+
+    expect(res.resolved).toBe(true);
+    const row = await redemptionRow(redemptionId);
+    // The customer still holds the money, so the cap must go on holding.
+    expect(row?.reversal_undetermined_at).not.toBeNull();
+    expect(row?.reversed_minor).toBe(0);
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(true);
+
+    // ...and a second mint is still refused, which is the money statement.
+    await seedCompetitionPass(orgId);
+    const second = await creditPassTowardSubscription(orgId);
+    expect(second.outcome).toBe("group_already_redeemed");
+    expect(stripeMock.createBalance).not.toHaveBeenCalled();
+
+    const audit = await auditRows(redemptionId);
+    expect(audit).toHaveLength(1);
+    expect(audit[0]!.detail.resolution).toBe("kept");
+    expect(audit[0]!.actor_id).toBe(actorId);
+  });
+
+  it("resolving ONE row leaves every OTHER undetermined row blocked", async () => {
+    const actorId = await seedActor();
+    const resolved = await seedUndeterminedRedemption();
+    const untouched = await seedUndeterminedRedemption();
+
+    await resolveUndeterminedPassCreditReversal(actorId, resolved.redemptionId, {
+      resolution: "clawed_back",
+      reversedMinor: 2500,
+      reason: "settled",
+    });
+
+    expect(await groupAlreadyRedeemed(resolved.subscriptionId)).toBe(false);
+    // The guard must not be satisfiable by resolving anything at all: this
+    // group nobody looked at is still capped, and still cannot mint.
+    expect(await groupAlreadyRedeemed(untouched.subscriptionId)).toBe(true);
+    expect((await redemptionRow(untouched.redemptionId))?.reversal_undetermined_at).not.toBeNull();
+    await seedCompetitionPass(untouched.orgId);
+    expect((await creditPassTowardSubscription(untouched.orgId)).outcome).toBe(
+      "group_already_redeemed",
+    );
+    expect(stripeMock.createBalance).not.toHaveBeenCalled();
+  });
+
+  it("is atomic with its audit row — a failed audit write leaves the cap held", async () => {
+    const { redemptionId, subscriptionId } = await seedUndeterminedRedemption();
+    // staff_audit_log.actor_id is a NOT NULL FK to users: an actor that does
+    // not exist makes the audit INSERT throw. If the column clear were not in
+    // the same transaction, the cap would already be freed with no record of
+    // who freed it — the exact failure this pattern exists to prevent.
+    const ghostActor = randomUUID();
+
+    await expect(
+      resolveUndeterminedPassCreditReversal(ghostActor, redemptionId, {
+        resolution: "clawed_back",
+        reversedMinor: 2500,
+        reason: "should roll back",
+      }),
+    ).rejects.toThrow();
+
+    const row = await redemptionRow(redemptionId);
+    expect(row?.reversal_undetermined_at).not.toBeNull();
+    expect(row?.reversed_minor).toBe(0);
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(true);
+  });
+
+  it("a replayed 'clawed_back' is a no-op and writes no second audit row", async () => {
+    const actorId = await seedActor();
+    const { redemptionId } = await seedUndeterminedRedemption();
+    const input = {
+      resolution: "clawed_back" as const,
+      reversedMinor: 2500,
+      reason: "settled",
+    };
+
+    expect((await resolveUndeterminedPassCreditReversal(actorId, redemptionId, input)).resolved).toBe(true);
+    expect((await resolveUndeterminedPassCreditReversal(actorId, redemptionId, input)).resolved).toBe(false);
+
+    expect(await auditRows(redemptionId)).toHaveLength(1);
+  });
+
+  it("a replayed 'kept' is a no-op and writes no second audit row", async () => {
+    const actorId = await seedActor();
+    const { redemptionId } = await seedUndeterminedRedemption();
+    const input = { resolution: "kept" as const, reason: "customer keeps it" };
+
+    expect((await resolveUndeterminedPassCreditReversal(actorId, redemptionId, input)).resolved).toBe(true);
+    expect((await resolveUndeterminedPassCreditReversal(actorId, redemptionId, input)).resolved).toBe(false);
+
+    expect(await auditRows(redemptionId)).toHaveLength(1);
+  });
+
+  it("a 'kept' row can still be re-resolved to 'clawed_back' once staff settle it", async () => {
+    const actorId = await seedActor();
+    const { redemptionId, subscriptionId } = await seedUndeterminedRedemption();
+
+    await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "kept",
+      reason: "leave it for now",
+    });
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(true);
+
+    const res = await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "clawed_back",
+      reversedMinor: 2500,
+      reason: "finance clawed it back after all",
+    });
+    expect(res.resolved).toBe(true);
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(false);
+    expect(await auditRows(redemptionId)).toHaveLength(2);
+  });
+
+  it("refuses an unknown redemption id with a 404", async () => {
+    const actorId = await seedActor();
+    await expect(
+      resolveUndeterminedPassCreditReversal(actorId, randomUUID(), {
+        resolution: "kept",
+        reason: "x",
+      }),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("refuses a redemption that was never undetermined with a 409", async () => {
+    const actorId = await seedActor();
+    const { redemptionId } = await seedUndeterminedRedemption();
+    // A cleanly, automatically reversed row: nothing to decide.
+    await sql`update pass_credit_redemptions
+                 set reversal_undetermined_at = null, reversed_minor = 2500
+               where id = ${redemptionId}`;
+
+    await expect(
+      resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+        resolution: "kept",
+        reason: "x",
+      }),
+    ).rejects.toMatchObject({ status: 409 });
+    expect(await auditRows(redemptionId)).toHaveLength(0);
+  });
+
+  it("refuses a claw-back larger than the grant, changing nothing", async () => {
+    const actorId = await seedActor();
+    const { redemptionId, subscriptionId } = await seedUndeterminedRedemption({ amountMinor: 2500 });
+
+    await expect(
+      resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+        resolution: "clawed_back",
+        reversedMinor: 9999,
+        reason: "fat finger",
+      }),
+    ).rejects.toBeInstanceOf(HttpError);
+
+    expect((await redemptionRow(redemptionId))?.reversal_undetermined_at).not.toBeNull();
+    expect(await groupAlreadyRedeemed(subscriptionId)).toBe(true);
+    expect(await auditRows(redemptionId)).toHaveLength(0);
+  });
+
+  it("requires reversedMinor on a claw-back — the row must not claim 0 was taken", async () => {
+    const actorId = await seedActor();
+    const { redemptionId } = await seedUndeterminedRedemption();
+
+    await expect(
+      resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+        resolution: "clawed_back",
+        reason: "no amount given",
+      }),
+    ).rejects.toBeInstanceOf(HttpError);
+    expect((await redemptionRow(redemptionId))?.reversal_undetermined_at).not.toBeNull();
+  });
+});
+
+describe.skipIf(!HAS_DB)("listUndeterminedPassCreditReversals", () => {
+  it("lists an unresolved row as open, then carries the decision once resolved", async () => {
+    const actorId = await seedActor();
+    const { redemptionId, orgId, intent } = await seedUndeterminedRedemption();
+
+    const open = (await listUndeterminedPassCreditReversals()).find((r) => r.id === redemptionId);
+    expect(open).toBeDefined();
+    expect(open!.status).toBe("open");
+    expect(open!.paymentIntent).toBe(intent);
+    expect(open!.orgId).toBe(orgId);
+    expect(open!.amountMinor).toBe(2500);
+    expect(open!.resolvedBy).toBeNull();
+
+    await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "kept",
+      reason: "customer keeps it",
+    });
+
+    const reviewed = (await listUndeterminedPassCreditReversals()).find((r) => r.id === redemptionId);
+    // Still holding the cap, but no longer an unanswered question.
+    expect(reviewed!.status).toBe("kept");
+    expect(reviewed!.resolvedBy).toBe(actorId);
+    expect(reviewed!.resolvedAt).not.toBeNull();
+    expect(reviewed!.reason).toBe("customer keeps it");
+  });
+
+  it("keeps a clawed-back row visible as closed history, not silently dropped", async () => {
+    const actorId = await seedActor();
+    const { redemptionId } = await seedUndeterminedRedemption();
+
+    await resolveUndeterminedPassCreditReversal(actorId, redemptionId, {
+      resolution: "clawed_back",
+      reversedMinor: 2500,
+      reason: "settled",
+    });
+
+    const closed = (await listUndeterminedPassCreditReversals()).find((r) => r.id === redemptionId);
+    expect(closed).toBeDefined();
+    expect(closed!.status).toBe("clawed_back");
+    expect(closed!.undeterminedAt).toBeNull();
+    expect(closed!.resolvedBy).toBe(actorId);
+  });
+
+  it("sorts unresolved rows before resolved ones — the worklist is the point", async () => {
+    const actorId = await seedActor();
+    const first = await seedUndeterminedRedemption();
+    const second = await seedUndeterminedRedemption();
+    await resolveUndeterminedPassCreditReversal(actorId, first.redemptionId, {
+      resolution: "kept",
+      reason: "reviewed",
+    });
+
+    const rows = await listUndeterminedPassCreditReversals();
+    const openIdx = rows.findIndex((r) => r.id === second.redemptionId);
+    const resolvedIdx = rows.findIndex((r) => r.id === first.redemptionId);
+    expect(openIdx).toBeGreaterThanOrEqual(0);
+    expect(resolvedIdx).toBeGreaterThanOrEqual(0);
+    expect(openIdx).toBeLessThan(resolvedIdx);
+  });
+});

--- a/apps/web/src/server/usecases/admin-plan.ts
+++ b/apps/web/src/server/usecases/admin-plan.ts
@@ -25,7 +25,7 @@ import {
  * reached from the staff console with an operator-supplied org id, so a 500
  * both blames us and pages someone for what is a data condition they are
  * looking straight at. 404 says the true thing: there is no billing to act on.
- * (This also restores restoreTrial's original 404, which V310 turned into a
+ * (This also restores restoreTrial's original 404, which V314 turned into a
  * 500.)
  */
 async function groupIdForOrg(orgId: string): Promise<string> {

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -41,6 +41,7 @@ import {
   invalidateOrgEntitlements,
 } from "@/lib/entitlements";
 import { orgIdsInGroup, subscriptionIdForOrg } from "@/lib/billing-group";
+import { LIVE_SUBSCRIPTION_STATUSES } from "@/lib/subscription-status";
 import { syncGroupQuantity } from "@/server/usecases/billing-groups";
 import {
   creditPassTowardSubscription,
@@ -752,14 +753,19 @@ export async function syncSeatAddonsForSubscription(
  * reads. So a failure is logged AND STAFF-ALERTED and processing continues:
  * rows still reconcile, only the PRICE stays stale.
  *
- * A FAILURE IS OBSERVABLE, NOT REPAIRED. There is no retry and no sweep: this
- * runs only when a `customer.subscription.created`/`.updated` event arrives, so
- * "the next event re-converges it" is worth nothing for a group Stripe has no
- * reason to emit another event about.
+ * A FAILURE IS OBSERVABLE, NOT REPAIRED. There is no retry here: this runs only
+ * when a `customer.subscription.created`/`.updated` event arrives, so "the next
+ * event re-converges it" is worth nothing for a group Stripe has no reason to
+ * emit another event about.
  * That group bills the wrong rate indefinitely, which is why every failure path
- * raises a staff alert rather than only a log. The daily reconciliation sweep
- * and the /admin mismatch list that would actually REPAIR it are tracked as
- * issue #332; until they land, the alert is the entire safety net.
+ * raises a staff alert rather than only a log.
+ *
+ * `sweepStaleOrgAddonPrices` (#332, below) is the second half of that net: it
+ * finds a group that went stale before the alert existed, or whose alert was
+ * missed. It REPORTS ONLY — it re-prices nothing — so this alert is still what
+ * a responder acts on, and the sweep is still not a repair. Note also that it
+ * is not yet SCHEDULED: the cron step and the /admin mismatch list that read it
+ * are the remaining halves of #332.
  */
 export async function convergeOrgAddonPrices(
   stripeSub: Stripe.Subscription,
@@ -827,9 +833,10 @@ export async function convergeOrgAddonPrices(
     // subscription event of any kind (a dunning retry, a seat purchase, a plan
     // edit) that clears those gates re-reads the claim and converges the item
     // then. What does not exist is anything
-    // that SCHEDULES such an event: no retry, and #332's sweep is unbuilt, which
-    // is the header's point. A group nothing else touches keeps billing the
-    // wrong rate until something touches it.
+    // that SCHEDULES such an event: no retry, and #332's sweep REPORTS rather
+    // than re-converging (and is not wired to a cron yet), which is the header's
+    // point. A group nothing else touches keeps billing the wrong rate until
+    // something touches it.
     //
     // And the alert it sends is MISLEADING in this case specifically: `reason`
     // reads "another subscription item already holds the target price (duplicate
@@ -888,7 +895,10 @@ export async function convergeOrgAddonPrices(
       // every rider on every `subscription.updated`, which is exactly the
       // per-event round trip the early return at the top of this function exists
       // to avoid. That trade belongs to #332's scheduled reconciliation, which
-      // pays it once a day per group instead of once an event per rider.
+      // pays it once a day per group instead of once an event per rider — and
+      // note the sweep as shipped does NOT close this window: it compares PRICE
+      // ids only, so a converged price hiding a stale QUANTITY is still invisible
+      // to both halves. Widening it to quantity is a change to that function.
       if (item.price?.id === expectedPriceId) continue;
       // A quantity-0 item is a removal in disguise; the row sync below flips
       // its row to canceled. Re-pricing it would be paying a Stripe write to
@@ -900,8 +910,10 @@ export async function convergeOrgAddonPrices(
       // a row the customer is paying for. Much less reachable than the
       // steady-state exit above: no app path produces a qty-0 rider item at all
       // — setExtraOrgs removes via `subscriptionItems.del` — so it takes a
-      // Dashboard edit AND an out-of-order delivery. Same remedy, same owner:
-      // #332.
+      // Dashboard edit AND an out-of-order delivery. Same owner, #332, but NOT
+      // yet the same remedy: the shipped sweep skips a qty-0 row (it reads
+      // `status = 'active'` org_addons rows, and the sync has already canceled
+      // this one) and compares prices, not quantities.
       if ((item.quantity ?? 0) <= 0) continue;
       // Hoisted so the catch below can report the price Stripe ACTUALLY holds
       // rather than the payload's, which may be superseded. Null only if the
@@ -942,7 +954,8 @@ export async function convergeOrgAddonPrices(
         // property STRUCTURAL — an exit added later inherits it by construction.
         //
         // "The next event repairs it" is worth nothing here: convergence fires
-        // only on a plan change, and #332's sweep does not exist yet.
+        // only on an event Stripe has a reason to emit for this group, and
+        // #332's sweep only reports — it never writes a row back.
         const idx = items.indexOf(item);
         if (idx >= 0) items[idx] = live;
         // Someone got there first — a purchase (setExtraOrgs re-prices AND
@@ -1115,6 +1128,317 @@ export async function maybeAlertOrgRepriceFailed(opts: {
       err,
     );
   }
+}
+
+/** One live extra-org rider found on a price that is NOT its group's plan rate
+ *  — or one the sweep could not price at all. The shape a staff list renders
+ *  and a manual Dashboard fix acts on. */
+export interface OrgAddonPriceMismatch {
+  /** The billing GROUP (subscriptions.id) — what a human looks up first. */
+  subscriptionId: string;
+  stripeSubscriptionId: string;
+  planKey: string;
+  /** The Stripe subscription ITEM. Always known here: the sweep starts from
+   *  org_addons rows, which are keyed on it. */
+  itemId: string;
+  /** What Stripe HOLDS. Null when the expected price could not be resolved, in
+   *  which case the item was never read — there was nothing to compare it to. */
+  currentPriceId: string | null;
+  /** The current plan's rider price, or null when the catalog could not name
+   *  one (unsynced) or the plan has no rider SKU at all. */
+  expectedPriceId: string | null;
+  /** How many organisations are riding at the wrong rate — the blast radius. */
+  qty: number;
+  reason: string;
+}
+
+/** How many mismatches one pass will EMAIL about. The full list is always
+ *  returned in `mismatches`, so nothing is lost by capping here; this only
+ *  bounds the inbox when a single systemic fault (an unsynced catalog) makes
+ *  every group in the database report at once. */
+export const ORG_PRICE_SWEEP_ALERT_CAP = 10;
+
+/**
+ * Periodic backstop for the extra-organisation rider's two rates (v17 gap
+ * #332). REPORTS, never repairs.
+ *
+ * WHY IT EXISTS. `convergeOrgAddonPrices` is the only thing that moves a rider
+ * onto its group's current rate, it runs ONLY on a
+ * `customer.subscription.created`/`.updated` delivery, and it deliberately
+ * never throws — so each of its reachable failures (an unsynced catalog, a
+ * currency outside the rider price's `currency_options` (the #191 class), a
+ * duplicate rider losing the target-price claim) ends in a log, a staff alert
+ * and a group left on the wrong price. Nothing SCHEDULES another event for that
+ * group, so "the next event re-converges it" buys nothing for a customer who
+ * never changes plan again. The alert covers the moment of failure; it does not
+ * cover a group that went stale before the alert existed, or one whose alert
+ * was missed. This is what covers those.
+ *
+ * The invariant is load-bearing rather than cosmetic: $9 on pro and $19 on
+ * pro_plus is what stops "Pro + riders" undercutting Pro Plus. A rider stuck on
+ * the pro price under a pro_plus plan IS that arbitrage; stuck the other way it
+ * is an overcharge. Either way it is a money fault, not a tidiness one.
+ *
+ * IT DOES NOT RE-PRICE, and that is the deliberate half of #332's third
+ * question. A sweep that repaired would be a BULK billing mutation — every
+ * fixed item bills a proration, unattended, against subscriptions whose owners
+ * are not present — and the fault that made them stale (an unsynced catalog, an
+ * unsupported currency) is very likely still present, so the repair would
+ * mostly fail and the successes would be the ones nobody vetted. Report first,
+ * read the list, then decide. Making it repair later is a change to this
+ * function, not to its callers.
+ *
+ * IT COMPARES PRICE IDS AGAINST LIVE STRIPE STATE, for two reasons. The DB
+ * records the rider's `stripe_item_id` and never its price, so there is nothing
+ * local to compare; and the whole failure class is "our idea of this
+ * subscription and Stripe's disagree", which a read of our own tables cannot
+ * see by construction. By ID and not by lookup key — the same comparison
+ * `convergeOrgAddonPrices` makes, and for the reason recorded there: a price
+ * REPLACED under the same lookup key is a genuinely different price that a
+ * key-wise comparison would call converged.
+ *
+ * COST is one `prices.list` per DISTINCT PLAN in the pass (memoised, not once
+ * per rider) plus one `subscriptionItems.retrieve` per live rider — and the
+ * working set is only groups that have BOUGHT an extra organisation, which is a
+ * small minority of subscriptions. `limit` bounds it hard.
+ *
+ * `total` IS NOT `checked`, AND THE GAP IS THE POINT. `limit` truncates a
+ * STABLE ordering (`a.created_at`), and unlike sweepStuckEvents' working set —
+ * which DRAINS, because a replayed row stops being stuck — this one does not: a
+ * rider stays live and re-selectable for ever, converged or not. So once the
+ * estate exceeds `limit`, the same oldest N are re-examined every pass and the
+ * NEWEST riders are never looked at, silently. Returning the unlimited count
+ * beside the examined one makes that visible (`checked < total` means this pass
+ * did not cover the estate) rather than leaving a backstop that has quietly
+ * stopped backing anything up. Both counts are read through ONE predicate
+ * builder for the same reason: a duplicated WHERE clause that drifted would make
+ * `total` a lie about the very thing it exists to police.
+ *
+ * NEVER THROWS ON A SINGLE ROW. One unreadable item must not abandon the rest
+ * of the sweep, so each Stripe read is caught and classified:
+ *  - `vanished`   — the item is gone from Stripe (`resource_missing`). Not a
+ *                   price fault and not alerted; the org_addons row outliving
+ *                   its item is a different bug with a different owner (#329).
+ *  - `unreadable` — any other Stripe failure. Explicitly NOT reported as a
+ *                   mismatch: a transient outage that rendered as "this group
+ *                   is billing the wrong rate" is exactly the false positive
+ *                   that teaches a responder to ignore the list.
+ *  - `unresolved` — we could not name the expected price (catalog unsynced, or
+ *                   a plan with no rider SKU at all). Reported and alerted,
+ *                   because a rider nobody can price is stale by definition.
+ *
+ * The DB read is deliberately gated on `LIVE_SUBSCRIPTION_STATUSES` and a
+ * non-null `stripe_subscription_id`: a canceled group keeps its Stripe id
+ * forever, and re-pricing (or paging anyone about) a departed customer's rider
+ * is noise. `status = 'active'` on the org_addons row excludes both the
+ * `canceled` freeze-not-delete rows and admin `granted` rows, which have no
+ * Stripe item and therefore no price to be wrong.
+ *
+ * REPEATS ITS ALERTS. There is no attempt counter to park a row with (unlike
+ * sweepStuckEvents, which has `replay_attempts`), so a group that stays broken
+ * is alerted again on the next pass. That is the intended behaviour for a money
+ * fault — it should nag until someone acts — and it is bounded by
+ * ORG_PRICE_SWEEP_ALERT_CAP per pass. The de-duplicated read is the /admin
+ * mismatch list (#332's second half), which renders `mismatches` directly.
+ */
+export async function sweepStaleOrgAddonPrices(limit = 500): Promise<{
+  total: number;
+  checked: number;
+  mismatched: number;
+  unresolved: number;
+  vanished: number;
+  unreadable: number;
+  alerted: number;
+  mismatches: OrgAddonPriceMismatch[];
+}> {
+  const mismatches: OrgAddonPriceMismatch[] = [];
+  let total = 0,
+    checked = 0,
+    mismatched = 0,
+    unresolved = 0,
+    vanished = 0,
+    unreadable = 0,
+    alerted = 0;
+  const done = () => ({
+    total,
+    checked,
+    mismatched,
+    unresolved,
+    vanished,
+    unreadable,
+    alerted,
+    mismatches,
+  });
+  // No Stripe account configured (CI, a local shell): there is nothing to
+  // compare against, and pretending otherwise would report every rider in the
+  // database as broken. Same guard, same reason, as sweepStuckEvents. `total`
+  // stays 0 rather than being counted anyway — nothing was examined, and a
+  // non-zero total beside a zero checked would read as a coverage failure.
+  if (!process.env.STRIPE_SECRET_KEY) return done();
+
+  // The ONE definition of "a rider whose price could be wrong", so the counted
+  // set and the examined set cannot drift. A fresh fragment per call rather than
+  // one shared value: each embedding binds its own parameters.
+  //
+  // `wallet_id` is TEXT with no FK (V323) — coalesce(group_subscription_id,
+  // org_id) — so the join casts rather than the column. An org-addon row for a
+  // GROUP always carries the subscription id, so an org-id wallet simply finds
+  // no row here and is skipped, which is correct: an ungrouped org has no
+  // Stripe subscription for a rider to ride.
+  const liveRiders = () => sql`
+      from org_addons a
+      join subscriptions s on s.id::text = a.wallet_id
+     where a.status = 'active'
+       and a.feature_key = ${ORG_ADDON_FEATURE_KEY}
+       and a.stripe_item_id is not null
+       and s.stripe_subscription_id is not null
+       and s.status in ${sql([...LIVE_SUBSCRIPTION_STATUSES])}`;
+
+  const [counted] = await sql<{ n: number }[]>`
+    select count(*)::int as n ${liveRiders()}`;
+  total = counted?.n ?? 0;
+
+  const rows = await sql<
+    {
+      subscription_id: string;
+      plan_key: string;
+      stripe_subscription_id: string;
+      stripe_item_id: string;
+      qty: number;
+    }[]
+  >`
+    select s.id::text as subscription_id, s.plan_key, s.stripe_subscription_id,
+           a.stripe_item_id, a.qty
+     ${liveRiders()}
+     order by a.created_at
+     limit ${limit}`;
+  if (total > rows.length) {
+    console.warn(
+      `[billing] extra-org rider sweep is TRUNCATED: ${rows.length} of ${total} live riders ` +
+        `examined this pass (limit ${limit}) — the newest riders are never reached`,
+    );
+  }
+
+  // One catalog lookup per DISTINCT plan, not per rider: every group on pro
+  // resolves the same price id, and `prices.list` is a network call. Memoised
+  // ACROSS FAILURES too — an unsynced catalog fails identically for every row,
+  // and retrying it per row would turn one outage into `limit` round trips.
+  const expectedByPlan = new Map<string, { priceId: string | null; reason: string }>();
+  async function expectedFor(planKey: string): Promise<{ priceId: string | null; reason: string }> {
+    const hit = expectedByPlan.get(planKey);
+    if (hit) return hit;
+    let result: { priceId: string | null; reason: string };
+    if (!orgAddonForPlan(planKey)) {
+      // Not a resolution failure — this plan HAS no rider SKU. Reachable
+      // because convergeOrgAddonPrices deliberately declines to cancel a rider
+      // on such a plan (removal belongs to the cancel paths), so a downgrade to
+      // community leaves a paid rider riding a plan that cannot price it. Today
+      // that state is invisible; naming it is the point of the sweep.
+      result = {
+        priceId: null,
+        reason:
+          `this group is on ${planKey}, which has no extra-organisation rider SKU, yet it is ` +
+          `still billed for one — nothing prices this item`,
+      };
+    } else {
+      try {
+        result = { priceId: await resolveOrgAddonPriceId(planKey), reason: "" };
+      } catch (err) {
+        result = {
+          priceId: null,
+          reason:
+            `the sweep could not resolve the ${planKey} rider price from the catalog — run ` +
+            `stripe:sync for this account: ${errText(err)}`,
+        };
+      }
+    }
+    expectedByPlan.set(planKey, result);
+    return result;
+  }
+
+  for (const row of rows) {
+    checked++;
+    const expected = await expectedFor(row.plan_key);
+    const base = {
+      subscriptionId: row.subscription_id,
+      stripeSubscriptionId: row.stripe_subscription_id,
+      planKey: row.plan_key,
+      itemId: row.stripe_item_id,
+      qty: row.qty,
+    };
+    if (!expected.priceId) {
+      // Nothing to compare against, so the item is deliberately NOT read: a
+      // round trip whose answer could not change the verdict.
+      unresolved++;
+      mismatches.push({
+        ...base,
+        currentPriceId: null,
+        expectedPriceId: null,
+        reason: expected.reason,
+      });
+      continue;
+    }
+    let live: Stripe.SubscriptionItem;
+    try {
+      live = await getStripe().subscriptionItems.retrieve(row.stripe_item_id);
+    } catch (err) {
+      if (isStripeResourceMissing(err)) {
+        vanished++;
+        console.warn(
+          `[billing] extra-org rider ${row.stripe_item_id} (group ${row.subscription_id}) is gone ` +
+            `from Stripe but its org_addons row is still active — no price to check`,
+        );
+        continue;
+      }
+      unreadable++;
+      console.error(
+        `[billing] could not read extra-org rider ${row.stripe_item_id} (group ` +
+          `${row.subscription_id}) — its rate is UNKNOWN this pass, not wrong`,
+        err,
+      );
+      continue;
+    }
+    if (live?.price?.id === expected.priceId) continue;
+    mismatched++;
+    mismatches.push({
+      ...base,
+      currentPriceId: live?.price?.id ?? null,
+      expectedPriceId: expected.priceId,
+      reason:
+        `reconciliation sweep: this rider is on ${live?.price?.id ?? "an unknown price"} but the ` +
+        `group's ${row.plan_key} plan bills ${expected.priceId} — convergence never completed and ` +
+        `nothing will retry it`,
+    });
+  }
+
+  // Logged for EVERY mismatch (the record when staff email is not configured);
+  // emailed for the first ORG_PRICE_SWEEP_ALERT_CAP only.
+  for (const m of mismatches) {
+    console.error(
+      `[billing] stale extra-org rider ${m.itemId} (qty ${m.qty}) on subscription ` +
+        `${m.stripeSubscriptionId} (group ${m.subscriptionId}, plan ${m.planKey}): ` +
+        `${m.currentPriceId ?? "unknown"} != ${m.expectedPriceId ?? "unresolved"} — ${m.reason}`,
+    );
+  }
+  // The env is re-read here rather than left to maybeAlertOrgRepriceFailed's own
+  // gate so the returned `alerted` counts what was actually attempted; a counter
+  // that incremented on a call the callee no-ops would report sends that never
+  // happened, and this number is what a cron response is judged on.
+  if (process.env.STAFF_ALERT_EMAIL) {
+    for (const m of mismatches.slice(0, ORG_PRICE_SWEEP_ALERT_CAP)) {
+      await maybeAlertOrgRepriceFailed({
+        subscriptionId: m.subscriptionId,
+        stripeSubscriptionId: m.stripeSubscriptionId,
+        planKey: m.planKey,
+        itemId: m.itemId,
+        currentPriceId: m.currentPriceId,
+        expectedPriceId: m.expectedPriceId,
+        reason: m.reason,
+      });
+      alerted++;
+    }
+  }
+  return done();
 }
 
 /**

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -12,6 +12,7 @@ import "server-only";
 // club's own bank account with its own KYC, and regrouping who pays for the
 // SOFTWARE has no effect on money in or out. Nothing in this file touches it.
 import type Stripe from "stripe";
+import type postgres from "postgres";
 import { sql } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { getStripe } from "@/lib/stripe";
@@ -869,6 +870,68 @@ export interface DetachResult {
 export type DetachMode = "ride_out" | "release";
 
 /**
+ * Record that a `ride_out` detach handed `orgId` a free period of a paid plan
+ * (#306). The grant itself is nothing but two column values on a brand-new
+ * subscriptions row — `plan_key` and `comped_until` — which say what the org
+ * ended up with but not that anyone granted it, who, when, or off whose
+ * subscription. And it IS a grant at somebody else's expense: the old payer
+ * keeps paying for the period, the departed org keeps using it, and the seat is
+ * spent, so re-adding that org is charged again.
+ *
+ * The sibling of `auditWalletForfeitedOnDetach` (#285) — same table, same
+ * shape, same reason. That one exists because a silent WALLET outcome was
+ * unacceptable; a comped plan is the same problem for a different asset. It
+ * lives HERE rather than beside it in lib/credits.ts because no credits are
+ * involved: this is plan entitlement, and credits.ts owns the ledger.
+ *
+ * `staff_audit_log` (V103), not `billing_events`: billing_events is the Stripe
+ * INGEST table, keyed by the Stripe event id it dedupes on (`id text primary
+ * key`, webhook body in `payload`), so a synthetic row there would invent an
+ * event Stripe never sent and squat on that dedupe key. staff_audit_log is the
+ * schema's only generic actor+target+detail sink and its `actor_id` carries no
+ * `is_staff` constraint — the argument #285 already made. Unlike sponsors.ts's
+ * actorless org-wide packages, a detach ALWAYS has a real user behind it
+ * (`actorUserId` is required and authorised above), so the NOT NULL `actor_id`
+ * is satisfied honestly rather than by proxy.
+ *
+ * `inherited_from` is not decoration. The `coalesce(current_period_end,
+ * comped_until)` below erases which date won, and the two are very different
+ * money: a period a customer actually paid for, versus a comp staff granted by
+ * hand. Only this field can tell a reader which one was passed on.
+ */
+async function auditCompGrantedOnDetach(
+  tx: postgres.TransactionSql,
+  a: {
+    actorUserId: string;
+    orgId: string;
+    oldGroupId: string;
+    newGroupId: string;
+    payerUserId: string;
+    planKey: string;
+    compedUntil: string;
+    inheritedFrom: "current_period_end" | "comped_until";
+    mode: DetachMode;
+  },
+): Promise<void> {
+  await tx`
+    insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+    values (${a.actorUserId}, 'billing_group.detach_comp_granted', 'org', ${a.orgId},
+            ${tx.json({
+              old_group_id: a.oldGroupId,
+              new_group_id: a.newGroupId,
+              // Who is out of pocket. The actor is often the LEAVER's owner, not
+              // the payer, so a row carrying only actor_id names the wrong party.
+              payer_user_id: a.payerUserId,
+              plan_key: a.planKey,
+              // Normalised here: the driver hands timestamptz back as a Date,
+              // and JSON.stringify would render one shape and a string another.
+              comped_until: new Date(a.compedUntil).toISOString(),
+              inherited_from: a.inheritedFrom,
+              mode: a.mode,
+            } as never)})`;
+}
+
+/**
  * Move `orgId` out of its billing group and onto a fresh one of its own.
  *
  * EITHER SIDE may initiate: the group's payer can push an org out, and the
@@ -980,6 +1043,15 @@ export async function detachOrgFromGroup(args: {
         : null;
     // No expiry date means no paid plan. Community is the only safe landing.
     const planKey = compedUntil ? group.plan_key : "community";
+    // Which of the two dates the coalesce above actually took. current_period_end
+    // wins when present, so its presence is the whole test. Recorded in the audit
+    // row because the coalesce is otherwise lossy — see auditCompGrantedOnDetach.
+    const inheritedFrom =
+      compedUntil == null
+        ? null
+        : group.current_period_end != null
+          ? ("current_period_end" as const)
+          : ("comped_until" as const);
 
     const [fresh] = await tx<{ id: string }[]>`
       insert into subscriptions
@@ -988,6 +1060,22 @@ export async function detachOrgFromGroup(args: {
               ${compedUntil}, ${group.trial_used_at}, now())
       returning id`;
     await tx`update organizations set subscription_id = ${fresh.id} where id = ${orgId}`;
+    // #306: a ride_out just minted a free paid period at the payer's expense.
+    // Only when one was ACTUALLY handed out — a release, or a group too far into
+    // dunning to hand anything on, grants nothing, and a trail that fired on
+    // every detach could not be read as "these orgs got free plan time".
+    if (compedUntil != null && inheritedFrom)
+      await auditCompGrantedOnDetach(tx, {
+        actorUserId,
+        orgId,
+        oldGroupId: group.id,
+        newGroupId: fresh.id,
+        payerUserId: group.owner_user_id,
+        planKey,
+        compedUntil,
+        inheritedFrom,
+        mode,
+      });
     // #285 decided the default: a departing org takes no share of the group's
     // pool, because a shared wallet has no per-org share to split off — just an
     // audit trail of what was left behind, for accountability.

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -546,6 +546,7 @@ interface CancelClaim {
   prev_plan: string;
   prev_comped: Date | null;
   prev_qty: number;
+  prev_cancel_at_period_end: boolean;
   stripe_subscription_id: string | null;
 }
 
@@ -558,7 +559,8 @@ async function cancelGroupIfEmpty(
     // the rollback below.
     const [prev] = await tx<CancelClaim[]>`
       select status as prev_status, plan_key as prev_plan, comped_until as prev_comped,
-             quantity_paid as prev_qty, stripe_subscription_id
+             quantity_paid as prev_qty, cancel_at_period_end as prev_cancel_at_period_end,
+             stripe_subscription_id
         from subscriptions where id = ${subscriptionId} for update`;
     if (!prev) return null;
     // Statement 2, and a NEW snapshot with it: this is where an attach that
@@ -588,10 +590,22 @@ async function cancelGroupIfEmpty(
       // Put it back exactly as it was. A row left saying `canceled` while Stripe
       // keeps charging is the worst outcome: it drops out of every
       // live-subscription filter, including the sweep's, so nothing retries.
+      //
+      // #315: `cancel_at_period_end` restores with the rest. The claim clears it
+      // because a group being cancelled OUTRIGHT has no period left to cancel at
+      // — but that reasoning only holds if the outright cancel lands. When
+      // Stripe refuses, the flag reverts to what it was, and what it was is the
+      // customer's standing instruction to stop billing at the period boundary,
+      // recorded nowhere else. Dropping it leaves a live, billable subscription
+      // that is no longer scheduled to end while the customer believes they
+      // cancelled — a worse state than never having attempted the cancel, and
+      // the one column here no reconcile sweep can rebuild, because intent
+      // cannot be re-derived from Stripe's or our own remaining state.
       await sql`
         update subscriptions
            set status = ${claimed.prev_status}, plan_key = ${claimed.prev_plan},
                comped_until = ${claimed.prev_comped}, quantity_paid = ${claimed.prev_qty},
+               cancel_at_period_end = ${claimed.prev_cancel_at_period_end},
                updated_at = now()
          where id = ${subscriptionId}`;
       console.error("cancelGroupIfEmpty: Stripe cancel failed", subscriptionId, err);

--- a/apps/web/src/server/usecases/billing-manage.ts
+++ b/apps/web/src/server/usecases/billing-manage.ts
@@ -1,9 +1,12 @@
 import "server-only";
 import type Stripe from "stripe";
+import { headers } from "next/headers";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { getActiveOrgId, requireUser } from "@/lib/auth";
+import { ORG_SCOPE_HEADER } from "@/lib/org-scope";
+import { orgBySlug } from "@/server/slug-resolve";
 import {
   syncPaymentMethodFlag,
   syncPaymentMethodFlagFromCards,
@@ -108,9 +111,52 @@ export async function segmentsForGroup(subscriptionId: string): Promise<PayerSeg
 }
 
 /**
+ * The org this REQUEST is for, from its own `x-seazn-org` header (v17 gap
+ * #334), or null when it carries none.
+ *
+ * The header is stamped by the client seams from the console URL the user is
+ * actually looking at, so it cannot lag the way `seazn_org` does — the cookie
+ * is corrected by an effect that runs after the destination page has painted,
+ * and a save inside that window used to be applied to the PREVIOUS group.
+ *
+ * A header that names nothing is a 400, never a fall back to the cookie: a
+ * silent fall back is exactly the bug, and it would come back the moment a
+ * slug went stale. 400 is the same class, and carries the same remedy ("pick an
+ * organisation again"), as a stale cookie.
+ *
+ * This resolves WHICH group, and nothing else — `requireBillingOwner`'s payer
+ * gate below is unchanged, so a forged header can only ever name a group the
+ * caller already pays for.
+ */
+async function requestScopedOrgId(): Promise<string | null> {
+  let slug: string | null = null;
+  try {
+    slug = (await headers()).get(ORG_SCOPE_HEADER);
+  } catch {
+    // No request scope at all (a cron job, a script). Nothing to prefer.
+    return null;
+  }
+  if (!slug) return null;
+  const resolved = await orgBySlug(slug);
+  // A renamed slug still identifies the org — one more hop, because the client
+  // may have been rendered before the rename. Anything beyond that is a slug
+  // the product does not know.
+  const settled = resolved && "renamedTo" in resolved ? await orgBySlug(resolved.renamedTo) : resolved;
+  if (!settled || "renamedTo" in settled) {
+    throw new HttpError(400, "No billing account for the selected organization.");
+  }
+  return settled.id;
+}
+
+/**
  * Payer-gated context shared by every manage route. Session auth comes FIRST so
  * an unauthenticated caller (e.g. a developer API key — these routes never read
  * Authorization) gets a clean 401, not a 400 about org state.
+ *
+ * WHICH group comes from the REQUEST when it names one (`x-seazn-org`, v17 gap
+ * #334) and from the `seazn_org` cookie otherwise. The two answers differ for
+ * exactly as long as the cookie lags the URL, and during that window the
+ * cookie's answer is the wrong bill.
  *
  * Gates on `subscriptions.owner_user_id`, NOT on the active org's owner role.
  * Billing belongs to the GROUP: a county association may pay for eight member
@@ -128,7 +174,7 @@ export async function requireBillingOwner(): Promise<{
   subscriptionId: string;
 }> {
   const user = await requireUser();
-  const orgId = await getActiveOrgId();
+  const orgId = (await requestScopedOrgId()) ?? (await getActiveOrgId());
   if (!orgId) throw new HttpError(400, "No active organization");
   // NOT requireSubscriptionIdForOrg: that raises 500 ("no billing group"),
   // which is right for an internal invariant but wrong here — the org id comes

--- a/apps/web/src/server/usecases/billing-manage.ts
+++ b/apps/web/src/server/usecases/billing-manage.ts
@@ -67,7 +67,7 @@ interface SubRow {
   currency: string | null;
 }
 
-/** The billing GROUP behind an org (V310) — many orgs may share one row. */
+/** The billing GROUP behind an org (V314) — many orgs may share one row. */
 async function subRow(orgId: string): Promise<SubRow | null> {
   const [sub] = await sql<SubRow[]>`
     select s.id, s.owner_user_id, s.plan_key, s.status, s.stripe_customer_id,

--- a/apps/web/src/server/usecases/credits-tab.ts
+++ b/apps/web/src/server/usecases/credits-tab.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { sql } from "@/lib/db";
 import { balance, packBalance, utcMonthStart, walletIdFor } from "@/lib/credits";
+import { orgPlanKey } from "@/lib/entitlements";
 import { getOrCreateReferralCode } from "@/lib/referral";
 
 /**
@@ -40,15 +41,20 @@ export interface CreditHistoryRow {
 export interface CreditsTabView {
   /** Pooled balance = `sum(ledger.delta)` (grant + pack). */
   balance: number;
-  /** Grant credits consumed this period = this month's grant-bucket `run_spend`,
-   *  clamped to [0, grantCap]. NOT `grantCap − grantBalance`: a never-granted org
-   *  has grantBalance 0 yet has used nothing, which that formula would misreport as
+  /** Grant credits consumed this period = this month's grant-bucket `run_spend`
+   *  NET of the refunds released against those holds (#319), clamped to
+   *  [0, grantCap]. NOT `grantCap − grantBalance`: a never-granted org has
+   *  grantBalance 0 yet has used nothing, which that formula would misreport as
    *  a full meter. */
   grantUsed: number;
-  /** This period's monthly grant = `ai.credits.monthly(plan) * quantity`, where
-   *  quantity is what `grantMonthlyForAllWallets` grants on: 1 for Community
-   *  (flat, never seat-scaled — SPEC-2 §11.2), `max(quantityPaid, live orgs)`
-   *  while the sub is TRIALING (#291), else `quantityPaid`. */
+  /** This period's monthly grant = `ai.credits.monthly(plan) * quantity`, both
+   *  factors taken from `grantMonthlyForAllWallets`'s own rule so the tab can
+   *  never quote a cap the sweep will not grant. PLAN is `orgPlanKey`'s
+   *  RESOLVED answer for the group's representative org, not the raw
+   *  `plan_key` (#318) — a suspended / past_due-beyond-grace / expired-comp
+   *  wallet reads Community. QUANTITY is 1 for Community (flat, never
+   *  seat-scaled — SPEC-2 §11.2), `max(quantityPaid, live orgs)` while the sub
+   *  is TRIALING (#291), else `quantityPaid`. */
   grantCap: number;
   /** Whole days until the calendar-month reset `grantMonthly` anchors on. */
   grantResetsInDays: number;
@@ -165,16 +171,36 @@ export async function creditHistory(walletId: string, limit = HISTORY_LIMIT): Pr
 export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
   const walletId = await walletIdFor(orgId);
 
-  const [plan] = await sql<{ plan_key: string; quantity_paid: number; status: string | null }[]>`
-    select coalesce(s.plan_key, 'community') as plan_key,
-           coalesce(s.quantity_paid, 1) as quantity_paid,
-           s.status
+  const [plan] = await sql<{ quantity_paid: number; status: string | null; rep_org_id: string }[]>`
+    select coalesce(s.quantity_paid, 1) as quantity_paid,
+           s.status,
+           coalesce(rep.id, o.id) as rep_org_id
       from organizations o
       left join subscriptions s on s.id = o.subscription_id
+      left join lateral (
+        select r.id from organizations r
+         where r.subscription_id = s.id and r.deleted_at is null
+         order by (r.status = 'suspended'), r.created_at
+         limit 1
+      ) rep on true
      where o.id = ${orgId}`;
-  const planKey = plan?.plan_key ?? "community";
   const quantityPaid = plan?.quantity_paid ?? 1;
   const trialing = plan?.status === "trialing";
+  // #318: the PLAN the sweep will actually grant on, not the raw `s.plan_key`.
+  // `orgPlanKey` degrades a suspended / past_due-beyond-grace / expired-comp /
+  // cancelled wallet to Community, so reading the raw column told a wallet
+  // that had just been granted 10 that its cap was 60.
+  //
+  // Resolved on the group's REPRESENTATIVE org — the `rep` lateral above is
+  // `grantMonthlyForAllWallets`'s own, verbatim (oldest live org, a suspended
+  // one only if every member is suspended), and carries the same hand-sync
+  // obligation as that copy and `groupOrgLimit`'s. Resolving on the VIEWING
+  // org instead would be wrong in the opposite direction: moderation
+  // suspension is deliberately scoped to one org, so a suspended member
+  // would read a Community cap for a pool its siblings still fund at Pro.
+  // For an ungrouped org the lateral finds nothing and `coalesce` falls back
+  // to the org itself, which is also the org that answers for its own wallet.
+  const planKey = await orgPlanKey(plan?.rep_org_id ?? orgId);
 
   const [entitlement] = await sql<{ int_value: number | null }[]>`
     select int_value from plan_entitlements
@@ -198,10 +224,27 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
       // PARAMETER (#292) — `date_trunc('month', now())` truncated in the DB
       // session's TimeZone (Europe/London in prod), so a spend at 23:30 UTC on
       // the last of the month counted into the NEXT month's meter.
+      //
+      // NET of refunds (#319), by the SAME ref-correlated subquery
+      // `spentThisPeriodByOrg` (credits.ts) nets the operator allocation cap
+      // with: a failed run's `release()` writes a `source='refund'` row with
+      // `ref = hold.id` and no `spent_by_org_id`, so the only way to see it is
+      // to net each hold by the refund rows pointing AT it. Summing gross
+      // `run_spend` left a released run reading as "used this month" for the
+      // rest of the month while the cap had already given it back — one
+      // quantity, two derives, three lines apart, disagreeing. A pack refund
+      // also uses `source='refund'` but its `ref` is a payment-intent id and
+      // can never match a `run_spend` row id, so it cannot leak in here.
       sql<{ used: string | null }[]>`
-      select coalesce(sum(-delta), 0)::text as used from ai_credit_ledger
-       where wallet_id = ${walletId} and bucket = 'grant' and source = 'run_spend'
-         and created_at >= ${periodStart}`,
+      select coalesce(sum(
+        -h.delta - coalesce((
+          select sum(r.delta) from ai_credit_ledger r
+           where r.source = 'refund' and r.ref = h.id::text
+        ), 0)
+      ), 0)::text as used
+        from ai_credit_ledger h
+       where h.wallet_id = ${walletId} and h.bucket = 'grant' and h.source = 'run_spend'
+         and h.created_at >= ${periodStart}`,
       creditHistory(walletId),
       sql<{ n: number }[]>`
       select count(*)::int as n from organizations
@@ -228,14 +271,10 @@ export async function getCreditsTab(orgId: string): Promise<CreditsTabView> {
   // docstring for the full rule). Reading the frozen count alone showed a
   // trialing group with a mid-trial rider "70 used / 60".
   //
-  // KNOWN DIVERGENCE, quantity only — the PLAN dimension is NOT unified: this
-  // reads the raw `s.plan_key` from the `plan` query above while the sweep
-  // resolves it through
-  // `orgPlanKey`, which degrades a suspended / past_due>14d / expired-comp
-  // wallet to Community. So a suspended Pro org is granted 10 but this tab
-  // still shows a cap of 60. Display-level only (the ledger and every spend
-  // path use the resolved plan); deliberately left for a follow-up rather than
-  // changed here, since switching it changes what customers see.
+  // PLAN follows it too, since #318: `planKey` above is `orgPlanKey`'s
+  // resolved answer for the group's representative org, so both dimensions of
+  // this cap are now the sweep's own — there is no derive left here that the
+  // grant cron does not share.
   const grantCap =
     perSeat *
     (planKey === "community" ? 1 : trialing ? Math.max(quantityPaid, sharedOrgCount) : quantityPaid);

--- a/apps/web/src/server/usecases/pass-credit.ts
+++ b/apps/web/src/server/usecases/pass-credit.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type Stripe from "stripe";
 import { getStripe } from "@/lib/stripe";
 import { sql } from "@/lib/db";
+import { HttpError } from "@/lib/errors";
 import { sendPassCreditReversalIncompleteAlertEmail } from "@/lib/email";
 import type { PassKey } from "@/lib/currency";
 
@@ -706,4 +707,294 @@ export async function reversePassCreditOnRefund(
       }).catch(() => {});
     }
   }
+}
+
+/* ────────────────────────────────────────────────────────────────────────────
+ * §6 — STAFF RESOLUTION of an undetermined reversal (#305, #286 phase 2)
+ *
+ * V337 (phase 1) made the undetermined branch hold `pass_credit_redemptions_
+ * group_cap` PERMANENTLY: `reversed_at` is stamped (it is still the webhook
+ * idempotency guard) but nothing was actually clawed back, so the widened
+ * partial index keeps treating the row as live. That is the right default —
+ * the customer provably still holds the £/$ credit, and freeing the cap would
+ * let the same group mint a SECOND one — but phase 1 shipped with no way out.
+ * Once staff settle the balance by hand in the Stripe dashboard, the row went
+ * on blocking the group forever and the alert email said so in as many words.
+ *
+ * This is the way out. Two design rules, both load-bearing:
+ *
+ *  1. **Both outcomes are expressible.** `clawed_back` ("I removed the credit
+ *     in Stripe") releases the cap; `kept` ("the customer keeps it") leaves
+ *     the cap held and records that a human decided so. A tool offering only
+ *     the first is a lever for handing out a second credit; one offering only
+ *     the second cannot resolve anything. Neither is the safe default, so
+ *     neither is a default — the caller must say which.
+ *  2. **Nothing here touches Stripe.** The claw-back this records ALREADY
+ *     HAPPENED, by hand, which is the only reason a human is in the loop at
+ *     all: the undetermined branch exists precisely because the balance pool
+ *     could not be attributed automatically. Creating a balance transaction
+ *     from here would debit a customer whose money was already taken back.
+ *
+ * The write and its `staff_audit_log` row commit TOGETHER (the admin-addons.ts
+ * / #272 adminAdjust pattern) — a crash between them could otherwise free a
+ * money-bearing cap with nobody's name against it, and the audit row is the
+ * ONLY record of who decided and which way (`reversal_undetermined_at` going
+ * NULL says the decision happened, not who made it).
+ *
+ * NO entitlement-cache invalidation is needed here, deliberately and checked:
+ * `pass_credit_redemptions` is read in exactly one place outside this file's
+ * own reversal lookup — `groupAlreadyRedeemed`, called live inside
+ * `creditPassTowardSubscription` on the checkout path. It feeds no
+ * `lib/entitlements.resolve()` branch and no `ent:<org>:*` cache key, so there
+ * is no TTL window in which a resolved row keeps behaving as unresolved.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * What a human concluded about an undetermined reversal.
+ *
+ * - `clawed_back` — staff removed the credit from the customer's Stripe
+ *   balance themselves. The money is back, so the group's lifetime cap must be
+ *   released: `reversal_undetermined_at` is cleared and `reversed_minor` is
+ *   corrected to what was actually taken.
+ * - `kept` — the customer keeps the credit (goodwill, un-splittable pool,
+ *   whatever finance decided). The cap must GO ON holding, exactly as before;
+ *   all that changes is that the row is no longer an unanswered question.
+ */
+export type PassCreditReversalResolution = "clawed_back" | "kept";
+
+/** `open` = nobody has decided yet. Otherwise the decision that was recorded. */
+export type PassCreditReversalStatus = "open" | PassCreditReversalResolution;
+
+/**
+ * `staff_audit_log.action` for a resolution. Exported so the admin surface and
+ * the tests agree on the string rather than each spelling it out — this is the
+ * only durable record of WHO decided, so a typo on one side silently splits
+ * the history in two.
+ */
+export const PASS_CREDIT_RESOLVE_ACTION = "pass_credit_reversal_resolve";
+
+export interface PassCreditReversalResolveInput {
+  resolution: PassCreditReversalResolution;
+  /**
+   * Minor units staff actually removed from the customer balance in Stripe.
+   * REQUIRED for `clawed_back` and bounded by the grant: the undetermined
+   * branch wrote `reversed_minor = 0` (nothing moved), and leaving that 0 while
+   * releasing the cap would leave the row claiming a reversal of nothing.
+   * Ignored for `kept`, where nothing moved and 0 is the truth.
+   */
+  reversedMinor?: number;
+  /** Free text — what staff checked, and where. Stored in the audit detail. */
+  reason: string;
+}
+
+/**
+ * Record a staff decision about ONE undetermined redemption.
+ *
+ * Unlike the other two exports in this file, this one THROWS: it is a staff
+ * action behind an admin route, not a webhook or checkout path, so a refusal
+ * must reach the operator as a typed error rather than be swallowed into a
+ * silent no-op.
+ *
+ * Idempotent on replay (double-clicked button, retried request): re-recording
+ * the decision the row already carries returns `{ resolved: false }` and writes
+ * NO second audit row — a duplicate there reads as two separate decisions.
+ * Changing one's mind is NOT a replay: a `kept` row can still be resolved
+ * `clawed_back` later when finance does take the money back, and that writes a
+ * second, genuine audit row.
+ *
+ * @returns whether this call actually recorded a decision.
+ * @throws HttpError 404 unknown redemption, 409 nothing undetermined to
+ *   resolve, 422 a claw-back amount that is not 0..grant.
+ */
+export async function resolveUndeterminedPassCreditReversal(
+  actorId: string,
+  redemptionId: string,
+  input: PassCreditReversalResolveInput,
+): Promise<{ resolved: boolean }> {
+  const { resolution, reason } = input;
+
+  return sql.begin(async (tx) => {
+    // `for update` serialises two operators (or one double-click) on the same
+    // row: without it both can read `reversal_undetermined_at` as set and both
+    // write an audit row for a single decision.
+    const [row] = await tx<
+      { id: string; org_id: string; amount_minor: number; reversal_undetermined_at: Date | null }[]
+    >`
+      select id, org_id, amount_minor, reversal_undetermined_at
+        from pass_credit_redemptions where id = ${redemptionId} for update`;
+    if (!row) throw new HttpError(404, "No such pass credit redemption.");
+
+    // The last decision recorded for this row, if any. There is no column for
+    // it — the audit log IS the record (see the §6 header) — so the replay
+    // guard reads it back from there.
+    const [prior] = await tx<{ resolution: string | null }[]>`
+      select detail->>'resolution' as resolution
+        from staff_audit_log
+       where action = ${PASS_CREDIT_RESOLVE_ACTION}
+         and detail->>'redemption_id' = ${redemptionId}
+       order by created_at desc, chain_seq desc
+       limit 1`;
+
+    if (row.reversal_undetermined_at === null) {
+      // Cap already free. Either this exact decision already landed (replay),
+      // or the row was never undetermined at all — an ordinary automatic
+      // reversal, which has nothing for a human to decide.
+      if (prior?.resolution === "clawed_back") return { resolved: false };
+      throw new HttpError(409, "This redemption has no undetermined reversal to resolve.");
+    }
+
+    let reversedMinor = 0;
+    if (resolution === "clawed_back") {
+      const claimed = input.reversedMinor;
+      if (!Number.isInteger(claimed) || claimed! < 0 || claimed! > row.amount_minor) {
+        throw new HttpError(
+          422,
+          `reversed_minor must be a whole number between 0 and the ${row.amount_minor} minor units originally granted.`,
+        );
+      }
+      reversedMinor = claimed!;
+      // THE release. `reversed_at` is deliberately untouched — it is the
+      // webhook-replay idempotency stamp, not a statement about money.
+      await tx`
+        update pass_credit_redemptions
+           set reversal_undetermined_at = null, reversed_minor = ${reversedMinor}
+         where id = ${redemptionId}`;
+    } else if (prior?.resolution === "kept") {
+      // Already reviewed and left standing — nothing changed, so nothing to log.
+      return { resolved: false };
+    }
+    // `kept` writes no column at all: the cap stays held exactly as V337 left
+    // it, and the audit row below is the whole of the change.
+
+    // Mirror logStaffAction's columns (lib/admin.ts) on THIS tx — never call
+    // logStaffAction itself here, it opens its own connection outside the tx.
+    // target_type 'org' / target_id the org: that is the entity an operator
+    // looks the decision up by, and the redemption is identified in `detail`.
+    await tx`
+      insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
+      values (${actorId}, ${PASS_CREDIT_RESOLVE_ACTION}, 'org', ${row.org_id}, ${tx.json({
+        redemption_id: redemptionId,
+        resolution,
+        reversed_minor: reversedMinor,
+        granted_minor: row.amount_minor,
+        reason,
+      } as never)})`;
+    return { resolved: true };
+  });
+}
+
+/** One undetermined (or since-resolved) redemption, for the staff worklist. */
+export interface UndeterminedPassCreditReversal {
+  id: string;
+  paymentIntent: string;
+  orgId: string;
+  orgName: string | null;
+  competitionName: string | null;
+  subscriptionId: string;
+  amountMinor: number;
+  reversedMinor: number | null;
+  currency: string;
+  redeemedAt: string;
+  reversedAt: string | null;
+  /** NULL once resolved `clawed_back`; still set for `open` and for `kept`. */
+  undeterminedAt: string | null;
+  status: PassCreditReversalStatus;
+  resolvedAt: string | null;
+  resolvedBy: string | null;
+  resolvedByName: string | null;
+  reason: string | null;
+}
+
+const UNDETERMINED_LIST_LIMIT = 200;
+
+/**
+ * The staff worklist the issue's inventory query (`select * from
+ * pass_credit_redemptions where reversal_undetermined_at is not null`) was a
+ * stand-in for, joined to the decision each row carries.
+ *
+ * Includes THREE states, not one:
+ *  - `open`        — still undetermined, nobody has decided. Cap held.
+ *  - `kept`        — decided: customer keeps the credit. Cap held ON PURPOSE.
+ *  - `clawed_back` — decided: staff took it back. Cap released.
+ *
+ * A `clawed_back` row no longer matches the inventory query at all, so it is
+ * reached through its audit row instead — dropping it would make the tool look
+ * like it had erased the record of its own most consequential action.
+ * Unresolved rows sort first: the whole value of the list is the queue.
+ */
+export async function listUndeterminedPassCreditReversals(): Promise<
+  UndeterminedPassCreditReversal[]
+> {
+  const rows = await sql<
+    {
+      id: string;
+      payment_intent: string;
+      org_id: string;
+      org_name: string | null;
+      competition_name: string | null;
+      subscription_id: string;
+      amount_minor: number;
+      reversed_minor: number | null;
+      currency: string;
+      redeemed_at: Date;
+      reversed_at: Date | null;
+      reversal_undetermined_at: Date | null;
+      resolution: string | null;
+      resolved_at: Date | null;
+      resolved_by: string | null;
+      resolved_by_name: string | null;
+      reason: string | null;
+    }[]
+  >`
+    select r.id, r.payment_intent, r.org_id, o.name as org_name,
+           c.name as competition_name, r.subscription_id, r.amount_minor,
+           r.reversed_minor, r.currency, r.redeemed_at, r.reversed_at,
+           r.reversal_undetermined_at,
+           a.detail->>'resolution' as resolution,
+           a.created_at as resolved_at,
+           a.actor_id::text as resolved_by,
+           coalesce(u.display_name, u.email) as resolved_by_name,
+           a.detail->>'reason' as reason
+      from pass_credit_redemptions r
+      left join organizations o on o.id = r.org_id
+      left join competitions c on c.id = r.competition_id
+      left join lateral (
+        select s.actor_id, s.created_at, s.detail
+          from staff_audit_log s
+         where s.action = ${PASS_CREDIT_RESOLVE_ACTION}
+           and s.detail->>'redemption_id' = r.id::text
+         order by s.created_at desc, s.chain_seq desc
+         limit 1
+      ) a on true
+      left join users u on u.id = a.actor_id
+     where r.reversal_undetermined_at is not null or a.actor_id is not null
+     order by (a.actor_id is not null),
+              coalesce(r.reversal_undetermined_at, a.created_at) desc
+     limit ${UNDETERMINED_LIST_LIMIT}`;
+
+  return rows.map((r) => ({
+    id: r.id,
+    paymentIntent: r.payment_intent,
+    orgId: r.org_id,
+    orgName: r.org_name,
+    competitionName: r.competition_name,
+    subscriptionId: r.subscription_id,
+    amountMinor: r.amount_minor,
+    reversedMinor: r.reversed_minor,
+    currency: r.currency,
+    redeemedAt: new Date(r.redeemed_at).toISOString(),
+    reversedAt: r.reversed_at ? new Date(r.reversed_at).toISOString() : null,
+    undeterminedAt: r.reversal_undetermined_at
+      ? new Date(r.reversal_undetermined_at).toISOString()
+      : null,
+    // An unrecognised stored value must not be dressed up as a decision.
+    status:
+      r.resolution === "clawed_back" || r.resolution === "kept"
+        ? (r.resolution as PassCreditReversalResolution)
+        : "open",
+    resolvedAt: r.resolved_at ? new Date(r.resolved_at).toISOString() : null,
+    resolvedBy: r.resolved_by,
+    resolvedByName: r.resolved_by_name,
+    reason: r.reason,
+  }));
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -72,6 +72,24 @@ export default defineConfig({
   test: {
     environment: "node",
     pool: "threads",
+    // Most of this suite talks to a real Postgres, and vitest's 5s default is
+    // not a budget those tests were ever written against — a loaded runner
+    // turns an honest 6s query into a red build. The repo's habit was to pass
+    // `--testTimeout=30000` by hand, but CI runs a bare `npm test`, so the
+    // habit protected local runs and not the one that gates merges.
+    //
+    // #363 removed a set of inline `{ timeout: 20000 }` pins on exactly that
+    // reasoning — "let the repo-wide convention govern". This is the line that
+    // makes such a convention exist. Without it, dropping the pins LOWERED
+    // those tests from 20s to 5s in CI, which is the opposite of the intent.
+    //
+    // Set here rather than per-test on purpose: an inline timeout silently
+    // OVERRIDES `--testTimeout`, so a file that pins its own is a file whose
+    // timeout nobody can tune from the outside. That was the whole defect
+    // behind #363 — someone hits a CI timeout, passes the flag, watches it fail
+    // identically, and concludes the test hangs.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     // Warns once when DATABASE_URL is absent: the DB suites then SKIP and the
     // run still exits 0, which has already been misread as a pass. See the file.
     globalSetup: ["./vitest.globalSetup.ts"],

--- a/scripts/backfill-pass-credit-redemptions.ts
+++ b/scripts/backfill-pass-credit-redemptions.ts
@@ -100,12 +100,42 @@ export async function groupAlreadyCapped(
   sql: ReturnType<typeof postgres>,
   subscriptionId: string,
 ): Promise<boolean> {
-  const [row] = await sql<{ one: number }[]>`
-    select 1 as one from pass_credit_redemptions
+  return (await describeCapStatus(sql, subscriptionId)) !== "free";
+}
+
+/**
+ * Which of the two opposite states the cap index is holding for this group,
+ * if any:
+ *   - "free" — no row counts against the cap, nothing to backfill/report.
+ *   - "capped_healthy" — a LIVE credit is holding the cap. This is the cap
+ *     doing exactly its job; healthy.
+ *   - "capped_undetermined" — the cap's one row is an UNDETERMINED reversal
+ *     (webhook fired, `reversed_at` stamped, but `reversal_undetermined_at`
+ *     says the money was never actually clawed back — V337 / #286 / #291).
+ *     BLOCKED, not healthy: nobody has decided what happens to that credit.
+ *
+ * #307: the backfill's summary used to fold both capped arms into a single
+ * "already capped" counter. That conflation makes an operator's run look
+ * clean when it is actually sitting on undecided money — this function is
+ * what lets the caller (the backfill's main loop) report the two states
+ * separately instead.
+ *
+ * `pass_credit_redemptions_group_cap` is a PARTIAL UNIQUE index over exactly
+ * this predicate, so at most one row per subscription can ever match either
+ * arm — `limit 1` is not a compromise, there is only ever one candidate.
+ */
+export async function describeCapStatus(
+  sql: ReturnType<typeof postgres>,
+  subscriptionId: string,
+): Promise<"free" | "capped_healthy" | "capped_undetermined"> {
+  const [row] = await sql<{ undetermined: boolean }[]>`
+    select (reversal_undetermined_at is not null) as undetermined
+    from pass_credit_redemptions
     where subscription_id = ${subscriptionId}
       and (reversed_at is null or reversal_undetermined_at is not null)
     limit 1`;
-  return !!row;
+  if (!row) return "free";
+  return row.undetermined ? "capped_undetermined" : "capped_healthy";
 }
 
 interface Candidate {
@@ -152,6 +182,7 @@ async function main(): Promise<void> {
     console.log(`Scanning ${subs.length} subscription(s) with a Stripe customer...\n`);
 
     let alreadyCapped = 0;
+    let undeterminedBlocked = 0;
     let candidatesFound = 0;
     let inserted = 0;
     let skippedNoCompetition = 0;
@@ -159,13 +190,27 @@ async function main(): Promise<void> {
     let skippedStripeUnreadable = 0;
     let skippedDbError = 0;
     const stackedGroups: string[] = [];
+    const undeterminedGroups: string[] = [];
     const truncatedCustomers: string[] = [];
 
     for (const sub of subs) {
       // Already capped — nothing to backfill, and nothing to even look at on
-      // Stripe for this group.
-      if (await groupAlreadyCapped(sql, sub.id)) {
+      // Stripe for this group. But WHICH of the two capped states this is
+      // matters for the summary (#307): a healthy live credit and an
+      // undetermined-blocked one are opposite operational states, so they are
+      // counted (and reported) separately rather than folded into one bucket.
+      const capStatus = await describeCapStatus(sql, sub.id);
+      if (capStatus === "capped_healthy") {
         alreadyCapped++;
+        continue;
+      }
+      if (capStatus === "capped_undetermined") {
+        undeterminedBlocked++;
+        undeterminedGroups.push(
+          `subscription=${sub.id}: lifetime-cap row is an UNDETERMINED reversal — the credit ` +
+            `was never actually clawed back. This group is BLOCKED pending manual staff ` +
+            `resolution (reversal_undetermined_at), NOT a healthy cap.`,
+        );
         continue;
       }
 
@@ -323,7 +368,8 @@ async function main(): Promise<void> {
 
     console.log("\n--- summary ---");
     console.log(`Subscriptions scanned: ${subs.length}`);
-    console.log(`Already capped (row exists): ${alreadyCapped}`);
+    console.log(`Already capped (healthy, live credit): ${alreadyCapped}`);
+    console.log(`BLOCKED — undetermined reversal, needs manual review: ${undeterminedBlocked}`);
     console.log(`Groups with a pre-V335 credit found: ${candidatesFound}`);
     console.log(`${WRITE ? "Inserted" : "Would insert"}: ${inserted}`);
     console.log(`Skipped — no matching competition_passes row: ${skippedNoCompetition}`);
@@ -338,6 +384,15 @@ async function main(): Promise<void> {
       console.log(`\nSTACKED GROUPS — ${stackedGroups.length} found, needs manual staff review:`);
       for (const line of stackedGroups) console.log(`  ${line}`);
     }
+    if (undeterminedGroups.length) {
+      console.log(
+        `\nUNDETERMINED-BLOCKED GROUPS — ${undeterminedGroups.length} found. The lifetime cap ` +
+          `is holding these on a reversal that was never resolved — the credit was never ` +
+          `actually clawed back. This is NOT the same as a healthy cap; needs manual staff ` +
+          `review, one inventory instead of one alert email at a time:`,
+      );
+      for (const line of undeterminedGroups) console.log(`  ${line}`);
+    }
     if (truncatedCustomers.length) {
       console.log(
         `\nTRUNCATED CUSTOMERS — ${truncatedCustomers.length} found. This run is INCOMPLETE ` +
@@ -350,10 +405,14 @@ async function main(): Promise<void> {
     if (!WRITE) {
       console.log("\nDry run complete. Nothing was written. Re-run with --write to apply.");
     }
-    // An incomplete run must not look identical to a complete one from the
-    // exit code alone — CI or a human running this unattended needs a signal
-    // that survives past the scrollback.
-    if (truncatedCustomers.length) {
+    // An incomplete run — OR one that found money nobody has decided about
+    // yet — must not look identical to a clean one from the exit code alone.
+    // CI or a human running this unattended needs a signal that survives past
+    // the scrollback. Undetermined-blocked groups (#307) get the same
+    // treatment as a truncated balance-transaction fetch: neither is
+    // something this script can fix by re-running it, but both are exactly
+    // the kind of state a silent 0 would hide.
+    if (truncatedCustomers.length || undeterminedGroups.length) {
       process.exitCode = 1;
     }
   } finally {

--- a/scripts/reconcile-stranded-wallets.ts
+++ b/scripts/reconcile-stranded-wallets.ts
@@ -33,11 +33,24 @@
 // `--write` is additionally gated behind RECONCILE_ALLOW=1 so that "staging
 // only" is enforced rather than merely documented (see `writeGateBlocked`).
 //
+// Every wallet routed to MANUAL REVIEW (#309) is ALSO written to a JSON
+// Lines artifact — one self-contained JSON object per line, `{wallet_id,
+// grant, pack, reason}` — so the rows needing a human decision can be worked
+// from a file instead of scraped from console.warn scrollback (see
+// `toManualReviewJsonl` for why JSONL over CSV/a single JSON array). This is
+// a local file write, independent of --write/RECONCILE_ALLOW: it never
+// touches the database, so it happens on every run including a dry run.
+// Defaults to `DEFAULT_MANUAL_REVIEW_OUT_PATH` in the current working
+// directory; override with `--out=<path>`.
+//
 //   node --env-file-if-exists=apps/web/.env.local --experimental-strip-types \
 //     scripts/reconcile-stranded-wallets.ts              # dry run
 //   RECONCILE_ALLOW=1 node --env-file-if-exists=apps/web/.env.local \
 //     --experimental-strip-types \
 //     scripts/reconcile-stranded-wallets.ts --write        # applies it
+//   node --env-file-if-exists=apps/web/.env.local --experimental-strip-types \
+//     scripts/reconcile-stranded-wallets.ts --out=/tmp/manual-review.jsonl
+import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import postgres from "postgres";
 
@@ -89,6 +102,38 @@ export function writeGateBlocked(write: boolean, allow: string | undefined): boo
   return write && allow !== "1";
 }
 
+/** Default path (relative to the process's cwd) for the manual-review
+ *  artifact; override with `--out=<path>`. */
+export const DEFAULT_MANUAL_REVIEW_OUT_PATH = "reconcile-stranded-wallets.manual-review.jsonl";
+
+/** One wallet the script could not (or should not) auto-merge, and why. */
+export interface ManualReviewRow {
+  wallet_id: string;
+  grant: number;
+  pack: number;
+  reason: string;
+}
+
+/**
+ * Serializes manual-review rows as JSON Lines — one self-contained JSON
+ * object per line — rather than CSV or a single top-level JSON array (#309).
+ *
+ *   - CSV needs column-escaping for `reason`, which is free text that can
+ *     itself carry commas/quotes (a Postgres error message, for instance);
+ *     JSON needs none.
+ *   - A single JSON array requires the whole array to close cleanly. This
+ *     script already treats "one bad wallet must not abort the rest" as load
+ *     bearing (the per-wallet try/catch below); JSONL carries that same
+ *     property into the artifact — every COMPLETE line stays parseable even
+ *     if the process is killed mid-run.
+ *
+ * Newline-terminated so a rerun's output can be safely `cat`-appended, and so
+ * the empty-input case is a clean empty string rather than a stray newline.
+ */
+export function toManualReviewJsonl(rows: ManualReviewRow[]): string {
+  return rows.map((row) => JSON.stringify(row)).join("\n") + (rows.length ? "\n" : "");
+}
+
 async function main(): Promise<void> {
   const url = process.env.DATABASE_URL;
   if (!url) {
@@ -96,6 +141,9 @@ async function main(): Promise<void> {
     process.exit(1);
   }
   const WRITE = process.argv.includes("--write");
+  const outArgPrefix = "--out=";
+  const outArg = process.argv.find((a) => a.startsWith(outArgPrefix));
+  const OUT_PATH = outArg ? outArg.slice(outArgPrefix.length) : DEFAULT_MANUAL_REVIEW_OUT_PATH;
   if (writeGateBlocked(WRITE, process.env.RECONCILE_ALLOW)) {
     console.error(
       "REFUSED: --write is gated behind RECONCILE_ALLOW=1.\n" +
@@ -136,6 +184,7 @@ async function main(): Promise<void> {
     let merged = 0;
     let noop = 0;
     let needsReview = 0;
+    const manualReviewRows: ManualReviewRow[] = [];
 
     for (const w of stranded) {
       // Indicative only: read outside any lock, so it is good enough to
@@ -146,6 +195,12 @@ async function main(): Promise<void> {
       try {
         if (classifyBucketAmounts(balances) === "no_positive_balance") {
           needsReview++;
+          manualReviewRows.push({
+            wallet_id: w.wallet_id,
+            grant: balances.grant,
+            pack: balances.pack,
+            reason: "no_positive_balance",
+          });
           console.warn(
             `MANUAL REVIEW: wallet=${w.wallet_id} grant=${balances.grant} pack=${balances.pack} ` +
               `— negative or zero positive balance, data integrity: no merge is possible.`,
@@ -160,6 +215,12 @@ async function main(): Promise<void> {
         const targetOrgId = chooseReconcileTarget(spenders);
         if (!targetOrgId) {
           needsReview++;
+          manualReviewRows.push({
+            wallet_id: w.wallet_id,
+            grant: balances.grant,
+            pack: balances.pack,
+            reason: "no_spend_attribution",
+          });
           console.warn(
             `MANUAL REVIEW: wallet=${w.wallet_id} grant=${balances.grant} pack=${balances.pack} ` +
               `— no spend attribution on this wallet, cannot determine an owning org.`,
@@ -171,6 +232,12 @@ async function main(): Promise<void> {
           select subscription_id, deleted_at from organizations where id = ${targetOrgId}`;
         if (!org || org.deleted_at) {
           needsReview++;
+          manualReviewRows.push({
+            wallet_id: w.wallet_id,
+            grant: balances.grant,
+            pack: balances.pack,
+            reason: "attributed_org_deleted",
+          });
           console.warn(
             `MANUAL REVIEW: wallet=${w.wallet_id} attributed org=${targetOrgId} no longer exists ` +
               `(deleted) — cannot determine a live wallet to merge into.`,
@@ -182,6 +249,12 @@ async function main(): Promise<void> {
           // Should be impossible (the wallet is provably stranded above), but
           // never merge a wallet into itself.
           needsReview++;
+          manualReviewRows.push({
+            wallet_id: w.wallet_id,
+            grant: balances.grant,
+            pack: balances.pack,
+            reason: "self_reference",
+          });
           console.warn(`MANUAL REVIEW: wallet=${w.wallet_id} resolves back to itself — skipping.`);
           continue;
         }
@@ -261,13 +334,21 @@ async function main(): Promise<void> {
       } catch (err) {
         // One bad wallet must not abort the remaining run.
         needsReview++;
+        const message = err instanceof Error ? err.message : String(err);
+        manualReviewRows.push({
+          wallet_id: w.wallet_id,
+          grant: balances.grant,
+          pack: balances.pack,
+          reason: `processing_error: ${message}`,
+        });
         console.warn(
-          `MANUAL REVIEW: wallet=${w.wallet_id} failed — ` +
-            `${err instanceof Error ? err.message : String(err)}. ` +
+          `MANUAL REVIEW: wallet=${w.wallet_id} failed — ${message}. ` +
             `Nothing was written for it (its transaction rolled back); investigate and re-run.`,
         );
       }
     }
+
+    writeFileSync(OUT_PATH, toManualReviewJsonl(manualReviewRows), "utf8");
 
     console.log("\n--- summary ---");
     console.log(`Stranded wallets found: ${stranded.length}`);
@@ -276,6 +357,10 @@ async function main(): Promise<void> {
     console.log(
       `Needs manual review (no attribution / stale org / no positive balance / failed): ` +
         `${needsReview}`,
+    );
+    console.log(
+      `Manual-review artifact: ${OUT_PATH} (${manualReviewRows.length} row(s), JSON Lines — ` +
+        `wallet_id, grant, pack, reason)`,
     );
     if (!WRITE) console.log("\nDry run complete. Nothing was written. Re-run with --write to apply.");
   } finally {


### PR DESCRIPTION
Wave 11 of the v17-gap remediation (#283) — the remaining backlog, run as two parallel batches with exclusive file ownership per agent.

## The money

| # | Defect | Consequence |
| --- | --- | --- |
| **#334** | Billing routes resolved their group from a cookie a client effect re-points *after* the page paints | A payer owning two bills saves on B while the cookie says A. The rider count is a group TOTAL, so choosing 1 while A holds 3 **cancels two of A's riders** — fully authorised, no refusal to catch it |
| **#333** | Billing, Credits and Add-ons sit behind a *membership* gate | A payer with no membership on the bill they fund could not open it at all. `transferGroup` moves `owner_user_id` alone, so this is reachable by design |
| **#315** | The failed-cancel rollback restored four columns and dropped `cancel_at_period_end` | A customer who asked to cancel, whose cancel then failed, silently has no standing instruction to stop billing. They believe they cancelled; the bill keeps arriving |
| **#332** | No backstop when extra-org price convergence fails | A rider bills its stale rate for ever, silently. Now reported daily — **and wired**, which is the half that makes it real |
| **#306** | `ride_out` detach minted free plan time with no record | A comp at the old payer's expense, provable nowhere |
| **#318 #319** | Credits tab read the raw plan and gross spend | A lapsed wallet granted 10 was told its cap was 60; refunded runs still counted as spent |
| **#305** | `reversal_undetermined_at` rows had no resolution path | Money sat undecided with no way to decide it |

## The checks that could not fail

- **#336** — `platform_fee_percent` cached under a global key. The reproduction is sharper than the issue: it is not a cross-file race, the suite **poisons itself** — one test caches `{v:12}` and its own second read is served that warm entry. What decided the outcome was whether `REDIS_URL` happened to be set.
- **#316** — the Redis CI guard counted `REDIS_URL` occurrences workflow-wide, so it could not tell "each suite has its own step" from "one step has three". Now correlated per step, and **proved against a deliberately broken workflow with a decoy that keeps the old count intact** — the old heuristic passes it, the new guard fails it.
- **#314** — four resolver arms had no case, each gap letting a specific widening ship green. Every new case was proved to *discriminate* by mutating the SQL resolver, not by watching it pass.
- **#363 + `1ad49d5e`** — the suite pinned `{ timeout: 20000 }` per test, which **overrides `--testTimeout`**. Removing the pins on the reasoning that "the repo convention governs" exposed that the convention did not exist: no `testTimeout` in config, and CI runs a bare `npm test`. As landed, the fix would have *lowered* those tests from 20s to 5s in CI. The config default is the actual fix.

## Two tasks were refused, and both refusals were right

**#311 was not implemented.** Deriving three status lists from `LIVE_SUBSCRIPTION_STATUSES` is only safe if they match it. Two omit `incomplete`, so deriving would have been a live billing change under a hygiene title. Underneath sits a real defect, now **#367**: `hasLiveSubscription` *includes* `incomplete` and routes such groups into `cancelGroupIfEmpty`, whose UPDATE then matches zero rows and does **nothing** — no log, no error. A group nobody is in, nobody paid for, nothing will clean up. What ships instead is two characterisation tests; widening either literal reds one, so the decision must be deliberate.

**#312 stopped at the migration file.** It corrected 33 citations and found their origin — `V314__billing_groups.sql` misnames itself as V310 in its own header. That was left alone on purpose: Flyway checksums applied migrations, so a two-character comment edit breaks `migrate` validation wherever V314 has run. Tracked as **#366** to ride along with the next coordinated migration.

## Verification

Every fix was re-run and mutation-tested by me independently, not accepted on the implementer's report.

- Full suite, **bare `npm test` exactly as CI invokes it**: `529 files, 514 passed, 15 skipped, 0 failed`
- `tsc` (app + scripts) clean · `lint` **0 errors** · `i18n:check` parity at 3542 keys
- Prod build clean; **smoke 619 passed / 0 failed** against a freshly migrated database

Three claims in the issues turned out to be **already fixed** — verified by mutation rather than by reading, since a stale issue and a live defect look identical until you try to break the guard.

## Known gaps, stated rather than implied

- **#354 was not screenshot-verified at 375px.** Every no-trial string is strictly shorter than the trial string it replaces inside a flex-wrap layout. That is an argument, not a check.
- **#332 reports, it does not repair.** A repairing sweep would be an unattended bulk billing mutation while the cause is likely still present.
- **#305's admin surface is desktop-only**, per the standing rule that /admin needs no mobile work.

## New issues filed

#365 (`ai-officials.md` repeats the two falsehoods just fixed) · #366 (V314's header) · #367 (the silent `incomplete` no-op)

Closes #303
Closes #305
Closes #306
Closes #307
Closes #309
Closes #312
Closes #314
Closes #315
Closes #316
Closes #318
Closes #319
Closes #332
Closes #333
Closes #334
Closes #336
Closes #338
Closes #354
Closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)