### PR TITLE
ci: adopt Turborepo with signed Remote Cache (typecheck, lint, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,21 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Turborepo Remote Cache (Vercel personal scope — `turbo link` writes the team
+# id to .turbo/config.json, which is gitignored, so CI has to be told).
+#
+# Fork PRs get an EMPTY TURBO_TOKEN because secrets are withheld from them.
+# That is not an error: turbo drops to the local cache and every task still
+# runs. Verified 2026-08-03 with both vars empty — 2 tasks successful.
+#
+# The signature key is checked on download; a mismatch is a SILENT permanent
+# cache miss, not a failure. So a wrong/absent key costs speed, never
+# correctness — but it also means CI will never tell you the key is wrong.
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAMID: team_YHIpnOtgzPbKRRZIePMhWVtG
+  TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
+
 jobs:
   # -------------------------------------------------------------------------
   # Fast, DB-free gate: typecheck + the full unit / property / grid suite.
@@ -44,8 +59,12 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npm run typecheck --workspace apps/web
-      - run: npm run typecheck --workspace packages/engine
+      # Both workspaces in one graph-ordered pass, restored from the Remote
+      # Cache when neither TS tree changed. turbo.json's globalDependencies
+      # pull in scripts/** + tsconfig.scripts.json, which apps/web's typecheck
+      # reads via its second `tsc -p ../../tsconfig.scripts.json` half — without
+      # that, a scripts/ edit would restore a stale green.
+      - run: npx turbo run typecheck
       - run: npm run engine:boundary
       # v3/03 §6: retired plan tier must never reappear in UI copy.
       - name: Plan-scrub grep gate (PROMPT-32)
@@ -85,7 +104,7 @@ jobs:
       # during render on a live-scoring countdown with no test coverage) and it
       # names the issue that will remove it: #355. Nothing else may join it.
       - name: eslint
-        run: npm run lint
+        run: npx turbo run lint
 
       - run: npm test --workspace apps/web
       # Live-Stripe tier probe (sk_test, test-mode): confirms our plan/tier
@@ -361,8 +380,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
 
+      # On a cache hit turbo restores apps/web/.next/** (minus .next/cache,
+      # which the actions/cache step above owns) — including the standalone
+      # tree the "Start server" step copies .next/static into.
+      #
+      # SKIP_TYPECHECK is declared in turbo.json's `build.env`, so a run with
+      # it set hashes differently from one without: a cached build can never
+      # be silently reused across the type-checked / not-type-checked split.
       - name: Build (production)
-        run: npm run build --workspace apps/web
+        run: npx turbo run build
         env:
           # tsc gate already ran in the test job — don't type-check twice.
           SKIP_TYPECHECK: "1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "workspaces": [
         "apps/*",
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "turbo": "^2.10.8"
+      }
     },
     "apps/web": {
       "name": "@seazn/web",
@@ -4692,6 +4695,92 @@
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       }
+    },
+    "node_modules/@turbo/darwin-64": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.8.tgz",
+      "integrity": "sha512-po+7rfJfUnFXjWlcoN2RwhErgzCdRtBc1T26vYPcywHlggmCQiQe1uWaE4j+BibI2uY9/2pDoFzMN0rmSaPFOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/darwin-arm64": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@turbo/darwin-arm64/-/darwin-arm64-2.10.8.tgz",
+      "integrity": "sha512-+zB2btDJ00lnPRuqOvpVvgl4x34k/djZQGZTTCfjn7JgNCl8QFY5Njo5+dqkY1g/+9gbbsnAvWm9CmJg9ebcXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@turbo/linux-64": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-64/-/linux-64-2.10.8.tgz",
+      "integrity": "sha512-K1dxqiVisyN7cViVsfQLs6xscQbYuI8aO2nbUhFURDACgEDfZRdP/b4CCxeosBJpcMfhYyiibWqJorCnvz9kKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android",
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/linux-arm64": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@turbo/linux-arm64/-/linux-arm64-2.10.8.tgz",
+      "integrity": "sha512-Gi77ibVnrE1fEmvr+/wBD/yvRqhwp/RQuCp2+//lv1U1wNFFyVg0V7Wj8FG9FXPFAw5QHReo8rxc9+wBSDZjzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android",
+        "linux"
+      ]
+    },
+    "node_modules/@turbo/windows-64": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-64/-/windows-64-2.10.8.tgz",
+      "integrity": "sha512-znnLO1haJPYTHoKMKwlAvlkjRiYbbhBzME6wIGaMd+fwir23U6jVd1ecaTWWi1fbnRVqxMfgDBKseQ/hLKb83g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@turbo/windows-arm64": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@turbo/windows-arm64/-/windows-arm64-2.10.8.tgz",
+      "integrity": "sha512-VN30vh3b3Czh2WzYHNTfF1FE0YMZ5aHsLO8dBMGHJewA6792wX6iJR8ZxlzFW6WdOu0gEAKIvlYhfyT81Wkm4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
@@ -14908,6 +14997,24 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/turbo": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.10.8.tgz",
+      "integrity": "sha512-9+8YX5QOkGXzZxcIykTHgaooRHGMWO+jfdyRK0o+rN0U7hBIig2MrJ8r/aNzIPDPhdA73SGb0O+tIztaModTMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "@turbo/darwin-64": "2.10.8",
+        "@turbo/darwin-arm64": "2.10.8",
+        "@turbo/linux-64": "2.10.8",
+        "@turbo/linux-arm64": "2.10.8",
+        "@turbo/windows-64": "2.10.8",
+        "@turbo/windows-arm64": "2.10.8"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "apps/*",
     "packages/*"
   ],
