### PR TITLE
fix(admin): count staff actions, not customers doing their own billing (#308)

### DIFF
--- a/apps/web/src/app/admin/audit/page.tsx
+++ b/apps/web/src/app/admin/audit/page.tsx
@@ -1,5 +1,6 @@
 import Link from "@/components/ui/console-link";
 import { sql } from "@/lib/db";
+import { CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS } from "@/lib/admin";
 
 export const dynamic = "force-dynamic";
 
@@ -75,7 +76,23 @@ export default async function AdminAuditPage() {
                 <td className="px-3 py-2 text-slate-500 text-xs whitespace-nowrap">
                   {new Date(r.created_at).toLocaleString()}
                 </td>
-                <td className="px-3 py-2 text-slate-300">{r.actor_email}</td>
+                <td className="px-3 py-2 text-slate-300">
+                  {r.actor_email}
+                  {/* #308: two self-service billing effects record themselves in
+                      this table with the CUSTOMER as actor. They are deliberately
+                      NOT hidden here — this page is the forensic record, and the
+                      V111 hash chain verifies over every row, so omitting some
+                      would destroy the accountability the write exists to provide
+                      AND make the chain unauditable against what is shown.
+                      Labelled instead, so nobody infers an organiser is staff.
+                      The dashboard tile and its glance list DO exclude them,
+                      because those answer "what did staff do today". */}
+                  {(CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS as readonly string[]).includes(r.action) && (
+                    <span className="ml-2 rounded bg-slate-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-slate-300">
+                      customer
+                    </span>
+                  )}
+                </td>
                 <td className="px-3 py-2 font-mono text-purple-300">{r.action}</td>
                 <td className="px-3 py-2 text-slate-400">
                   {r.target_type === "org" || r.target_type === "user" ? (

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import Link from "@/components/ui/console-link";
 import { sql } from "@/lib/db";
+import { CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS } from "@/lib/admin";
 
 export default async function AdminDashboard() {
   const [counts] = await sql<{
@@ -9,7 +10,12 @@ export default async function AdminDashboard() {
       (select count(*)::int from users where deleted_at is null)          as users,
       (select count(*)::int from organizations where status = 'active')   as orgs,
       (select count(*)::int from subscriptions where plan_key <> 'community' and status in ('trialing','active')) as active_subs,
-      (select count(*)::int from staff_audit_log where created_at >= now() - interval '24 hours') as staff_actions_today`;
+      -- STAFF actions, so the self-service rows customers write into the same
+      -- table are excluded (#308). Counting them made this tile a measure of
+      -- how many organisations detached today, under a label that says staff.
+      (select count(*)::int from staff_audit_log
+        where created_at >= now() - interval '24 hours'
+          and action <> all(${sql.array([...CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS])}::text[])) as staff_actions_today`;
 
   const recentAudit = await sql<{
     id: string; actor_email: string; action: string; target_type: string;
@@ -17,6 +23,7 @@ export default async function AdminDashboard() {
   }[]>`
     select s.id, u.email as actor_email, s.action, s.target_type, s.target_id, s.created_at
     from staff_audit_log s join users u on u.id = s.actor_id
+    where s.action <> all(${sql.array([...CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS])}::text[])
     order by s.created_at desc limit 20`;
 
   return (

--- a/apps/web/src/lib/__tests__/admin-audit-actor-truth.test.ts
+++ b/apps/web/src/lib/__tests__/admin-audit-actor-truth.test.ts
@@ -1,0 +1,90 @@
+// `staff_audit_log` is the schema's only generic actor+target+detail sink, so a
+// couple of CUSTOMER self-service effects record themselves there too (#285's
+// forfeited wallet, #306's ride_out comp). That is right for the record and
+// wrong for /admin, which reads the table as "what staff did" — hence
+// CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS and the exclusions on the dashboard.
+//
+// The risk this file exists for: someone adds a THIRD direct insert with the
+// customer as actor, does not know the list exists, and silently re-opens #308.
+// Nothing about writing that insert would tell them. So this scans the source
+// for direct inserts and fails when one uses an action the list does not carry.
+//
+// Source-scanning rather than DB-backed on purpose: the defect is a missing
+// registration at author time, which no runtime fixture can observe.
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS } from "@/lib/admin";
+
+const SRC = path.resolve(__dirname, "../..");
+/** `lib/admin.ts` owns the sanctioned staff writer; its insert is the reference
+ *  implementation, not a violation. */
+const WRITER = path.join(SRC, "lib", "admin.ts");
+
+/** Every .ts/.tsx under src, excluding tests. */
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === "__tests__" || e.name === "node_modules") continue;
+      sourceFiles(full, out);
+    } else if (/\.tsx?$/.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Dotted action literals appearing in a direct `insert into staff_audit_log`.
+ *
+ * Deliberately NOT trying to match balanced parentheses: the real inserts wrap
+ * across lines and nest `sql.json({...})` inside the values list, so a
+ * paren-matching regex is fragile in exactly the way that makes a guard read
+ * green while matching nothing. It takes a fixed window after the statement
+ * and pulls dotted string literals out of it — over-inclusive by design, since
+ * a false positive fails loudly and a false negative fails silently.
+ */
+function directInsertActions(src: string): string[] {
+  const found: string[] = [];
+  for (const m of src.matchAll(/insert into staff_audit_log/g)) {
+    const window = src.slice(m.index!, m.index! + 600);
+    for (const lit of window.matchAll(/['"]([a-z_]+(?:\.[a-z_]+)+)['"]/g)) found.push(lit[1]!);
+  }
+  return found;
+}
+
+describe("staff_audit_log actor truth (#308)", () => {
+  const files = sourceFiles(SRC).filter((f) => f !== WRITER);
+
+  it("scans a plausible number of source files", () => {
+    // Guards the guard: a wrong root would iterate nothing and pass vacuously,
+    // which is the exact shape of failure this repo keeps having to unlearn.
+    expect(files.length).toBeGreaterThan(200);
+  });
+
+  it("every direct insert uses an action registered as customer self-service", () => {
+    const unregistered: string[] = [];
+    for (const file of files) {
+      const actions = directInsertActions(fs.readFileSync(file, "utf8"));
+      for (const a of actions) {
+        if ((CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS as readonly string[]).includes(a)) continue;
+        unregistered.push(`${path.relative(SRC, file)} writes '${a}'`);
+      }
+    }
+    // A staff action must go through logStaffAction; a customer one must be
+    // registered so /admin can exclude it. A direct insert of an unregistered
+    // dotted action is neither, and is how #308 would come back.
+    expect(unregistered).toEqual([]);
+  });
+
+  it("finds the two known customer writers, so the scanner is not silently matching nothing", () => {
+    const seen = new Set(files.flatMap((f) => directInsertActions(fs.readFileSync(f, "utf8"))));
+    for (const a of CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS) expect(seen).toContain(a);
+  });
+
+  it("the registered list holds nothing that no longer exists in the source", () => {
+    // The mirror of the check above: a stale entry silently permits an action
+    // nobody writes any more, and would hide a real one that took its name.
+    const seen = new Set(files.flatMap((f) => directInsertActions(fs.readFileSync(f, "utf8"))));
+    expect([...CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS].filter((a) => !seen.has(a))).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/admin.ts
+++ b/apps/web/src/lib/admin.ts
@@ -29,6 +29,31 @@ export async function requireSuperadmin(): Promise<StaffUser> {
   return staff;
 }
 
+/**
+ * Actions written to `staff_audit_log` by a CUSTOMER acting on their own
+ * account, not by staff (v17 gap #308).
+ *
+ * The table is the schema's only generic actor+target+detail sink, so two
+ * self-service billing effects record themselves here for accountability — a
+ * departing organisation's forfeited wallet balance (#285) and the comped plan
+ * a `ride_out` detach hands out (#306). Both carry the CUSTOMER as `actor_id`,
+ * because the customer is who did it.
+ *
+ * That is right for the record and wrong for `/admin`, which reads the same
+ * table as "what staff did". Unfiltered, a busy day of ordinary detaches reads
+ * as staff activity, so the number people glance at to spot unusual staff
+ * behaviour is mostly not staff behaviour.
+ *
+ * These happen to be dot-namespaced where everything `logStaffAction` writes is
+ * a bare name, but that convention is enforced nowhere and a future author has
+ * no reason to know it. Hence an explicit list, plus a guard test that fails
+ * when a direct insert appears with an action that is not on it.
+ */
+export const CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS = [
+  "billing_group.detach_wallet_not_carried",
+  "billing_group.detach_comp_granted",
+] as const;
+
 /** Record a staff action in the audit log. */
 export async function logStaffAction(
   actorId: string,

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -1011,6 +1011,12 @@ export async function auditWalletForfeitedOnDetach(
 ): Promise<void> {
   const grant = Math.max(0, await bucketBalance(tx, oldWalletId, "grant"));
   const pack = Math.max(0, await bucketBalance(tx, oldWalletId, "pack"));
+  // Nothing was left behind, so there is nothing to be accountable for (#308).
+  // This row exists to answer "what did that organisation forfeit"; written when
+  // the answer is "nothing" it is pure volume, and it is the common case — most
+  // organisations detach with an empty wallet. Every such row also had to be
+  // filtered back out of /admin, so the cheapest fix is not to create it.
+  if (grant === 0 && pack === 0) return;
   await tx`
     insert into staff_audit_log (actor_id, action, target_type, target_id, detail)
     values (${actorUserId}, 'billing_group.detach_wallet_not_carried', 'org', ${orgId},

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -1398,6 +1398,28 @@ describe.skipIf(!HAS_DB)("detach of the LAST org carries the wallet out (#304)",
     expect(audit?.detail?.via).toBe("detach");
   });
 
+  it("REGRESSION (#308): writes NO forfeit row when there was nothing to forfeit", async () => {
+    // The row answers "what did this organisation leave behind". Written when
+    // the answer is "nothing" it is pure volume — and it is the COMMON case,
+    // since most organisations detach with an empty wallet. Every such row then
+    // had to be filtered back out of /admin, so the honest fix is not to create
+    // it. The case above proves the row still appears when a balance really is
+    // forfeited, which makes this a narrowing rather than a removal.
+    const payer = await makeUser("payer");
+    const clubOwner = await makeUser("clubowner");
+    const group = await makeGroup(payer, { stripeSubId: "sub_308_empty_" + uniq() });
+    await makeOrg(group, payer); // a sibling stays, so the forfeit path is the one taken
+    const orgId = await makeOrg(group, clubOwner);
+    // No ledger rows seeded: the group's wallet is empty on both buckets.
+
+    await detachOrgFromGroup({ actorUserId: clubOwner, orgId, mode: "release" });
+
+    const [row] = await sql<{ n: number }[]>`
+      select count(*)::int as n from staff_audit_log
+       where target_id = ${orgId} and action = 'billing_group.detach_wallet_not_carried'`;
+    expect(row!.n).toBe(0);
+  });
+
   it("leaves the pool REACHABLE, not merely moved", async () => {
     // A balance that reads right while the ledger still points at a wallet
     // nothing resolves to is the same bug one layer down. Two things have to


### PR DESCRIPTION
The last open item from the original v17 audit's own backlog.

## The defect

`staff_audit_log` is the schema's only generic actor+target+detail sink, so two self-service billing effects record themselves there with the **customer** as `actor_id`: the wallet balance a departing organisation forfeits (#285) and the comped plan a `ride_out` detach hands out (#306).

Right for the record, wrong for `/admin`. The **"Staff actions (24h)"** tile counted every row, so on a busy day it was mostly a count of how many organisations detached — under a label saying staff. That number exists so unusual staff behaviour is visible; it cannot do that while ordinary customer activity dominates it.

## The split, which is the interesting part

- **Dashboard tile + recent-activity list — exclude them.** Those answer "what did staff do today".
- **`/admin/audit` — keep them, label them `customer`.** That page is the forensic record, and the V111 hash chain verifies over *every* row. Hiding some would destroy the accountability the write exists to provide *and* leave the chain unauditable against what is shown. The issue proposed filtering "the tile + feed"; filtering the audit page would have been the wrong half of that.

## Keeping it fixed

The two kinds are distinguishable by convention — customer rows are dot-namespaced, everything `logStaffAction` writes is a bare name — but nothing enforces it and a future author has no reason to know. So `CUSTOMER_SELF_SERVICE_AUDIT_ACTIONS` is explicit, and a guard scans the source for direct inserts and fails on any action it does not carry. Un-registering one reds it.

**The guard caught its own first draft.** Its scanner tried to match balanced parentheses and matched nothing against the real multi-line inserts. The "finds the two known writers" canary failed rather than the suite passing vacuously — which is the only reason the working version exists. Worth noting given this repo's recent history with checks that cannot fail.

## Also: stop writing the row when nothing was forfeited

It answers "what did this organisation leave behind". Written when the answer is "nothing" it is pure volume, and that is the **common** case — most organisations detach with an empty wallet. Every such row then had to be filtered back out of `/admin`, so the cheaper fix is not to create it. The pre-existing case proves the row still appears when a balance really is forfeited, so this narrows rather than removes; deleting the guard clause reds the new test.

## Verification

- `billing-group-move` 79/79 · new guard 4/4 · `credits-wallet-merge` + `detach-notify` green
- Both changes mutation-checked: un-registering an action reds the guard; deleting the zero-balance clause reds the regression
- `tsc` clean · `lint` 0 errors, 73 warnings (baseline)
- Admin surfaces left desktop-only per the standing rule — no responsive work

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)