### PR TITLE
fix(v17): a help article that sold the wrong plan, a refusal nobody could hear, and the door that let both in

### DIFF
--- a/apps/web/content/help/scheduling/ai-officials.md
+++ b/apps/web/content/help/scheduling/ai-officials.md
@@ -4,7 +4,7 @@ description: Staff your matches automatically — AI Officials assigns officials
 order: 9
 ---
 
-**AI Officials** is the second phase of AI scheduling: once the times are set, it staffs the matches. Assign referees and other officials across the whole timetable from one instruction — or leave the instruction empty for a sensible default spread. Like the schedule pass it is **propose-only**: nothing is written until you apply. Automatic officials assignment is a **Pro Plus** feature.
+**AI Officials** is the second phase of AI scheduling: once the times are set, it staffs the matches. Assign referees and other officials across the whole timetable from one instruction — or leave the instruction empty for a sensible default spread. Like the schedule pass it is **propose-only**: nothing is written until you apply. Like the schedule pass, it needs no upgrade — it runs on **every plan, Community included**.
 
 ## Where it fits
 
@@ -19,9 +19,11 @@ You reach the officials pass from the AI console straight after the [schedule pa
 
 Give it an instruction ("keep the same referee across a team's group games") to steer it, or run it with no instruction to get the deterministic solver's default spread. The engine referee checks every proposal and repairs blocking clashes for up to two rounds before showing you what's left.
 
-## Run quotas
+## Credits and rate limits
 
-Unlike schedule generations, **officials AI runs are not metered** — restaff as often as you like. The empty-instruction default spread is produced without a model call at all, so it's effectively free.
+AI Officials is metered the same way as the schedule pass: every run spends **one AI credit** from your organisation's shared wallet, including the no-instruction default spread, which makes no model call but still draws from the wallet. A run that fails or times out is **refunded**, so it never costs you a credit. See [AI credits](/help/billing/credits) for the monthly grant, buying packs, and how a billing group shares one wallet.
+
+Separately, officials AI has its own burst brake of **5 runs an hour per division** — independent of the schedule pass's own hourly limit, so a busy hour staffing matches doesn't use up your scheduling budget or the other way round.
 
 Instruction runs carry the same data guarantee as the [schedule pass](/help/scheduling/ai-scheduling): only this division's officials brief is sent to one of our AI providers, and it is **not used to train AI models**. See our [sub-processors list](/legal/sub-processors) for the full set.
 

--- a/apps/web/src/lib/__tests__/credits-bootstrap-grant.test.ts
+++ b/apps/web/src/lib/__tests__/credits-bootstrap-grant.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(!HAS_DB)("createOrgForUser — AI credit wallet bootstrap grant"
     expect(await balance(walletId)).toBe(10);
   });
 