+  "packageManager": "npm@11.17.0",
   "scripts": {
     "dev": "npm run dev --workspace apps/web",
     "build": "npm run build --workspace apps/web",
@@ -37,5 +38,8 @@
     "openapi:gen": "node --experimental-strip-types scripts/openapi-gen.ts",
     "check:rls": "node --experimental-strip-types scripts/check-rls.ts",
     "backfill:pass-credit-redemptions": "node --env-file-if-exists=apps/web/.env.local --experimental-strip-types scripts/backfill-pass-credit-redemptions.ts"
+  },
+  "devDependencies": {
+    "turbo": "^2.10.8"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+
+  // Artifacts are HMAC-SHA256 signed before upload and verified on download;
+  // anything that fails verification is treated as a cache miss rather than
+  // trusted. Requires TURBO_REMOTE_CACHE_SIGNATURE_KEY (32+ bytes) to be the
+  // SAME value on every machine that reads or writes the cache — CI and every
+  // dev box. A mismatched key is not an error: turbo silently misses forever.
+  "remoteCache": {
+    "signature": true
+  },
+
+  // Package tasks hash only their own package's files. These three tasks all
+  // read root-level sources that live outside apps/web and packages/engine:
+  //
+  //   * apps/web `typecheck` is `tsc --noEmit && tsc -p ../../tsconfig.scripts.json`
+  //     — the second half type-checks the whole of scripts/.
+  //
+  // Without these, editing scripts/ leaves a stale typecheck cached green.
+  "globalDependencies": ["tsconfig.scripts.json", "scripts/**"],
+
+  "tasks": {
+    // apps/web is the only package with a build; @seazn/engine ships raw TS via
+    // exports and has no build script, so `^build` is a no-op edge that exists
+    // to keep the ordering correct if the engine ever gains one. The dependency
+    // graph (`"@seazn/engine": "*"`) already makes an engine source change
+    // invalidate the web build.
+    "build": {
+      "dependsOn": ["^build"],
+      // .next/cache is Next's own incremental compiler cache and is restored
+      // separately by actions/cache in ci.yml — keep it out of the artifact.
+      "outputs": [".next/**", "!.next/cache/**"],
+      // NEXT_PUBLIC_* is inlined into the client bundle at build time, so it
+      // MUST be part of the hash. Turborepo's framework inference adds that
+      // prefix automatically for Next packages; it is listed anyway so the
+      // contract is readable here rather than implied.
+      "env": [
+        "NEXT_PUBLIC_*",
+        "NEXT_TELEMETRY_DISABLED",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT",
+        "SENTRY_AUTH_TOKEN",
+        "SKIP_TYPECHECK"
+      ]
+    },
+
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+
+    "lint": {
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
`turbo link` had written the team id into `.turbo/config.json` — which is gitignored, so CI never saw it. Nothing in the repo ran turbo at all: no `turbo.json`, no dependency, no workflow step. This wires it up.

## What changed

- **`turbo.json`** (new) — `build` / `typecheck` / `lint`, with `remoteCache.signature: true` so artifacts are HMAC-SHA256 signed on upload and verified on download.
- **`package.json`** — `turbo@2.10.8` devDependency, plus `packageManager` (turbo 2.10 refuses to resolve the workspace without it).
- **`.github/workflows/ci.yml`** — workflow-level env for the three `TURBO_*` vars; two typecheck steps collapse to one `npx turbo run typecheck`; lint and the production build route through turbo.

Root `package.json` scripts are unchanged, so the Dockerfile's `npm run build --workspace apps/web` behaves exactly as before and nobody is forced through turbo locally.

## Two hashing details that are load-bearing

`globalDependencies` covers `scripts/**` and `tsconfig.scripts.json`. apps/web's typecheck is `tsc --noEmit && tsc -p ../../tsconfig.scripts.json` — the second half reads root-level sources a package-scoped hash would miss, so a `scripts/` edit would otherwise restore a stale green.

`build.env` lists `SKIP_TYPECHECK` next to `NEXT_PUBLIC_*`, so a build made with the tsc gate skipped can't be reused for one without it. Hash `41cfc9e9` with `SKIP_TYPECHECK=1` vs `58b2abf6` without.

## Measured on this branch

| task | cold | cached |
|---|---|---|
| typecheck (both workspaces) | 1m06s | 34ms |
| build (production) | 56.1s | 4.7s |
| remote round-trip, `--remote-only` after wiping local cache | 20.5s | 627ms |

The cached build restores the full standalone tree — `server.js`, `static/`, `BUILD_ID` — so the "Start server" step's `cp -R apps/web/.next/static …` still has its inputs on a cache hit. `.next/cache` is excluded from turbo's outputs; the existing `actions/cache` step keeps owning it.

## Failure modes checked, not assumed

- **Wrong signature key** → silent cache miss, tasks re-run, exit 0. Costs speed, never correctness — but CI will never tell you the key is wrong.
- **Empty `TURBO_TOKEN`** → "remote caching disabled", falls back to the local cache, green. That's the fork-PR shape, since secrets are withheld there.

## Before this does anything

Two repo secrets are needed. Without them CI stays green and simply runs uncached:

- `TURBO_TOKEN` — a Vercel **access token** (vercel.com/account/tokens), not the short-lived one `turbo login` stored.
- `TURBO_REMOTE_CACHE_SIGNATURE_KEY` — 32+ bytes, identical in CI and on every dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)