### PR TITLE
fix(pads): stop reading a ref during render in the period-pad countdown

### DIFF
--- a/apps/web/src/components/__tests__/_hook-harness.tsx
+++ b/apps/web/src/components/__tests__/_hook-harness.tsx
@@ -134,10 +134,11 @@ function hookDispatcherSlot(): { H: HookDispatcher | null } {
  */
 export function renderIsland<P>(
   Component: (props: P) => ReactNode,
-  props: P,
+  initialProps: P,
   expand: (node: ReactNode) => ReactElement[] = (node) => walk(node),
 ) {
   const slot = hookDispatcherSlot();
+  let props = initialProps;
   const cells: Cell[] = [];
   let cursor = 0;
   let output: ReactNode = null;
@@ -212,5 +213,15 @@ export function renderIsland<P>(
   run();
   // Functions, not values: every interaction re-renders, and reading a stale
   // tree would let assertions pass against markup the user never saw.
-  return { tree: () => expand(output), text: () => textOf(output) };
+  return {
+    tree: () => expand(output),
+    text: () => textOf(output),
+    /** Re-render with new props, the way a parent handing down fresh data
+     *  would — hook state (cells, effect cleanups, memos) carries over, so an
+     *  effect keyed on a prop that changed re-runs exactly once. */
+    rerender: (nextProps: P) => {
+      props = nextProps;
+      run();
+    },
+  };
 }

--- a/apps/web/src/components/v2/pads/__tests__/period-pad-countdown.test.tsx
+++ b/apps/web/src/components/v2/pads/__tests__/period-pad-countdown.test.tsx
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PeriodPad } from "@/components/v2/pads/period-pad";
+import { propsOf, renderIsland, textOf, walk } from "@/components/__tests__/_hook-harness";
+import type { LiveState, SideInfo, SportInfo } from "@/components/v2/fixture-console";
+
+// #355: countdown() used to read stampsRef (a ref) during render. The stamp
+// state now lives in useState, so these pin the same visible behaviour the
+// ref version had — full duration on arrival, ticking down, and a clean slot
+// for whatever suspension comes next — without the render-reads-a-ref hazard.
+const side = (id: string, name: string): SideInfo => ({ id, name, members: [], lineup: [] });
+
+const sport: SportInfo = {
+  key: "icehockey",
+  config: { suspensions: { classes: { minor: { minutes: 2, teamShort: true } } } },
+  scorerLabel: "Scorer",
+  positionGroups: [],
+  roles: [],
+  lineupSize: 6,
+  fidelityTiers: [
+    {
+      tier: 3,
+      eventTypes: [
+        "icehockey.goal",
+        "icehockey.period.advance",
+        "icehockey.suspension.start",
+        "icehockey.suspension.end",
+        "icehockey.shootout.attempt",
+      ],
+    },
+  ],
+};
+
+function liveWith(suspensions: unknown[]): LiveState {
+  return {
+    status: "in_play",
+    last_seq: 1,
+    summary: { headline: "0 — 0" },
+    state: { phase: "P1", goals: { home: 0, away: 0 }, suspensions },
+    outcome: null,
+  };
+}
+
+const noSuspensions = liveWith([]);
+const home = side("h", "Harbor");
+const away = side("a", "Summit");
+const baseProps = { sport, home, away, send: async () => true, busy: false };
+
+const hintText = (tree: ReturnType<typeof walk>) => {
+  const hint = tree.find(
+    (el) => el.type === "span" && String(propsOf(el).className ?? "").includes("text-amber-700"),
+  );
+  return hint ? textOf(hint) : null;
+};
+
+describe("PeriodPad countdown (#355 — no ref read during render)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-29T12:00:00.000Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows the class's full duration the moment a suspension appears mid-match", () => {
+    const island = renderIsland(PeriodPad, { ...baseProps, live: noSuspensions });
+    expect(hintText(island.tree())).toBeNull();
+
+    island.rerender({
+      ...baseProps,
+      live: liveWith([{ side: "home", classKey: "minor", teamShort: true, permanent: false }]),
+    });
+    expect(hintText(island.tree())).toBe("2:00");
+  });
+
+  it("ticks down once a second as the penalty runs", () => {
+    const island = renderIsland(PeriodPad, {
+      ...baseProps,
+      live: liveWith([{ side: "home", classKey: "minor", teamShort: true, permanent: false }]),
+    });
+    expect(hintText(island.tree())).toBe("2:00");
+
+    vi.advanceTimersByTime(5000);
+    expect(hintText(island.tree())).toBe("1:55");
+
+    vi.advanceTimersByTime(60000);
+    expect(hintText(island.tree())).toBe("0:55");
+  });
+
+  it("cleans up the stamp when the suspension ends, so the next one starts fresh", () => {
+    const island = renderIsland(PeriodPad, {
+      ...baseProps,
+      live: liveWith([{ side: "home", classKey: "minor", teamShort: true, permanent: false }]),
+    });
+    vi.advanceTimersByTime(10000);
+    expect(hintText(island.tree())).toBe("1:50");
+
+    // Released: the scorer's explicit action, not a timeout.
+    island.rerender({ ...baseProps, live: noSuspensions });
+    expect(hintText(island.tree())).toBeNull();
+
+    vi.advanceTimersByTime(30000);
+    island.rerender({
+      ...baseProps,
+      live: liveWith([{ side: "away", classKey: "minor", teamShort: true, permanent: false }]),
+    });
+    // A stale stamp from the first suspension would show < 2:00 here.
+    expect(hintText(island.tree())).toBe("2:00");
+  });
+
+  it("stops ticking once no suspensions remain", () => {
+    const clearSpy = vi.spyOn(globalThis, "clearInterval");
+    const island = renderIsland(PeriodPad, {
+      ...baseProps,
+      live: liveWith([{ side: "home", classKey: "minor", teamShort: true, permanent: false }]),
+    });
+    island.rerender({ ...baseProps, live: noSuspensions });
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});

--- a/apps/web/src/components/v2/pads/period-pad.tsx
+++ b/apps/web/src/components/v2/pads/period-pad.tsx
@@ -8,7 +8,7 @@
 // own `nextAdvance`, and the shootout recorder. The strength chip stays
 // visible while any team-short suspension runs. Countdown hints are wall-
 // clock sugar — the fold trusts only start/release events (v6/00 §6.1).
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type { SendEvent, SideInfo, SportInfo, LiveState } from "@/components/v2/fixture-console";
 import { useMsg } from "@/components/i18n/dict-provider";
 
@@ -97,17 +97,29 @@ export function PeriodPad({
   const classes = cfg.suspensions?.classes ?? null;
 
   // Wall-clock countdown hints: stamp suspensions we see appear. Display
-  // only — release is always the scorer's explicit action.
-  const stampsRef = useRef<Map<number, number>>(new Map());
+  // only — release is always the scorer's explicit action. Stamps live in
+  // state (not a ref) so `countdown()` below can read them during render
+  // without the "ref read during render" hazard: a ref mutation alone
+  // schedules no render, so anything that depended on it would go stale.
+  const [stamps, setStamps] = useState<Map<number, number>>(() => new Map());
   const [, forceTick] = useState(0);
   useEffect(() => {
-    const stamps = stampsRef.current;
-    suspensions.forEach((_, i) => {
-      if (!stamps.has(i)) stamps.set(i, Date.now());
+    setStamps((prev) => {
+      let next: Map<number, number> | null = null;
+      suspensions.forEach((_, i) => {
+        if (!prev.has(i)) {
+          next ??= new Map(prev);
+          next.set(i, Date.now());
+        }
+      });
+      for (const key of prev.keys()) {
+        if (key >= suspensions.length) {
+          next ??= new Map(prev);
+          next.delete(key);
+        }
+      }
+      return next ?? prev;
     });
-    for (const key of [...stamps.keys()]) {
-      if (key >= suspensions.length) stamps.delete(key);
-    }
   }, [suspensions]);
   useEffect(() => {
     if (suspensions.length === 0) return;
@@ -119,7 +131,7 @@ export function PeriodPad({
     if (classes === null) return null;
     const cls = classes[susp.classKey];
     if (!cls || cls.minutes === null) return susp.permanent ? msg("pad.pp.matchCountdown") : null;
-    const started = stampsRef.current.get(index);
+    const started = stamps.get(index);
     if (started === undefined) return `${cls.minutes}:00`;
     const left = Math.max(0, cls.minutes * 60 - Math.floor((Date.now() - started) / 1000));
     const mm = Math.floor(left / 60);
@@ -173,19 +185,6 @@ export function PeriodPad({
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
           <p className="mb-2 text-xs font-medium text-amber-800">{msg("pad.pp.runningPenalties")}</p>
           <ul className="space-y-1.5">
-            {/*
-              countdown() below reads stampsRef during render. The rule is right
-              about the pattern and wrong about the consequence HERE: the stamp is
-              written by an effect, so on the first render after a suspension
-              appears the read misses and returns the class's full duration rather
-              than a wrong number, and the 1s forceTick interval above is what
-              re-renders it thereafter. Fixing it properly means moving the
-              computation into the tick effect — a structural change to a
-              live-scoring display with no test coverage, which is not something to
-              do inside a lint sweep. #355 carries the tests and the restructure.
-              This is the ONE error the CI lint gate skips; nothing else may join it.
-            */}
-            {/* eslint-disable-next-line react-hooks/refs -- tracked as #355 */}
             {suspensions.map((susp, i) => {
               const side = sideInfo(susp.side);
               const hint = countdown(i, susp);


### PR DESCRIPTION
Fixes #355.

Moves the period-pad countdown's `stampsRef` (a `useRef<Map>` read during render, the one `react-hooks/refs` suppression left after #344's lint sweep) into `useState` instead, so `countdown()` reads state during render rather than a ref. Removes the suppression. Adds a fake-timer test for the countdown, extending the repo's no-jsdom hook harness with a minimal `rerender()` to simulate a suspension arriving as a prop change.

Could not run `npm run lint`/`npm run test` in this session (no `npm` permission, no `node_modules`) — please verify in CI.

Generated with [Claude Code](https://claude.ai/code)