### PR TITLE
fix(ci,auth,e2e): serve what production serves, stop caching payout free-text, cover the third attach body (#356 #341 #343)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,8 +346,8 @@ jobs:
       # `next dev` pins to HALF the machine's RAM — ~3.5 GB on the 7 GB
       # runner, vs ~16 GB on a dev laptop, which is why this only ever died
       # in CI). Near that ceiling Turbopack's on-demand route compiles also
-      # started 404ing transiently. `next start` has neither the watchdog nor
-      # per-request compiles — and it's what production runs anyway.
+      # started 404ing transiently. The standalone server has neither the
+      # watchdog nor per-request compiles — and it's what production runs.
 
       # Persist the compiler cache between runs so the production build only
       # pays for what changed (nextjs.org/docs/pages/guides/ci-build-caching).
@@ -367,17 +367,50 @@ jobs:
           # tsc gate already ran in the test job — don't type-check twice.
           SKIP_TYPECHECK: "1"
 
+      # Start the server PRODUCTION runs (#356). `next start` does not serve an
+      # `output: standalone` build at all — it warns and serves the
+      # non-standalone tree, so this job was exercising a serving path fly.toml
+      # never uses. It only appeared to work because the untraced `.next` tree
+      # is still on disk from the build step one line above.
+      #
+      # `.next/static` is NOT copied into the standalone output. Without it the
+      # server answers /api/health and page HTML 200 while every
+      # /_next/static/*.js 404s — the app renders and then does nothing (#342).
+      # The `rm -rf` is load-bearing: `cp -R src dst` with dst present copies
+      # INTO it, so a re-run yields .next/static/static/….
+      #
+      # Path note: outputFileTracingRoot is the monorepo root, so the server is
+      # at .next/standalone/apps/web/server.js — not the .next/standalone/
+      # server.js that Next's own warning names.
       - name: Start server
         run: |
-          npm run start --workspace apps/web > dev-server.log 2>&1 &
+          rm -rf apps/web/.next/standalone/apps/web/.next/static
+          cp -R apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static
+          node apps/web/.next/standalone/apps/web/server.js > dev-server.log 2>&1 &
           echo "waiting for server…"
+          up=""
           for i in $(seq 1 90); do
             if curl -sf http://localhost:3000/api/health >/dev/null; then
-              echo "server up after ${i}s window"; exit 0
+              echo "server up after ${i}s window"; up=1; break
             fi
             sleep 2
           done
-          echo "server did not become healthy"; cat dev-server.log; exit 1
+          if [ -z "$up" ]; then
+            echo "server did not become healthy"; cat dev-server.log; exit 1
+          fi
+          # Health says the process is listening; it does NOT say the app can
+          # hydrate. Prove one real chunk serves, or a mis-staged static tree
+          # reaches the suite as product-shaped failures.
+          chunk=$(ls apps/web/.next/static/chunks/*.js 2>/dev/null | head -1)
+          if [ -z "$chunk" ]; then
+            echo "no built chunks found — build output is not where expected"; exit 1
+          fi
+          asset="/_next/${chunk#apps/web/.next/}"
+          if ! curl -sf "http://localhost:3000$asset" >/dev/null; then
+            echo "static asset $asset 404s — standalone tree not staged"
+            cat dev-server.log; exit 1
+          fi
+          echo "static assets serve ($asset)"
 
       - name: Run smoke test
         run: npm run test:smoke

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -132,22 +132,49 @@ jobs:
       # Pre-compiled production build, not `next dev`: `next dev` pins its V8
       # heap to half the runner RAM and restarts past ~80% use (transient 404s
       # from Turbopack's on-demand compiles near the ceiling) — flaky under a
-      # full Playwright run. `next start` has neither watchdog nor per-request
-      # compiles, and matches production.
+      # full Playwright run. The standalone server has neither watchdog nor
+      # per-request compiles, and is what production runs.
       - name: Build (production)
         run: npm run build --workspace apps/web
 
+      # Serve the standalone output, the way fly.toml does (#356). `next start`
+      # does not serve an `output: standalone` build — it warns and falls back
+      # to the untraced .next tree, which is a different serving path from
+      # production and cannot catch a standalone-only regression.
+      #
+      # `.next/static` is not part of the standalone output. Without staging it
+      # the server answers /api/health and HTML 200 while every
+      # /_next/static/*.js 404s — specs then fail one at a time on clicks that
+      # look like product bugs (#342, which is what e2e/global-setup.ts's third
+      # probe now refuses to run through).
+      #
+      # `rm -rf` first: `cp -R src dst` with dst present copies INTO it.
       - name: Start server
         run: |
-          npm run start --workspace apps/web > dev-server.log 2>&1 &
+          rm -rf apps/web/.next/standalone/apps/web/.next/static
+          cp -R apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static
+          node apps/web/.next/standalone/apps/web/server.js > dev-server.log 2>&1 &
           echo "waiting for server…"
+          up=""
           for i in $(seq 1 90); do
             if curl -sf http://localhost:3000/api/health >/dev/null; then
-              echo "server up after ${i}s window"; exit 0
+              echo "server up after ${i}s window"; up=1; break
             fi
             sleep 2
           done
-          echo "server did not become healthy"; cat dev-server.log; exit 1
+          if [ -z "$up" ]; then
+            echo "server did not become healthy"; cat dev-server.log; exit 1
+          fi
+          chunk=$(ls apps/web/.next/static/chunks/*.js 2>/dev/null | head -1)
+          if [ -z "$chunk" ]; then
+            echo "no built chunks found — build output is not where expected"; exit 1
+          fi
+          asset="/_next/${chunk#apps/web/.next/}"
+          if ! curl -sf "http://localhost:3000$asset" >/dev/null; then
+            echo "static asset $asset 404s — standalone tree not staged"
+            cat dev-server.log; exit 1
+          fi
+          echo "static assets serve ($asset)"
 
       # Browsers cached per Playwright version.
       - name: Cache Playwright browsers

--- a/apps/web/e2e/billing-groups.spec.ts
+++ b/apps/web/e2e/billing-groups.spec.ts
@@ -286,6 +286,44 @@ test.describe.serial("billing groups", () => {
     await page.keyboard.press("Escape");
   });
 
+  test("a trialing payer is not told their bill goes up", async ({ page }) => {
+    // The THIRD attach body (#299 round 4, coverage gap #343). This case is the
+    // one `freeSlots` alone gets WRONG rather than merely vague:
+    // `syncGroupQuantity` freezes `quantity_paid` during a trial, so seats == orgs
+    // and `freeSlots` is 0 — identical to the charged case above, which is why a
+    // two-way choice handed a trialing payer "your bill goes up by …". Nothing is
+    // prorated on that path at all (`proration_behavior: "none"`,
+    // `previewAttachCharge` returns null), so the sentence was simply false.
+    //
+    // Seats are therefore left at 2 with 2 orgs on the bill DELIBERATELY: with a
+    // freed slot the free body would pass this test for the wrong reason.
+    await baseline();
+    // trial_end must be in the FUTURE: V332's backstop degrades a `trialing`
+    // group whose trial ended over a day ago to community, which would take the
+    // panel somewhere else entirely.
+    const trialEnd = new Date(Date.now() + 7 * 86_400_000).toISOString();
+    await setOrgSubscriptionSql(orgA, {
+      plan_key: "pro",
+      status: "trialing",
+      trial_end: trialEnd,
+    });
+    await activate(page, orgA);
+    await page.goto("/settings/billing");
+    const panel = panelOf(page);
+    await expect(panel).toBeVisible({ timeout: 20_000 });
+
+    await panel.getByRole("button", { name: `Group C ${TAG}` }).click();
+    const dialog = page.getByRole("alertdialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("rides your free trial");
+    // Same discriminator the free case uses, and for the same reason: the trial
+    // body contains "nothing is added to a bill now", so a negative on "added to"
+    // would fail on true copy. "your bill goes up by" is the phrase that appears
+    // in BOTH charged bodies and in neither of the other two.
+    await expect(dialog).not.toContainText("your bill goes up by");
+    await page.keyboard.press("Escape");
+  });
+
   test("a full plan says so instead of offering a move it would refuse", async ({ page }) => {
     // groupOrgLimit resolves through the OLDEST org in the group, so the
     // override goes on A.

--- a/apps/web/src/app/api/users/me/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/me/__tests__/route.test.ts
@@ -56,9 +56,7 @@ async function seedOrgWithPlan(plan: string): Promise<OrgMembership> {
     ...org!,
     logo_url: null,
     logo_storage_path: null,
-    payment_instructions: null,
     branding: null,
-    default_payment_method: "offline",
     timezone: null,
     role: "owner",
   };

--- a/apps/web/src/lib/__tests__/user-orgs-payout-fields.test.ts
+++ b/apps/web/src/lib/__tests__/user-orgs-payout-fields.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { getUserOrgs } from "@/lib/auth";
+
+/**
+ * `getUserOrgs` must not carry payout free-text (#341).
+ *
+ * Its result is not an ordinary query result. It is (a) written to Redis as
+ * plaintext JSON under `orgs:<userId>` for 120s and (b) returned verbatim as the
+ * body of `GET /api/orgs`, a nav endpoint any member may call. So every column
+ * the select names is copied into a second vendor and shipped to every member of
+ * every org they belong to.
+ *
+ * `payment_instructions` is free text an owner writes to tell offline entrants
+ * how to pay them — bank details, IBANs, UPI handles, `z.string().max(5000)`.
+ * Nothing downstream of this list ever read it: the settings page and the
+ * registration use-case each run their own scoped select.
+ *
+ * The assertion is on the RETURNED array because that is the identical object
+ * passed to `cacheSet` — there is no second serialisation step that could
+ * differ. Asserting the SQL text instead would pass on a query that selected
+ * `o.*`.
+ */
+describe.skipIf(!process.env.DATABASE_URL)("getUserOrgs carries no payout fields (#341)", () => {
+  const seed = async () => {
+    const s = randomUUID().slice(0, 8);
+    const [user] = await sql<{ id: string }[]>`
+      insert into users (email, display_name, email_verified)
+      values (${`orgs-payout-${s}@test.local`}, 'Payout Probe', true) returning id`;
+    const [org] = await sql<{ id: string }[]>`
+      insert into organizations (name, slug, created_by, payment_instructions,
+                                 default_payment_method)
+      values (${`Payout Probe ${s}`}, ${`payout-probe-${s}`}, ${user!.id},
+              'IBAN GB29 NWBK 6016 1331 9268 19', 'offline')
+      returning id`;
+    await sql`
+      insert into org_members (org_id, user_id, role)
+      values (${org!.id}, ${user!.id}, 'owner')`;
+    return { userId: user!.id, orgId: org!.id };
+  };
+
+  it("returns the membership without payment_instructions or default_payment_method", async () => {
+    const { userId, orgId } = await seed();
+    const orgs = await getUserOrgs(userId);
+
+    // Canary: the probe row must actually be in the result, or every absence
+    // assertion below is vacuous.
+    const row = orgs.find((o) => o.id === orgId);
+    expect(row, "seeded org missing from getUserOrgs result").toBeDefined();
+
+    // `in` rather than a truthiness check: a null value would still be a leaked
+    // column on an org that simply has not set its instructions yet.
+    expect("payment_instructions" in row!).toBe(false);
+    expect("default_payment_method" in row!).toBe(false);
+  });
+
+  it("still carries the identity columns the nav needs", async () => {
+    // The other half of the guard: a select trimmed too far breaks the org
+    // switcher and page-auth rather than leaking, and would otherwise pass the
+    // test above.
+    const { userId, orgId } = await seed();
+    const row = (await getUserOrgs(userId)).find((o) => o.id === orgId)!;
+    for (const k of ["id", "name", "slug", "created_by", "created_at", "logo_url",
+                     "logo_storage_path", "branding", "timezone", "role"]) {
+      expect(k in row, `identity column ${k} missing from getUserOrgs`).toBe(true);
+    }
+  });
+
+  it("the payout columns are still readable where they belong", async () => {
+    // Proves the fix moved the exposure rather than deleting the data — the
+    // org-settings lane reads them with its own scoped select.
+    const { orgId } = await seed();
+    const [row] = await sql<{ payment_instructions: string | null }[]>`
+      select payment_instructions from organizations where id = ${orgId}`;
+    expect(row!.payment_instructions).toContain("IBAN");
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -119,14 +119,24 @@ export async function requireUser(): Promise<User> {
 // Organizations / roles
 // ---------------------------------------------------------------------------
 
-/** Every organization the user belongs to, with their role, newest first. */
+/**
+ * Every organization the user belongs to, with their role, newest first.
+ *
+ * The select is the IDENTITY lane only — no `payment_instructions`, no
+ * `default_payment_method` (#341). This result is cached in Redis as plaintext
+ * JSON under `orgsKey(userId)` and handed back verbatim by `GET /api/orgs`, so
+ * every column here is copied into a second vendor and shipped to every member
+ * on a nav request. Payout free-text (bank details, IBANs, UPI handles) has no
+ * business in either, and no consumer of this list ever read it: the org
+ * settings page and the registration use-case each run their own scoped select.
+ */
 export async function getUserOrgs(userId: string): Promise<OrgMembership[]> {
   const cached = await cacheGet<OrgMembership[]>(orgsKey(userId));
   if (cached) return cached;
 
   const orgs = await sql<OrgMembership[]>`
     select o.id, o.name, o.slug, o.created_by, o.created_at,
-           o.logo_url, o.logo_storage_path, o.payment_instructions, o.default_payment_method, o.branding,
+           o.logo_url, o.logo_storage_path, o.branding,
            o.timezone, m.role
     from org_members m
     join organizations o on o.id = m.org_id

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -31,7 +31,18 @@ export const READ_ROLES = ["owner", "admin", "viewer"] as const;
 export const SCORER_SCOPE_TYPES = ["competition", "division", "fixture"] as const;
 export type ScorerScopeType = (typeof SCORER_SCOPE_TYPES)[number];
 
-export interface Organization {
+/**
+ * An organization as the IDENTITY lane sees it: nav, org switcher, page auth.
+ *
+ * Deliberately carries NO payout fields (#341). `payment_instructions` is free
+ * text an owner writes to tell offline entrants how to pay them — in practice
+ * bank details, IBANs, UPI IDs — and this shape is what `getUserOrgs` caches in
+ * Redis for 120s and what `GET /api/orgs`, a nav endpoint, returns to every
+ * member. The two places that genuinely need those columns read them
+ * themselves, scoped to the one org being edited or paid:
+ * `o/[orgSlug]/settings/connect/page.tsx` and `usecases/registrations.ts`.
+ */
+export interface OrgSummary {
   id: string;
   name: string;
   slug: string;
@@ -39,9 +50,6 @@ export interface Organization {
   created_at: string;
   logo_url: string | null;
   logo_storage_path: string | null;
-  payment_instructions: string | null;
-  /** Preselect for NEW division registration settings (spec 2026-07-12 §3). */
-  default_payment_method: "offline" | "stripe";
   /** `{ colors: { primary: "#hex" } }` — same shape as competitions.branding. */
   branding: unknown;
   /**
@@ -53,8 +61,15 @@ export interface Organization {
   timezone: string | null;
 }
 
+/** The identity shape plus the payout columns, for the org-settings lane. */
+export interface Organization extends OrgSummary {
+  payment_instructions: string | null;
+  /** Preselect for NEW division registration settings (spec 2026-07-12 §3). */
+  default_payment_method: "offline" | "stripe";
+}
+
 /** An organization paired with the current user's role in it. */
-export interface OrgMembership extends Organization {
+export interface OrgMembership extends OrgSummary {
   role: OrgRole;
 }
 


### PR DESCRIPTION
Three v17-gap follow-ups that are all the same shape: something we ship or verify was not what we thought it was.

Closes #341. Closes #356. Closes #343.

---

## #341 — the org list carried payout free-text into Redis and out of a nav endpoint

`getUserOrgs` selected `payment_instructions` and `default_payment_method`, and its result is not an ordinary query result:

- it is written to Redis as **plaintext JSON** under `orgs:<userId>` for 120s, and
- it is returned **verbatim** as the body of `GET /api/orgs`, the org-switcher endpoint any member may call.

So both columns were copied into a second vendor and shipped to every member of every org they belong to. `payment_instructions` is `z.string().max(5000)` of free text an owner writes to tell offline entrants how to pay them — bank details, IBANs, UPI handles.

Not a payment-data leak (no card, subscription or invoice record is cached anywhere), and the data already lives in Postgres — this is a second copy in a second place, on one of the hottest cached keys.

**Nothing read them.** Every consumer of this list is nav or page-auth. The two places that genuinely need the columns each run their own scoped select: `o/[orgSlug]/settings/connect/page.tsx` and `usecases/registrations.ts`.

The fix is a type split, so the compiler enforces it rather than a comment:

```ts
export interface OrgSummary { id, name, slug, created_by, created_at,
                              logo_url, logo_storage_path, branding, timezone }
export interface Organization extends OrgSummary { payment_instructions; default_payment_method }
export interface OrgMembership extends OrgSummary { role: OrgRole }
```

`tsc` then found every downstream reader — there was exactly one, a test fixture. `Organization` (org settings, `createOrgForUser`) is unchanged.

**Test:** DB-backed, asserting on the returned array *because that is the identical object handed to `cacheSet`* — asserting the SQL text instead would pass on a query that selected `o.*`. Uses `"key" in row` rather than truthiness: a null value is still a leaked column on an org that has not set its instructions yet. Plus a canary that the identity columns survive, so a select trimmed too far fails too.

Mutation-verified: restoring the two columns to the select reds the guard.

---

## #356 — CI served a build production never serves

`next.config.js` sets `output: "standalone"`, and `fly.toml` deploys `node .next/standalone/apps/web/server.js`. Both the CI smoke job and `e2e.yml` started the server with `next start`, which **does not serve a standalone build**. Reproduced here on Next 16.2.9:

```
⚠ "next start" does not work with "output: standalone" configuration.
  Use "node .next/standalone/server.js" instead.
```

It only appeared to work because the untraced `.next` tree is still on disk from the build step one line above — so CI was exercising a serving path production never uses, and no standalone-only regression could be caught by either job.

Both jobs now do what `docs/runbooks/e2e-local.md` already told humans to do:

```bash
rm -rf apps/web/.next/standalone/apps/web/.next/static
cp -R apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static
node apps/web/.next/standalone/apps/web/server.js
```

The `rm -rf` is load-bearing — `cp -R src dst` with `dst` present copies *into* it, so a re-run yields `static/static/…`.

**And a probe, because `/api/health` cannot see this failure.** The staging step is the easy half to get wrong, and its symptom is the #342 shape: HTML answers 200 while every `/_next/static/*.js` 404s, so the app renders and then does nothing and specs fail one at a time looking like product bugs. Each job now curls one real chunk after health and fails loudly if it 404s.

Verified against a real build of this repo, both directions:

| | HTML | chunk |
|---|---|---|
| static staged | 200 | **200** |
| static not staged | 200 | **404** |

`e2e.yml`'s triggers are untouched — the workflow stays disabled, per the constraint in the issue.

---

## #343 — no e2e case for the third attach body

W7 added a third attach-confirmation body for a **trialing** payer. It exists because `syncGroupQuantity` freezes `quantity_paid` during a trial, so `freeSlots` computes to 0 and the two-way choice handed a trialing payer the **charged** body — "your bill goes up by …" — while `proration_behavior` was `"none"` and `previewAttachCharge` returned null. Nothing was prorated at all; the sentence was simply false.

It was pinned at unit level and in the copy digest, but no spec ever opened that dialog. Now one does:

```
✓ billing groups › a trialing payer is not told their bill goes up
```

Seats are deliberately left equal to the org count, so `freeSlots` is 0 and the case cannot pass by landing on the *free* body instead. `trial_end` is set in the future — V332's backstop degrades a `trialing` group whose trial ended over a day ago, which would take the panel somewhere else entirely. The discriminator is `"your bill goes up by"`, the phrase in both charged bodies and neither of the others; a negative on "added to your next invoice" would fail on true copy, which the surrounding cases already document.

**Executed, not just written.** The worktree could not build (Turbopack refuses a `node_modules` symlink pointing outside the project root), so it got a real `npm ci`, a production build, the standalone staging above, and a migrated throwaway database:

```
17 passed (34.0s)   ← whole billing-groups.spec.ts, including the new case
```

Mutation-verified end to end: with `attachConfirmKey`'s `trialing` arm removed and the app **rebuilt**, the new case is the one that fails.

---

## Verification

- `tsc` clean; `status-vocabulary`, `help-copy`, `inline-timeout` guards green
- new #341 test 3/3, mutation-verified
- `billing-groups.spec.ts` 17/17 against a standalone production build
- the standalone serve sequence and its negative control run by hand, table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
