### PR TITLE
fix(engine): join the feed edge on fixture id, not ext_key (#443)

### DIFF
--- a/apps/web/src/server/usecases/__tests__/competition-schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-ai-repair.test.ts
@@ -5,6 +5,7 @@
 // is clean on its own and only a solve over the WHOLE board can see it. A
 // per-division solver would report nothing to fix and hand a double-booked court
 // to the organiser.
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const parse = vi.fn();
@@ -15,7 +16,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
-import { runCompetitionAiPlan } from "../competition-schedule-ai";
+import { jointSolverConfig, runCompetitionAiPlan } from "../competition-schedule-ai";
 import type { CompetitionPack } from "../competition-schedule-ai";
 import { resetZ3 } from "@seazn/engine/scheduling";
 
@@ -236,5 +237,67 @@ describe("solver repair in runCompetitionAiPlan (#401)", () => {
         .content,
     ) as { focus_fixture_ids?: string[] };
     expect(repairTurn.focus_fixture_ids).toEqual(expect.arrayContaining([F1, F2]));
+  });
+});
+
+// The JOINT half of the #443 namespace guard. `schedule-ai-repair.test.ts`
+// covers the single-division producer; these two cover the competition path,
+// where the same mistake would be even quieter — a joint run spans divisions, so
+// a feed edge that resolves to nothing takes the whole competition's feeder-rest
+// enforcement with it while still displaying as a compiled rule.
+//
+// TRIPWIRES, not bug reproductions: both pass against correct code today.
+describe("joint RuleFixture producers stay in the fixture-id namespace (#443)", () => {
+  /** `makePack`'s ids are uuids and its ext keys are "a1"/"b1", so the two
+   *  namespaces are disjoint and "resolves to an id" cannot pass by coincidence.
+   *  F1 (Alpha) feeds F2 (Beta) — deliberately CROSS-DIVISION, which is the edge
+   *  the engine only began enforcing once the division guard came off. */
+  const feedPack = (): CompetitionPack => {
+    const p = makePack();
+    return {
+      ...p,
+      fixtures: {
+        ...p.fixtures,
+        movable: p.fixtures.movable.map((f) =>
+          f.id === F1 ? { ...f, feeds: { ...f.feeds, winner_to: F2 } } : f,
+        ),
+      },
+    };
+  };
+
+  it("jointSolverConfig emits winnerTo as a fixture id, never an ext_key", () => {
+    const rf = jointSolverConfig(feedPack()).ruleFixtures ?? [];
+    const ids = new Set(rf.map((f) => f.id));
+    const extKeys = new Set(rf.map((f) => f.extKey).filter((k): k is string => k !== null));
+    // Guard the guard: if the fixture ever made ids and ext keys equal, every
+    // assertion below would pass in both states.
+    expect([...ids].some((id) => extKeys.has(id))).toBe(false);
+
+    const feeds = rf.filter((f) => f.winnerTo !== null);
+    expect(feeds).toHaveLength(1);
+    expect(ids.has(feeds[0]!.winnerTo!)).toBe(true);
+    expect(extKeys.has(feeds[0]!.winnerTo!)).toBe(false);
+    // And the edge is the one that was wired, attributed to the FEEDER's own
+    // division — not the dependent's.
+    expect(feeds[0]!.id).toBe(F1);
+    expect(feeds[0]!.winnerTo).toBe(F2);
+    expect(feeds[0]!.divisionId).toBe(D1);
+  });
+
+  it("every RuleFixture in both usecases comes from the ONE shared builder", () => {
+    // This is what makes the guard above cover `verifyJoint` too, which needs a
+    // whole plan to call and is not worth building one for. #443 was two copies
+    // of a join drifting onto a shared wrong assumption; the durable fix is that
+    // there is only ever one copy. `winnerTo:` is the field only a RuleFixture
+    // literal carries, so counting it counts the producers.
+    const read = (rel: string): string =>
+      readFileSync(new URL(rel, import.meta.url), "utf8");
+    const single = read("../schedule-ai.ts");
+    const joint = read("../competition-schedule-ai.ts");
+    const producers = (s: string): number => (s.match(/winnerTo:/g) ?? []).length;
+
+    expect(/export function toRuleFixture\(/.test(single)).toBe(true);
+    expect(producers(single)).toBe(1); // the builder itself
+    expect(producers(joint)).toBe(0); // both joint sites delegate to it
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
@@ -231,6 +231,11 @@ describe("solver repair in runAiPlan (#401)", () => {
 // the engine can catch a producer that starts emitting an ext_key here, because
 // `RuleFixture` types both fields as `string | null`.
 //
+// SCOPE: this covers `packRuleFixtures` — the single-division path — by calling
+// it. It does NOT reach the two joint producers on its own; they are covered in
+// `competition-schedule-ai-repair.test.ts`, which also pins that all three go
+// through the one shared `toRuleFixture` builder.
+//
 // `makePack` is the right board for it: its ids are uuids and its ext keys are
 // "f1".."f4", so the two namespaces are disjoint and "resolves to an id" cannot
 // pass by coincidence.

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
@@ -15,7 +15,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
-import { runAiPlan } from "../schedule-ai";
+import { packRuleFixtures, runAiPlan } from "../schedule-ai";
 import type { SchedulePack } from "../schedule-ai";
 import { resetZ3 } from "@seazn/engine/scheduling";
 
@@ -220,5 +220,38 @@ describe("solver repair in runAiPlan (#401)", () => {
         .content,
     ) as { focus_fixture_ids?: string[]; verifier_conflicts: unknown[] };
     expect(repairTurn.focus_fixture_ids).toEqual(expect.arrayContaining([F1, F2]));
+  });
+});
+
+// A TRIPWIRE, not a bug reproduction — the producer is already correct and this
+// passes today. It exists because the engine's feed-edge join now reads
+// `winnerTo` as a FIXTURE ID (#443), and the way that rule dies is silent: a
+// join that resolves nothing reports nothing, so `min_rest_minutes` would go on
+// compiling and displaying as enforced while binding nothing at all. Nothing in
+// the engine can catch a producer that starts emitting an ext_key here, because
+// `RuleFixture` types both fields as `string | null`.
+//
+// `makePack` is the right board for it: its ids are uuids and its ext keys are
+// "f1".."f4", so the two namespaces are disjoint and "resolves to an id" cannot
+// pass by coincidence.
+describe("packRuleFixtures namespace tripwire (#443)", () => {
+  it("emits winnerTo in the FIXTURE-ID namespace, never the ext_key one", () => {
+    const base = makePack();
+    const movable = base.fixtures.movable.map((f, i) =>
+      i === 0 ? { ...f, feeds: { ...f.feeds, winner_to: F2 } } : f,
+    );
+    const withFeed: SchedulePack = { ...base, fixtures: { ...base.fixtures, movable } };
+
+    const rf = packRuleFixtures(withFeed);
+    const ids = new Set(rf.map((f) => f.id));
+    const extKeys = new Set(rf.map((f) => f.extKey).filter((k): k is string => k !== null));
+    // Guard the guard: if the fixture ever made ids and ext keys equal, every
+    // assertion below would pass in both states.
+    expect([...ids].some((id) => extKeys.has(id))).toBe(false);
+
+    const feeds = rf.filter((f) => f.winnerTo !== null);
+    expect(feeds).toHaveLength(1);
+    expect(ids.has(feeds[0]!.winnerTo!)).toBe(true);
+    expect(extKeys.has(feeds[0]!.winnerTo!)).toBe(false);
   });
 });

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -61,6 +61,7 @@ import {
   planRungs,
   runLadder,
   schedulingAiModel,
+  toRuleFixture,
   unschedulableRule,
   windowBounds,
   zonedIso,
@@ -1351,13 +1352,12 @@ export function verifyConfigFor(
  */
 export function jointSolverConfig(pack: CompetitionPack): VerifyConfig & { courts: string[] } {
   const divisions = pack.divisions;
-  const ruleFixtures: RuleFixture[] = pack.fixtures.movable.map((f) => ({
-    id: f.id,
-    extKey: f.ext_key,
-    divisionId: f.division_id,
-    ...(f.pool !== null ? { poolId: f.pool } : {}),
-    winnerTo: f.feeds.winner_to,
-  }));
+  // Built by the shared producer, not a literal of its own (#443) — see
+  // `toRuleFixture`. Each fixture's OWN division, because a joint pack spans
+  // several.
+  const ruleFixtures: RuleFixture[] = pack.fixtures.movable.map((f) =>
+    toRuleFixture(f, f.division_id),
+  );
   const settings = divisions.map((d) => d.settings);
   const max = (pick: (s: (typeof settings)[number]) => number): number =>
     settings.reduce((acc, s) => Math.max(acc, pick(s)), 0);
@@ -1523,13 +1523,12 @@ export function verifyJoint(plan: AiSchedulePlan, pack: CompetitionPack): Confli
   const restByDivision = Object.fromEntries(
     pack.divisions.map((d) => [d.id, d.settings.perEntrantMinRest]),
   );
-  const ruleFixtures: RuleFixture[] = pack.fixtures.movable.map((f) => ({
-    id: f.id,
-    extKey: f.ext_key,
-    divisionId: f.division_id,
-    ...(f.pool !== null ? { poolId: f.pool } : {}),
-    winnerTo: f.feeds.winner_to,
-  }));
+  // Same shared producer as `jointSolverConfig` (#443): the verifier and the
+  // solver must be handed rule fixtures built by ONE piece of code, or they can
+  // disagree about which fixture a feed edge names.
+  const ruleFixtures: RuleFixture[] = pack.fixtures.movable.map((f) =>
+    toRuleFixture(f, f.division_id),
+  );
   const hard: HardConstraint[] = [
     ...pack.parsed.hard,
     ...pack.divisions.flatMap((d) => d.settings.constraints?.hard ?? []),

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -1477,17 +1477,43 @@ function toObstacleAssignments(pack: SchedulePack): Assignment[] {
   }));
 }
 
+/**
+ * THE one place a `RuleFixture` is built — for the single-division pack here and
+ * for both joint producers in `competition-schedule-ai.ts` (#443).
+ *
+ * It is one function rather than three literals because of what #443 was: two
+ * copies of a join drifted onto a shared wrong assumption, and the second copy
+ * is exactly what made the first invisible. `winnerTo` and `id` must stay in ONE
+ * namespace — `winnerTo` carries `fixtures.winner_to_fixture`, a uuid FK to
+ * `fixtures.id`, and the engine now joins the feed edge on that id. `extKey`
+ * carries `fixtures.ext_key`, nullable text, and is a different namespace with
+ * no converter anywhere.
+ *
+ * A producer that put an ext key in `winnerTo` would type-check — `RuleFixture`
+ * declares both `string | null` — and would fail SILENTLY, because a join that
+ * resolves nothing reports nothing: `min_rest_minutes` would go on compiling and
+ * displaying as enforced while binding nothing at all. One producer means one
+ * thing to guard, and `schedule-ai-repair.test.ts` guards it.
+ *
+ * `divisionId` is a parameter because the two packs source it differently: the
+ * single-division pack takes it from the division it is a pack OF, the joint
+ * pack from each fixture's own `division_id`.
+ */
+export function toRuleFixture(f: PackFixture, divisionId: string): RuleFixture {
+  return {
+    id: f.id,
+    extKey: f.ext_key,
+    divisionId,
+    ...(f.pool !== null ? { poolId: f.pool } : {}),
+    winnerTo: f.feeds.winner_to,
+  };
+}
+
 /** The fixture metadata typed rules need and `Assignment` does not carry (#398).
  *  `winnerTo` is the ONLY definition of terminal — never a round number, which
  *  is a display label an elimination bracket numbers sparsely. */
 export function packRuleFixtures(pack: SchedulePack): RuleFixture[] {
-  return pack.fixtures.movable.map((f) => ({
-    id: f.id,
-    extKey: f.ext_key,
-    divisionId: pack.division.id,
-    ...(f.pool !== null ? { poolId: f.pool } : {}),
-    winnerTo: f.feeds.winner_to,
-  }));
+  return pack.fixtures.movable.map((f) => toRuleFixture(f, pack.division.id));
 }
 
 /** Exported for the same reason the joint twin `verifyConfigFor` is: it is a

--- a/packages/engine/src/scheduling/calendar-instruction.test.ts
+++ b/packages/engine/src/scheduling/calendar-instruction.test.ts
@@ -526,9 +526,12 @@ describe("scoping", () => {
       expect(withDeps.filter((c) => c.reason === "order")).toHaveLength(1);
     });
 
-    it("does not cross divisions on a reused ext_key", () => {
-      // Two divisions can both wire an "sl-g2-d1"-shaped key; a feed edge is only
-      // an edge within one division's bracket.
+    it("an ext_key that merely EQUALS a winnerTo is not a feed edge (#443)", () => {
+      // Renamed from "does not cross divisions on a reused ext_key": the guard
+      // that used to answer this case was `divisionId`, and it only existed
+      // because the join compared `extKey` against `winnerTo` and two divisions
+      // can both wire a key like "SF1". The join is now on fixture id, so a text
+      // key that happens to read like a `winner_to_fixture` names nothing.
       const crossed: RuleFixture[] = [
         { id: "sl-g1-d1", extKey: "SF1", winnerTo: "F", divisionId: "d1" },
         { id: "sl-g2-d2", extKey: "F", winnerTo: null, divisionId: "d2" },
@@ -554,6 +557,118 @@ describe("scoping", () => {
           }),
         ),
       ).toEqual([]);
+    });
+
+    // --- #443: the feed edge is a FIXTURE ID, not an ext_key ---------------
+    //
+    // `winnerTo` carries `fixtures.winner_to_fixture` — a uuid FK to
+    // `fixtures.id`. `extKey` carries `fixtures.ext_key`, nullable text. The
+    // join used to compare one against the other, so on every real payload it
+    // matched ZERO pairs: this rule compiled, displayed as enforced, and bound
+    // nothing. The encoder carried the same join, which is why `repairAndVerify`
+    // could not see it either.
+    //
+    // Every helper above defaults `extKey = id`, which is exactly what made the
+    // defect invisible. These cases spell both namespaces out and keep them
+    // DELIBERATELY different — a uuid `winnerTo` beside a real, unequal ext key.
+    describe("the feed edge joins on fixture id, not ext_key (#443)", () => {
+      const FEEDER_ID = "0b3f5a7c-1d2e-4f60-8a91-000000000001";
+      const DEP_ID = "0b3f5a7c-1d2e-4f60-8a91-000000000002";
+      const MATCH_MIN = 30;
+
+      /** Two fixtures on their own courts with no shared entrants or people, so
+       *  `court`, `rest` and `person_overlap` can never be mistaken for the
+       *  proof — the instruction rule is the only thing that can speak. */
+      const uuidBoard = (dependentIso: string, depDivision = "d1"): Assignment[] => {
+        const card = (fixtureId: string, iso: string, court: string, divisionId: string): Assignment => ({
+          fixtureId,
+          court,
+          startAt: at(iso),
+          endAt: at(iso) + MATCH_MIN * 60_000,
+          entrants: [],
+          people: [],
+          divisionId,
+        });
+        return [
+          card(FEEDER_ID, "2026-07-24T10:00:00Z", "Court 1", "d1"),
+          card(DEP_ID, dependentIso, "Court 2", depDivision),
+        ];
+      };
+
+      const verifyRf = (b: Assignment[], ruleFixtures: RuleFixture[]): Conflict[] =>
+        instr(
+          validateAssignments(b, {
+            ...BASE_CONFIG,
+            tz: TZ,
+            matchMinutes: MATCH_MIN,
+            hard: [feedRest("feeder_to_dependent")],
+            ruleFixtures,
+          }),
+        );
+
+      it("REJECTS a uuid feed whose dependent carries a DIFFERENT ext key", () => {
+        const rfs: RuleFixture[] = [
+          { id: FEEDER_ID, extKey: "SF1", winnerTo: DEP_ID, divisionId: "d1" },
+          { id: DEP_ID, extKey: "F", winnerTo: null, divisionId: "d1" },
+        ];
+        const found = verifyRf(uuidBoard("2026-07-24T10:50:00Z"), rfs);
+        expect(found.map((c) => c.fixtureId)).toEqual([DEP_ID]);
+        expect(found[0]?.detail).toBe("starts 20 min after its feeder, instruction requires 40");
+      });
+
+      it("ACCEPTS the same uuid feed once the gap is honoured", () => {
+        const rfs: RuleFixture[] = [
+          { id: FEEDER_ID, extKey: "SF1", winnerTo: DEP_ID, divisionId: "d1" },
+          { id: DEP_ID, extKey: "F", winnerTo: null, divisionId: "d1" },
+        ];
+        expect(verifyRf(uuidBoard("2026-07-24T11:15:00Z"), rfs)).toEqual([]);
+      });
+
+      it("reaches a dependent whose ext_key is NULL — the column is nullable", () => {
+        // `V214__fixtures.sql` declares `ext_key text` NULLABLE, so under the old
+        // join a bracket wired without generator keys missed UNCONDITIONALLY:
+        // `null !== <uuid>` for every pair, every time. Any uuid→ext_key mapping
+        // would have reproduced exactly this hole.
+        const rfs: RuleFixture[] = [
+          { id: FEEDER_ID, extKey: "SF1", winnerTo: DEP_ID, divisionId: "d1" },
+          { id: DEP_ID, extKey: null, winnerTo: null, divisionId: "d1" },
+        ];
+        expect(verifyRf(uuidBoard("2026-07-24T10:50:00Z"), rfs).map((c) => c.fixtureId)).toEqual([DEP_ID]);
+      });
+
+      it("enforces a feed edge that CROSSES divisions", () => {
+        // `winner_to_fixture` is a uuid FK: it names exactly ONE fixture row,
+        // wherever that row sits. The old `divisionId` guard existed solely to
+        // disambiguate a reused text key; keeping it beside an id join would
+        // silently drop a legitimate cross-division feed — the same
+        // binds-nothing failure this issue is about.
+        const rfs: RuleFixture[] = [
+          { id: FEEDER_ID, extKey: "SF1", winnerTo: DEP_ID, divisionId: "d1" },
+          { id: DEP_ID, extKey: "F", winnerTo: null, divisionId: "d2" },
+        ];
+        expect(verifyRf(uuidBoard("2026-07-24T10:50:00Z", "d2"), rfs).map((c) => c.fixtureId)).toEqual([
+          DEP_ID,
+        ]);
+      });
+
+      it("a same-division ext_key coincidence still creates NO edge", () => {
+        // The mirror of the case above, with the division guard out of the way:
+        // the ONLY thing that makes a feed edge is `winnerTo === <a fixture id>`.
+        // Before #443 this pair was an edge and reported a conflict.
+        const rfs: RuleFixture[] = [
+          { id: FEEDER_ID, extKey: "SF1", winnerTo: "F", divisionId: "d1" },
+          { id: DEP_ID, extKey: "F", winnerTo: null, divisionId: "d1" },
+        ];
+        expect(verifyRf(uuidBoard("2026-07-24T10:50:00Z"), rfs)).toEqual([]);
+      });
+
+      it("a terminal feeder (winnerTo === null) short-circuits before any join", () => {
+        const rfs: RuleFixture[] = [
+          { id: FEEDER_ID, extKey: "SF1", winnerTo: null, divisionId: "d1" },
+          { id: DEP_ID, extKey: "F", winnerTo: null, divisionId: "d1" },
+        ];
+        expect(verifyRf(uuidBoard("2026-07-24T10:50:00Z"), rfs)).toEqual([]);
+      });
     });
   });
 

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -701,10 +701,25 @@ if (tz !== undefined) {
         if (f.winnerTo === null) continue;
         const feeder = placedById.get(f.id);
         if (feeder === undefined) continue;
-        for (const d of ruleFixtures) {
-          // The feed edge, by the same ext_key the bracket is wired with, and
-          // within one division — two divisions can reuse a key like "SF1".
-          if (d.extKey !== f.winnerTo || d.divisionId !== f.divisionId) continue;
+        // THE FEED EDGE IS A FIXTURE ID, NOT AN EXT KEY (#443). `winnerTo`
+        // carries `fixtures.winner_to_fixture` — a uuid FK to `fixtures.id`.
+        // `extKey` carries `fixtures.ext_key`, which is nullable text and lives
+        // in a different namespace entirely; nothing converts one into the
+        // other. This join used to compare them, so on every real payload it
+        // matched ZERO pairs and the whole rule compiled, displayed as enforced,
+        // and bound nothing.
+        //
+        // No division guard either. The old one existed only to disambiguate a
+        // reused generator key like "SF1"; a uuid FK names exactly one fixture
+        // row wherever it sits, so there is nothing left to disambiguate — and
+        // keeping the guard would silently DROP a legitimate cross-division
+        // feed, which is the same binds-nothing failure in a smaller costume.
+        //
+        // `repair.ts` carries this join verbatim: the solver may not hold an
+        // opinion of its own about what a rule means (#401).
+        {
+          const d = fixtureById.get(f.winnerTo);
+          if (d === undefined) continue;
           const dependent = placedById.get(d.id);
           if (dependent === undefined) continue;
           if (!scopeCoversFixture(h.scope, f, feeder) && !scopeCoversFixture(h.scope, d, dependent)) continue;

--- a/packages/engine/src/scheduling/repair.test.ts
+++ b/packages/engine/src/scheduling/repair.test.ts
@@ -840,6 +840,56 @@ describe("the rule families, end to end", () => {
   );
 
   it(
+    "joins the feed edge by fixture id, not ext_key (#443)",
+    async () => {
+      // `winnerTo` is `fixtures.winner_to_fixture` — a uuid FK to `fixtures.id`.
+      // `extKey` is `fixtures.ext_key`, nullable text. The encoder compared one
+      // against the other, so on every real payload it asserted NOTHING, and
+      // `repairAndVerify` was blind because the verifier shared the assumption.
+      // Every ext key below is deliberately UNEQUAL to every id.
+      //
+      // The board carries a genuine court clash as well, so z3 runs whether or
+      // not the feed constraint is encoded. That is what makes the gap assertion
+      // a test of the ENCODER rather than of the pre-check verifier: without the
+      // constraint the solver repairs the clash, leaves the dependent where it
+      // sits, and the 90-minute gap is simply never asked for.
+      const config: VerifyConfig & { courts: readonly string[] } = {
+        ...BASE_CONFIG,
+        tz: "UTC",
+        courts,
+        window: { from: at("2026-08-10T08:00:00Z"), to: at("2026-08-10T20:00:00Z") },
+        ruleFixtures: [
+          { id: "sl-g1-d1", extKey: "SF-A", divisionId: "d1", winnerTo: "sl-g2-d1" },
+          { id: "sl-g2-d1", extKey: "FINAL-A", divisionId: "d1", winnerTo: null },
+          { id: "sl-g2-d2", extKey: "GRP-B", divisionId: "d2", winnerTo: null },
+        ],
+        hard: [
+          {
+            type: "min_rest_minutes",
+            minutes: 90,
+            rest_scope: "feeder_to_dependent",
+            scope: { kind: "competition" },
+          },
+        ],
+      };
+      const proposal = assign(STEP, SHARED, [
+        ["sl-g1-d1", "2026-08-10T09:00:00Z", "C1"], // feeder, ends 09:40
+        ["sl-g2-d2", "2026-08-10T09:20:00Z", "C1"], // the court clash that forces a solve
+        ["sl-g2-d1", "2026-08-10T10:00:00Z", "C2"], // dependent — 20 min after the feeder
+      ]);
+      const deps: OrderDependency[] = [{ fixtureId: "sl-g2-d1", dependsOn: "sl-g1-d1", direct: true }];
+
+      const r = await repairSchedule({ proposal, config, dependencies: deps, budgetMs: 60_000 });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      const byId = new Map(r.assignments.map((a) => [a.fixtureId, a]));
+      expect(byId.get("sl-g2-d1")!.startAt - byId.get("sl-g1-d1")!.endAt).toBeGreaterThanOrEqual(90 * MIN);
+      expect(validateAssignments(r.assignments, config, [], deps)).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
     "stays finite with no pack window and no session windows",
     async () => {
       // The ONLY configuration in which the unconditional ±30-day bound on every

--- a/packages/engine/src/scheduling/repair.ts
+++ b/packages/engine/src/scheduling/repair.ts
@@ -498,10 +498,20 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
           if (f.winnerTo === null) continue;
           const feeder = boardById.get(f.id);
           if (feeder === undefined) continue;
-          for (const dd of ruleFixtures) {
-            // The feed edge, by the same ext_key the bracket is wired with, and
-            // within one division — two divisions can reuse a key like "SF1".
-            if (dd.extKey !== f.winnerTo || dd.divisionId !== f.divisionId) continue;
+          // THE FEED EDGE IS A FIXTURE ID, NOT AN EXT KEY (#443) — the same join
+          // `validateInstructionRules` makes, for the same reason. `winnerTo` is
+          // `fixtures.winner_to_fixture` (a uuid FK to `fixtures.id`); `extKey`
+          // is the nullable text `fixtures.ext_key`, a different namespace with
+          // no converter anywhere. Comparing them matched zero pairs on every
+          // real payload, so this encoder asserted nothing — and because the
+          // verifier shared the assumption, `repairAndVerify` could not see it.
+          //
+          // No division guard: a uuid FK names exactly one fixture row wherever
+          // it sits, so a reused generator key can no longer be mistaken for a
+          // feed, and guarding would silently drop a cross-division one.
+          {
+            const dd = fixtureById.get(f.winnerTo);
+            if (dd === undefined) continue;
             const dependent = boardById.get(dd.id);
             if (dependent === undefined) continue;
             if (!idx.has(f.id) && !idx.has(dd.id)) continue;


### PR DESCRIPTION
Fixes #443.

## The defect

`RuleFixture.winnerTo` carries `fixtures.winner_to_fixture`, a **uuid** FK. `RuleFixture.extKey` carries `fixtures.ext_key`, **nullable text**. Two joins compared them directly:

- `packages/engine/src/scheduling/calendar.ts:707` — the verifier
- `packages/engine/src/scheduling/repair.ts:504` — the z3 encoder

No code path converts one namespace into the other, so on every real payload the join matched **zero pairs** and the feeder-rest half of `min_rest_minutes` silently never fired. `repairAndVerify` could not catch it: encoder and verifier shared the assumption, so the safety net was blind to it.

## Why join on `id` rather than resolving uuid → ext_key at the adapter

The issue left this open. Rejected the adapter option after checking all three producers:

- All three assign the raw uuid — `schedule-ai.ts:1489`, `competition-schedule-ai.ts:1359` and `:1531` — all tracing to `schedule-ai.ts:976`, `winner_to: f.winner_to_fixture`.
- `fixtures.ext_key` is **nullable** (`V214__fixtures.sql:31-33`). A uuid → ext_key map would silently miss on any null-ext_key row — the same failure mode, relocated.
- `winnerTo` has exactly two consumers in the engine: the `terminal` selector (`calendar.ts:620`) and these two joins. Nothing else reads it.

So the uuid is the canonical namespace and the join moves to it. The inner scan becomes a `fixtureById` lookup that already existed in both files.

## The `divisionId` guard is dropped

`winner_to_fixture` names exactly one fixture row, so the reused-`"SF1"` ambiguity the guard defended against cannot arise. Keeping it would silently drop a legitimate cross-division feed — the same binds-nothing failure as the bug itself. Both files agree.

Worth knowing: cross-division feeds are **not producible today** — `wireCrossFeeds` scopes its stage lookup to one `division_id` (`stages.ts:1057-1058`). So the guard removal is inert on current data, and the cross-division test is a forward-looking assertion rather than a live path.

## One producer, not three

The second commit extracts a shared `toRuleFixture(f, divisionId)` builder used by all three call sites. Rationale: #443 *was* two copies of a join drifting onto a shared wrong assumption, so a test that merely enumerates producers has the same shape as the bug — it needs updating when a fourth appears, and nothing fails if it is not. Emitted output is unchanged at all three sites.

## Behaviour change — deliberate

**Schedules that validate clean today can now report feeder-rest conflicts.** That is the defect being fixed. Blast radius is bounded: `instruction` is not in `isBlockingConflict` (`calendar.ts:185-192`) nor `BLOCKING_FAMILIES` (`repair-domain.ts:51`), so a board that cannot satisfy the newly-live constraint degrades to `relaxed: ["instruction"]` rather than `infeasible`, and the apply gate does not start refusing writes.

## Tests

All verified failing before the change by reverting only the source and keeping the tests:

```
calendar-instruction.test.ts   37 pass  4 fail   ->  41 pass  0 fail
repair.test.ts -t "#443"        0 pass  1 fail   ->   1 pass  0 fail
```

The four verifier cases: a **differing** ext_key, a **NULL** ext_key, a cross-division feed, and an ext_key coincidence that must *not* create an edge. The encoder case failed with `expected 2400000 to be greater than or equal to 5400000` — a 40-minute feed gap against a 90-minute rule.

Namespace tripwire, proven by mutation. Bypassing the shared builder with an inline `winnerTo: f.ext_key`:

```
MUTANT   files 2  total 12  pass 10  fail 2
REVERTED files 2  total 12  pass 12  fail 0
```

`total` held at 12 across both, so no suite silently dropped out of collection.

## Gates

All on a measured-idle box, each run stamping its resolved cwd and `readlink -f node_modules/@seazn/engine`:

```
engine    89 files  2081 pass  0 fail   1 pending
apps/web 587 files  5190 pass  0 fail  50 pending   (DB: fresh schema, db:apply + sync:sports)
lint      0 errors, 79 warnings  (identical to main's baseline)
openapi   0 drift
```

`pending 50` rather than ~1800 confirms the DB-backed suites actually ran rather than skipping themselves.

## Bench — stated limitation, not a clean result

#443 asked for the W6 scale bench to be re-run, on the grounds that making the join fire adds real constraints. **The bench cannot answer that question**: `repair-synthetic-board.ts:28` deliberately omits `hard` instruction rules, so `min_rest_minutes` is not on the bench board and this change is inert there. The identical `k=2` across all three trees is the proof.

Measured anyway, at 87-90% CPU idle, one run at a time:

| n | tree | status | total ms | probe ms | search ms |
|---|---|---|---|---|---|
| 50 | main | repaired k=2 | 4 188 | 2 565 | 1 083 |
| 50 | this branch | repaired k=2 | 3 836 | 2 359 | 982 |
| 120 | main | timeout | 180 161 | 178 727 | 0 |
| 120 | this branch | timeout | 180 157 | 178 688 | 0 |

No regression, but see #455 — on unmodified `main` the probe phase consumes the entire budget at n=120 and the 500-movable tier is unreachable on this host, so the W6 table does not reproduce here at all.

## Not covered

No e2e, no smoke. The surface does not exist: `min_rest_minutes`, `rest_scope`, `feeder_to_dependent`, `winner_to_fixture`, `ruleFixtures` return **0 hits** across `apps/web/e2e/`, and `scripts/smoke.ts`'s only AI-schedulable division is `kind: "league"` (`smoke.ts:6060`) — a league has no bracket, so no feed edge exists on any smoke board to bind to. Tracked in #452.

## Follow-ups filed

- #452 — no e2e/smoke surface for feeder-rest
- #453 — the rule still binds nothing when either end is outside the movable set, and loser-side feeds have no edge at all (`RuleFixture` has no `loserTo` although `feedDependencies` already emits order deps for `loser_to_fixture`)
- #455 — repair bench probe bottleneck on `main`

## Merge note

Shares two files with `fix/repair-rounding-widen`: `packages/engine/src/scheduling/repair.ts` (different regions — the join here, rounding there) and `apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts`. Whichever lands second needs a rebase and a re-run, not a blind merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