-  it("the daily cron run in the same calendar month is a no-op for the bootstrap-granted wallet", { timeout: 30000 }, async () => {
+  it("the daily cron run in the same calendar month is a no-op for the bootstrap-granted wallet", async () => {
     const userId = await makeUser();
     const org = await createOrgForUser(userId, "Fresh Org Two");
     const walletId = await walletIdFor(org.id);

--- a/apps/web/src/lib/__tests__/help-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/help-copy-truth.test.ts
@@ -21,6 +21,7 @@ import stripePlans from "@/config/stripe-plans.json";
 import { sql } from "@/lib/db";
 import { PASS_CREDIT_GRANT } from "@/lib/pricing-cards";
 import {
+  aiOfficialsPlanGateFaults,
   BOUNDED_SCOPE_GRAMMAR,
   FEE_LADDER_PLAN_KEYS,
   mentionsRateAfterPass,
@@ -104,6 +105,15 @@ afterAll(async () => {
  * this list and into real scans once #303 corrected the copy. What remains
  * below is a real gap with a real issue, and listing it as data rather than
  * leaving it silently unscanned is the point.
+ *
+ * #365: `scheduling/ai-officials.md` was the THIRD copy of #303's unmetered-run
+ * falsehood, plus its own "Automatic officials assignment is a Pro Plus
+ * feature" — untouched because #303's guard was only ever invoked on
+ * `ai-scheduling.md` by name. Fixed here (see `scheduling/ai-officials.md is
+ * gated too`, further down) and the unmetered-run guard is now run over EVERY
+ * article in the tree (see `no help article anywhere claims an AI run is
+ * unmetered/free`, further down) rather than added as a fourth named file — so
+ * a fourth copy reds this suite instead of waiting for someone to notice.
  */
 const KNOWN_GAPS = [
   "lib/pricing-cards.ts + e2e/pro-plus-tier.spec.ts — card bullets pinned verbatim (#303)",
@@ -113,7 +123,7 @@ const KNOWN_GAPS = [
   "app/globals.css .competition-prose table — `display: block` is what gives that scroll box its overflow, and it drops the implicit table role in some assistive tech (row/column relationships stop being announced). Mitigation is an explicit role=\"table\"/rowgroup set, which the same sanitiser strips (#303)",
   // ── Round 4 bookkeeping: the residuals, named rather than left implicit ────
   "THE AXIS IS CIRCULAR. `claiming` is computed by running `en.halfClaim` over the tree, so an article only joins the half-rate axis — and therefore only earns a gate — if that vocabulary already matches it. The vocabulary has been measured at 0/12 and 0/24, so an article stating the rate in an unseen shape is invisible to the axis AND ungated. The axis narrows the ungated set; it does not close it (#303)",
-  "THE FOURTH ARTICLE. `billing/plans.md` states the plan org caps and the fee ladder and is inventory-gated. `billing/downgrade.md` and `scheduling/ai-scheduling.md` now carry the fee-lock/run-cap/unmetered-run vocabulary scans (below), which is real coverage but NOT the word-for-word inventory gate — a reword that stays inside the vocabulary's blind spots is still possible. `billing/credits.md`, `billing/operator.md` and every other non-billing, non-scheduling article remain fully ungated and unscanned, defended only by the vocabulary above (#303)",
+  "THE FOURTH ARTICLE. `billing/plans.md` states the plan org caps and the fee ladder and is inventory-gated. `billing/downgrade.md`, `scheduling/ai-scheduling.md` and `scheduling/ai-officials.md` now carry the fee-lock/run-cap/unmetered-run vocabulary scans (below), which is real coverage but NOT the word-for-word inventory gate — a reword that stays inside the vocabulary's blind spots is still possible. `billing/credits.md`, `billing/operator.md` and every other non-billing, non-scheduling article remain fully ungated and unscanned, defended only by the vocabulary above (#303, #365)",
   "COMMENTS OWNED BY A CLOSING TOKEN SURVIVE `codeOnly` — NOT just the JSX idiom. `forEachChild` never visits TOKENS, so any comment whose nearest owner is a closing token is never blanked: `{/* … */}`, but equally an end-of-block comment on its own line, a comment in an empty block, the last call argument, the last array element, the last object property, the end of an interface body, a `switch`, or an `if`. Only an end-of-file comment is blanked. Measured tree-wide: 569 comment lines / 32,229 chars across 168 of 1,460 files. Direction is FAIL-SAFE — a negative scan can red on a comment that mentions a banned idiom, but can never miss real code — which is why it is recorded rather than fixed. Recorded as .tsx-only in round 5; that scoping was wrong and would have left the next reader hunting a JSX bug (#338)",
   "LITERAL-FREE SPANS ARE UNAUDITED, AND THIS ONE IS FAIL-OPEN. `blankedInsideLiteralFaults` proves every changed character lies OUTSIDE every string/regex/template-part/JSX literal, which closes the historical family (a `/*` inside a string ate 193 lines of division-settings.tsx) — proven by a length-preserving blank across every file raising 14,857 faults. It does NOT audit a stripper that eats a span containing NO literal at all. Constructed and it PASSES: blanking the largest literal-free span per file ships 79/79 green while destroying 1,061,443 chars across 1,341 of 1,460 files, largest single span 11,831 chars in server/usecases/billing-events.ts — LARGER than the 11,384 the historical bug actually ate. So this is not a corner case, it is most of the tree. THE COST ESTIMATE IN THE TASK 7 REPORT IS WRONG and that is the part that matters: closing this does NOT need a re-parse-and-compare 'doubling the walk'. It is a string check on the CHANGED CHARACTERS ONLY — take each maximal run of changed offsets, extend across neighbouring changed/space chars, require that span's raw text to be comments and whitespace only. O(changed chars), no re-parse, sub-millisecond per file. A wrong cost estimate is what stops a thing ever being closed (#338)",
   "FRONTMATTER PARSER DIVERGENCE, STILL LIVE. `server/help-content.ts`'s parseFrontmatter splits on `indexOf(\":\")` and is last-wins, so an indented `  description:` or a spaced `description :` is still RENDERED as the article's description while `copy-truth.ts`'s claimSurfaces regex (`^([A-Za-z_][\\w-]*):`) does not match it — the field scores 0 gate faults and is invisible to every rule. A falsehood delivered that way ships green (#303)",
@@ -352,6 +362,137 @@ AI Schedule needs no upgrade — it runs on **every plan, Community included**. 
 The quota is a **lifetime total per division** — it doesn't reset weekly or monthly, and a new division starts a fresh count. Refine and repair each use one generation. A run that fails or times out **does not** count. Separately, every plan has a burst brake of **5 AI runs per hour per division**. **Officials AI runs are not metered** — once you have automatic officials assignment, you can restaff as often as you like.`;
     expect(retiredRunCapProseFaults("x", oldTable)).not.toEqual([]);
     expect(unmeteredAiRunProseFaults("x", oldTable)).not.toEqual([]);
+  });
+});
+
+describe("scheduling/ai-officials.md is gated too (#365)", () => {
+  const aiOfficials = helpArticleBySlug("scheduling/ai-officials");
+
+  it("never claims AI Officials needs Pro Plus", () => {
+    expect(aiOfficialsPlanGateFaults("ai-officials.md", aiOfficials)).toEqual([]);
+  });
+
+  it("never claims an AI run — schedule or officials — is unmetered", () => {
+    expect(unmeteredAiRunProseFaults("ai-officials.md", aiOfficials)).toEqual([]);
+  });
+
+  // MUTATION PROOF, half 1 of #365: the exact "Automatic officials assignment
+  // is a Pro Plus feature" sentence, established false against officials-ai.ts
+  // and against plan_entitlements (the ONLY row for officials.auto is
+  // pro_plus-only, and that gate lives in a different function, officials.ts's
+  // autoAssignOfficials/applyOfficialAssignments).
+  //
+  // `officialsAiPlanForDivision` does hold ONE `requireFeature` —
+  // `officials.roles_multi`, and only when the policy names more than one role
+  // (officials-ai.ts:1037). It is not a plan gate in practice: V319 opened that
+  // key on every plan including community, which is what makes the replacement
+  // sentence true. Since the claim now rests on a matrix ROW rather than on the
+  // absence of a call, the describe below pins the row.
+  it("reds on the exact Pro-Plus-gate sentence #365 found", () => {
+    const reverted = aiOfficials.replace(
+      "Like the schedule pass, it needs no upgrade — it runs on **every plan, Community included**.",
+      "Automatic officials assignment is a **Pro Plus** feature.",
+    );
+    expect(reverted, "the replacement never matched — the article moved").not.toBe(aiOfficials);
+    expect(aiOfficialsPlanGateFaults("x", reverted)).not.toEqual([]);
+  });
+
+  // MUTATION PROOF, half 2 of #365: the exact "officials AI runs are not
+  // metered … restaff as often as you like … effectively free" sentence —
+  // established false against credits.ts's spendCredit, whose reserve/settle
+  // wraps officialsAiPlanForDivision's ENTIRE call, including the
+  // no-instruction default spread that makes no model call.
+  it("reds on the exact unmetered sentence #365 found", () => {
+    const reverted = aiOfficials.replace(
+      /## Credits and rate limits\n\n[\s\S]*?(?=\n\nInstruction runs carry)/,
+      `## Run quotas
+
+Unlike schedule generations, **officials AI runs are not metered** — restaff as often as you like. The empty-instruction default spread is produced without a model call at all, so it's effectively free.`,
+    );
+    expect(reverted, "the replacement never matched — the article moved").not.toBe(aiOfficials);
+    expect(unmeteredAiRunProseFaults("x", reverted)).not.toEqual([]);
+  });
+});
+
+/**
+ * The "every plan, Community included" half of #365, pinned to the matrix
+ * rather than to prose.
+ *
+ * The two guards above are VOCABULARY scans: they forbid the false sentence
+ * from coming back. Neither can notice the opposite failure — the sentence
+ * staying word-for-word identical while the thing it describes changes
+ * underneath it. That is precisely how the article became wrong the first time.
+ *
+ * `officials.roles_multi` is the one entitlement `officialsAiPlanForDivision`
+ * requires (and only for a multi-role policy). V319 set it true on every plan,
+ * community included, which is what makes "it needs no upgrade" true today. Put
+ * it back behind a paid tier and the article is false again with no edit to it,
+ * so the row is what this asserts.
+ */
+describe.skipIf(!HAS_DB)("ai-officials.md's 'every plan' claim is the matrix's (#365)", () => {
+  it("officials.roles_multi is open on every plan the matrix carries", async () => {
+    const rows = await sql<{ plan_key: string; bool_value: boolean | null }[]>`
+      select plan_key, bool_value from plan_entitlements
+      where feature_key = 'officials.roles_multi' order by plan_key`;
+    // Canary: a typo'd feature key would return zero rows and every assertion
+    // below would pass vacuously.
+    expect(rows.length, "no officials.roles_multi rows — the gate's key moved").toBeGreaterThan(3);
+    expect(
+      rows.map((r) => r.plan_key),
+      "the article names Community by name",
+    ).toContain("community");
+    expect(
+      rows.filter((r) => r.bool_value !== true).map((r) => r.plan_key),
+      "ai-officials.md says AI Officials runs on every plan — these plans no longer allow it",
+    ).toEqual([]);
+  });
+});
+
+/**
+ * TREE-WIDE, #365. `unmeteredAiRunProseFaults` was invoked on exactly one
+ * named article — `ai-scheduling.md` — until this task, which is precisely how
+ * `ai-officials.md` carried the SAME false claim, untouched, since #303. Rather
+ * than add a second name to a list (the shape that missed it the first time),
+ * this scans EVERY article `allHelpArticles()` returns, so a THIRD copy of the
+ * claim reds this suite on its own, wherever it lands, without anyone adding
+ * its filename here first.
+ *
+ * `aiOfficialsPlanGateFaults` (the Pro-Plus-gate half of #365) is DELIBERATELY
+ * NOT included in this tree-wide scan — see its JSDoc in `copy-truth.ts`:
+ * `officials.md` states an almost identically worded TRUE claim about a
+ * different, deterministic gate, and a vocabulary broad enough to catch the
+ * false claim here would also catch that true one. That guard stays scoped to
+ * `ai-officials.md` by name (above), which is the honest fix for a claim whose
+ * truth depends on which article is making it, not on the words alone.
+ */
+const unmeteredFaultsAcrossTree = (
+  extra: Array<{ slug: string; text: string }> = [],
+): string[] => {
+  const faults: string[] = [];
+  for (const article of allHelpArticles().values()) {
+    faults.push(...unmeteredAiRunProseFaults(`${article.slug}.md`, helpArticleBySlug(article.slug)));
+  }
+  for (const e of extra) {
+    faults.push(...unmeteredAiRunProseFaults(`${e.slug}.md`, e.text));
+  }
+  return faults;
+};
+
+describe("no help article anywhere claims an AI run is unmetered/free (#365)", () => {
+  it("the tree, as it stands today, makes the claim nowhere", () => {
+    expect(unmeteredFaultsAcrossTree()).toEqual([]);
+  });
+
+  // ANTI-VACUITY, the point of scanning the tree rather than a list: a THIRD
+  // copy of the claim, in an article nobody named here, must still red.
+  it("would catch a third copy of the claim, in an article this list never named", () => {
+    const faults = unmeteredFaultsAcrossTree([
+      {
+        slug: "some/other-article-nobody-named",
+        text: "Officials AI runs are not metered on any plan — restaff as often as you like.",
+      },
+    ]);
+    expect(faults.join(" ")).toContain("unmetered");
   });
 });
 
@@ -901,7 +1042,7 @@ describe("an added falsehood fails whatever it says", () => {
    * claims is a reading, not a lookup. Claiming otherwise in this comment would
    * be the very defect the round is about.
    */
-  it("every file a `why` cites exists, and every line it cites is in range", { timeout: 60_000 }, () => {
+  it("every file a `why` cites exists, and every line it cites is in range", () => {
     const sources = [
       ["_approved-copy.ts", webSource("lib/__tests__/_approved-copy.ts")],
       ["_approved-dictionary-copy.ts", webSource("lib/__tests__/_approved-dictionary-copy.ts")],
@@ -1480,7 +1621,7 @@ describe("the add-ons article's behaviour claims are pinned to the code", () => 
   // 9.3s in the full run (file total 10.5s). Quoting the isolated figure would
   // be the same kind of optimism this wave keeps correcting elsewhere, so both
   // are here. The 60s is real headroom for a loaded machine, not decoration.
-  it("freezes exactly the two axes the article says, and orgs.max_owned is not one", { timeout: 60_000 }, () => {
+  it("freezes exactly the two axes the article says, and orgs.max_owned is not one", () => {
     const source = webSource("server/usecases/entitlement-freeze.ts");
     const frozen = [...source.matchAll(/getLimit\(orgId,\s*"([^"]+)"\)/g)].map((m) => m[1]!);
 
@@ -2040,7 +2181,7 @@ describe("the add-ons article's behaviour claims are pinned to the code", () => 
   // sentence on the page: the day somebody builds either control, the article
   // starts telling customers to email support for a button that is on screen.
   // Nothing about the copy can detect that, so this watches the CODE.
-  it("says 'no control in Settings yet' only while that is still true", { timeout: 60_000 }, () => {
+  it("says 'no control in Settings yet' only while that is still true", () => {
     // The purchase entry points. A control means a component or page reaching
     // for one of these — the API routes and the usecases themselves are not
     // evidence of a UI, which is exactly the distinction the sentence makes.

--- a/apps/web/src/lib/__tests__/inline-timeout-truth.test.ts
+++ b/apps/web/src/lib/__tests__/inline-timeout-truth.test.ts
@@ -1,0 +1,325 @@
+// A per-test `{ timeout: N }` (or `{ retry: N }`) SILENTLY OVERRIDES
+// `--testTimeout` / `--retry` on the CLI. That is the non-obvious part, and it
+// is what made #363 expensive to diagnose: someone hits a CI timeout, passes
+// the documented flag, watches the suite fail identically, and reasonably
+// concludes the test hangs rather than that their flag was ignored.
+//
+// `1ad49d5e` (#363) gave `vitest.config.ts` a real `testTimeout: 30_000` /
+// `hookTimeout: 30_000` default, so the repo now has a config the whole suite
+// shares instead of a hand-typed habit. Nothing stops the next file (or the
+// next line in an existing file) from pinning its own inline timeout again —
+// and if it does, it becomes a file whose timeout nobody can tune from
+// outside, silently. This scans for exactly that re-creation.
+//
+// Vitest's own types are the reason this is scoped to `it`/`test`/`describe`
+// and to the OBJECT-LITERAL form only:
+//   - `it`/`test`/`describe` accept `(name, options, fn)` where `options` can
+//     carry `{ timeout, retry, ... }` — this is the shape #363 actually used
+//     and the one this file finds live in the repo today.
+//   - `beforeAll`/`afterAll`/`beforeEach`/`afterEach` accept only a bare
+//     NUMBER as a third argument (`fn, timeout?: number`) — no object form
+//     exists for hooks, so `{ timeout }` there is already a type error tsc
+//     catches on its own; a bare numeric hook-level pin is the same class of
+//     footgun but out of scope here (issue #370 asked for the object-literal
+//     shape specifically, and no instance of the numeric form exists in the
+//     repo as of this writing — `grep -E '\b(before|after)(All|Each)\([^)]*,
+//     \s*[0-9]'` finds none).
+//
+// Source-scanning rather than an ESLint rule, per #370: the pattern is a
+// property in an object-literal argument, which a small hand-rolled arg
+// parser handles fine and a custom rule would not repay the cost of writing.
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SRC = path.resolve(__dirname, "../..");
+
+/** Every `*.test.ts`/`*.test.tsx` under src (this file included — it never
+ *  pins its own timeout, so scanning it is harmless). */
+function testFiles(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === "node_modules") continue;
+      testFiles(full, out);
+    } else if (/\.test\.tsx?$/.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// A small hand-rolled parser for exactly the surface this needs: given the
+// index of an opening '(', find the index of its matching ')', respecting
+// strings (including template-literal `${...}` interpolation), line comments,
+// and block comments — the same reasoning admin-audit-actor-truth.test.ts
+// gives for NOT trying to be a full JS parser, applied one level deeper
+// because here the thing being balanced is the argument LIST, not a fixed
+// window after it.
+// ---------------------------------------------------------------------------
+
+/** src[i] is the opening quote (`'`, `"`, or `` ` ``). Returns the index of
+ *  the matching closing quote, skipping escapes and `${...}` interpolation. */
+function skipString(src: string, i: number, quote: string): number {
+  let j = i + 1;
+  while (j < src.length) {
+    const c = src[j];
+    if (c === "\\") {
+      j += 2;
+      continue;
+    }
+    if (c === quote) return j;
+    if (quote === "`" && c === "$" && src[j + 1] === "{") {
+      j = skipBraces(src, j + 1) + 1;
+      continue;
+    }
+    j++;
+  }
+  return j;
+}
+
+/** src[i] is an opening '{'. Returns the index of its matching '}'. */
+function skipBraces(src: string, i: number): number {
+  let depth = 0;
+  let j = i;
+  while (j < src.length) {
+    const c = src[j];
+    if (c === "'" || c === '"' || c === "`") {
+      j = skipString(src, j, c);
+      j++;
+      continue;
+    }
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth === 0) return j;
+    }
+    j++;
+  }
+  return j;
+}
+
+/** src[i] is an opening '('. Returns the index of its matching ')'. */
+function findParenEnd(src: string, i: number): number {
+  let depth = 0;
+  let j = i;
+  while (j < src.length) {
+    const c = src[j];
+    if (c === "'" || c === '"' || c === "`") {
+      j = skipString(src, j, c);
+      j++;
+      continue;
+    }
+    if (c === "/" && src[j + 1] === "/") {
+      const nl = src.indexOf("\n", j);
+      j = nl === -1 ? src.length : nl;
+      continue;
+    }
+    if (c === "/" && src[j + 1] === "*") {
+      const end = src.indexOf("*/", j + 2);
+      j = end === -1 ? src.length : end + 2;
+      continue;
+    }
+    if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth === 0) return j;
+    }
+    j++;
+  }
+  return src.length - 1;
+}
+
+/** Splits an argument-list body on top-level commas only. */
+function splitTopLevel(s: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  let i = 0;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === "'" || c === '"' || c === "`") {
+      i = skipString(s, i, c);
+      i++;
+      continue;
+    }
+    if (c === "/" && s[i + 1] === "/") {
+      const nl = s.indexOf("\n", i);
+      i = nl === -1 ? s.length : nl;
+      continue;
+    }
+    if (c === "/" && s[i + 1] === "*") {
+      const end = s.indexOf("*/", i + 2);
+      i = end === -1 ? s.length : end + 2;
+      continue;
+    }
+    if (c === "(" || c === "[" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === "}") depth--;
+    else if (c === "," && depth === 0) {
+      parts.push(s.slice(start, i));
+      start = i + 1;
+    }
+    i++;
+  }
+  parts.push(s.slice(start));
+  return parts;
+}
+
+/** Matches a bare (un-chained) call, `it.only(`, `it.each(`, `describe.skipIf(`,
+ *  etc. — the chain suffix is resolved below by following curried calls. */
+const CALL_RE = /\b(it|test|describe)(?:\.\w+)*\s*\(/g;
+
+interface Violation {
+  file: string;
+  line: number;
+  testName: string;
+  snippet: string;
+}
+
+/** True if `//` appears on the match's own line before the match starts —
+ *  i.e. the call site itself is commented out. (Block comments spanning into
+ *  the line are not handled; a false positive from one fails loudly, per the
+ *  same over-inclusive-by-design reasoning admin-audit-actor-truth.test.ts
+ *  documents, rather than silently hiding a real pin.) */
+function isLineCommentedOut(src: string, matchIndex: number): boolean {
+  const lineStart = src.lastIndexOf("\n", matchIndex) + 1;
+  const before = src.slice(lineStart, matchIndex);
+  return before.includes("//");
+}
+
+function scanFile(absPath: string, relPath: string): Violation[] {
+  const src = fs.readFileSync(absPath, "utf8");
+  const violations: Violation[] = [];
+  let m: RegExpExecArray | null;
+  CALL_RE.lastIndex = 0;
+  while ((m = CALL_RE.exec(src))) {
+    if (isLineCommentedOut(src, m.index)) continue;
+    const openIdx = m.index + m[0].length - 1;
+    let bodyStart = openIdx + 1;
+    let bodyEnd = findParenEnd(src, openIdx);
+    // Follow curried chains — `it.each(table)(name, fn, opts)`,
+    // `describe.skipIf(cond)(name, fn)` — whose REAL test args are in the
+    // call that follows the first one, not the table/condition argument.
+    let cursor = bodyEnd + 1;
+    for (;;) {
+      let j = cursor;
+      while (j < src.length && /\s/.test(src[j]!)) j++;
+      if (src[j] !== "(") break;
+      const nextEnd = findParenEnd(src, j);
+      bodyStart = j + 1;
+      bodyEnd = nextEnd;
+      cursor = nextEnd + 1;
+    }
+    const body = src.slice(bodyStart, bodyEnd);
+    const args = splitTopLevel(body);
+    const firstArg = (args[0] ?? "").trim();
+    const openQuote = firstArg[0];
+    let testName = "(unnamed)";
+    if (openQuote === '"' || openQuote === "'" || openQuote === "`") {
+      // Reuses the same string-skipper used for arg parsing, so a test name
+      // containing an escaped or nested-backtick character is captured in
+      // full rather than truncated at the first lookalike delimiter.
+      const closeIdx = skipString(firstArg, 0, openQuote);
+      testName = firstArg.slice(1, closeIdx);
+    }
+    for (const arg of args) {
+      const trimmed = arg.trim();
+      if (!trimmed.startsWith("{")) continue; // not an options object — the callback fn, a name, or a table
+      if (!/\b(timeout|retry)\s*:/.test(trimmed)) continue;
+      const line = src.slice(0, bodyStart).split("\n").length;
+      violations.push({ file: relPath, line, testName, snippet: trimmed.slice(0, 80) });
+    }
+  }
+  return violations;
+}
+
+/**
+ * Allowlist for genuine exceptions: a deliberately slow integration case that
+ * truly needs its own bound beyond the repo-wide default. Keyed on
+ * `${relativeFile}::${testName}` rather than line number, so unrelated edits
+ * above the pin don't rot the entry — only the pin's removal, or the test's
+ * rename, does.
+ *
+ * This list may only ever SHRINK: the second test below fails if an entry
+ * stops matching a real pin, so a fixed file cannot leave a stale exemption
+ * behind to hide the next one. It is empty right now — see the guard's
+ * current finding in the task report for what it found instead of being
+ * allowlisted here.
+ */
+const ALLOWLIST: Readonly<Record<string, string>> = {};
+
+describe("no test/hook re-pins an inline timeout or retry (#370)", () => {
+  // Excludes this file itself: its synthetic sample string below deliberately
+  // contains the literal shape being scanned for, as plain text inside a
+  // template literal the OUTER file's naive text scan can't tell apart from
+  // real code — the same reason admin-audit-actor-truth.test.ts's own scanner
+  // excludes its writer file, one level removed (there it's "don't flag the
+  // reference implementation"; here it's "don't flag your own fixture text").
+  const SELF = path.basename(__filename);
+  const files = testFiles(SRC).filter((f) => path.basename(f) !== SELF);
+
+  it("finds a plausible number of test files", () => {
+    // Guards the guard: a wrong root would iterate nothing and pass every
+    // assertion below vacuously — the exact failure shape this repo keeps
+    // having to relearn (migration-header-truth.test.ts,
+    // admin-audit-actor-truth.test.ts).
+    expect(files.length).toBeGreaterThan(400);
+  });
+
+  it("recognizes the planted-pin shape on a synthetic sample, so the parser is not silently matching nothing", () => {
+    // Independent of any real file on disk: proves scanFile finds the exact
+    // shape #363 removed and this guard exists to catch, in all three
+    // positions a chained call can put it, and does NOT flag ordinary calls
+    // (a plain `it(name, fn)`, or an in-body call to an unrelated function
+    // that merely happens to take a `{ timeout }` option, like `sql.end` or
+    // `vi.waitFor`).
+    const sample = `
+      it("plain test, no pin", () => {
+        vi.waitFor(() => expect(1).toBe(1), { timeout: 5000 });
+        return sql.end({ timeout: 5 });
+      });
+      it("direct pin", { timeout: 60_000 }, () => { doWork(); });
+      test("retry pin", { retry: 2 }, async () => { doWork(); });
+      it.each([1, 2])("each pin %i", (n) => { doWork(n); }, { timeout: 1000 });
+      describe.skipIf(!HAS_DB)("chained pin", { timeout: 9000 }, () => {
+        it("nested, unrelated", () => { sql.end({ timeout: 5 }); });
+      });
+      // it("commented out pin", { timeout: 1 }, () => {});
+    `;
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "inline-timeout-truth-"));
+    const file = path.join(dir, "sample.test.ts");
+    fs.writeFileSync(file, sample);
+    try {
+      const found = scanFile(file, "sample.test.ts").map((v) => v.testName);
+      expect(found.sort()).toEqual(["chained pin", "direct pin", "each pin %i", "retry pin"].sort());
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("no it/test/describe call pins its own { timeout } or { retry } outside the allowlist", () => {
+    const unexplained: string[] = [];
+    for (const file of files) {
+      const relPath = path.relative(SRC, file);
+      for (const v of scanFile(file, relPath)) {
+        const key = `${relPath}::${v.testName}`;
+        if (key in ALLOWLIST) continue;
+        unexplained.push(`${relPath}:${v.line} — "${v.testName}" — ${v.snippet}`);
+      }
+    }
+    expect(unexplained).toEqual([]);
+  });
+
+  it("the allowlist holds nothing that has stopped needing it", () => {
+    // The mirror of the check above: a stale entry silently permits a pin
+    // that no longer exists (or was renamed), and would hide a real new one
+    // that reused the same key.
+    const liveKeys = new Set<string>();
+    for (const file of files) {
+      const relPath = path.relative(SRC, file);
+      for (const v of scanFile(file, relPath)) liveKeys.add(`${relPath}::${v.testName}`);
+    }
+    const stale = Object.keys(ALLOWLIST).filter((k) => !liveKeys.has(k));
+    expect(stale).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/copy-truth.ts
+++ b/apps/web/src/lib/copy-truth.ts
@@ -1308,6 +1308,55 @@ export function unmeteredAiRunProseFaults(label: string, markdown: string): stri
   return faults;
 }
 
+/**
+ * v17 gap #365: `content/help/scheduling/ai-officials.md` said "Automatic
+ * officials assignment is a Pro Plus feature." That sentence describes a REAL
+ * gate — just not this one. `officials.ts`'s `officials.auto` feature key
+ * (V290; `plan_entitlements` has `bool_value=true` for `pro_plus` only, `false`
+ * for `pro`/`community` — measured against the local DB) gates a DIFFERENT,
+ * deterministic "quick auto-assign" action (`autoAssignOfficials` /
+ * `applyOfficialAssignments`, both call `requireFeature(auth.orgId,
+ * "officials.auto")`), and `officials.md` correctly documents THAT gate. The
+ * LLM-driven AI Officials architect this article is about is a separate code
+ * path: `officials-ai.ts`'s own orchestrator comment states it directly — "the
+ * AI officials path is NOT plan-gated" — `officialsAiPlanForDivision` never
+ * calls `requireFeature` on any tier; it is metered by the AI credit wallet
+ * instead (SPEC-1 §5, §7 / SPEC-2 §5.2), the same wallet the guard above
+ * defends.
+ *
+ * DELIBERATELY NOT run tree-wide, unlike the guard above: the two features
+ * share almost identical human phrasing ("automatic officials assignment … is
+ * a Pro Plus feature") for two different gates, so a vocabulary broad enough to
+ * catch the false claim in THIS article would also catch `officials.md`'s TRUE
+ * one — the ambiguity is in the English, not in the regex. Scoping this
+ * function's one call site to `ai-officials.md` (see
+ * `help-copy-truth.test.ts`) is the fix; the pattern is written narrowly enough
+ * that it does not currently match `officials.md`'s wording either (the
+ * parenthetical "(propose/apply)" breaks the adjacency the first pattern
+ * requires), but that is a bonus, not the safety mechanism.
+ */
+export function aiOfficialsPlanGateFaults(label: string, markdown: string): string[] {
+  const patterns = [
+    /\bautomatic\s+officials?\s+assignment\s+is\s+a\b[^.;]{0,20}\bpro\s+plus\b[^.;]{0,20}\bfeature\b/i,
+    /\bAI\s+officials?\b[^.;]{0,40}\b(?:is|are)\s+a\b[^.;]{0,20}\bpro\s+plus\b[^.;]{0,20}\bfeature\b/i,
+    /\bAI\s+officials?\b[^.;]{0,40}\brequires?\b[^.;]{0,20}\bpro\s+plus\b/i,
+    /\bpro\s+plus\s+only\b[^.;]{0,40}\bAI\s+officials?\b|\bAI\s+officials?\b[^.;]{0,40}\bpro\s+plus\s+only\b/i,
+  ];
+  const faults: string[] = [];
+  for (const block of claimTexts(markdown)) {
+    for (const sentence of sentences(block)) {
+      for (const pattern of patterns) {
+        if (pattern.test(sentence)) {
+          faults.push(
+            `${label}: "${sentence.slice(0, 72)}…" claims AI Officials needs Pro Plus — the AI officials path is NOT plan-gated (officials-ai.ts:officialsAiPlanForDivision never calls requireFeature); only the separate, deterministic officials.auto action is (officials.ts, V290, plan_entitlements pro_plus-only)`,
+          );
+        }
+      }
+    }
+  }
+  return faults;
+}
+
 // ── The pass's duration and credit grant, in prose ───────────────────────────
 
 /**

--- a/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
+++ b/apps/web/src/server/usecases/__tests__/billing-group-move.test.ts
@@ -2370,33 +2370,89 @@ describe.skipIf(!HAS_DB)("a live subscription with nothing left to bill", () => 
     expect(Number(n)).toBe(1);
   });
 
-  it("never cancels an INCOMPLETE group whose last org was soft deleted — cancelGroupIfEmpty's status list excludes 'incomplete' (#311)", async () => {
+  it("REFUSES AUDIBLY when an INCOMPLETE group's last org departs — declining is not the same as having acted (#311, #367)", async () => {
     // syncGroupQuantity's own gate is hasLiveSubscription, which correctly
     // treats 'incomplete' as live (LIVE_SUBSCRIPTION_STATUSES), so it reaches
     // the orphaned branch and calls the private cancelGroupIfEmpty exactly as
     // it would for an 'active' group. But that function's claiming UPDATE has
     // its OWN hand-written `status in ('trialing', 'active', 'past_due')`,
-    // which excludes 'incomplete' — so the UPDATE matches zero rows, the
-    // claim silently fails, and the group is left billing Stripe for an org
-    // that no longer exists, with nothing left to ever retry it. This pins
-    // that CURRENT behaviour; #311 stops short of deriving this list from the
-    // constant because doing so (this group would start being cancelled) is a
-    // live behaviour change, not a pure refactor.
+    // which excludes 'incomplete' — so the UPDATE matches zero rows.
+    //
+    // NOT cancelling is correct and stays (#367): 'incomplete' means Stripe's
+    // first invoice is unpaid, which it voids itself within 23 hours, so a
+    // cancel would be sent for a subscription Stripe is about to destroy
+    // anyway. What was wrong was that the refusal was INDISTINGUISHABLE from a
+    // successful cancel — same return shape, no log, no error. A guard that
+    // declines silently reads exactly like one that is broken, which is what
+    // cost a wave to notice. So: still no cancel, still 'incomplete', but the
+    // refusal must now say so, and say WHY.
     const payer = await makeUser("payer");
     const stripeSubId = "sub_incomplete_orphan_" + uniq();
     const group = await makeGroup(payer, { stripeSubId, status: "incomplete", periodEndDays: 30 });
     const orgId = await makeOrg(group, payer);
     await sql`update organizations set deleted_at = now() where id = ${orgId}`;
 
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    // Read the spy BEFORE restoring it. vi's mockRestore also RESETS, so
+    // `warn.mock.calls` is empty afterwards and every assertion on it passes
+    // vacuously — the exact shape of check this issue is about.
+    let said = "";
+    let erred: string[] = [];
     try {
       await syncGroupQuantity(group);
     } finally {
+      said = warn.mock.calls.map((c) => c.map(String).join(" ")).join("\n");
+      erred = err.mock.calls.map((c) => c.map(String).join(" "));
+      warn.mockRestore();
       err.mockRestore();
     }
 
     expect(stripeMock.subscriptionsCancel).not.toHaveBeenCalled();
     expect((await readGroup(group)).status).toBe("incomplete");
+    // The audible half. Naming the group alone would not be enough to act on:
+    // the line has to carry the status that caused the refusal, or the next
+    // reader is back to re-deriving it from the SQL.
+    expect(said).toMatch(/declined|refus/i);
+    expect(said).toContain(group);
+    expect(said).toContain("incomplete");
+    // And the outcome must not be dressed up as the failure it is not: a refusal
+    // reported as `cancel_failed` would light up the orphan branch's "CANCEL
+    // FAILED, will retry" error — untrue, since no cancel was ever attempted —
+    // and on the detach path would send the group to dropEmptyGroup.
+    expect(erred).toEqual([]);
+  });
+
+  it("stays QUIET when the group simply is not empty — a race is not a refusal", async () => {
+    // The counterpart to the test above, and the reason the decline is
+    // diagnosed empty-first rather than status-first. detach calls
+    // cancelGroupIfEmpty unconditionally on the group it left, including when
+    // other orgs remain — the overwhelmingly common outcome. If the new log
+    // fired on every claim that matched nothing it would fire on every ordinary
+    // detach, and an alarm that cries on the happy path is one nobody reads.
+    // The group is 'incomplete' on purpose: BOTH halves of the claim's
+    // predicate fail here, and "not empty" is still the honest answer.
+    const payer = await makeUser("payer");
+    const group = await makeGroup(payer, {
+      stripeSubId: "sub_incomplete_busy_" + uniq(),
+      status: "incomplete",
+      periodEndDays: 30,
+      quantityPaid: 2,
+    });
+    const leaver = await makeOrg(group, payer);
+    await makeOrg(group, payer);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Captured before the restore, which resets the spy — see the note above.
+    let said: string[] = [];
+    try {
+      await detachOrgFromGroup({ actorUserId: payer, orgId: leaver });
+    } finally {
+      said = warn.mock.calls.map((c) => c.map(String).join(" "));
+      warn.mockRestore();
+    }
+
+    expect(said).toEqual([]);
   });
 });
 

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -385,7 +385,11 @@ export async function syncGroupQuantity(
     const outcome = await cancelGroupIfEmpty(subscriptionId);
     // "not_empty" is a legitimate outcome, not a failure: an org arrived between
     // the count above and this claim, and the group is billable after all.
-    if (outcome !== "not_empty")
+    // "not_cancellable" has already logged its own reason — including the status
+    // that caused the refusal — inside cancelGroupIfEmpty. Re-reporting it here
+    // as "CANCEL FAILED, will retry" would be both a duplicate and a lie: no
+    // cancel was attempted and nothing retries it.
+    if (outcome === "cancelled" || outcome === "cancel_failed")
       console.error(
         `[billing] group ${subscriptionId} has a live subscription and no organisations — ` +
           (outcome === "cancelled" ? "cancelled" : "CANCEL FAILED, will retry"),
@@ -422,6 +426,20 @@ export async function reconcileGroupQuantities(limit = 500): Promise<{
   const groups = await sql<{ id: string }[]>`
     select s.id from subscriptions s
      where s.stripe_subscription_id is not null
+       -- 'incomplete' is absent ON PURPOSE, and this list diverging from
+       -- LIVE_SUBSCRIPTION_STATUSES is not an oversight (#311, #367).
+       -- 'incomplete' means Stripe's first invoice has not been paid, and it has
+       -- a hard 23-HOUR ceiling: Stripe then moves the subscription to
+       -- 'incomplete_expired' and voids that invoice itself. This is a DAILY
+       -- cron, so a group can be seen in that state at most once, and by the run
+       -- that could act on it the subscription is either 'active' (already
+       -- selected here, drift and all) or dead. Including it would therefore
+       -- correct nothing that stays corrected — and it would mean changing an
+       -- item quantity while the first invoice is still open and unpaid, which
+       -- Stripe does not document. Unspecified behaviour, on an unpaid invoice,
+       -- executed unattended, for no benefit. cancelGroupIfEmpty omits it too,
+       -- for a DIFFERENT reason stated there; the two sites legitimately want
+       -- different sets, which is why neither derives from the constant.
        and s.status in ('trialing', 'active', 'past_due')
        and s.quantity_paid <> (
              select count(*) from organizations o
@@ -540,6 +558,21 @@ export async function orgsWithoutGroup(
  *
  * `not_empty` is a normal outcome, not an error: an org arrived, and the group
  * is billable after all.
+ *
+ * `not_cancellable` is the fourth outcome, and it exists because for a long time
+ * there were only three (#367). The claim can match nothing for TWO reasons —
+ * an org arrived, or the status is outside the set this will cancel — and
+ * reporting both as `not_empty` meant a group that was refused looked exactly
+ * like a group that had been cancelled: same shape, no log, no error. A guard
+ * that declines silently is indistinguishable from one that is broken, and it
+ * cost a wave to notice that this was the former. So the two are now told apart
+ * and the refusal is logged with the status that caused it.
+ *
+ * The status is deliberately NOT widened to match LIVE_SUBSCRIPTION_STATUSES.
+ * The one status that reaches this in practice is `incomplete`, which Stripe
+ * expires and voids by itself inside 23 hours; cancelling would send Stripe a
+ * cancel for a subscription it is about to destroy anyway. See the note on
+ * reconcileGroupQuantities, which omits the same status for a different reason.
  */
 interface CancelClaim {
   prev_status: string;
@@ -552,8 +585,8 @@ interface CancelClaim {
 
 async function cancelGroupIfEmpty(
   subscriptionId: string,
-): Promise<"cancelled" | "not_empty" | "cancel_failed"> {
-  const claimed = (await sql.begin(async (tx) => {
+): Promise<"cancelled" | "not_empty" | "not_cancellable" | "cancel_failed"> {
+  const attempt = (await sql.begin(async (tx) => {
     // Statement 1: take the row lock, and WAIT for whoever holds it (an attach
     // in flight). Nothing is decided here — the previous values are captured for
     // the rollback below.
@@ -579,9 +612,40 @@ async function cancelGroupIfEmpty(
                select 1 from organizations o
                 where o.subscription_id = s.id and o.deleted_at is null)
       returning s.id`;
-    return claim ? prev : null;
-  })) as CancelClaim | null;
-  if (!claimed) return "not_empty";
+    if (claim) return { prev, claimed: true, empty: true };
+    // The claim matched nothing. The row is LOCKED, so exactly one of the two
+    // predicates above failed, and which one is the whole point of this
+    // function's fourth outcome — so ask, rather than assume the innocent one.
+    //
+    // Diagnosed by ELIMINATION rather than by re-testing the status in TS: a
+    // second copy of that status list would be one more thing to keep in step
+    // with the SQL, and the two drifting apart is precisely the class of defect
+    // this change exists to make audible. If no live organisation exists, the
+    // emptiness half held and the status half is the only remaining explanation.
+    const [{ n }] = await tx<{ n: string }[]>`
+      select count(*)::text as n from organizations o
+       where o.subscription_id = ${subscriptionId} and o.deleted_at is null`;
+    return { prev, claimed: false, empty: Number(n) === 0 };
+  })) as { prev: CancelClaim; claimed: boolean; empty: boolean } | null;
+  // No row at all: nothing to cancel and nothing to report.
+  if (!attempt) return "not_empty";
+  if (!attempt.claimed) {
+    // An org arrived while statement 1 was blocked on the attach's lock. This is
+    // the ordinary outcome of every detach that leaves somebody behind, and an
+    // alarm that fires on the happy path is one nobody reads.
+    if (!attempt.empty) return "not_empty";
+    console.warn(
+      `[billing] cancelGroupIfEmpty DECLINED to cancel group ${subscriptionId}: it has no live ` +
+        `organisations, but its status is '${attempt.prev.prev_status}', which is outside the ` +
+        `set this claim cancels ('trialing', 'active', 'past_due'). Nothing was cancelled at ` +
+        `Stripe and nothing here will retry. For 'incomplete' that is deliberate — the first ` +
+        `invoice is unpaid, and Stripe voids it and expires the subscription itself within 23 ` +
+        `hours (#367). Any OTHER status reaching this line is worth chasing: it means a group ` +
+        `is live at Stripe and billing for nobody.`,
+    );
+    return "not_cancellable";
+  }
+  const claimed = attempt.prev;
 
   if (claimed.stripe_subscription_id) {
     try {
@@ -1152,7 +1216,14 @@ export async function detachOrgFromGroup(args: {
   // why doing it in one statement does not close the window.
   let cancelled: string | null = null;
   const outcome = await cancelGroupIfEmpty(result.from);
-  if (outcome !== "not_empty") {
+  // Only the two outcomes that CHANGED something end the detach here.
+  // `not_cancellable` falls through with `not_empty`, deliberately: the group
+  // was refused, not cancelled, so the seat decrement below still has to run,
+  // and dropEmptyGroup must NOT be reached — whether an org-less group with a
+  // status outside that set should be reaped locally is a decision nobody has
+  // taken (#367), and taking it accidentally, here, on the else branch of a
+  // condition written for `cancel_failed`, is how it would get taken badly.
+  if (outcome === "cancelled" || outcome === "cancel_failed") {
     if (outcome === "cancelled") cancelled = result.from;
     else await dropEmptyGroup(result.from);
     return { subscription_id: result.to, cancelled_group: cancelled };


### PR DESCRIPTION
Three issues filed on 2026-07-29 while auditing the v17 gap waves, each a case of
something being true in a comment or a test name but not in the code.

**#365 — scheduling/ai-officials.md stated two things the code contradicts.**
It called automatic officials assignment a Pro Plus feature: the pro_plus-only
`officials.auto` row gates a DIFFERENT, deterministic action in officials.ts,
while `officialsAiPlanForDivision` is not plan-gated — its one `requireFeature`
is `officials.roles_multi`, which V319 opened on every plan including community.
And it said officials AI runs are "not metered … effectively free": `spendCredit`
wraps the entire call, including the no-instruction default spread that makes no
model call, so every run costs one credit (refunded if the run fails).

The article now states the credit spend, the refund, and the real 5-runs-an-hour
per-division brake. #303's unmetered-run vocabulary scan — which existed, and
which ai-officials.md was the third copy to evade — now runs over every article
`allHelpArticles()` returns, not just ai-scheduling.md. The plan-gate scan stays
scoped to this one article deliberately: officials.md carries an almost
identically worded claim about the other gate that is TRUE, and a vocabulary wide
enough to catch the false one would red the true one.

The replacement sentence rests on a matrix ROW rather than on the absence of a
call, so a DB-backed test pins `officials.roles_multi` open on every plan. A
prose scan cannot catch the opposite failure — the sentence staying identical
while the thing it describes moves underneath it — which is how the article went
wrong in the first place.

**#367 — cancelGroupIfEmpty could decline to cancel and say nothing.**
Its claim cancels only `trialing`/`active`/`past_due`. A group whose last
organisation leaves while it sits in another status matched nothing, and the
zero-row result was indistinguishable from the ordinary "someone is still here"
outcome, so it returned "not_empty" and went quiet — a subscription live at
Stripe, billing for nobody, with no trace.

The claim now reports which of its two predicates failed, diagnosed by
elimination (the row is locked, so one `count(*)` of live orgs inside the same
transaction settles it) rather than by a second copy of the status list in TS —
that copy drifting from the SQL is the class of defect this exists to make
audible. An org-less refusal warns, naming the group and its status, and returns
`not_cancellable`. Behaviour is byte-identical for all three pre-existing
outcomes: `not_cancellable` falls through with `not_empty`, so the seat decrement
still runs and `dropEmptyGroup` is still not reached.

Deliberately NOT done here: adding `incomplete` to the cancellable set (it would
change an item quantity while the first invoice is open and unpaid), and reaping
the org-less row (it carries `trial_used_at`, so deleting it would hand the payer
a fresh trial by abandoning a checkout — a farm). Both are recorded on #367.

**#370 — nothing stopped an inline `{ timeout }` from re-opening #363's door.**
A per-test `{ timeout }` OVERRIDES `--testTimeout`, and CI runs a bare `npm test`,
so one inline pin silently sets the bound for that test whatever the config says.
The new guard parses every `it`/`test`/`describe` call site — balanced-paren, not
a regex window, so `.each(...)` and `.skipIf(...)` chains are covered — and
flags any object argument carrying `timeout:` or `retry:`. It ships with an
allowlist keyed by file + test name, a test that fails when an allowlist entry
goes stale, and a canary asserting the scan reached 400+ test files.

It found four pre-existing pins on its first run: one duplicating the 30s default
exactly, three at 60s on tests measured at 51ms, 2.1s and 3ms. All four removed
rather than allowlisted — an allowlist entry asserts a genuine need, and none of
them had one.

Closes #365
Closes #370

---

## Verification

Every agent's work was re-run and mutation-checked independently rather than accepted from its report.

| check | result |
|---|---|
| `tsc --noEmit -p .` | clean |
| `npm run lint` | 0 errors, 73 warnings (baseline) |
| `vitest run src/lib src/server` (real DB, V343 + sports synced) | 3199 tests, 3150 pass, **0 fail**, 49 pending |
| mutation — silence #367's warn | 1 red, naming the assertion; restored → 80/80 |
| mutation — flip `officials.roles_multi` to false for community | new matrix pin reds; restored → 95/95 |
| mutation — #370's guard vs a planted inline pin | reds naming the planted file; it also found the 4 real pins below |

One first-run failure — `funnel.test.ts`, `expected 'generic' to be 'badminton'` — was my verification database missing `sync:sports`, not a defect. Green after syncing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)