### PR TITLE
fix(test): restore the one inline timeout that was load-bearing, and allowlist it

### DIFF
--- a/apps/web/src/lib/__tests__/help-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/help-copy-truth.test.ts
@@ -1621,7 +1621,14 @@ describe("the add-ons article's behaviour claims are pinned to the code", () => 
   // 9.3s in the full run (file total 10.5s). Quoting the isolated figure would
   // be the same kind of optimism this wave keeps correcting elsewhere, so both
   // are here. The 60s is real headroom for a loaded machine, not decoration.
-  it("freezes exactly the two axes the article says, and orgs.max_owned is not one", () => {
+  //
+  // RESTORED after #372 removed it. That removal measured this test ALONE
+  // (2.1s) and read it as leftover padding — past the paragraph above, which
+  // had already said the isolated figure is the misleading one. Re-measured
+  // inside a full `vitest run` of all 532 files: 41.8s, and it failed on the
+  // 30s config default. Allowlisted in inline-timeout-truth.test.ts, which is
+  // what that allowlist is for.
+  it("freezes exactly the two axes the article says, and orgs.max_owned is not one", { timeout: 60_000 }, () => {
     const source = webSource("server/usecases/entitlement-freeze.ts");
     const frozen = [...source.matchAll(/getLimit\(orgId,\s*"([^"]+)"\)/g)].map((m) => m[1]!);
 

--- a/apps/web/src/lib/__tests__/inline-timeout-truth.test.ts
+++ b/apps/web/src/lib/__tests__/inline-timeout-truth.test.ts
@@ -242,11 +242,21 @@ function scanFile(absPath: string, relPath: string): Violation[] {
  *
  * This list may only ever SHRINK: the second test below fails if an entry
  * stops matching a real pin, so a fixed file cannot leave a stale exemption
- * behind to hide the next one. It is empty right now — see the guard's
- * current finding in the task report for what it found instead of being
- * allowlisted here.
+ * behind to hide the next one.
+ *
+ * An entry needs a duration measured INSIDE a full `vitest run`, not in
+ * isolation. The one entry below is here because #372 deleted its pin on an
+ * isolated 2.1s reading and the test then took 41.8s under the real suite: the
+ * two numbers differ by 20x, and only the second one is the one CI experiences.
+ * A justification quoting the isolated figure is not a justification.
  */
-const ALLOWLIST: Readonly<Record<string, string>> = {};
+const ALLOWLIST: Readonly<Record<string, string>> = {
+  'lib/__tests__/help-copy-truth.test.ts::freezes exactly the two axes the article says, and orgs.max_owned is not one':
+    "First consumer of allAuditedSources() — it pays the whole walk-and-parse " +
+    "cost that later tests get memoised for free. Measured 2.1s alone and " +
+    "41.8s in a full 532-file run, where it failed the 30s default. #372 " +
+    "removed this pin reading only the isolated figure; restored.",
+};
 
 describe("no test/hook re-pins an inline timeout or retry (#370)", () => {
   // Excludes this file itself: its synthetic sample string below deliberately


### PR DESCRIPTION
#372 removed four inline `{ timeout }` pins on the grounds that the repo now has
a 30s config default and none of the four tests needed its own bound. Three of
those removals were right. The fourth was wrong, and it was wrong for the exact
reason the pin's own comment gave.

`help-copy-truth.test.ts`'s "freezes exactly the two axes the article says"
is the FIRST consumer of `allAuditedSources()`, so it pays the whole
walk-and-parse cost that every later test in the file gets memoised for free.
Measured alone it takes ~2.1s. Measured inside a full `vitest run` of all 532
test files — which is how CI runs it — it takes **41.8s**, and it fails on the
30s default.

The comment above it already said so, in as many words: "measured 1.65s alone
and 9.3s in the full run … The 60s is real headroom for a loaded machine, not
decoration." The removal quoted the isolated figure and read past the paragraph
explaining why the isolated figure is the misleading one.

So the pin is back, with an entry in `inline-timeout-truth.test.ts`'s allowlist
— which is what that allowlist exists for. The entry records both numbers, and
the allowlist's doc comment now requires a duration measured inside a full run:
a justification quoting an isolated figure is not a justification.

The other three removals stand, re-measured under the same full-suite load:
766ms, 99ms, and one whose pin (30s) exactly duplicated the default. None had a
comment claiming otherwise.

CI on main was green with the pin gone — it did not break anything. What it did
was remove the margin that keeps this test from going red the first time a
runner is busy, which is a failure that would arrive looking like a flake.

Verified: the guard accepts the allowlisted pin (4/4); deleting the pin while
leaving the entry reds the stale-allowlist test, so the list can still only
shrink.

---

## Measured, under a full 532-file `vitest run`

| test | alone | full run | verdict |
|---|---|---|---|
| `freezes exactly the two axes…` | 2.1s | **41.8s → failed** | pin restored + allowlisted |
| `every file a \`why\` cites exists…` | 51ms | 766ms | removal stands |
| `says 'no control in Settings yet'…` | 3ms | 99ms | removal stands |
| `the daily cron run…` (credits) | 14ms | pins 30s = the default | removal stands |

After restoring: 4417 tests, 4365 pass, the restored test green at 8.9s. The two remaining reds (`credits-bootstrap-grant`, `credits-monthly-cron`, both exactly ~30s) are present identically on the merged baseline commit and are local contention from running 532 files against one shared Postgres — CI gives each run its own database and is green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)