### PR TITLE
fix(billing): retire an org-less billing group from Stripe's own answer (#375)

### DIFF
--- a/apps/web/src/app/api/cron/billing-quantity/route.test.ts
+++ b/apps/web/src/app/api/cron/billing-quantity/route.test.ts
@@ -18,10 +18,12 @@ const mocks = vi.hoisted(() => ({
   reconcile: vi.fn(),
   orphans: vi.fn(),
   addonPrices: vi.fn(),
+  orphanGroups: vi.fn(),
 }));
 vi.mock("@/server/usecases/billing-groups", () => ({
   reconcileGroupQuantities: mocks.reconcile,
   countOrgsWithoutGroup: mocks.orphans,
+  sweepOrphanGroups: mocks.orphanGroups,
 }));
 vi.mock("@/server/usecases/billing-events", () => ({
   sweepStaleOrgAddonPrices: mocks.addonPrices,
@@ -40,6 +42,7 @@ const authorize = () => {
   hdrs.store = new Headers({ "x-cron-secret": "s3cret" });
   mocks.reconcile.mockResolvedValue({ checked: 3, corrected: 1 });
   mocks.orphans.mockResolvedValue(0);
+  mocks.orphanGroups.mockResolvedValue({ checked: 2, retired: 1, stillLive: 0, failed: 0 });
   mocks.addonPrices.mockResolvedValue({
     total: 2,
     checked: 2,
@@ -88,5 +91,18 @@ describe("POST /api/cron/billing-quantity", () => {
     expect(body.data).toMatchObject({ checked: 3, corrected: 1, orphanOrgs: 0 });
     expect(mocks.reconcile).toHaveBeenCalledTimes(1);
     expect(mocks.orphans).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the org-less GROUP sweep and reports it (#375)", async () => {
+    // Same reasoning as the #332 assertion above, on the mirror-image guard: an
+    // org with no group vs a GROUP with no orgs. `stillLive` is the field an
+    // operator acts on — a subscription alive at Stripe with nobody on the bill
+    // — so a run whose counts never reach the response is the same as no run.
+    authorize();
+    const body = (await (await POST()).json()) as {
+      data: { orphanGroups?: { checked: number; retired: number; stillLive: number } };
+    };
+    expect(mocks.orphanGroups).toHaveBeenCalledTimes(1);
+    expect(body.data.orphanGroups).toMatchObject({ checked: 2, retired: 1, stillLive: 0 });
   });
 });

--- a/apps/web/src/app/api/cron/billing-quantity/route.ts
+++ b/apps/web/src/app/api/cron/billing-quantity/route.ts
@@ -1,7 +1,11 @@
 import { headers } from "next/headers";
 import { handler } from "@/lib/http";
 import { HttpError } from "@/lib/errors";
-import { countOrgsWithoutGroup, reconcileGroupQuantities } from "@/server/usecases/billing-groups";
+import {
+  countOrgsWithoutGroup,
+  reconcileGroupQuantities,
+  sweepOrphanGroups,
+} from "@/server/usecases/billing-groups";
 import { sweepStaleOrgAddonPrices } from "@/server/usecases/billing-events";
 
 /** POST /api/cron/billing-quantity — daily: for every live billing group whose
@@ -34,11 +38,21 @@ export async function POST() {
     // Report-only, deliberately: a repairing sweep would be an unattended bulk
     // billing mutation, and whatever left a group on a stale price is likely
     // still there to do it again. `mismatched > 0` is the signal to look.
-    const [reconcile, orphanOrgs, addonPrices] = await Promise.all([
+    //
+    // orphanGroups is the mirror image of orphanOrgs (#375): an org with no
+    // group, versus a GROUP with no orgs. It retires the second in place from
+    // Stripe's own answer — the state `cancelGroupIfEmpty` declines to touch,
+    // most often an abandoned first checkout stuck at `incomplete`. Daily is
+    // the right cadence: Stripe expires such a subscription within 23 hours and
+    // the sweep only looks at rows untouched for a day, so an earlier run would
+    // read a checkout somebody is still paying. `stillLive > 0` is the signal
+    // to look — a subscription alive at Stripe with nobody on the bill.
+    const [reconcile, orphanOrgs, addonPrices, orphanGroups] = await Promise.all([
       reconcileGroupQuantities(),
       countOrgsWithoutGroup(),
       sweepStaleOrgAddonPrices(),
+      sweepOrphanGroups(),
     ]);
-    return { ...reconcile, orphanOrgs, addonPrices };
+    return { ...reconcile, orphanOrgs, addonPrices, orphanGroups };
   });
 }

--- a/apps/web/src/lib/__tests__/status-vocabulary-truth.test.ts
+++ b/apps/web/src/lib/__tests__/status-vocabulary-truth.test.ts
@@ -35,6 +35,13 @@ const STRIPE_ONLY_STATUSES = ["incomplete_expired", "unpaid", "paused"] as const
 const TRANSLATION_BOUNDARY = new Set([
   "lib/billing.ts",
   "server/usecases/billing-events.ts",
+  // `isTerminalStripeStatus` — the one predicate over STRIPE's vocabulary,
+  // added when `sweepOrphanGroups` needed the same question the webhook guard
+  // asks (#375). It lives in this leaf module because billing-events already
+  // imports billing-groups, so the two callers cannot import each other; the
+  // alternative was a second hand-written copy of these two strings, which is
+  // exactly what this guard exists to prevent.
+  "lib/subscription-status.ts",
 ]);
 
 const SRC = path.resolve(__dirname, "../..");

--- a/apps/web/src/lib/subscription-status.ts
+++ b/apps/web/src/lib/subscription-status.ts
@@ -64,3 +64,22 @@ export function hasLiveSubscription(
     LIVE_SUBSCRIPTION_STATUSES.includes(sub.status ?? "")
   );
 }
+
+/**
+ * Is a STRIPE status terminal — the subscription is over and will not bill again?
+ *
+ * The argument is a status straight off Stripe, BEFORE `STATUS_MAP` translates
+ * it, which is why `incomplete_expired` appears here and nowhere in the app's
+ * own vocabulary: STATUS_MAP folds it into `canceled`, so no row we write ever
+ * carries it (lib/billing.ts, #375).
+ *
+ * One definition, two callers phrasing it opposite ways: `isLiveStripeStatus` in
+ * usecases/billing-events.ts (the webhook write guard) and `sweepOrphanGroups`
+ * in usecases/billing-groups.ts ("did Stripe finish this off?"). They cannot
+ * import each other — billing-events already imports billing-groups — so it
+ * lives in this leaf module, which is also what stops the two from keeping
+ * hand-written copies of the same two strings.
+ */
+export function isTerminalStripeStatus(status: string): boolean {
+  return status === "canceled" || status === "incomplete_expired";
+}

--- a/apps/web/src/server/usecases/__tests__/orphan-group-sweep.test.ts
+++ b/apps/web/src/server/usecases/__tests__/orphan-group-sweep.test.ts
@@ -1,0 +1,222 @@
+// The org-less billing group nothing retired (#375, split out of #367).
+//
+// Real Postgres, mocked Stripe. The mock is deliberately STRICT: it throws for
+// any subscription id this file did not seed. `sweepOrphanGroups` is a
+// schema-wide sweep and the suite runs files in parallel against one shared
+// schema, so a permissive mock would let it write a canned status onto rows
+// belonging to other suites. A throw lands those in `failed`, which writes
+// nothing — the blast radius is zero, and the assertions below stay about our
+// own rows rather than about counts nobody controls (#321).
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import type Stripe from "stripe";
+
+const subs = vi.hoisted(() => new Map<string, unknown>());
+const retrieved = vi.hoisted(() => [] as string[]);
+const cancelled = vi.hoisted(() => [] as string[]);
+vi.mock("@/lib/stripe", () => ({
+  getStripe: () => ({
+    subscriptions: {
+      retrieve: async (id: string) => {
+        retrieved.push(id);
+        const sub = subs.get(id);
+        if (!sub) throw new Error(`no such subscription: ${id}`);
+        return sub;
+      },
+      cancel: async (id: string) => {
+        cancelled.push(id);
+        return subs.get(id);
+      },
+    },
+  }),
+}));
+
+import { sql } from "@/lib/db";
+import { sweepOrphanGroups } from "@/server/usecases/billing-groups";
+
+const TAG = randomUUID().slice(0, 8);
+
+/** A Stripe subscription with no items: `planItem` answers null, so the sync
+ *  keeps whatever plan the row already holds instead of resolving a price. The
+ *  status is the only thing these tests are about. */
+function fakeSub(id: string, status: string): Stripe.Subscription {
+  return {
+    id,
+    status,
+    items: { data: [] },
+    trial_end: null,
+    cancel_at_period_end: false,
+    currency: "usd",
+    customer: `cus_${id}`,
+    default_payment_method: null,
+  } as unknown as Stripe.Subscription;
+}
+
+/** The payer every fixture group belongs to. `subscriptions.owner_user_id` is
+ *  NOT NULL — a group always has somebody paying it, even an abandoned one. */
+let ownerId = "";
+async function owner(): Promise<string> {
+  if (ownerId) return ownerId;
+  const [u] = await sql<{ id: string }[]>`
+    insert into users (email, display_name, email_verified)
+    values (${`orphan-owner-${TAG}@test.local`}, 'Orphan Owner', true) returning id`;
+  ownerId = u!.id;
+  return ownerId;
+}
+
+/** A billing group with a Stripe id, a status, and NO organisations. */
+async function seedOrphan(
+  status: string,
+  opts: { stripeStatus?: string; agedDays?: number; stripeMissing?: boolean } = {},
+): Promise<{ id: string; stripeId: string }> {
+  const s = `${TAG}-${randomUUID().slice(0, 6)}`;
+  const stripeId = `sub_orphan_${s}`;
+  const [{ id }] = await sql<{ id: string }[]>`
+    insert into subscriptions (owner_user_id, plan_key, status, quantity_paid,
+                               stripe_subscription_id, stripe_customer_id, trial_used_at)
+    values (${await owner()}, 'pro', ${status}, 1, ${stripeId}, ${`cus_${s}`}, now())
+    returning id`;
+  // updated_at is `now()` on insert, and the sweep only looks at rows untouched
+  // for a day — so every fixture that should be SELECTED has to be aged here.
+  const days = opts.agedDays ?? 2;
+  await sql`update subscriptions set updated_at = now() - (${days} || ' days')::interval
+             where id = ${id}`;
+  if (!opts.stripeMissing) subs.set(stripeId, fakeSub(stripeId, opts.stripeStatus ?? status));
+  return { id, stripeId };
+}
+
+async function row(id: string) {
+  const [r] = await sql<
+    {
+      status: string;
+      plan_key: string;
+      stripe_subscription_id: string | null;
+      stripe_customer_id: string | null;
+      trial_used_at: string | null;
+    }[]
+  >`
+    select status, plan_key, stripe_subscription_id, stripe_customer_id, trial_used_at
+      from subscriptions where id = ${id}`;
+  return r!;
+}
+
+beforeEach(() => {
+  retrieved.length = 0;
+  cancelled.length = 0;
+});
+
+afterAll(async () => {
+  await sql`delete from subscriptions where stripe_subscription_id like ${`sub_orphan_${TAG}%`}`;
+  if (ownerId) await sql`delete from users where id = ${ownerId}`;
+});
+
+describe.skipIf(!process.env.DATABASE_URL)("sweepOrphanGroups (#375)", () => {
+  it("retires an abandoned checkout in place once Stripe says it expired", async () => {
+    // The exact state the issue is about: `cancelGroupIfEmpty` declined this row
+    // because `incomplete` is outside the set it cancels, and nothing else looks
+    // at it. Stripe voided the invoice and expired the subscription hours later.
+    const { id, stripeId } = await seedOrphan("incomplete", {
+      stripeStatus: "incomplete_expired",
+    });
+
+    const res = await sweepOrphanGroups();
+
+    expect(retrieved).toContain(stripeId);
+    expect(res.retired).toBeGreaterThanOrEqual(1);
+    const after = await row(id);
+    // `canceled`, not `incomplete_expired` — the sweep writes through
+    // STATUS_MAP's one translation rather than carrying a second copy of it.
+    expect(after.status).toBe("canceled");
+    // IN PLACE: the identity the row exists to carry survives. Dropping it would
+    // clear trial_used_at and hand the payer a fresh trial for the price of
+    // abandoning an unpaid checkout (#241's farm, on a different path).
+    expect(after.stripe_subscription_id).toBe(stripeId);
+    expect(after.stripe_customer_id).not.toBeNull();
+    expect(after.trial_used_at).not.toBeNull();
+    // Nothing is cancelled at Stripe: it is already dead there.
+    expect(cancelled).toEqual([]);
+  });
+
+  it("does not cancel a subscription Stripe still calls live — it raises it", async () => {
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { id, stripeId } = await seedOrphan("incomplete", { stripeStatus: "active" });
+
+      const res = await sweepOrphanGroups();
+
+      expect(res.stillLive).toBeGreaterThanOrEqual(1);
+      // The row is corrected to Stripe's answer — a group claiming `incomplete`
+      // while Stripe bills it monthly is drift in the expensive direction.
+      expect((await row(id)).status).toBe("active");
+      // But the subscription itself is left alone. An unattended cancel of a
+      // paying customer's subscription is not a sweep's call to make.
+      expect(cancelled).toEqual([]);
+      expect(
+        warn.mock.calls.some((c) => String(c[0]).includes("live and billing for nobody")),
+      ).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("leaves a group that still has an organisation alone", async () => {
+    // The canary against a predicate that selects everything: without this, a
+    // sweep that ignored the org count would pass every other test here.
+    const { id, stripeId } = await seedOrphan("incomplete", {
+      stripeStatus: "incomplete_expired",
+    });
+    const [{ id: userId }] = await sql<{ id: string }[]>`
+      insert into users (email, display_name, email_verified)
+      values (${`orphan-sweep-${TAG}@test.local`}, 'Orphan Probe', true) returning id`;
+    await sql`
+      insert into organizations (name, slug, created_by, subscription_id)
+      values (${`Orphan Probe ${TAG}`}, ${`orphan-probe-${TAG}`}, ${userId}, ${id})`;
+    try {
+      await sweepOrphanGroups();
+      expect(retrieved).not.toContain(stripeId);
+      expect((await row(id)).status).toBe("incomplete");
+    } finally {
+      await sql`delete from organizations where subscription_id = ${id}`;
+      await sql`delete from users where id = ${userId}`;
+    }
+  });
+
+  it("leaves a row touched within the last day alone", async () => {
+    // A detach in flight, or a checkout the customer is still paying: Stripe has
+    // 23 hours to expire an `incomplete` subscription, so anything younger than
+    // a day has not reached its final answer yet.
+    const { id, stripeId } = await seedOrphan("incomplete", {
+      stripeStatus: "incomplete_expired",
+      agedDays: 0,
+    });
+    await sweepOrphanGroups();
+    expect(retrieved).not.toContain(stripeId);
+    expect((await row(id)).status).toBe("incomplete");
+  });
+
+  it("leaves an already-cancelled group alone", async () => {
+    // The wider net the issue warned about: an org-less `canceled` group is
+    // every ordinary cancellation ever made, and there is nothing left to
+    // retire. Selecting it would cost a Stripe read per cancelled customer, for
+    // ever, to change nothing.
+    const { id, stripeId } = await seedOrphan("canceled");
+    await sweepOrphanGroups();
+    expect(retrieved).not.toContain(stripeId);
+    expect((await row(id)).status).toBe("canceled");
+  });
+
+  it("leaves the row untouched when Stripe cannot be read", async () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { id } = await seedOrphan("incomplete", { stripeMissing: true });
+      const res = await sweepOrphanGroups();
+      expect(res.failed).toBeGreaterThanOrEqual(1);
+      // Writing `canceled` off a FAILED read is the guess this refuses to make:
+      // a key with the wrong mode, or a transient 500, would otherwise retire
+      // live groups in bulk.
+      expect((await row(id)).status).toBe("incomplete");
+    } finally {
+      err.mockRestore();
+    }
+  });
+});

--- a/apps/web/src/server/usecases/billing-events.ts
+++ b/apps/web/src/server/usecases/billing-events.ts
@@ -41,7 +41,7 @@ import {
   invalidateOrgEntitlements,
 } from "@/lib/entitlements";
 import { orgIdsInGroup, subscriptionIdForOrg } from "@/lib/billing-group";
-import { LIVE_SUBSCRIPTION_STATUSES } from "@/lib/subscription-status";
+import { LIVE_SUBSCRIPTION_STATUSES, isTerminalStripeStatus } from "@/lib/subscription-status";
 import { syncGroupQuantity } from "@/server/usecases/billing-groups";
 import {
   creditPassTowardSubscription,
@@ -543,9 +543,14 @@ async function mayWriteGroup(
 /** Terminal STRIPE statuses. Everything else still owns the subscription: our
  *  STATUS_MAP collapses unpaid/paused into past_due and keeps incomplete
  *  distinct (#206 — it conveys no plan), and every one of those is in
- *  LIVE_SUBSCRIPTION_STATUSES, so "not terminal" still means "live". */
+ *  LIVE_SUBSCRIPTION_STATUSES, so "not terminal" still means "live".
+ *
+ *  The two-string list moved to lib/subscription-status.ts when
+ *  `sweepOrphanGroups` needed the same question (#375). This file cannot be the
+ *  home of it: billing-groups.ts would have to import from here, and this module
+ *  already imports THAT one. */
 function isLiveStripeStatus(status: Stripe.Subscription.Status): boolean {
-  return status !== "canceled" && status !== "incomplete_expired";
+  return !isTerminalStripeStatus(status);
 }
 
 async function handleSubscriptionChanged(stripeSub: Stripe.Subscription) {

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -19,6 +19,7 @@ import { getStripe } from "@/lib/stripe";
 import {
   assertPriceBillsQuantity,
   syncPaymentMethodFlagForSubscription,
+  syncSubscriptionForGroup,
 } from "@/lib/billing";
 import { auditWalletForfeitedOnDetach, mergeWalletOnAttach } from "@/lib/credits";
 import {
@@ -468,6 +469,104 @@ export async function reconcileGroupQuantities(limit = 500): Promise<{
       `[billing] quantity reconcile hit its limit of ${limit} — some groups were not visited`,
     );
   return { checked: groups.length, corrected, failed };
+}
+
+/**
+ * Retire a billing group that has no organisations left and a status our own
+ * writes will never move again (#375, split out of #367).
+ *
+ * The state this exists for: `cancelGroupIfEmpty` refuses — correctly — to
+ * cancel a group whose status is outside `('trialing','active','past_due')`,
+ * and the status that actually reaches it is `incomplete`, an abandoned first
+ * checkout. Nothing then retires the row. `reconcileGroupQuantities` skips it
+ * (it selects the same three statuses), and `dropEmptyGroup` will not take it
+ * because it ever reached Stripe. So the row sits at `incomplete` for ever,
+ * describing a subscription Stripe destroyed within 23 hours.
+ *
+ * THREE things this deliberately does not do:
+ *
+ *  1. **It does not delete.** The row carries `trial_used_at`, the Stripe
+ *     customer link and any dispute history, and the partial unique index on
+ *     `stripe_customer_id` depends on it existing. Deleting it would hand the
+ *     payer a fresh trial for the price of abandoning a checkout — the farm
+ *     #241 closed on the detach path. The row is retired IN PLACE.
+ *  2. **It does not guess.** The obvious predicate — "org-less and
+ *     `incomplete`, therefore dead" — infers Stripe's state from ours. This
+ *     asks Stripe and writes back what it says, through
+ *     `syncSubscriptionForGroup`, the one writer that owns that translation.
+ *     There is no second copy of STATUS_MAP here, and none of the
+ *     `incomplete_expired` predicate that matches nothing (see lib/billing.ts).
+ *  3. **It does not cancel at Stripe.** Everything selected here is either
+ *     already dead there, or alive and billing for nobody — and the second case
+ *     is an alarm for a human, not an unattended cancel of a live subscription.
+ *
+ * The one-day floor keeps this away from a detach still in flight and puts the
+ * whole 23-hour `incomplete` window behind us, so the answer Stripe gives is
+ * the final one rather than a checkout somebody is still paying.
+ */
+export async function sweepOrphanGroups(limit = 200): Promise<{
+  checked: number;
+  retired: number;
+  stillLive: number;
+  failed: number;
+}> {
+  const groups = await sql<
+    { id: string; stripe_subscription_id: string; status: string }[]
+  >`
+    select s.id, s.stripe_subscription_id, s.status
+      from subscriptions s
+     where s.stripe_subscription_id is not null
+       -- Already terminal: nothing left to retire. This is also what keeps the
+       -- sweep off every ordinarily-cancelled group, which is the wider net a
+       -- naive "canceled and org-less" predicate would have cast (#375).
+       and s.status <> 'canceled'
+       and s.updated_at < now() - interval '1 day'
+       and not exists (
+             select 1 from organizations o
+              where o.subscription_id = s.id and o.deleted_at is null)
+     order by s.updated_at
+     limit ${limit}`;
+  let retired = 0,
+    stillLive = 0,
+    failed = 0;
+  for (const g of groups) {
+    try {
+      const stripeSub = await getStripe().subscriptions.retrieve(g.stripe_subscription_id);
+      // Write whatever Stripe says, terminal or not: a row claiming `incomplete`
+      // while Stripe says `active` is drift in the expensive direction, and the
+      // same call fixes both. Plan, period end and payment-method flag come
+      // along with it, because they were stamped from the same stale object.
+      await syncSubscriptionForGroup(g.id, stripeSub);
+      await invalidateGroupEntitlements(g.id);
+      if (stripeSub.status === "canceled" || stripeSub.status === "incomplete_expired") {
+        retired++;
+      } else {
+        stillLive++;
+        // The case the #367 warn said was worth chasing, now with Stripe's own
+        // answer attached. Not cancelled from here: a live subscription with no
+        // organisations may be a detach mid-flight or a support action in
+        // progress, and an unattended cancel of a paying customer's
+        // subscription is not a sweep's decision to make.
+        console.error(
+          `[billing] group ${g.id} has no organisations, but Stripe says its subscription ` +
+            `${g.stripe_subscription_id} is '${stripeSub.status}' — live and billing for nobody. ` +
+            `Row updated to match; the subscription was NOT cancelled.`,
+        );
+      }
+    } catch (err) {
+      // One unreadable subscription (deleted at Stripe, wrong key, archived
+      // price) must not stop the sweep for everybody else. Left untouched
+      // rather than assumed dead: writing `canceled` off a failed read is
+      // exactly the guess this function refuses to make.
+      failed++;
+      console.error(`[billing] orphan-group sweep failed for group ${g.id}`, err);
+    }
+  }
+  if (groups.length === limit)
+    console.warn(
+      `[billing] orphan-group sweep hit its limit of ${limit} — some groups were not visited`,
+    );
+  return { checked: groups.length, retired, stillLive, failed };
 }
 
 /**

--- a/apps/web/src/server/usecases/billing-groups.ts
+++ b/apps/web/src/server/usecases/billing-groups.ts
@@ -29,7 +29,7 @@ import {
 import { activeOrgCount, assertWithinGroupCap, groupOrgLimit } from "@/lib/billing-group";
 import { orgAddonForPlan } from "@/lib/org-addons";
 import { planItem } from "@/lib/subscription-items";
-import { hasLiveSubscription } from "@/lib/subscription-status";
+import { hasLiveSubscription, isTerminalStripeStatus } from "@/lib/subscription-status";
 import { intervalForPrice } from "@/lib/billing-manage";
 import { toLocale, type Locale } from "@/lib/i18n-constants";
 import {
@@ -538,7 +538,11 @@ export async function sweepOrphanGroups(limit = 200): Promise<{
       // along with it, because they were stamped from the same stale object.
       await syncSubscriptionForGroup(g.id, stripeSub);
       await invalidateGroupEntitlements(g.id);
-      if (stripeSub.status === "canceled" || stripeSub.status === "incomplete_expired") {
+      // Asked through the SHARED predicate, not a local pair of string
+      // comparisons: `incomplete_expired` is a Stripe-only status our own
+      // writes never produce, and a second copy of that list here is the drift
+      // `status-vocabulary-truth` exists to prevent (#375/#378).
+      if (isTerminalStripeStatus(stripeSub.status)) {
         retired++;
       } else {
         stillLive++;


### PR DESCRIPTION
Closes #375.

## The state nothing owned

`cancelGroupIfEmpty` refuses — correctly — to cancel a billing group whose status is outside `('trialing','active','past_due')`. The status that actually reaches that refusal is `incomplete`: an abandoned first checkout. #367 made the refusal audible; it deliberately left the row alone.

Nothing else picks it up:

| | why it skips the row |
|---|---|
| `cancelGroupIfEmpty` | status outside its set — the refusal itself |
| `reconcileGroupQuantities` | selects the same three statuses |
| `dropEmptyGroup` | refuses anything that ever reached Stripe |

So the row sits at `incomplete` for ever, describing a subscription Stripe destroyed within 23 hours.

## The shape, and three things it deliberately is not

**It does not delete.** The row carries `trial_used_at`, the Stripe customer link and any dispute history, and the partial unique index on `stripe_customer_id` depends on it existing. Deleting it would hand the payer a fresh trial for the price of abandoning an unpaid checkout — #241's farm on a different path. The row is retired **in place**.

**It does not guess.** The obvious predicate — "org-less and `incomplete`, therefore dead" — infers Stripe's state from ours. This asks Stripe and writes back what it says, through `syncSubscriptionForGroup`, the one writer that owns that translation. No second copy of `STATUS_MAP` here, and none of the `incomplete_expired` predicate that matches nothing (#378).

**It does not cancel at Stripe.** Everything selected is either already dead there, or alive and billing for nobody — and the second case is an alarm for a human, not an unattended cancel of a live subscription.

```ts
export async function sweepOrphanGroups(limit = 200): Promise<{
  checked: number; retired: number; stillLive: number; failed: number;
}>
```

The selection answers the issue's own worry that a sweep would cast a wider net than intended:

```sql
where s.stripe_subscription_id is not null
  and s.status <> 'canceled'                    -- every ordinary cancellation, excluded
  and s.updated_at < now() - interval '1 day'   -- past Stripe's 23h incomplete ceiling
  and not exists (select 1 from organizations o
                   where o.subscription_id = s.id and o.deleted_at is null)
```

`status <> 'canceled'` is what keeps this off the org-less-but-already-cancelled population the issue asked about: there is nothing left to retire there, and selecting them would cost one Stripe read per cancelled customer, daily, for ever, to change nothing.

The one-day floor keeps it away from a detach still in flight and puts the whole `incomplete` window behind us, so Stripe's answer is the final one rather than a checkout somebody is still paying.

## Where it runs

The daily `/api/cron/billing-quantity`, beside `countOrgsWithoutGroup` — which is its mirror image: an **org** with no group, versus a **group** with no orgs. `stillLive > 0` is the new signal to look at: a subscription alive at Stripe with nobody on the bill.

## What the issue asked, and what this answers

1. *Is an org-less non-cancellable group a problem, or untidy?* Untidy in the common case — Stripe stops billing on its own. What made it worth fixing is that the row **lies**: it claims `incomplete`, a LIVE status, so it is inside `LIVE_SUBSCRIPTION_STATUSES` and blocks a second checkout for that payer while conveying no plan. Retiring it to `canceled` is what lets them buy again.
2. *What distinguishes the abandoned-checkout case?* Nothing in our schema had to — Stripe knows, and this asks. No new column, no heuristic on `trial_used_at`.
3. *Measure first.* Still true, and now cheap: the sweep reports `checked / retired / stillLive / failed` on every run.

## Verification

6 DB-backed tests with a **strict** Stripe double — it throws for any subscription id the file did not seed, so a schema-wide sweep running beside parallel suites can write nothing outside its own fixtures (#321's lesson).

| case | asserts |
|---|---|
| abandoned checkout, Stripe says `incomplete_expired` | row → `canceled`; `stripe_subscription_id`, `stripe_customer_id`, `trial_used_at` all survive; no Stripe cancel call |
| Stripe says `active` | row corrected to `active`, `stillLive` raised, **no cancel call**, error names "live and billing for nobody" |
| group still has an organisation | never retrieved (the canary — without it a predicate that selects everything passes every other case) |
| touched within the last day | never retrieved |
| already `canceled` | never retrieved |
| Stripe read throws | `failed` raised, row **untouched** at `incomplete` |

Mutation-verified, both guards:

- `interval '1 day'` → `+ interval '1 day'` reds *"leaves a row touched within the last day alone"*
- dropping `s.status <> 'canceled'` reds *"leaves an already-cancelled group alone"*

86/86 across this file plus `billing-group-move.test.ts`; `tsc` clean; lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
