### PR TITLE
docs+test(billing): say what STATUS_MAP's collapse costs, and guard it (#375)

### DIFF
--- a/apps/web/src/lib/__tests__/status-vocabulary-truth.test.ts
+++ b/apps/web/src/lib/__tests__/status-vocabulary-truth.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { LIVE_SUBSCRIPTION_STATUSES } from "@/lib/subscription-status";
+
+/**
+ * Our `subscriptions.status` vocabulary is deliberately SMALLER than Stripe's:
+ * `STATUS_MAP` (lib/billing.ts) folds `unpaid`/`paused` into `past_due` and
+ * `incomplete_expired` into `canceled`, keeping only `incomplete` distinct.
+ *
+ * The cost of that is a silent one. A Stripe status we never store still LOOKS
+ * like a legal value to anyone reading Stripe's docs, so `where status =
+ * 'incomplete_expired'` is easy to write, type-checks, runs, and matches
+ * nothing — for ever, with no error. It nearly shipped once: #367's proposed
+ * sweep for abandoned checkouts selected exactly that (see #375).
+ *
+ * This is the guard the comment in STATUS_MAP cannot be. It fails when a
+ * Stripe-only status name appears anywhere outside the two files that are
+ * legitimately talking about STRIPE's vocabulary rather than ours.
+ */
+
+/** Stripe subscription statuses that `STATUS_MAP` never yields. */
+const STRIPE_ONLY_STATUSES = ["incomplete_expired", "unpaid", "paused"] as const;
+
+/**
+ * The two files that legitimately name them, and why:
+ *
+ *  - `lib/billing.ts` — STATUS_MAP itself, the translation boundary.
+ *  - `server/usecases/billing-events.ts` — `isLiveStripeStatus` compares a
+ *    `Stripe.Subscription.Status` straight off the webhook, BEFORE translation.
+ *
+ * Anywhere else, the string is being compared against a value this codebase
+ * writes, and it can never match one.
+ */
+const TRANSLATION_BOUNDARY = new Set([
+  "lib/billing.ts",
+  "server/usecases/billing-events.ts",
+]);
+
+const SRC = path.resolve(__dirname, "../..");
+
+function sourceFiles(dir: string, out: string[] = []): string[] {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === "node_modules" || e.name === "__tests__") continue;
+      sourceFiles(full, out);
+    } else if (/\.tsx?$/.test(e.name) && !/\.test\.tsx?$/.test(e.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("nothing outside the translation boundary names a Stripe-only status (#375)", () => {
+  const files = sourceFiles(SRC);
+
+  it("finds a plausible number of source files", () => {
+    // Guards the guard: a wrong root iterates nothing and passes vacuously —
+    // the failure shape this repo keeps relearning.
+    expect(files.length).toBeGreaterThan(300);
+  });
+
+  it("still finds the statuses at the boundary, so the scan is looking at real text", () => {
+    // If STATUS_MAP is ever restructured out of a plain literal, the check
+    // below could go quiet for the wrong reason. This proves the strings are
+    // findable where they are known to live.
+    const billing = fs.readFileSync(path.join(SRC, "lib/billing.ts"), "utf8");
+    for (const s of STRIPE_ONLY_STATUSES) expect(billing).toContain(s);
+  });
+
+  it("no other file compares against a status our own writes never produce", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const rel = path.relative(SRC, file);
+      if (TRANSLATION_BOUNDARY.has(rel)) continue;
+      const src = fs.readFileSync(file, "utf8");
+      src.split("\n").forEach((line, i) => {
+        // Comments may discuss them freely — it is code that silently misses.
+        // Three comment forms reach here, and the third is not obvious: SQL
+        // lives in template literals in this codebase, so a `-- 'incomplete_
+        // expired'` line inside a query's own commentary is prose, not a
+        // predicate. Only a line whose whole content is the SQL comment is
+        // stripped, so a real `where status = 'x' -- note` still counts.
+        const code = line
+          .replace(/\/\/.*$/, "")
+          .replace(/^\s*\*.*$/, "")
+          .replace(/^\s*--.*$/, "");
+        for (const s of STRIPE_ONLY_STATUSES) {
+          if (code.includes(`"${s}"`) || code.includes(`'${s}'`)) {
+            offenders.push(
+              `${rel}:${i + 1} names "${s}" — STATUS_MAP never writes it, so a ` +
+                `comparison against subscriptions.status can never match. See ` +
+                `lib/billing.ts's STATUS_MAP; the raw Stripe status lives in ` +
+                `billing_events.payload.`,
+            );
+          }
+        }
+      });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("every status STATUS_MAP can produce is one the rest of the code knows", () => {
+    // The mapping's VALUES must stay inside our vocabulary: LIVE_SUBSCRIPTION_
+    // STATUSES plus the one terminal value. A mapping to anything else would
+    // read as non-live by negation and degrade an org that is actually paying.
+    const ours = new Set([...LIVE_SUBSCRIPTION_STATUSES, "canceled"]);
+    const billing = fs.readFileSync(path.join(SRC, "lib/billing.ts"), "utf8");
+    const block = billing.match(/const STATUS_MAP[^=]*=\s*\{([\s\S]*?)\n\};/);
+    expect(block, "STATUS_MAP is no longer a plain object literal").not.toBeNull();
+    const values = [...block![1]!.matchAll(/^\s*\w+:\s*"([^"]+)"/gm)].map((m) => m[1]!);
+    expect(values.length, "parsed no entries out of STATUS_MAP").toBeGreaterThan(5);
+    expect(values.filter((v) => !ours.has(v))).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/billing.ts
+++ b/apps/web/src/lib/billing.ts
@@ -442,6 +442,20 @@ const STATUS_MAP: Record<string, string> = {
   // subscription — see LIVE_SUBSCRIPTION_STATUSES), so a second checkout is
   // blocked; the entitlement resolver degrades it to community until it pays.
   incomplete: "incomplete",
+  // …but `incomplete_expired` COLLAPSES into canceled, and that asymmetry is
+  // deliberate. `incomplete` needs its own name because it is LIVE and its
+  // liveness has consequences (no second checkout, no past_due grace).
+  // `incomplete_expired` is terminal, and every consumer of our vocabulary
+  // treats it exactly as `canceled`: outside LIVE_SUBSCRIPTION_STATUSES, plan
+  // degraded, re-subscribe allowed. A separate name would buy no behaviour and
+  // would have to be added to every `status in (…)` list.
+  //
+  // The consequence is worth stating, because it has already misled someone
+  // (#367 → #375): NO ROW EVER CARRIES 'incomplete_expired'. A query written as
+  // `where status = 'incomplete_expired'` matches nothing, silently, for ever.
+  // The distinction is not lost, only moved — billing_events.payload keeps the
+  // raw Stripe event, so `payload->'data'->'object'->>'status'` still answers
+  // "did this subscription die unpaid or churn after paying?".
   incomplete_expired: "canceled",
   unpaid: "past_due",
   paused: "past_due",


### PR DESCRIPTION
Refs #375, #367. The answer to "what should we do about STATUS_MAP": **keep it, say what it costs, and make the cost impossible to trip over silently.**

## What STATUS_MAP does, and why it is right

`lib/billing.ts` translates Stripe's subscription-status vocabulary into a
deliberately smaller one of our own:

| Stripe | ours | why |
|---|---|---|
| `incomplete` | `incomplete` | **LIVE.** Its liveness has consequences — no second checkout, no `past_due` grace, excluded from the quantity cron because Stripe kills it in 23h anyway |
| `incomplete_expired` | `canceled` | terminal; every consumer treats it identically to `canceled` |
| `unpaid`, `paused` | `past_due` | non-terminal, plan degraded, recoverable |

The asymmetry is not an oversight. A separate `incomplete_expired` name would
buy no behaviour anywhere — outside `LIVE_SUBSCRIPTION_STATUSES`, plan degraded,
re-subscribe allowed, exactly like `canceled` — and would have to be added to
every `status in (…)` list in the codebase, each of which is a chance to forget
it and degrade a paying org by negation.

So: no change to the mapping. `subscription-status.ts` already documents the
smaller-vocabulary design.

## The cost nothing was stating

**No row this codebase writes ever carries `incomplete_expired`.**

Which means a query written as:

```sql
where status = 'incomplete_expired'
```

reads correctly against Stripe's documentation, type-checks, runs, and matches
nothing — silently, for ever, with no error at any layer.

That is not hypothetical. The reaping sketch that came out of #367 selected
exactly that predicate. It would have shipped as a daily cron that did nothing,
and looked like it was working. Caught in review, recorded in #375.

## 1. The comment, at the boundary

Fourteen lines above `incomplete_expired: "canceled"`, stating the asymmetry,
its reason, and — the part that matters — **where the distinction went**. It is
not lost. `billing_events.payload` keeps the raw Stripe event, so

```sql
payload->'data'->'object'->>'status'
```

still answers "did this subscription die unpaid, or churn after paying?" for
anyone who needs the finer grain. Losing the answer and losing the *column* are
different things, and the comment says which one happened.

## 2. The guard, because a comment cannot fail

`status-vocabulary-truth.test.ts` — four assertions:

**It fails when a Stripe-only status is named outside the translation boundary.**
`incomplete_expired`, `unpaid`, `paused` may appear in exactly two files, and the
allowlist records why each is legitimate:

- `lib/billing.ts` — STATUS_MAP itself, the translation boundary
- `server/usecases/billing-events.ts` — `isLiveStripeStatus`, comparing a
  `Stripe.Subscription.Status` straight off the webhook, **before** translation

Anywhere else, the string is being compared against a value we write, and can
never match one.

**Comment-stripping has three forms, and the third is not obvious.** SQL lives
in template literals in this codebase, so a `-- 'incomplete_expired'` line
inside a query's own commentary is prose, not a predicate. `billing-groups.ts:433`
was the false positive that found it. Only a line whose *whole* content is the
SQL comment is stripped — a real `where status = 'x' -- note` still counts.

**It pins the mapping's VALUES inside our vocabulary** (`LIVE_SUBSCRIPTION_STATUSES`
+ `canceled`). A mapping to anything else reads as non-live by negation and
degrades an org that is actually paying — the expensive direction of this bug.

**Two canaries against the vacuous pass**, which is the failure shape this repo
keeps relearning: the walk must find >300 source files (a wrong root iterates
nothing and passes), and the statuses must still be findable at the boundary
(so a STATUS_MAP restructured out of a plain literal fails loudly rather than
going quiet).

## Verification

4/4 green, and mutation-verified rather than assumed:

| mutation | result |
|---|---|
| `const _mut = "incomplete_expired"` in `subscription-status.ts` | reds, naming `lib/subscription-status.ts:68` and explaining why it can never match |
| `paused: "past_due"` → `paused: "suspended"` | reds — `expected [ 'suspended' ] to deeply equal []` |

Both restored; tree clean. Runs in 514ms, no DB, no inline timeout.

## What this does not do

It does not retire the org-less `canceled` billing groups that #375 is actually
about — that needs a decision (and a production count) nobody has taken. This
only guarantees that whoever writes that sweep cannot write it against a
predicate that matches nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
