### PR TITLE
fix(engine): widen an immovable obstacle when rounding, never round it

### DIFF
--- a/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
@@ -169,6 +169,50 @@ describe("solver repair in runAiPlan (#401)", () => {
     expect(changed).toHaveLength(1);
   });
 
+  it("carries a model start's SECONDS all the way into the solver and back out again", async () => {
+    // The adapter boundary, pinned in both directions.
+    //
+    // `AiSchedulePlan.scheduled_at` is an RFC-3339 string the model writes and
+    // nothing on the way to `toEngineAssignments` truncates, so an engine
+    // `Assignment.startAt` is routinely NOT on a minute. The z3 repair encoder
+    // works in whole minutes, so it has to round every one of those outward —
+    // and this test exists so that nobody "fixes" that by quantising here
+    // instead, where it would silently move a fixture the organiser placed.
+    //
+    // The clash is SUB-MINUTE and exists only in milliseconds: F1 runs
+    // 14:00:00-14:30:00 and F2 opens at 14:29:40 on the same court. Rounded to
+    // the nearest minute the two are back to back and there is nothing to
+    // repair, so a solver run at all is the proof the seconds survived.
+    parse.mockResolvedValueOnce(
+      planResponse(
+        plan([
+          assign(F1, "2026-08-01T14:00:00+01:00", "Court 1"),
+          assign(F2, "2026-08-01T14:29:40+01:00", "Court 1"),
+          assign(F3, "2026-08-01T14:00:20+01:00", "Court 2"),
+          assign(F4, "2026-08-01T14:30:20+01:00", "Court 2"),
+        ]),
+      ),
+    );
+
+    const out = await runAiPlan(pack, movableIds);
+
+    expect(out.blocking).toEqual([]);
+    expect(out.repair.engine).toBe("z3");
+    expect(out.repair.solver_ran).toBe(true);
+    expect(out.repair.status).toBe("repaired");
+    expect(out.repair.moved).toBe(1);
+    expect(parse).toHaveBeenCalledTimes(1);
+
+    // And back out: a fixture the solver did not move keeps its instant to the
+    // millisecond, seconds included. Compared as an INSTANT, not as a string —
+    // the offset the model wrote is not the offset we serialise.
+    const byId = new Map(out.proposal.map((p) => [p.fixture_id, p]));
+    for (const id of [F3, F4]) {
+      const emitted = new Date(byId.get(id)!.scheduled_at).getTime();
+      expect(emitted % 60_000).toBe(20_000);
+    }
+  });
+
   it("stamps engine 'none' and never runs the solver when the first plan verifies clean", async () => {
     parse.mockResolvedValueOnce(planResponse(cleanPlan));
 

--- a/packages/engine/src/scheduling/repair-subminute.test.ts
+++ b/packages/engine/src/scheduling/repair-subminute.test.ts
@@ -307,6 +307,189 @@ describe("repair encodes sub-minute instants conservatively", () => {
   );
 
   it(
+    "refuses an off-minute original that really runs PAST the pack window",
+    async () => {
+      // `inRuns` bounds a start from ABOVE as well as below — the runs are legal
+      // START instants already narrowed by the fixture's own duration, so
+      // `window.to = 20:00` with a 40-minute card gives a run ending 19:20:00.
+      //
+      // `floorMin(19:20:40)` is that same 19:20 minute, so the unmoved escape
+      // sat exactly on the bound and the encoder called a card that really runs
+      // to 20:00:40 legal. Through `repairSchedule` — which is what both web
+      // runners reach — that came back `repaired`, 40 seconds past the window,
+      // with nothing thrown.
+      const movable = card("m1", t("2026-08-10T19:20:40Z"), 40 * MIN, "C1", "e-move");
+      await expectMovedAndClean({ proposal: [movable], config: config(["C1"]), movedId: "m1" });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "refuses an off-minute original that really runs INTO a blackout",
+    async () => {
+      // The same upper bound, reached through the fourth family. `blackout` runs
+      // are per-court and subtract `bo.from - durationMs + 1`, so a 30-minute
+      // card in front of a 12:00 blackout may start no later than 11:30:00.000 —
+      // and `floorMin(11:30:40)` is 11:30.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1"]),
+        blackouts: [{ from: t("2026-08-10T12:00:00Z"), to: t("2026-08-10T13:00:00Z") }],
+      };
+      const movable = card("m1", t("2026-08-10T11:30:40Z"), 30 * MIN, "C1", "e-move");
+      await expectMovedAndClean({ proposal: [movable], config: cfg, movedId: "m1" });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "leaves an off-minute original alone when it is really LEGAL under not_after",
+    async () => {
+      // The other half of the same bound, and the reason it is not simply
+      // `- 1 minute` everywhere. `hhmmInTz` truncates, so `not_after 19:00`
+      // legitimately admits the whole 19:00 minute and a start at 19:00:40 is
+      // LEGAL. Subtracting the slack alone would refuse it and move a card the
+      // organiser placed correctly, so the original placement is added back as
+      // an exact escape wherever it is really inside a run.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1"]),
+        ruleFixtures: [
+          { id: "clashing", extKey: "clashing", winnerTo: null },
+          { id: "late", extKey: "late", winnerTo: null },
+        ],
+        hard: [{ type: "not_after", time: "19:00", scope: { kind: "competition" } }],
+      };
+      const obstacle = card("fixed", t("2026-08-10T15:00:00Z"), 40 * MIN, "C1", "e-fixed");
+      const clashing = card("clashing", t("2026-08-10T15:00:00Z"), 40 * MIN, "C1", "e-clash");
+      const late = card("late", t("2026-08-10T19:00:40Z"), 40 * MIN, "C1", "e-late");
+      const proposal = [clashing, late];
+      expect(validateAssignments(proposal, cfg, [obstacle])).not.toEqual([]);
+
+      const r = await repairAndVerify({
+        proposal,
+        existing: [obstacle],
+        config: cfg,
+        budgetMs: 60_000,
+      });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      // ONE move, and it is the card that was actually double-booked. `late`
+      // keeps its instant, seconds and all.
+      expect(r.moved).toEqual(["clashing"]);
+      const byId = new Map(r.assignments.map((a) => [a.fixtureId, a]));
+      expect(byId.get("late")!.startAt).toBe(t("2026-08-10T19:00:40Z"));
+      expect(validateAssignments(r.assignments, cfg, [obstacle])).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "does not charge an unmoved card's extra minute to cards that really abut it",
+    async () => {
+      // Minimality, which is the property this wave exists to deliver.
+      //
+      // A ends 10:30:20 and B starts 10:30:20: `validateAssignments` lets
+      // intervals touch, so the pair is legal exactly where it stands. On the
+      // minute grid A is charged 31 minutes from 10:00 and B floors to 10:30, so
+      // `30 >= 31` is false and the encoder invents a clash between two cards
+      // that have none — turning a one-move board into a two-move board, and a
+      // saturated court into a spurious `infeasible`.
+      //
+      // Only C is really in the way, so the minimal repair is to move C.
+      const a = card("a", t("2026-08-10T10:00:20Z"), 30 * MIN, "C1", "e-a");
+      const b = card("b", t("2026-08-10T10:30:20Z"), 30 * MIN, "C1", "e-b");
+      const c = card("c", t("2026-08-10T10:15:00Z"), 30 * MIN, "C1", "e-c");
+      const cfg = config(["C1"]);
+      expect(validateAssignments([a, b, c], cfg)).not.toEqual([]);
+      // The pair the encoder used to break is REALLY clean on its own.
+      expect(validateAssignments([a, b], cfg)).toEqual([]);
+
+      const r = await repairAndVerify({ proposal: [a, b, c], config: cfg, budgetMs: 60_000 });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      expect(r.k).toBe(1);
+      expect(r.moved).toEqual(["c"]);
+      // And the two that stayed keep their instants to the millisecond.
+      const byId = new Map(r.assignments.map((x) => [x.fixtureId, x]));
+      expect(byId.get("a")!.startAt).toBe(t("2026-08-10T10:00:20Z"));
+      expect(byId.get("b")!.startAt).toBe(t("2026-08-10T10:30:20Z"));
+      expect(validateAssignments(r.assignments, cfg)).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "fits a MOVED off-minute card into a hole exactly its own length",
+    async () => {
+      // The other half of "charge the still extent only when still". Both the
+      // head slack and the tail minute are owed by the UNMOVED escape and by
+      // nothing else, so a card that has been snapped to the grid must be
+      // measured at exactly `ceilMin(duration)` from exactly `s`.
+      //
+      // The window runs 09:00-11:00 and obstacles hold 09:00-10:30 and
+      // 11:00-12:00, so the only legal placement is 10:30-11:00 — a hole exactly
+      // 30 minutes wide. A card charged 31 minutes, or pushed a minute earlier
+      // by a slack it no longer owes, does not fit, and `court` is blocking, so
+      // the answer is a final `infeasible` on a board with an obvious repair.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1"]),
+        window: { from: t("2026-08-10T09:00:00Z"), to: t("2026-08-10T11:00:00Z") },
+      };
+      const before = card("o1", t("2026-08-10T09:00:00Z"), 90 * MIN, "C1", "e-o1");
+      const after = card("o2", t("2026-08-10T11:00:00Z"), 60 * MIN, "C1", "e-o2");
+      const movable = card("m1", t("2026-08-10T09:00:20Z"), 30 * MIN, "C1", "e-move");
+      const existing = [before, after];
+      expect(validateAssignments([movable], cfg, existing)).not.toEqual([]);
+
+      const r = await repairAndVerify({
+        proposal: [movable],
+        existing,
+        config: cfg,
+        budgetMs: 60_000,
+      });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      expect(r.assignments[0]!.startAt).toBe(t("2026-08-10T10:30:00Z"));
+      expect(validateAssignments(r.assignments, cfg, existing)).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "does not charge an unmoved card's extra minute against an IMMOVABLE it really abuts",
+    async () => {
+      // The movable-versus-immovable form of the same minimality trap. `a` really
+      // starts the instant the obstacle ends, which `validateAssignments`
+      // accepts, but on the grid the obstacle's end ceils to 10:31 while `a`'s
+      // start floors to 10:30. Without the original placement added back as an
+      // exact fact, `a` is dragged off a slot it was entitled to keep.
+      const obstacle = card("fixed", t("2026-08-10T10:00:20Z"), 30 * MIN, "C1", "e-fixed");
+      const blocker = card("p", t("2026-08-10T09:00:00Z"), 40 * MIN, "C2", "e-p");
+      const a = card("a", t("2026-08-10T10:30:20Z"), 30 * MIN, "C1", "e-a");
+      const b = card("b", t("2026-08-10T09:00:00Z"), 40 * MIN, "C2", "e-b");
+      const cfg = config(["C1", "C2"]);
+      const existing = [obstacle, blocker];
+      // `a` against the obstacle is clean on its own; only `b` is really in
+      // anyone's way.
+      expect(validateAssignments([a], cfg, [obstacle])).toEqual([]);
+      expect(validateAssignments([a, b], cfg, existing)).not.toEqual([]);
+
+      const r = await repairAndVerify({
+        proposal: [a, b],
+        existing,
+        config: cfg,
+        budgetMs: 60_000,
+      });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      expect(r.moved).toEqual(["b"]);
+      const byId = new Map(r.assignments.map((x) => [x.fixtureId, x]));
+      expect(byId.get("a")!.startAt).toBe(t("2026-08-10T10:30:20Z"));
+      expect(validateAssignments(r.assignments, cfg, existing)).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
     "will not let a min_rest feeder rule ESCAPE on rounding — the escape clause rounds the other way",
     async () => {
       // `Or(start_dd < end_f, start_dd >= end_f + minutes)`. The first disjunct
@@ -385,7 +568,13 @@ describe("a whole board with nothing on the minute", () => {
         config: board.config,
         budgetMs: 60_000,
       });
-      expect(["clean", "repaired", "infeasible", "timeout"]).toContain(r.status);
+      // NOT the full status union: `repairAndVerify` returns early for anything
+      // other than `repaired`/`clean` and never re-runs the verifier, so an
+      // `infeasible` or a `timeout` would pass this test having checked nothing.
+      // Over-constraint makes `infeasible` a live outcome for exactly the
+      // all-off-minute boards this probe builds, which is the shape it would
+      // have quietly stopped covering.
+      expect(["clean", "repaired"]).toContain(r.status);
     },
     SOLVE_TIMEOUT,
   );

--- a/packages/engine/src/scheduling/repair-subminute.test.ts
+++ b/packages/engine/src/scheduling/repair-subminute.test.ts
@@ -1,0 +1,392 @@
+// The z3 repair encoder works in MINUTES; `validateAssignments` works in
+// MILLISECONDS. Every conversion between the two is therefore a place the two
+// can disagree, and a disagreement in the WRONG direction is a board the solver
+// proves clean and the verifier rejects — `RepairVerificationError` with
+// `kind: "encoding_drift"` when it is loud, and a published clash when it is not.
+//
+// The rule the whole file exists to pin: **a rounded interval must be a
+// SUPERSET of the real one.** Occupancy rounds outward (start down, end up),
+// and a value used as a bound rounds to the side that makes the constraint
+// STRONGER, never to "nearest".
+//
+// Sub-minute instants are reachable from the product, not a thought experiment:
+// `AddFixture.scheduled_at` is a client-supplied RFC-3339 string with no
+// seconds restriction, the single-move PATCH writes it verbatim, the column is
+// `timestamptz`, and the AI usecase feeds `new Date(...).getTime()` straight
+// into `Assignment.startAt`. Nothing between the wire and this encoder
+// truncates to the minute.
+//
+// Every case below is minute-aligned APART FROM the one value under test, so a
+// failure names its own call site.
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import {
+  validateAssignments,
+  type Assignment,
+  type OrderDependency,
+  type VerifyConfig,
+} from "./calendar.ts";
+import { repairAndVerify } from "./repair.ts";
+import { at, BASE_CONFIG, STEP_RULE_FIXTURES } from "./payload-fixtures.ts";
+import { syntheticBoard } from "./repair-synthetic-board.ts";
+import { dayKeyInTz } from "./tz.ts";
+import { resetZ3 } from "./z3-load.ts";
+
+// Same teardown discipline as `repair.test.ts`: `isolate: false` means every
+// test here shares one WASM heap, which only grows across solves until the
+// pthread worker dies mid-solve.
+afterAll(async () => {
+  await resetZ3();
+});
+afterEach(async () => {
+  await resetZ3();
+});
+
+const MIN = 60_000;
+const SEC = 1_000;
+const SOLVE_TIMEOUT = 120_000;
+
+const t = (iso: string): number => at(iso);
+
+/** A card with an explicit millisecond duration — `assign` only takes whole
+ *  minutes, and a sub-minute duration is one of the things under test. */
+const card = (
+  fixtureId: string,
+  startAt: number,
+  durationMs: number,
+  court: string,
+  entrant: string,
+): Assignment => ({
+  fixtureId,
+  court,
+  startAt,
+  endAt: startAt + durationMs,
+  entrants: [entrant],
+  // Deliberately EMPTY: `sharesParticipant` must stay false so the `court` and
+  // `order` families are the only things binding, and a failure cannot be a
+  // person clash wearing a court clash's clothes.
+  people: [],
+});
+
+const config = (courts: readonly string[]): VerifyConfig & { courts: readonly string[] } => ({
+  ...BASE_CONFIG,
+  tz: "UTC",
+  courts,
+  window: { from: t("2026-08-10T08:00:00Z"), to: t("2026-08-10T20:00:00Z") },
+});
+
+/**
+ * Asserts the board is REALLY dirty in milliseconds, then that repair both
+ * survives its own verifier and actually moves the card.
+ *
+ * `repairAndVerify` rather than `repairSchedule`: when the encoder is too
+ * permissive the solver answers k=0 with nothing relaxed, and that exact shape
+ * is what `encoding_drift` is thrown for. A bare `repairSchedule` would hand
+ * back `status: "repaired", moved: []` and only an assertion would notice.
+ */
+async function expectMovedAndClean(input: {
+  proposal: Assignment[];
+  existing?: Assignment[];
+  dependencies?: OrderDependency[];
+  config: VerifyConfig & { courts: readonly string[] };
+  movedId: string;
+}): Promise<void> {
+  const existing = input.existing ?? [];
+  const dependencies = input.dependencies ?? [];
+  expect(validateAssignments(input.proposal, input.config, existing, dependencies)).not.toEqual([]);
+
+  const r = await repairAndVerify({
+    proposal: input.proposal,
+    existing,
+    dependencies,
+    config: input.config,
+    budgetMs: 60_000,
+  });
+  expect(r.status).toBe("repaired");
+  if (r.status !== "repaired") return;
+  expect(r.relaxed).toEqual([]);
+  expect(r.moved).toEqual([input.movedId]);
+  expect(validateAssignments(r.assignments, input.config, existing, dependencies)).toEqual([]);
+}
+
+describe("repair encodes sub-minute instants conservatively", () => {
+  it(
+    "widens an immovable that ENDS mid-minute — a rounded-down end hands its last seconds away",
+    async () => {
+      // Obstacle ends 10:00:20. `roundMin` said 10:00, so `start >= eEnd`
+      // admitted the movable's own 10:00:00 and NOTHING moved. `ceilMin` is the
+      // only direction under which the encoded obstacle contains the real one.
+      const obstacle = card("fixed", t("2026-08-10T09:20:00Z"), 40 * MIN + 20 * SEC, "C1", "e-fixed");
+      const movable = card("m1", t("2026-08-10T10:00:00Z"), 40 * MIN, "C1", "e-move");
+      await expectMovedAndClean({
+        proposal: [movable],
+        existing: [obstacle],
+        config: config(["C1"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "widens an immovable that STARTS mid-minute — a rounded-up start hands its first seconds away",
+    async () => {
+      // Obstacle starts 10:29:40; the movable runs 10:00–10:30. `roundMin` said
+      // 10:30 and `start <= eStart - durMin` let the movable sit flush against a
+      // boundary 20 seconds later than the real one. `floorMin` is the fix.
+      const obstacle = card("fixed", t("2026-08-10T10:29:40Z"), 40 * MIN, "C1", "e-fixed");
+      const movable = card("m1", t("2026-08-10T10:00:00Z"), 30 * MIN, "C1", "e-move");
+      await expectMovedAndClean({
+        proposal: [movable],
+        existing: [obstacle],
+        config: config(["C1"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "rounds a movable's own DURATION up — a rounded-down duration shortens the card z3 is packing",
+    async () => {
+      // Only the duration is off the minute: the movable runs 10:00:00–10:40:20
+      // and the obstacle starts at a clean 10:40:00. `roundMin(40m20s)` is 40, so
+      // the encoder packed a 40-minute card and left the last 20 seconds
+      // overlapping. `ceilMin` is the only conservative direction for an extent.
+      const obstacle = card("fixed", t("2026-08-10T10:40:00Z"), 40 * MIN, "C1", "e-fixed");
+      const movable = card("m1", t("2026-08-10T10:00:00Z"), 40 * MIN + 20 * SEC, "C1", "e-move");
+      await expectMovedAndClean({
+        proposal: [movable],
+        existing: [obstacle],
+        config: config(["C1"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "rounds an immovable FEEDER's end up — it is a LOWER bound on the dependent's start",
+    async () => {
+      // `start_target >= end_source + rest`. Understating `end_source` weakens
+      // the inequality, so the source's end must round UP. Different courts, so
+      // `order` is the only family in play.
+      const source = card("fixed", t("2026-08-10T09:20:00Z"), 40 * MIN + 20 * SEC, "C1", "e-fixed");
+      const target = card("m1", t("2026-08-10T10:00:00Z"), 40 * MIN, "C2", "e-move");
+      await expectMovedAndClean({
+        proposal: [target],
+        existing: [source],
+        dependencies: [{ fixtureId: "m1", dependsOn: "fixed", direct: true }],
+        config: config(["C1", "C2"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "rounds an immovable DEPENDENT's start down — it is the greater side of the same inequality",
+    async () => {
+      // Same inequality, opposite end: here the TARGET is immovable and its
+      // start is the left-hand side. Overstating it satisfies the constraint on
+      // paper, so it must round DOWN — the direction is a property of the
+      // inequality, not of the field.
+      const target = card("fixed", t("2026-08-10T10:00:40Z"), 40 * MIN, "C1", "e-fixed");
+      const source = card("m1", t("2026-08-10T09:21:00Z"), 40 * MIN, "C2", "e-move");
+      await expectMovedAndClean({
+        proposal: [source],
+        existing: [target],
+        dependencies: [{ fixtureId: "fixed", dependsOn: "m1", direct: true }],
+        config: config(["C1", "C2"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "rounds a movable's ORIGINAL start down — k=0 re-emits that instant to the millisecond",
+    async () => {
+      // The one place a MOVABLE start is not on the grid: `s.eq(origStartMin)`
+      // keeps k=0 representable, and a fixture that does not move re-emits
+      // `a.startAt` unrounded. So `origStartMin` is where the encoder says that
+      // instant sits, and rounding it UP hides the seconds before it.
+      //
+      // This case survives the obstacle fix on its own: the obstacle ends
+      // 10:00:55 → `ceilMin` 10:01, and `roundMin(10:00:50)` is ALSO 10:01, so
+      // `start >= eEnd` still admitted a card really starting at 10:00:50.
+      const obstacle = card("fixed", t("2026-08-10T09:20:00Z"), 40 * MIN + 55 * SEC, "C1", "e-fixed");
+      const movable = card("m1", t("2026-08-10T10:00:50Z"), 40 * MIN, "C1", "e-move");
+      await expectMovedAndClean({
+        proposal: [movable],
+        existing: [obstacle],
+        config: config(["C1"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "covers the TAIL of an unmoved off-minute card — floor(start) + ceil(duration) is not enough",
+    async () => {
+      // The obstacle here is minute-aligned at BOTH ends and the duration is a
+      // whole 30 minutes, so nothing but the original start is off the grid.
+      //
+      // 10:00:20 + 30 min really ends 10:30:20, but `floorMin(start) = 10:00`
+      // plus `ceilMin(30 min) = 30` encodes an end of 10:30 — the fraction the
+      // floor dropped off the head reappears at the tail. So the minutes a
+      // fixture is packed with must cover its ORIGINAL placement as well as a
+      // move onto the grid.
+      const obstacle = card("fixed", t("2026-08-10T10:30:00Z"), 40 * MIN, "C1", "e-fixed");
+      const movable = card("m1", t("2026-08-10T10:00:20Z"), 30 * MIN, "C1", "e-move");
+      await expectMovedAndClean({
+        proposal: [movable],
+        existing: [obstacle],
+        config: config(["C1"]),
+        movedId: "m1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "will not let an off-minute original satisfy a not_before bound it really breaks",
+    async () => {
+      // The domain's lower bound is `ceilMin("09:00") = 09:00` — the safe
+      // direction, untouched. What broke was the OTHER side of the comparison:
+      // `roundMin(08:59:40)` is also 09:00, so the original placement satisfied
+      // its own instruction and `s.eq(origStartMin)` kept it there at k=0.
+      //
+      // Reachable from the model, not from a fixture editor: an LLM start of
+      // "…T08:59:40+00:00" clears `z.string().datetime({ offset: true })` and
+      // survives `toMs` with its seconds intact.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1"]),
+        ruleFixtures: [{ id: "m1", extKey: "m1", winnerTo: null }],
+        hard: [{ type: "not_before", time: "09:00", scope: { kind: "competition" } }],
+      };
+      const movable = card("m1", t("2026-08-10T08:59:40Z"), 40 * MIN, "C1", "e-move");
+      await expectMovedAndClean({ proposal: [movable], config: cfg, movedId: "m1" });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "buckets an off-minute start on the day the verifier counts it, not the next one",
+    async () => {
+      // `max_fixtures_per_day` is counted by `dayKeyInTz` in milliseconds and by
+      // a per-day literal in minutes. A start of 23:59:40 rounded to nearest
+      // becomes the next day's midnight, so the encoder satisfied a 1/day cap by
+      // filing the card on a day the verifier never put it on.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1", "C2"]),
+        window: { from: t("2026-08-10T00:00:00Z"), to: t("2026-08-13T00:00:00Z") },
+        ruleFixtures: [
+          { id: "late", extKey: "late", winnerTo: null },
+          { id: "early", extKey: "early", winnerTo: null },
+        ],
+        hard: [{ type: "max_fixtures_per_day", count: 1, scope: { kind: "competition" } }],
+      };
+      // Both really fall on 2026-08-10, which is two under a cap of one.
+      const late = card("late", t("2026-08-10T23:59:40Z"), 40 * MIN, "C1", "e-late");
+      const early = card("early", t("2026-08-10T20:00:00Z"), 40 * MIN, "C2", "e-early");
+      const proposal = [late, early];
+      expect(validateAssignments(proposal, cfg)).not.toEqual([]);
+
+      const r = await repairAndVerify({ proposal, config: cfg, budgetMs: 60_000 });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      expect(r.relaxed).toEqual([]);
+      // Either card may be the one that moves; what is not negotiable is that
+      // ONE does, and that the two end up on different days.
+      expect(r.moved).toHaveLength(1);
+      expect(new Set(r.assignments.map((a) => dayKeyInTz(a.startAt, "UTC"))).size).toBe(2);
+      expect(validateAssignments(r.assignments, cfg)).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "will not let a min_rest feeder rule ESCAPE on rounding — the escape clause rounds the other way",
+    async () => {
+      // `Or(start_dd < end_f, start_dd >= end_f + minutes)`. The first disjunct
+      // says "the dependent starts before its feeder ends, so this is an
+      // ordering problem and the rest rule does not measure it" — exactly the
+      // `continue` `validateAssignments` makes. It is an ESCAPE, so it rounds
+      // the opposite way to the constraint beside it: the dependent's start UP
+      // and the feeder's end DOWN. Rounded to nearest it opens a gap, because
+      // `round(start) + round(duration)` can overshoot `round(start + duration)`
+      // by a minute and lift the encoded feeder end above the real one.
+      //
+      // Both ends are MOVABLE deliberately: `validateAssignments` measures this
+      // rule off `assignments` alone, so a pair with an immovable end is never
+      // measured and could not drift.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1", "C2"]),
+        ruleFixtures: STEP_RULE_FIXTURES.map((f) => ({ ...f })),
+        hard: [
+          {
+            type: "min_rest_minutes",
+            minutes: 90,
+            rest_scope: "feeder_to_dependent",
+            scope: { kind: "competition" },
+          },
+        ],
+      };
+      // Feeder 09:00:40 + 40m40s → 09:41:20; dependent starts on that instant,
+      // so the verifier measures a gap of zero against a rule asking for 90.
+      //
+      // Built by hand rather than through `assign`: the STEP payload's shared
+      // human would put these two under the `person` family as well, and the
+      // over-wide encoded feeder this test is about would then be caught by
+      // that instead — a pass proving nothing about the escape clause.
+      const feeder = card("sl-g1-d1", t("2026-08-10T09:00:40Z"), 40 * MIN + 40 * SEC, "C1", "e-f");
+      const dependent = card("sl-g2-d1", t("2026-08-10T09:41:20Z"), 40 * MIN, "C2", "e-d");
+      await expectMovedAndClean({
+        proposal: [feeder, dependent],
+        config: cfg,
+        movedId: "sl-g1-d1",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+});
+
+/**
+ * The nearest thing this package has to the probe that caught the other four
+ * unit-mismatch bugs in this wave: a whole generated board handed to
+ * `repairAndVerify`, which throws rather than returns when the solver's answer
+ * and the verifier's disagree.
+ *
+ * `syntheticBoard` builds every start as a whole-minute offset from a
+ * minute-aligned epoch — which is exactly why the generator has never been able
+ * to see this class of bug. Jitter is applied here rather than in the generator
+ * so the scale and decompose suites keep the board they were calibrated on.
+ * Deterministic, not random: the same board twice, and a failure that can be
+ * reproduced by reading the file.
+ */
+describe("a whole board with nothing on the minute", () => {
+  it(
+    "survives its own verifier once every start and end carries seconds",
+    async () => {
+      const board = syntheticBoard({ n: 20, clashEvery: 5 });
+      expect(board.clashes).toBeGreaterThan(0);
+      const jittered = board.proposal.map((a, i) => ({
+        ...a,
+        startAt: a.startAt + (((i * 37) % 59) + 1) * SEC,
+        endAt: a.endAt + (((i * 23) % 59) + 1) * SEC,
+      }));
+      // No assertion on the STATUS beyond "it is one of the four": the point of
+      // the probe is that `repairAndVerify` did not throw, which is the solver
+      // defending every board it called clean.
+      const r = await repairAndVerify({
+        proposal: jittered,
+        dependencies: board.dependencies,
+        config: board.config,
+        budgetMs: 60_000,
+      });
+      expect(["clean", "repaired", "infeasible", "timeout"]).toContain(r.status);
+    },
+    SOLVE_TIMEOUT,
+  );
+});

--- a/packages/engine/src/scheduling/repair-subminute.test.ts
+++ b/packages/engine/src/scheduling/repair-subminute.test.ts
@@ -25,7 +25,7 @@ import {
   type OrderDependency,
   type VerifyConfig,
 } from "./calendar.ts";
-import { repairAndVerify } from "./repair.ts";
+import { repairAndVerify, repairSchedule } from "./repair.ts";
 import { at, BASE_CONFIG, STEP_RULE_FIXTURES } from "./payload-fixtures.ts";
 import { syntheticBoard } from "./repair-synthetic-board.ts";
 import { dayKeyInTz } from "./tz.ts";
@@ -612,6 +612,54 @@ describe("repair encodes sub-minute instants conservatively", () => {
   );
 
   it(
+    "still refuses a feed edge when the fixture CANNOT stay where the escape assumes",
+    async () => {
+      // The escape's own antecedent, which nothing else in this file can see
+      // fail. Every other test here proves the escape FIRES when it should;
+      // this one proves it stops applying the moment its premise stops holding.
+      //
+      // `bothAtOrigin` says "…and every movable end is still exactly where it
+      // began". Drop that and the escape becomes an unconditional TRUE: the
+      // `order` family is satisfied no matter where the solver puts the card,
+      // and a board with no legal answer comes back `repaired` carrying a
+      // blocking `order` conflict.
+      //
+      // `t`'s only hole inside the window is the morning — BEFORE its feeder
+      // ends — so the honest answer is that there is nowhere to put it.
+      const source = card("s", t("2026-08-10T09:00:20Z"), 40 * MIN, "C1", "e-s");
+      const fill1 = card("b1", t("2026-08-10T09:40:20Z"), 80 * MIN, "C1", "e-b1");
+      const fill2 = card("b2", t("2026-08-10T09:00:00Z"), 120 * MIN, "C2", "e-b2");
+      const target = card("t", t("2026-08-10T09:40:20Z"), 40 * MIN, "C2", "e-t");
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1", "C2"]),
+        window: { from: t("2026-08-10T08:00:00Z"), to: t("2026-08-10T11:00:00Z") },
+      };
+      const existing = [source, fill1, fill2];
+      const dependencies: OrderDependency[] = [
+        { fixtureId: "t", dependsOn: "s", direct: true },
+      ];
+      // The board really is dirty, and only on the court.
+      expect(
+        validateAssignments([target], cfg, existing, dependencies).map((c) => c.reason),
+      ).toEqual(["court"]);
+
+      const r = await repairSchedule({
+        proposal: [target],
+        existing,
+        dependencies,
+        config: cfg,
+        budgetMs: 60_000,
+      });
+      // `infeasible` is the RIGHT answer here, and it is the assertion: a
+      // `repaired` board would be one the verifier rejects.
+      expect(r.status).toBe("infeasible");
+      if (r.status !== "infeasible") return;
+      expect(r.families).toContain("order");
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
     "will not let a min_rest feeder rule ESCAPE on rounding — the escape clause rounds the other way",
     async () => {
       // `Or(start_dd < end_f, start_dd >= end_f + minutes)`. The first disjunct
@@ -673,7 +721,7 @@ describe("repair encodes sub-minute instants conservatively", () => {
 describe("a whole board with nothing on the minute", () => {
   it(
     "survives its own verifier once every start and end carries seconds",
-    async () => {
+    async (ctx) => {
       const board = syntheticBoard({ n: 20, clashEvery: 5 });
       expect(board.clashes).toBeGreaterThan(0);
       const jittered = board.proposal.map((a, i) => ({
@@ -695,13 +743,17 @@ describe("a whole board with nothing on the minute", () => {
       // over-constraint makes `infeasible` a live outcome for exactly the
       // all-off-minute boards this probe builds — so it would pass having
       // checked nothing, on the failure this file exists to catch.
-      //
-      // `timeout` stays admissible. It is a property of the box, not of the
-      // encoding: the solve is serialised process-wide, so a loaded host can
-      // spend the budget queueing. Excluding it makes this test fail for a
-      // reason it cannot diagnose.
       expect(r.status).not.toBe("infeasible");
-      expect(["clean", "repaired", "timeout"]).toContain(r.status);
+      // `timeout` is not a pass either, for the same reason — it returns before
+      // the verifier too, so a loaded box would quietly turn this file's only
+      // whole-board probe into a no-op exactly when it is slowest. SKIPPED, so
+      // that green always means a board was actually defended.
+      //
+      // Nothing to do with the z3 lock: it is in-process (`z3-load.ts`) and this
+      // file's tests run one at a time under `isolate: false`, so there is no
+      // queue to wait behind. Only host CPU can burn the budget here.
+      if (r.status === "timeout") ctx.skip();
+      expect(["clean", "repaired"]).toContain(r.status);
     },
     SOLVE_TIMEOUT,
   );

--- a/packages/engine/src/scheduling/repair-subminute.test.ts
+++ b/packages/engine/src/scheduling/repair-subminute.test.ts
@@ -490,6 +490,128 @@ describe("repair encodes sub-minute instants conservatively", () => {
   );
 
   it(
+    "does not make a merely-abutting feed edge between two PINNED cards infeasible",
+    async () => {
+      // `order` is a BLOCKING family, so getting this wrong is not a lost
+      // minute. `s` ends 09:40:20 and `t` starts on that instant — which
+      // `validateAssignments` accepts, `target.startAt >= source.endAt + rest`
+      // — but the target's start floors while the source's end ceils, so the
+      // encoded edge read `N >= N + 1` and the whole solve came back
+      // `infeasible` naming `order`, on a board whose only real conflict is a
+      // court double-booking somewhere else entirely.
+      //
+      // Both ends are `existing` because that is how PINNED fixtures reach the
+      // solver, and a pinned pair has no z3 variable to relax: every run for
+      // that competition died here and fell through to the paid LLM round.
+      const source = card("s", t("2026-08-10T09:00:20Z"), 40 * MIN, "C1", "e-s");
+      const target = card("t", t("2026-08-10T09:40:20Z"), 40 * MIN, "C2", "e-t");
+      const blocker = card("blk", t("2026-08-10T12:00:00Z"), 40 * MIN, "C3", "e-blk");
+      const clashing = card("m2", t("2026-08-10T12:00:00Z"), 40 * MIN, "C3", "e-m2");
+      const cfg = config(["C1", "C2", "C3"]);
+      const existing = [source, target, blocker];
+      const dependencies: OrderDependency[] = [
+        { fixtureId: "t", dependsOn: "s", direct: true },
+      ];
+      // The verifier's own reading of that feed edge: nothing to answer for.
+      const pre = validateAssignments([clashing], cfg, existing, dependencies);
+      expect(pre.map((c) => c.reason)).toEqual(["court"]);
+
+      await expectMovedAndClean({
+        proposal: [clashing],
+        existing,
+        dependencies,
+        config: cfg,
+        movedId: "m2",
+      });
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "does not drag a MOVABLE feed edge apart when its ends really abut",
+    async () => {
+      // The same edge with both ends free to move. Not `infeasible` here, just
+      // wrong: the solver satisfies the invented shortfall by shifting a card
+      // that had nothing to answer for, and reports two moves on a board whose
+      // minimal repair is one.
+      const source = card("s", t("2026-08-10T09:00:20Z"), 40 * MIN, "C1", "e-s");
+      const target = card("t", t("2026-08-10T09:40:20Z"), 40 * MIN, "C2", "e-t");
+      const blocker = card("blk", t("2026-08-10T12:00:00Z"), 40 * MIN, "C3", "e-blk");
+      const clashing = card("m2", t("2026-08-10T12:00:00Z"), 40 * MIN, "C3", "e-m2");
+      const cfg = config(["C1", "C2", "C3"]);
+      const dependencies: OrderDependency[] = [
+        { fixtureId: "t", dependsOn: "s", direct: true },
+      ];
+      const proposal = [source, target, clashing];
+      expect(
+        validateAssignments(proposal, cfg, [blocker], dependencies).map((c) => c.reason),
+      ).toEqual(["court"]);
+
+      const r = await repairAndVerify({
+        proposal,
+        existing: [blocker],
+        dependencies,
+        config: cfg,
+        budgetMs: 60_000,
+      });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      expect(r.k).toBe(1);
+      expect(r.moved).toEqual(["m2"]);
+      const byId = new Map(r.assignments.map((x) => [x.fixtureId, x]));
+      expect(byId.get("s")!.startAt).toBe(t("2026-08-10T09:00:20Z"));
+      expect(byId.get("t")!.startAt).toBe(t("2026-08-10T09:40:20Z"));
+      expect(validateAssignments(r.assignments, cfg, [blocker], dependencies)).toEqual([]);
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
+    "does not report a min_rest feed rule as RELAXED on a board that honours it exactly",
+    async () => {
+      // The non-blocking half of the same defect, which is why it degrades to a
+      // relaxed family rather than an infeasible board — a rule the organiser
+      // wrote, reported as given up, on a schedule that keeps it to the second.
+      //
+      // Feeder ends 09:40:20, dependent starts 11:10:20: a gap of exactly the 90
+      // minutes the rule asks for.
+      const cfg: VerifyConfig & { courts: readonly string[] } = {
+        ...config(["C1", "C2", "C3"]),
+        ruleFixtures: STEP_RULE_FIXTURES.map((f) => ({ ...f })),
+        hard: [
+          {
+            type: "min_rest_minutes",
+            minutes: 90,
+            rest_scope: "feeder_to_dependent",
+            scope: { kind: "competition" },
+          },
+        ],
+      };
+      const feeder = card("sl-g1-d1", t("2026-08-10T09:00:20Z"), 40 * MIN, "C1", "e-f");
+      const dependent = card("sl-g2-d1", t("2026-08-10T11:10:20Z"), 40 * MIN, "C2", "e-d");
+      const blocker = card("blk", t("2026-08-10T14:00:00Z"), 40 * MIN, "C3", "e-blk");
+      const clashing = card("m2", t("2026-08-10T14:00:00Z"), 40 * MIN, "C3", "e-m2");
+      const proposal = [feeder, dependent, clashing];
+      expect(validateAssignments(proposal, cfg, [blocker]).map((c) => c.reason)).toEqual(["court"]);
+
+      const r = await repairAndVerify({
+        proposal,
+        existing: [blocker],
+        config: cfg,
+        budgetMs: 60_000,
+      });
+      expect(r.status).toBe("repaired");
+      if (r.status !== "repaired") return;
+      expect(r.relaxed).toEqual([]);
+      expect(r.moved).toEqual(["m2"]);
+      const byId = new Map(r.assignments.map((x) => [x.fixtureId, x]));
+      expect(byId.get("sl-g1-d1")!.startAt).toBe(t("2026-08-10T09:00:20Z"));
+      expect(byId.get("sl-g2-d1")!.startAt).toBe(t("2026-08-10T11:10:20Z"));
+    },
+    SOLVE_TIMEOUT,
+  );
+
+  it(
     "will not let a min_rest feeder rule ESCAPE on rounding — the escape clause rounds the other way",
     async () => {
       // `Or(start_dd < end_f, start_dd >= end_f + minutes)`. The first disjunct
@@ -568,13 +690,18 @@ describe("a whole board with nothing on the minute", () => {
         config: board.config,
         budgetMs: 60_000,
       });
-      // NOT the full status union: `repairAndVerify` returns early for anything
-      // other than `repaired`/`clean` and never re-runs the verifier, so an
-      // `infeasible` or a `timeout` would pass this test having checked nothing.
-      // Over-constraint makes `infeasible` a live outcome for exactly the
-      // all-off-minute boards this probe builds, which is the shape it would
-      // have quietly stopped covering.
-      expect(["clean", "repaired"]).toContain(r.status);
+      // `infeasible` is the vacuity that matters: `repairAndVerify` returns early
+      // for anything but `repaired`/`clean` and never re-runs the verifier, and
+      // over-constraint makes `infeasible` a live outcome for exactly the
+      // all-off-minute boards this probe builds — so it would pass having
+      // checked nothing, on the failure this file exists to catch.
+      //
+      // `timeout` stays admissible. It is a property of the box, not of the
+      // encoding: the solve is serialised process-wide, so a loaded host can
+      // spend the budget queueing. Excluding it makes this test fail for a
+      // reason it cannot diagnose.
+      expect(r.status).not.toBe("infeasible");
+      expect(["clean", "repaired", "timeout"]).toContain(r.status);
     },
     SOLVE_TIMEOUT,
   );

--- a/packages/engine/src/scheduling/repair.ts
+++ b/packages/engine/src/scheduling/repair.ts
@@ -303,22 +303,29 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
   const start = domains.map((_, i) => Z3.Int.const(`s_${i}`));
   const courtVar = domains.map((_, i) => Z3.Int.const(`c_${i}`));
   const movedVar = domains.map((_, i) => Z3.Bool.const(`m_${i}`));
-  // The minutes a fixture is PACKED with, which must cover its real span on
-  // both the placements it can take:
+  // The minutes a fixture is PACKED with. A fixture has TWO extents, because it
+  // has two possible placements and they do not round the same way:
   //
-  //   * moved — `s` is a grid minute and the emitted start is exactly
-  //     `s * MS_PER_MIN`, so `ceilMin(durationMs)` covers it;
-  //   * unmoved — `s` is `origStartMin`, a FLOOR, and the emitted start is the
-  //     original instant to the millisecond (see the `still` branch at the end
-  //     of the solve). The fraction the floor dropped off the head reappears at
-  //     the tail, so 10:00:20 + 30 min needs 31 minutes, not 30.
+  //   * MOVED — the emitted start is exactly `s * MS_PER_MIN` (see the `still`
+  //     branch at the end of the solve), so `ceilMin(durationMs)` is its true
+  //     extent and nothing more is owed;
+  //   * UNMOVED — `s` is `origStartMin`, a FLOOR, and the emitted start is the
+  //     original instant to the millisecond. The fraction the floor dropped off
+  //     the head reappears at the tail, so 10:00:20 + 30 min needs 31 minutes.
   //
-  // One number for both, because `durMin` is also the extent every pair, court
-  // and feed constraint measures; the max costs at most one minute of solution
-  // space and only for a fixture that was off the minute to begin with.
-  const durMinHi = domains.map((d) =>
-    Math.max(ceilMin(d.durationMs), ceilMin(d.origStartAt + d.durationMs) - floorMin(d.origStartAt)),
-  );
+  // Charging the unmoved extent to BOTH used to look like a minute of harmless
+  // slack. It is not: a fixture that has already been snapped to the grid can
+  // never spend it down, so back-to-back cards read as clashing, a board needs
+  // two moves where one is minimal, and a saturated court (24 x 31 min against a
+  // 720-minute window) comes back `infeasible` while being perfectly repairable.
+  // `court` is a blocking family, so that `infeasible` is final.
+  const durMinMoved = domains.map((d) => ceilMin(d.durationMs));
+  const durMinStill = domains.map((d) => ceilMin(d.origStartAt + d.durationMs) - floorMin(d.origStartAt));
+  // Always 0 or 1, and 0 for every fixture that begins on a whole minute — which
+  // is what keeps the encoding of an on-the-minute board byte-identical to the
+  // one before any of this existed. `Math.max(ceilMin(dur), ...)` used to guard
+  // this and was dead: `ceil(f + d) >= ceil(d)` for `f >= 0`, always.
+  const stillExtra = domains.map((_, i) => durMinStill[i]! - durMinMoved[i]!);
   // The other direction, for the ONE place a fixture's end is the smaller side
   // of a comparison rather than an occupancy: the min_rest escape clause below.
   const durMinLo = domains.map((d) => floorMin(d.durationMs));
@@ -328,7 +335,7 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
   // `not_before 09:00` bound of `ceilMin(09:00)`, or a 23:59:40 start claim the
   // NEXT day's cap literal while `dayKeyInTz` counts it on the day before.
   // Flooring keeps k=0 representable without making an illegal original look
-  // legal, and `durMinHi` above pays for the head the floor gives away.
+  // legal, and `durMinStill` above pays for the head the floor gives away.
   const origStartMin = domains.map((d) => floorMin(d.origStartAt));
   // How far a movable's REAL start can sit ABOVE its encoded `s`: one minute
   // when the original is off the minute (the unmoved escape re-emits it
@@ -337,6 +344,40 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     floorMin(d.origStartAt) * MS_PER_MIN === d.origStartAt ? 0 : 1,
   );
   const origCourtIdx = domains.map((d) => courtIndex.get(d.origCourt) ?? 0);
+
+  /**
+   * `start + duration + r` for fixture `i`, charging the unmoved extent ONLY on
+   * the branch where the fixture is actually unmoved.
+   *
+   * `movedVar[i]` is `s != origStartMin || court != origCourt` (asserted below),
+   * which is exactly the condition under which the emitted instant is
+   * `s * MS_PER_MIN` rather than the original. So the `If` is not an
+   * approximation of the still case — it IS the still case.
+   *
+   * For a fixture that starts on a whole minute `stillExtra` is 0 and this
+   * builds the same single constant term it always did: no `If`, no extra node,
+   * nothing for z3 to propagate.
+   */
+  const endOf = (i: number, r: number): Arith<"repair"> =>
+    stillExtra[i] === 0
+      ? start[i]!.add(durMinMoved[i]! + r)
+      : start[i]!
+          .add(Z3.If(movedVar[i]!, Z3.Int.val(durMinMoved[i]!), Z3.Int.val(durMinStill[i]!)))
+          .add(r);
+  /** The fixture is exactly where it began — same minute, same court. */
+  const isStill = (i: number): Bool<"repair"> => Z3.Not(movedVar[i]!);
+  /**
+   * The LATEST minute fixture `i` can really start, which is `s` itself unless
+   * the unmoved escape is taken and the emitted instant is the off-minute
+   * original. Gated on `movedVar` for the same reason as `endOf`: a card that
+   * has been snapped to the grid starts exactly on `s` and owes no slack, and
+   * charging it anyway costs a whole minute of a bound it can never win back —
+   * enough to refuse the only hole a card actually fits in.
+   */
+  const startHiOf = (i: number): Arith<"repair"> =>
+    startSlackMin[i] === 0
+      ? start[i]!
+      : start[i]!.add(Z3.If(movedVar[i]!, Z3.Int.val(0), Z3.Int.val(startSlackMin[i]!)));
 
   const fam = Object.fromEntries(
     REPAIR_FAMILIES.map((f) => [f, Z3.Bool.const(famLiteralName(f))]),
@@ -347,10 +388,41 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
 
   const TRUE = Z3.And();
   const FALSE = Z3.Or();
-  const inRuns = (x: Arith<"repair">, runs: readonly { from: number; to: number }[]): Bool<"repair"> =>
-    runs.length === 0
-      ? FALSE
-      : Z3.Or(...runs.map((r) => Z3.And(x.ge(ceilMin(r.from)), x.le(floorMin(r.to)))));
+  /**
+   * "Fixture `i` starts inside one of these legal runs."
+   *
+   * `runs` are legal START instants in milliseconds, already narrowed by the
+   * fixture's own duration (`repair-domain.ts`), so BOTH ends of each run bound
+   * the start — `ge` from below and `le` from ABOVE. The upper half is why this
+   * takes an index rather than a bare term: on the unmoved escape the real start
+   * sits up to a minute above `s`, and `s <= floorMin(r.to)` was letting a card
+   * that really runs 40 seconds past the pack window sit there and be called
+   * clean. `window`, `instruction`, `start_window` and `blackout` all bound a
+   * start from above, so all four were exposed; the day-cap literal is the one
+   * upper bound that is safe untouched, because a day boundary is always on a
+   * minute.
+   *
+   * `- slack` is safe but not tight, so the ORIGINAL placement is added back as
+   * an escape whenever it is really inside a run and the grid form alone would
+   * refuse it. That fact is exact — the original instant is known to the
+   * millisecond — and it is the same reasoning that keeps k=0 representable.
+   */
+  const inRuns = (i: number, runs: readonly { from: number; to: number }[]): Bool<"repair"> => {
+    if (runs.length === 0) return FALSE;
+    const slack = startSlackMin[i]!;
+    const lo = start[i]!;
+    const hi = startHiOf(i);
+    const grid = Z3.Or(
+      ...runs.map((r) => Z3.And(lo.ge(ceilMin(r.from)), hi.le(floorMin(r.to)))),
+    );
+    if (slack === 0) return grid;
+    const orig = domains[i]!.origStartAt;
+    const reallyInside = runs.some((r) => orig >= r.from && orig <= r.to);
+    const gridAdmits = runs.some(
+      (r) => origStartMin[i]! >= ceilMin(r.from) && origStartMin[i]! + slack <= floorMin(r.to),
+    );
+    return reallyInside && !gridAdmits ? Z3.Or(grid, isStill(i)) : grid;
+  };
 
   // --- per-fixture structure ------------------------------------------------
   for (let i = 0; i < domains.length; i++) {
@@ -383,12 +455,12 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
 
     for (const family of ["window", "instruction", "start_window"] as const) {
       const runs = d.byFamily[family];
-      if (runs !== undefined) assume(family, inRuns(s, runs));
+      if (runs !== undefined) assume(family, inRuns(i, runs));
     }
     if (d.byFamily.blackout !== undefined) {
       for (const c of courts) {
         const ci = courtIndex.get(c)!;
-        assume("blackout", Z3.Implies(courtVar[i]!.eq(ci), inRuns(s, d.courtIntervals[c] ?? [])));
+        assume("blackout", Z3.Implies(courtVar[i]!.eq(ci), inRuns(i, d.courtIntervals[c] ?? [])));
       }
     }
 
@@ -426,11 +498,25 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     const [i, j] = pairs[p]!;
     const ai = proposalById.get(domains[i]!.fixtureId)!;
     const aj = proposalById.get(domains[j]!.fixtureId)!;
-    const sep = (r: number): Bool<"repair"> =>
-      Z3.Or(
-        start[i]!.ge(start[j]!.add(durMinHi[j]! + r)),
-        start[j]!.ge(start[i]!.add(durMinHi[i]! + r)),
-      );
+    // A minute grid cannot say "10:30:20", so a pair that really abuts — A ends
+    // 10:30:20, B starts 10:30:20, which `validateAssignments` accepts — reads
+    // as a clash once A's unmoved extent is charged against B's floored start.
+    // The board then needs two moves where one is minimal, and a court packed
+    // with off-minute cards reads as one long chain of clashes.
+    //
+    // So the ORIGINAL relationship is added back where the grid alone would
+    // refuse it. It is an exact fact, not a relaxation: `bothStill` pins both
+    // fixtures to the instants that were measured in milliseconds here.
+    const bothStill = (): Bool<"repair"> => Z3.And(isStill(i), isStill(j));
+    const msApart = (r: number): boolean =>
+      ai.startAt - aj.endAt >= r * MS_PER_MIN || aj.startAt - ai.endAt >= r * MS_PER_MIN;
+    const gridApart = (r: number): boolean =>
+      origStartMin[i]! >= origStartMin[j]! + durMinStill[j]! + r ||
+      origStartMin[j]! >= origStartMin[i]! + durMinStill[i]! + r;
+    const sep = (r: number): Bool<"repair"> => {
+      const grid = Z3.Or(start[i]!.ge(endOf(j, r)), start[j]!.ge(endOf(i, r)));
+      return msApart(r) && !gridApart(r) ? Z3.Or(grid, bothStill()) : grid;
+    };
     assume("court", Z3.Implies(courtVar[i]!.eq(courtVar[j]!), sep(gapMin)));
     if (sharesParticipant(ai, aj)) {
       // Overlap is blocking and rest is not, so they are asserted under
@@ -476,12 +562,27 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
       if (
         spanFrom !== null &&
         spanTo !== null &&
-        (spanFrom >= eEnd + reach || spanTo + durMinHi[i]! + reach <= eStart)
+        // The PRUNE takes the larger extent deliberately: pruning less is safe,
+        // pruning more drops a constraint.
+        (spanFrom >= eEnd + reach || spanTo + durMinStill[i]! + reach <= eStart)
       ) {
         continue;
       }
-      const clear = (r: number): Bool<"repair"> =>
-        Z3.Or(start[i]!.ge(eEnd + r), start[i]!.le(eStart - durMinHi[i]! - r));
+      // Same exact-fact escape as the movable pair above, with only one side
+      // free to move: an immovable is always where it says it is.
+      const msClear = (r: number): boolean =>
+        ai.startAt - e.endAt >= r * MS_PER_MIN || e.startAt - ai.endAt >= r * MS_PER_MIN;
+      const gridClear = (r: number): boolean =>
+        origStartMin[i]! >= eEnd + r || origStartMin[i]! + durMinStill[i]! + r <= eStart;
+      const clear = (r: number): Bool<"repair"> => {
+        const grid = Z3.Or(
+          start[i]!.ge(eEnd + r),
+          stillExtra[i] === 0
+            ? start[i]!.le(eStart - durMinMoved[i]! - r)
+            : endOf(i, r).le(eStart),
+        );
+        return msClear(r) && !gridClear(r) ? Z3.Or(grid, isStill(i)) : grid;
+      };
       const ci = courtIndex.get(e.court);
       if (ci !== undefined) assume("court", Z3.Implies(courtVar[i]!.eq(ci), clear(gapMin)));
       if (sharesParticipant(ai, e)) {
@@ -509,8 +610,9 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
   const startHi = (id: string): Arith<"repair"> | number => {
     const i = idx.get(id);
     // A movable's real start is `s` exactly, except on the unmoved escape, where
-    // it can be up to a minute later — `startSlackMin` is that minute.
-    return i !== undefined ? start[i]!.add(startSlackMin[i]!) : ceilMin(boardById.get(id)!.startAt);
+    // it can be up to a minute later — `startHiOf` is that minute, charged only
+    // on the branch that actually takes the escape.
+    return i !== undefined ? startHiOf(i) : ceilMin(boardById.get(id)!.startAt);
   };
   const endLo = (id: string): Arith<"repair"> | number => {
     const i = idx.get(id);
@@ -518,7 +620,7 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
   };
   const endHi = (id: string): Arith<"repair"> | number => {
     const i = idx.get(id);
-    return i !== undefined ? start[i]!.add(durMinHi[i]!) : ceilMin(boardById.get(id)!.endAt);
+    return i !== undefined ? endOf(i, 0) : ceilMin(boardById.get(id)!.endAt);
   };
   const plus = (x: Arith<"repair"> | number, n: number): Arith<"repair"> | number =>
     typeof x === "number" ? x + n : x.add(n);
@@ -777,14 +879,25 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
         // millisecond. Round-tripping it through minutes would rewrite a board
         // the organiser may already have published.
         //
-        // This is the one place the board leaves the minute grid, and it is why
-        // `origStartMin` floors and `durMinHi` carries the leftover fraction:
-        // the interval z3 reasoned about, `[origStartMin, origStartMin +
-        // durMinHi]`, has to contain the instants emitted here, or a card the
-        // solver proved clear of an obstacle re-enters it on the way out. The
-        // remaining asymmetry — a still fixture's real start sitting above its
-        // encoded `s` — is what `startSlackMin` pays for at the one site that
-        // uses a start as an upper bound.
+        // This is the one place the board leaves the minute grid, and it is what
+        // every rounding decision above is written against. Three consequences,
+        // and missing any one of them ships a clash:
+        //
+        //   * the TAIL — `origStartMin` floors, so the interval z3 reasoned
+        //     about must be `[origStartMin, origStartMin + durMinStill]` to
+        //     contain what is emitted here. `durMinStill` is charged only on
+        //     this branch (`endOf`), because a fixture that DID move is exactly
+        //     on the grid and paying for a fraction it no longer has is
+        //     over-constraint it can never spend down.
+        //   * the HEAD — the real start sits up to a minute ABOVE `s`, so every
+        //     site that bounds a start from ABOVE owes `startSlackMin`: the four
+        //     families in `inRuns` and `startHi` in the feed-order expressions.
+        //     The day-cap literal is the one upper bound that does not, because
+        //     a day boundary is always on a minute.
+        //   * the SLACK ITSELF is not free — it refuses placements that are
+        //     really legal. Where the original placement is known to be legal in
+        //     milliseconds, it is added back as an explicit escape (`isStill`)
+        //     rather than left as a lost minute.
         const startAt = still ? a.startAt : startMin * MS_PER_MIN;
         solved.set(d.fixtureId, {
           ...a,

--- a/packages/engine/src/scheduling/repair.ts
+++ b/packages/engine/src/scheduling/repair.ts
@@ -622,6 +622,43 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     const i = idx.get(id);
     return i !== undefined ? endOf(i, 0) : ceilMin(boardById.get(id)!.endAt);
   };
+  //
+  // The same four, evaluated at the instant the board CAME IN rather than as a
+  // z3 term — what each accessor collapses to when the fixture does not move.
+  // They exist to ask "does the grid form refuse a placement that is really
+  // legal?", which is the question the exact-fact escapes below turn on.
+  const origStartLoMin = (id: string): number => {
+    const i = idx.get(id);
+    return i !== undefined ? origStartMin[i]! : floorMin(boardById.get(id)!.startAt);
+  };
+  const origStartHiMin = (id: string): number => {
+    const i = idx.get(id);
+    return i !== undefined ? origStartMin[i]! + startSlackMin[i]! : ceilMin(boardById.get(id)!.startAt);
+  };
+  const origEndLoMin = (id: string): number => {
+    const i = idx.get(id);
+    return i !== undefined ? origStartMin[i]! + durMinLo[i]! : floorMin(boardById.get(id)!.endAt);
+  };
+  const origEndHiMin = (id: string): number => {
+    const i = idx.get(id);
+    return i !== undefined ? origStartMin[i]! + durMinStill[i]! : ceilMin(boardById.get(id)!.endAt);
+  };
+  /**
+   * "Every one of these fixtures is exactly where it began."
+   *
+   * An id that is not movable contributes nothing — an immovable is always at
+   * its origin — so a pair of immovables yields `Z3.And()`, which is TRUE. That
+   * is the whole point: a feed edge between two pinned cards has no z3 variable
+   * to relax, and a grid form that refuses it is refusing the only placement
+   * that exists.
+   */
+  const bothAtOrigin = (...ids: readonly string[]): Bool<"repair"> =>
+    Z3.And(
+      ...ids
+        .map((id) => idx.get(id))
+        .filter((i): i is number => i !== undefined)
+        .map(isStill),
+    );
   const plus = (x: Arith<"repair"> | number, n: number): Arith<"repair"> | number =>
     typeof x === "number" ? x + n : x.add(n);
   const geq = (a: Arith<"repair"> | number, b: Arith<"repair"> | number): Bool<"repair"> => {
@@ -657,9 +694,26 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     // side and rounds down, the source's end is the larger side and rounds up.
     // Either one taken the other way makes the encoded rule weaker than the
     // millisecond one it stands for.
+    //
+    // But rounding the two ends of ONE instant in opposite directions turns a
+    // feed edge that merely abuts — `t` starting the moment `s` ends, which
+    // `validateAssignments` accepts — into `N >= N + 1`. `order` is a BLOCKING
+    // family, so that is not a lost minute: with both ends immovable the whole
+    // solve returns `infeasible` naming `order` on a board whose only real
+    // conflict is somewhere else, and pinned fixtures reach the solver as
+    // `existing`. Two pinned cards on a feed edge, back-to-back at an off-minute
+    // instant, killed the z3 path for that competition outright and dropped
+    // every run through to the paid LLM repair round.
+    //
+    // So the exact fact is added back, exactly as `sep` and `clear` do it. With
+    // no movable end `bothAtOrigin` is TRUE, which is correct and not a
+    // weakening: there is no other placement to be wrong about.
+    const grid = geq(startLo(dep.fixtureId), plus(endHi(dep.dependsOn), rest));
+    const msHolds = target.startAt - source.endAt >= rest * MS_PER_MIN;
+    const gridHolds = origStartLoMin(dep.fixtureId) >= origEndHiMin(dep.dependsOn) + rest;
     assume(
       dep.direct === true ? "order" : "order_soft",
-      geq(startLo(dep.fixtureId), plus(endHi(dep.dependsOn), rest)),
+      msHolds && !gridHolds ? Z3.Or(grid, bothAtOrigin(dep.fixtureId, dep.dependsOn)) : grid,
     );
   }
 
@@ -711,12 +765,30 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
             // overshoot `round(start + duration)` by a minute, lifting the
             // encoded feeder end above the real one and walking a fixture that
             // is squarely inside the forbidden band out through the escape.
+            //
+            // And the same exact-fact escape as the `order` edge above, for the
+            // same reason: rounding the two ends of one instant apart makes a
+            // pair that really rests exactly `minutes` read as a minute short.
+            // Milder here only because `instruction` is not blocking, so it
+            // degrades to `relaxed: ["instruction"]` rather than `infeasible` —
+            // which still means a rule the organiser wrote is reported as given
+            // up on a board that honours it.
+            const gridForm = Z3.Or(
+              lt(startHi(dd.id), endLo(f.id)),
+              geq(startLo(dd.id), plus(endHi(f.id), rule.minutes)),
+            );
+            // Mirrors `validateAssignments` exactly: a dependent before its
+            // feeder's end is not measured at all, and the gap is otherwise
+            // compared against `rule.minutes`.
+            const msOk =
+              dependent.startAt < feeder.endAt ||
+              dependent.startAt - feeder.endAt >= rule.minutes * MS_PER_MIN;
+            const gridOk =
+              origStartHiMin(dd.id) < origEndLoMin(f.id) ||
+              origStartLoMin(dd.id) >= origEndHiMin(f.id) + rule.minutes;
             assume(
               "instruction",
-              Z3.Or(
-                lt(startHi(dd.id), endLo(f.id)),
-                geq(startLo(dd.id), plus(endHi(f.id), rule.minutes)),
-              ),
+              msOk && !gridOk ? Z3.Or(gridForm, bothAtOrigin(dd.id, f.id)) : gridForm,
             );
           }
         }

--- a/packages/engine/src/scheduling/repair.ts
+++ b/packages/engine/src/scheduling/repair.ts
@@ -188,9 +188,32 @@ export class RepairVerificationError extends Error {
  *  cap with an exit. */
 const START_GUARD_MS = 30 * MS_PER_DAY;
 
+/**
+ * THE ENCODER'S UNIT IS THE MINUTE; THE VERIFIER'S IS THE MILLISECOND. There is
+ * therefore no "nearest" here — every conversion picks the direction that keeps
+ * the encoding a SUPERSET of reality, and picks it from the inequality the value
+ * lands in:
+ *
+ *   * an OCCUPANCY (a fixture, an immovable, a blocked run) rounds OUTWARD —
+ *     start down, end up — so the minutes z3 packs contain the real interval;
+ *   * a value that appears as the SMALLER side of a `>=` rounds DOWN, and the
+ *     larger side rounds UP, so the encoded constraint is at least as strong as
+ *     the real one.
+ *
+ * `Math.round` is never either of those. An immovable ending at 10:00:20 rounded
+ * to 10:00 hands its last twenty seconds to whatever z3 puts next, the solver
+ * calls the board clean, and the millisecond verifier does not — `encoding_drift`
+ * when it is loud (`repairAndVerify`), a published clash when it is not.
+ * Deliberately absent, so it cannot come back by autocomplete.
+ *
+ * Sub-minute instants are reachable from the product: `AddFixture.scheduled_at`
+ * is a client-supplied RFC-3339 string with no seconds restriction, the
+ * single-move PATCH stores it verbatim into a `timestamptz`, and both the AI
+ * usecase and the plain read path hand `Date.parse` straight to
+ * `Assignment.startAt`. Nothing upstream truncates to the minute.
+ */
 const ceilMin = (ms: number): number => Math.ceil(ms / MS_PER_MIN);
 const floorMin = (ms: number): number => Math.floor(ms / MS_PER_MIN);
-const roundMin = (ms: number): number => Math.round(ms / MS_PER_MIN);
 
 /** z3 renders `|fam:court|` quoted when an assumption name contains a colon,
  *  which then does not match on the way back out of the unsat core. */
@@ -280,8 +303,39 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
   const start = domains.map((_, i) => Z3.Int.const(`s_${i}`));
   const courtVar = domains.map((_, i) => Z3.Int.const(`c_${i}`));
   const movedVar = domains.map((_, i) => Z3.Bool.const(`m_${i}`));
-  const durMin = domains.map((d) => roundMin(d.durationMs));
-  const origStartMin = domains.map((d) => roundMin(d.origStartAt));
+  // The minutes a fixture is PACKED with, which must cover its real span on
+  // both the placements it can take:
+  //
+  //   * moved — `s` is a grid minute and the emitted start is exactly
+  //     `s * MS_PER_MIN`, so `ceilMin(durationMs)` covers it;
+  //   * unmoved — `s` is `origStartMin`, a FLOOR, and the emitted start is the
+  //     original instant to the millisecond (see the `still` branch at the end
+  //     of the solve). The fraction the floor dropped off the head reappears at
+  //     the tail, so 10:00:20 + 30 min needs 31 minutes, not 30.
+  //
+  // One number for both, because `durMin` is also the extent every pair, court
+  // and feed constraint measures; the max costs at most one minute of solution
+  // space and only for a fixture that was off the minute to begin with.
+  const durMinHi = domains.map((d) =>
+    Math.max(ceilMin(d.durationMs), ceilMin(d.origStartAt + d.durationMs) - floorMin(d.origStartAt)),
+  );
+  // The other direction, for the ONE place a fixture's end is the smaller side
+  // of a comparison rather than an occupancy: the min_rest escape clause below.
+  const durMinLo = domains.map((d) => floorMin(d.durationMs));
+  // FLOOR, not nearest. This is where the encoder believes the original
+  // placement sits, and `s.eq(origStartMin)` is the only way a start escapes the
+  // grid — so rounding UP lets an original that is really at 08:59:40 satisfy a
+  // `not_before 09:00` bound of `ceilMin(09:00)`, or a 23:59:40 start claim the
+  // NEXT day's cap literal while `dayKeyInTz` counts it on the day before.
+  // Flooring keeps k=0 representable without making an illegal original look
+  // legal, and `durMinHi` above pays for the head the floor gives away.
+  const origStartMin = domains.map((d) => floorMin(d.origStartAt));
+  // How far a movable's REAL start can sit ABOVE its encoded `s`: one minute
+  // when the original is off the minute (the unmoved escape re-emits it
+  // unrounded), zero otherwise. Only needed where `s` is an UPPER bound.
+  const startSlackMin = domains.map((d) =>
+    floorMin(d.origStartAt) * MS_PER_MIN === d.origStartAt ? 0 : 1,
+  );
   const origCourtIdx = domains.map((d) => courtIndex.get(d.origCourt) ?? 0);
 
   const fam = Object.fromEntries(
@@ -374,8 +428,8 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     const aj = proposalById.get(domains[j]!.fixtureId)!;
     const sep = (r: number): Bool<"repair"> =>
       Z3.Or(
-        start[i]!.ge(start[j]!.add(durMin[j]! + r)),
-        start[j]!.ge(start[i]!.add(durMin[i]! + r)),
+        start[i]!.ge(start[j]!.add(durMinHi[j]! + r)),
+        start[j]!.ge(start[i]!.add(durMinHi[i]! + r)),
       );
     assume("court", Z3.Implies(courtVar[i]!.eq(courtVar[j]!), sep(gapMin)));
     if (sharesParticipant(ai, aj)) {
@@ -407,8 +461,12 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     const spanFrom = d.span === null ? null : ceilMin(d.span.from);
     const spanTo = d.span === null ? null : floorMin(d.span.to);
     for (const e of existing) {
-      const eStart = roundMin(e.startAt);
-      const eEnd = roundMin(e.endAt);
+      // OUTWARD, always. An immovable is an occupancy, and a rounded occupancy
+      // that is narrower than the real one is a gap the solver will happily
+      // park a fixture in: an obstacle ending 10:00:20 rounded to 10:00 makes
+      // `start >= eEnd` true of a card that really overlaps it by 20 seconds.
+      const eStart = floorMin(e.startAt);
+      const eEnd = ceilMin(e.endAt);
       // Only the MOVABLE side is ever the outer `a` in `validateAssignments`,
       // so this pair is judged one-directionally and owes exactly this number —
       // NOT the max. The max would over-constrain and report a spurious
@@ -418,12 +476,12 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
       if (
         spanFrom !== null &&
         spanTo !== null &&
-        (spanFrom >= eEnd + reach || spanTo + durMin[i]! + reach <= eStart)
+        (spanFrom >= eEnd + reach || spanTo + durMinHi[i]! + reach <= eStart)
       ) {
         continue;
       }
       const clear = (r: number): Bool<"repair"> =>
-        Z3.Or(start[i]!.ge(eEnd + r), start[i]!.le(eStart - durMin[i]! - r));
+        Z3.Or(start[i]!.ge(eEnd + r), start[i]!.le(eStart - durMinHi[i]! - r));
       const ci = courtIndex.get(e.court);
       if (ci !== undefined) assume("court", Z3.Implies(courtVar[i]!.eq(ci), clear(gapMin)));
       if (sharesParticipant(ai, e)) {
@@ -438,13 +496,29 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
   // feeder-rest semantic from calendar.ts, not a re-derivation of it. The
   // advancing player is a participant of the fixture they feed, so a dependent
   // may not start at the feeder's final whistle.
-  const startExpr = (id: string): Arith<"repair"> | number => {
+  //
+  // FOUR accessors, not two. A fixture's start and end each have a lower and an
+  // upper minute, they differ only for values that are off the minute, and which
+  // one a site needs is decided by the inequality it sits in — never by the
+  // field. Picking "nearest" for both is how an encoded feed edge ends up a
+  // minute away from the one the verifier measures.
+  const startLo = (id: string): Arith<"repair"> | number => {
     const i = idx.get(id);
-    return i !== undefined ? start[i]! : roundMin(boardById.get(id)!.startAt);
+    return i !== undefined ? start[i]! : floorMin(boardById.get(id)!.startAt);
   };
-  const endExpr = (id: string): Arith<"repair"> | number => {
+  const startHi = (id: string): Arith<"repair"> | number => {
     const i = idx.get(id);
-    return i !== undefined ? start[i]!.add(durMin[i]!) : roundMin(boardById.get(id)!.endAt);
+    // A movable's real start is `s` exactly, except on the unmoved escape, where
+    // it can be up to a minute later — `startSlackMin` is that minute.
+    return i !== undefined ? start[i]!.add(startSlackMin[i]!) : ceilMin(boardById.get(id)!.startAt);
+  };
+  const endLo = (id: string): Arith<"repair"> | number => {
+    const i = idx.get(id);
+    return i !== undefined ? start[i]!.add(durMinLo[i]!) : floorMin(boardById.get(id)!.endAt);
+  };
+  const endHi = (id: string): Arith<"repair"> | number => {
+    const i = idx.get(id);
+    return i !== undefined ? start[i]!.add(durMinHi[i]!) : ceilMin(boardById.get(id)!.endAt);
   };
   const plus = (x: Arith<"repair"> | number, n: number): Arith<"repair"> | number =>
     typeof x === "number" ? x + n : x.add(n);
@@ -477,9 +551,13 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
     // covers `order` only when `direct === true`), so they go under their own
     // relaxable literal. Under `order` they made the relaxed path report
     // `infeasible` over a conflict the verifier merely warns about.
+    // `start_target >= end_source + rest`: the target's start is the SMALLER
+    // side and rounds down, the source's end is the larger side and rounds up.
+    // Either one taken the other way makes the encoded rule weaker than the
+    // millisecond one it stands for.
     assume(
       dep.direct === true ? "order" : "order_soft",
-      geq(startExpr(dep.fixtureId), plus(endExpr(dep.dependsOn), rest)),
+      geq(startLo(dep.fixtureId), plus(endHi(dep.dependsOn), rest)),
     );
   }
 
@@ -520,11 +598,22 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
             }
             // Only a dependent placed AFTER its feeder is measured — one placed
             // before is an ordering violation and is reported as `order`.
+            //
+            // The two disjuncts round OPPOSITE ways, because one is a
+            // constraint and the other is an ESCAPE from it. "Starts before its
+            // feeder ends" must be certain in milliseconds before it excuses a
+            // fixture, so it takes the dependent's LATEST start against the
+            // feeder's EARLIEST end; the rest clause beside it takes the
+            // earliest start against the latest end. Rounded to nearest they
+            // leak into each other: `round(start) + round(duration)` can
+            // overshoot `round(start + duration)` by a minute, lifting the
+            // encoded feeder end above the real one and walking a fixture that
+            // is squarely inside the forbidden band out through the escape.
             assume(
               "instruction",
               Z3.Or(
-                lt(startExpr(dd.id), endExpr(f.id)),
-                geq(startExpr(dd.id), plus(endExpr(f.id), rule.minutes)),
+                lt(startHi(dd.id), endLo(f.id)),
+                geq(startLo(dd.id), plus(endHi(f.id), rule.minutes)),
               ),
             );
           }
@@ -687,6 +776,15 @@ async function solveRepair(input: RepairInput): Promise<RepairResult> {
         // A fixture that did not move keeps its ORIGINAL instant to the
         // millisecond. Round-tripping it through minutes would rewrite a board
         // the organiser may already have published.
+        //
+        // This is the one place the board leaves the minute grid, and it is why
+        // `origStartMin` floors and `durMinHi` carries the leftover fraction:
+        // the interval z3 reasoned about, `[origStartMin, origStartMin +
+        // durMinHi]`, has to contain the instants emitted here, or a card the
+        // solver proved clear of an obstacle re-enters it on the way out. The
+        // remaining asymmetry — a still fixture's real start sitting above its
+        // encoded `s` — is what `startSlackMin` pays for at the one site that
+        // uses a start as an upper bound.
         const startAt = still ? a.startAt : startMin * MS_PER_MIN;
         solved.set(d.fixtureId, {
           ...a,


### PR DESCRIPTION
## The defect

The z3 repair encoder quantises to minutes; the verifier works in milliseconds. Movable domains were already bounded conservatively (`ceilMin` on lower bounds, `floorMin` on upper), but **immovable obstacles went through `roundMin`**.

An obstacle ending at `10:00:20` rounded **down** to `10:00`, so z3 permitted a movable to start at `10:00` and overlap the real obstacle by 20 seconds — a board the solver calls clean and the verifier rejects.

This is the fifth instance of one bug class W6 kept hitting: *an encoder unit that is not the verifier's unit*. The other four (span pruned on all families, day cap per bucket not per day, clipped first/last day bucket, session crossing local midnight) were each invisible to a green suite.

## Sub-minute instants are reachable, not theoretical

- `apps/web/src/server/api-v1/schemas.ts:490` — `AddFixture.scheduled_at` is a client-supplied `z.string().datetime({offset:true})` with no seconds restriction
- `apps/web/src/server/usecases/schedule.ts:869` — the single-move PATCH writes it verbatim
- `db/migration/v2-engine/tables/V214__fixtures.sql:19` — `scheduled_at timestamptz`, microsecond precision
- `apps/web/src/server/usecases/competition-schedule-ai.ts:546` — `new Date(r.scheduled_at).getTime()` straight into an `Assignment`

Nothing in the path truncates to the minute. The only quantisation in the whole chain was inside `repair.ts` itself.

## The fix

`roundMin` is **deleted**, not corrected at its call sites, so it cannot return by autocomplete. Every site now names its direction and the inequality that justifies it:

| site | direction | justifying inequality |
|---|---|---|
| obstacle start | `floorMin` | RHS of `s <= eStart - dur - r` |
| obstacle end | `ceilMin` | RHS of `s >= eEnd + r` |
| movable duration | `ceilMin(origEnd) - floorMin(origStart)` | an extent, on both sides of `clear()` and in the span prune |
| original start | `floorMin` | the only off-grid escape |
| feed start/end | split lo/hi | each appears on both sides of an inequality, so one direction cannot serve both |

Behaviour is **identical for minute-aligned input**, which is why the existing suite was blind to the original defect.

## Three review rounds, two self-inflicted regressions caught

This branch is four commits because each fix exposed the next. Recording it because the pattern is the point:

1. **`f9e455c6`** fixed obstacle rounding — but `origStartMin → floorMin` un-guarded `inRuns`, whose `s.le(floorMin(r.to))` bounds a start from *above* for four families. A card at `19:20:40` under a 20:00 pack window came back `repaired` while running 40 s past the window, and nothing threw. Caught by review, not by tests.
2. **`4381c5b9`** fixed that and the `durMinHi` over-constraint — but left the direct `order` feed dep comparing `N >= N+1` on an abutting off-minute pair. `order ∈ BLOCKING_FAMILIES`, so it returned a final `infeasible` on a board the verifier calls order-clean. Worse than it sounds: **pinned fixtures enter as `existing`** (`schedule-ai.ts:1844-1845`), so two pinned fixtures on a feed edge, back-to-back at an off-minute instant — writable verbatim through the single-move PATCH — made every solver attempt for that competition fall through to the paid LLM repair round.
3. **`3b95a9ab`** fixed that with the escape `sep`/`clear` already use, and the `min_rest` twin.
4. **`357750ca`** pins the escape's antecedent. Review mutated `bothAtOrigin`'s body to a constant `TRUE`, dropping the `isStill` guards, and the suite still passed **20/20** — the commit's own guarantee was the one thing its tests could not see fail.

## Evidence

Original 11 tests, verified by reverting only the source:

```
repair-subminute.test.ts   0 pass  11 fail  ->  11 pass  0 fail
```

Every one failed with a real `RepairVerificationError: repair encoding drift: the solver satisfied every family with nothing moved, on a board the verifier rejects`, plus a whole-board jitter probe failing with `repair produced a schedule its own verifier rejects: 2 conflict(s)` — the solver made to defend a board it had called clean.

Per-round, each against the preceding commit:

- window/blackout escapes: `encoding_drift` before, pass after
- `durMinHi`: `expected 2 to be 1`, `expected 'infeasible' to be 'repaired'`
- `order` escape: immovable pair `infeasible -> repaired k:1`; movable pair `k:2 -> k:1`
- antecedent test: red under mutation (`expected 'repaired' to be 'infeasible'`), other 20 green, reverted -> 21/21

Mutation-tested throughout, with `total` pinned each round so no suite dropped out of collection.

The jitter probe now `expect(r.status).not.toBe("infeasible")` then `ctx.skip()` on `timeout` — an earlier tightening made it *pass* on timeout, which is a no-op precisely when the box is loaded. Skip path verified by forcing `budgetMs: 1`: `pass 20, pending 1, fail 0`.

## Gates

```
engine    90 files  2095 pass  0 fail   1 pending
apps/web 587 files  5188 pass  0 fail  50 pending   (DB: fresh schema, db:apply + sync:sports)
lint      0 errors, 79 warnings  (identical to main's baseline)
openapi   0 drift
```

## Bench

At 87-90% CPU idle, one run at a time:

| n | tree | status | total ms | probe ms |
|---|---|---|---|---|
| 50 | main | repaired k=2 | 4 188 | 2 565 |
| 50 | this branch | repaired k=2 | 3 756 | 2 319 |
| 120 | main | timeout | 60 168 | 58 619 |
| 120 | this branch | timeout | 60 156 | 58 760 |

No regression (0.2% at n=120). An earlier run showed this branch 3x slower; that reading was contaminated by a concurrent test run and did not reproduce under controlled conditions. See #455 — on unmodified `main` the probe consumes the whole budget at n=120 and the 500-movable tier is unreachable on this host.

## Not covered

No e2e, no smoke. `apps/web/e2e/ai-architect.spec.ts:925` does cover solver repair, but its clash is manufactured at `ai-fixture-server.ts:148-155` by copying card 0's slot onto card 1 — no off-minute instant anywhere. Making it sub-minute is a one-line change, deliberately not shipped without a local prod-build e2e run to verify it. Tracked in #452.

## Known residual

The `min_rest` half degrades to `relaxed: ["instruction"]` rather than blocking, verified byte-identical to the pre-fix output on an unsatisfiable board. A pre-existing verifier/encoder asymmetry remains where the encoder reads `boardById` and the verifier reads `placedById` — over-enforcement in the safe direction, holding only while `ruleFixtures ⊆ movable`. Tracked in #453.

## Merge note

Shares two files with `fix/feeder-rest-join-443`: `packages/engine/src/scheduling/repair.ts` (different regions — rounding here, the feed-edge join there) and `apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts`. Whichever lands second needs a rebase and a re-run, not a blind merge.

Recommend squashing on merge: `f9e455c6` is red in isolation at `schedule-ai-repair.test.ts:172`, so the intermediate commits are not individually bisectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
