### PR TITLE
Bind the rules the organiser actually stored: pool/division identity, durable hard rules, and one rest semantics (#446, #447, #459)

### DIFF
--- a/apps/web/src/server/usecases/__tests__/competition-schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-ai-repair.test.ts
@@ -284,20 +284,33 @@ describe("joint RuleFixture producers stay in the fixture-id namespace (#443)", 
     expect(feeds[0]!.divisionId).toBe(D1);
   });
 
-  it("every RuleFixture in both usecases comes from the ONE shared builder", () => {
+  it("every RuleFixture in all three usecases comes from the ONE shared builder", () => {
     // This is what makes the guard above cover `verifyJoint` too, which needs a
     // whole plan to call and is not worth building one for. #443 was two copies
     // of a join drifting onto a shared wrong assumption; the durable fix is that
     // there is only ever one copy. `winnerTo:` is the field only a RuleFixture
     // literal carries, so counting it counts the producers.
+    //
+    // `schedule.ts` joined the list in #447: the board paths need RuleFixtures
+    // too, and they hold the same five facts on a `fixtures` ROW under different
+    // column names. That is a signature problem, not a data one, so
+    // `rowToRuleFixture` renames its columns and delegates rather than writing a
+    // fourth literal — which is why the count below stays at one.
     const read = (rel: string): string =>
       readFileSync(new URL(rel, import.meta.url), "utf8");
     const single = read("../schedule-ai.ts");
     const joint = read("../competition-schedule-ai.ts");
+    const board = read("../schedule.ts");
     const producers = (s: string): number => (s.match(/winnerTo:/g) ?? []).length;
 
     expect(/export function toRuleFixture\(/.test(single)).toBe(true);
     expect(producers(single)).toBe(1); // the builder itself
     expect(producers(joint)).toBe(0); // both joint sites delegate to it
+    expect(producers(board)).toBe(0); // and so does the board's row adapter
+    // Anchored on the RETURN, not on a bare `toRuleFixture(`: the loose form is
+    // a substring of `export function rowToRuleFixture(`, so it would pass even
+    // if the delegation had been replaced by a literal. The real teeth are the
+    // zero above; this pins that the delegate is what produces the value.
+    expect(/return toRuleFixture\(/.test(board)).toBe(true);
   });
 });

--- a/apps/web/src/server/usecases/__tests__/competition-schedule-verify.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-verify.test.ts
@@ -806,6 +806,64 @@ describe("joint engine assignments (#350)", () => {
     expect(byId.get(F2)!.endAt - byId.get(F2)!.startAt).toBe(90 * 60_000);
   });
 
+  // #446 — `divisionId` above was stamped from the start; `poolId` was not, on
+  // the stated grounds that it "matches the single-division path exactly". The
+  // single-division path was the same bug, not a baseline: `restByGroup` and
+  // `startWindows` both target a POOL as well as a division, the pack has always
+  // carried `PackFixture.pool`, and the placer has always read it — so a
+  // pool-targeted rule bound while drafting and evaporated at verification.
+  it("stamps the pool as well as the division, so a pool-targeted rule survives", () => {
+    const POOL = "aaaa1111-1111-4111-8111-111111111111";
+    const p = pack(
+      [
+        division(D1, "Alpha", {
+          settings: settings({
+            matchMinutes: 30,
+            perEntrantMinRest: 30,
+            courts: ["Court 1", "Court 2"],
+            constraints: constraints({ restByGroup: { [POOL]: 180 } }),
+          }),
+        }),
+      ],
+      [
+        fixture(F1, D1, { pool: POOL, home: E1, away: E2 }),
+        fixture(F2, D1, { pool: POOL, seq: 1, home: E1, away: E3 }),
+      ],
+    );
+    const out = toJointEngineAssignments(
+      // 30 minutes apart: clears the 30-minute default rest, breaches the 180
+      // the pool asks for.
+      plan([assign(F1, at("09:00"), "Court 1"), assign(F2, at("10:00"), "Court 2")]),
+      p,
+    );
+    expect(out.map((a) => a.poolId)).toEqual([POOL, POOL]);
+    expect(verifyJoint(plan([assign(F1, at("09:00"), "Court 1"), assign(F2, at("10:00"), "Court 2")]), p)
+      .map((c) => c.reason)).toContain("rest");
+  });
+
+  // The negative half: a fixture in NO pool must omit the key rather than carry
+  // `undefined`, and a rule keyed on some other pool must stay silent. Without
+  // this the assertion above is satisfied by stamping any non-empty string.
+  it("omits the pool for a pool-less fixture and ignores another pool's rule", () => {
+    const OTHER = "aaaa2222-2222-4222-8222-222222222222";
+    const p = pack(
+      [
+        division(D1, "Alpha", {
+          settings: settings({
+            matchMinutes: 30,
+            perEntrantMinRest: 30,
+            courts: ["Court 1", "Court 2"],
+            constraints: constraints({ restByGroup: { [OTHER]: 180 } }),
+          }),
+        }),
+      ],
+      [fixture(F1, D1, { home: E1, away: E2 }), fixture(F2, D1, { seq: 1, home: E1, away: E3 })],
+    );
+    const rows = plan([assign(F1, at("09:00"), "Court 1"), assign(F2, at("10:00"), "Court 2")]);
+    expect(toJointEngineAssignments(rows, p).every((a) => !("poolId" in a))).toBe(true);
+    expect(verifyJoint(rows, p).map((c) => c.reason)).not.toContain("rest");
+  });
+
   it("mirrors feed dependencies across every division's movable fixtures", () => {
     const p = pack(
       [division(D1, "Alpha"), division(D2, "Beta")],

--- a/apps/web/src/server/usecases/__tests__/schedule-durable-hard-surfaces.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-durable-hard-surfaces.test.ts
@@ -1,0 +1,334 @@
+// #447 — the DURABLE half: a `constraints.hard` rule written through the API,
+// read back off `schedule_settings.config` jsonb, and enforced on every non-AI
+// surface.
+//
+// The sibling file (`schedule-durable-hard.test.ts`) pins the builders. This one
+// pins the product: the rule is PERSISTED by `putScheduleSettings`, re-parsed by
+// `loadSettings`, and then each of the four board entry points is driven for
+// real against Postgres. Nothing here constructs a config — that is the point.
+// Every engine test injects `hard` straight into a `VerifyConfig` literal, which
+// bypasses the one function that dropped it, which is exactly why the suite was
+// blind to this for a whole wave.
+//
+// WHY THE SPY. Three of the four surfaces RETURN their conflicts, so the rule
+// binding is directly observable. `moveFixture` does not: it returns void and
+// uses its conflict list only for `assertNoNewBlocking`, and an instruction
+// conflict is warn-only, so nothing it does is observable from outside. Wrapping
+// the two engine entry points and recording the config each surface hands them
+// is therefore the only proof available that the durable rule reaches the
+// verifier on the drag path — and it is a real proof: a config with no `hard`,
+// no `tz` or no `ruleFixtures` is precisely the defect.
+//
+// Real Postgres required; skipped without DATABASE_URL (CI runs them).
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { VerifyConfig } from "@seazn/engine/scheduling";
+
+const seen = vi.hoisted(() => ({ configs: [] as unknown[] }));
+
+vi.mock("@seazn/engine/scheduling", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@seazn/engine/scheduling")>();
+  return {
+    ...actual,
+    validateAssignments: (...args: Parameters<typeof actual.validateAssignments>) => {
+      seen.configs.push(args[1]);
+      return actual.validateAssignments(...args);
+    },
+    validateInstructionRules: (...args: Parameters<typeof actual.validateInstructionRules>) => {
+      seen.configs.push(args[1]);
+      return actual.validateInstructionRules(...args);
+    },
+  };
+});
+
+const { sql } = await import("@/lib/db");
+const { createCompetition } = await import("../competitions");
+const { createDivision } = await import("../divisions");
+const { createEntrants } = await import("../entrants");
+const { createStages, generateStageFixtures } = await import("../stages");
+const {
+  putScheduleSettings,
+  getScheduleSettings,
+  autoSchedule,
+  applySchedule,
+  moveFixture,
+  validateSchedule,
+} = await import("../schedule");
+type AuthCtx = import("@/server/api-v1/auth").AuthCtx;
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const DIVISION_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+const T0 = "2026-08-01T09:00:00.000Z";
+const MIN = 60_000;
+const at = (minutes: number) => new Date(Date.parse(T0) + minutes * MIN).toISOString();
+
+// The rule under test. Unit-free and wall-clock (#398): "no fixture may start
+// before noon", stated once, stored once, and owed on every surface. Every
+// fixture this board can produce starts at 09:00 or 09:30, so a surface that
+// honours it reports and a surface that drops it is silent — no arithmetic in
+// the assertions and no dependence on the placer's packing order.
+const NOT_BEFORE_NOON = {
+  type: "not_before" as const,
+  time: "12:00",
+  scope: { kind: "competition" as const },
+};
+
+async function seedProOrg(): Promise<AuthCtx> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug) values (${"Org " + suffix}, ${"org-" + suffix})
+    returning id`;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(DIVISION_CONFIG)}, true)
+    on conflict do nothing`;
+  for (const feature of ["scheduling.constraints", "scheduling.board"]) {
+    await sql`
+      insert into org_entitlement_overrides (org_id, feature_key, bool_value)
+      values (${orgId}, ${feature}, true)
+      on conflict (org_id, feature_key) do update set bool_value = true`;
+  }
+  return { orgId, via: "session", userId: null, role: "owner", keyId: null };
+}
+
+/** Every config the surface just handed the engine must carry all three fields.
+ *  Asserted together on purpose: `hard` without `tz` is a fix that binds
+ *  nothing, and `hard` without `ruleFixtures` binds only half of
+ *  `min_rest_minutes`. Any one of the three missing is the bug. */
+function expectRuleReachedTheVerifier(surface: string): void {
+  const configs = seen.configs as VerifyConfig[];
+  expect(configs.length, `${surface} never called the verifier`).toBeGreaterThan(0);
+  for (const c of configs) {
+    expect(c.constraints?.hard, `${surface} dropped the durable rule`).toEqual([NOT_BEFORE_NOON]);
+    expect(c.tz, `${surface} dropped the org zone`).toBe("UTC");
+    expect((c.ruleFixtures ?? []).length, `${surface} dropped the rule fixtures`).toBeGreaterThan(0);
+  }
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+beforeEach(() => {
+  seen.configs.length = 0;
+});
+
+describe.skipIf(!HAS_DB)("a durable constraints.hard rule on the board paths (#447)", () => {
+  it("binds on auto-schedule, the apply gate, the conflict report and the drag path", async () => {
+    const auth = await seedProOrg();
+    const competition = await createCompetition(auth, {
+      name: "Durable Rules",
+      visibility: "public",
+      branding: {},
+    });
+    const division = await createDivision(auth, competition.id, {
+      name: "Open",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+      eligibility: [],
+    });
+    await createEntrants(
+      auth,
+      division.id,
+      Array.from({ length: 4 }, (_, i) => ({
+        kind: "individual" as const,
+        display_name: `E${i + 1}`,
+        seed: i + 1,
+        members: [],
+      })),
+    );
+    const [groups] = await createStages(auth, division.id, [
+      { seq: 1, kind: "group", name: "Groups", config: { pools: { count: 1 } } },
+    ]);
+
+    // --- persist ----------------------------------------------------------
+    await putScheduleSettings(auth, division.id, {
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        courts: ["Court 1", "Court 2"],
+        perEntrantMinRest: 0,
+        blackouts: [],
+        sessionWindows: [],
+        // The zod OUTPUT type: everything but `hard` carries a default, and a
+        // defaulted field is REQUIRED downstream — which is exactly the reason
+        // `hard` is `.optional()` rather than `.default([])`.
+        constraints: {
+          hard: [NOT_BEFORE_NOON],
+          noBackToBack: false,
+          startWindows: [],
+          fieldFairness: "off",
+          parallelism: "mixed",
+          crossPersonClash: "warn",
+        },
+      },
+      tz: "UTC",
+    });
+    // Durability, proven off the row rather than off the object we just passed:
+    // this is `ScheduleConfig.parse` over `schedule_settings.config` jsonb, the
+    // same read `loadSettings` does on every one of the four surfaces below.
+    const stored = await sql<{ config: { constraints?: { hard?: unknown[] } } }[]>`
+      select config from schedule_settings where division_id = ${division.id}`;
+    expect(stored[0]!.config.constraints?.hard).toEqual([NOT_BEFORE_NOON]);
+    expect((await getScheduleSettings(auth, division.id)).config.constraints?.hard).toEqual([
+      NOT_BEFORE_NOON,
+    ]);
+
+    expect((await generateStageFixtures(auth, groups!.id)).created).toBe(6);
+
+    // --- 1. auto-schedule -------------------------------------------------
+    const proposal = await autoSchedule(auth, groups!.id, false);
+    expect(proposal.assignments).toHaveLength(6);
+    // Every card the placer produced starts before noon, so every one of them
+    // breaches the stored rule. The placer has no term for a typed rule — it
+    // reports only what it could not FIT — so before the fix this came back with
+    // an empty conflict list and an organiser building a board saw nothing.
+    const autoInstruction = proposal.conflicts.filter((c) => c.code === "warn.instruction");
+    expect(autoInstruction).toHaveLength(6);
+    expect(autoInstruction.every((c) => !c.blocking)).toBe(true);
+    expect(autoInstruction[0]!.detail).toContain("violating not_before 12:00");
+    expectRuleReachedTheVerifier("autoSchedule");
+
+    // --- 2. the apply gate ------------------------------------------------
+    seen.configs.length = 0;
+    const applied = await applySchedule(auth, groups!.id, {
+      assignments: proposal.assignments.map((a) => ({
+        fixture_id: a.fixture_id,
+        scheduled_at: a.scheduled_at,
+        court_label: a.court_label,
+      })),
+      source: "auto",
+    });
+    // THE PRODUCT DECISION, pinned. The write is REPORTED, not refused: an
+    // instruction conflict is warn-only (`isBlockingConflict` covers court,
+    // person_overlap, window and direct order alone) and `assertNoNewBlocking`
+    // filters by exactly that predicate. So an organiser whose existing board
+    // breaches a rule they stored can still save it — they are told, and they
+    // are not locked out of the board they need in order to fix it.
+    expect(applied.applied).toBe(6);
+    expect(applied.conflicts.filter((c) => c.code === "warn.instruction")).toHaveLength(6);
+    expect(applied.conflicts.every((c) => !c.blocking)).toBe(true);
+    expectRuleReachedTheVerifier("applySchedule");
+
+    // --- 3. the board conflict report -------------------------------------
+    seen.configs.length = 0;
+    const report = await validateSchedule(auth, division.id);
+    const reported = report.conflicts.filter((c) => c.code === "warn.instruction");
+    expect(reported).toHaveLength(6);
+    expect(reported.every((c) => !c.blocking)).toBe(true);
+    expectRuleReachedTheVerifier("validateSchedule");
+
+    // --- 4. the drag path -------------------------------------------------
+    seen.configs.length = 0;
+    const [card] = await sql<{ id: string }[]>`
+      select id from fixtures where stage_id = ${groups!.id} order by round_no, seq_in_round limit 1`;
+    // 11:00 on an empty court: the applied board runs 09:00–10:30, so nothing
+    // physical is in the way and the ONLY thing wrong with the destination is
+    // the stored rule. Warn-only, so the move is accepted — and the config it
+    // was judged against is the only thing that can show the rule was in force.
+    await moveFixture(auth, card!.id, { scheduled_at: at(120), court_label: "Court 2" });
+    expectRuleReachedTheVerifier("moveFixture");
+
+    // The drag path's own conflict list is computed and then discarded
+    // (`moveFixture` returns void), so the badge an organiser sees after a drop
+    // comes from the report above. That is why surface 3 carries the assertion
+    // on the moved card rather than surface 4.
+    const afterMove = await validateSchedule(auth, division.id);
+    expect(
+      afterMove.conflicts.filter((c) => c.code === "warn.instruction" && c.fixture_id === card!.id),
+    ).toHaveLength(1);
+  });
+
+  // Guard the guard: with no durable rule stored, none of the four surfaces may
+  // invent one. Without this, an adapter that reported "instruction"
+  // unconditionally would satisfy every assertion above.
+  it("reports nothing when the organiser stored no rule", async () => {
+    const auth = await seedProOrg();
+    const competition = await createCompetition(auth, {
+      name: "No Rules",
+      visibility: "public",
+      branding: {},
+    });
+    const division = await createDivision(auth, competition.id, {
+      name: "Open",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+      eligibility: [],
+    });
+    await createEntrants(
+      auth,
+      division.id,
+      Array.from({ length: 4 }, (_, i) => ({
+        kind: "individual" as const,
+        display_name: `E${i + 1}`,
+        seed: i + 1,
+        members: [],
+      })),
+    );
+    const [groups] = await createStages(auth, division.id, [
+      { seq: 1, kind: "group", name: "Groups", config: { pools: { count: 1 } } },
+    ]);
+    await putScheduleSettings(auth, division.id, {
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        courts: ["Court 1", "Court 2"],
+        perEntrantMinRest: 0,
+        blackouts: [],
+        sessionWindows: [],
+        // A constraints object that is PRESENT and carries no `hard`. Omitting
+        // `constraints` entirely would make the assertion at the end of this
+        // test vacuous — `constraints?.hard` is undefined because `constraints`
+        // itself is, which says nothing about whether `hard` is defaulted.
+        constraints: {
+          noBackToBack: false,
+          startWindows: [],
+          fieldFairness: "off",
+          parallelism: "mixed",
+          crossPersonClash: "warn",
+        },
+      },
+      tz: "UTC",
+    });
+    await generateStageFixtures(auth, groups!.id);
+
+    const proposal = await autoSchedule(auth, groups!.id, false);
+    expect(proposal.conflicts.filter((c) => c.code === "warn.instruction")).toHaveLength(0);
+    await applySchedule(auth, groups!.id, {
+      assignments: proposal.assignments.map((a) => ({
+        fixture_id: a.fixture_id,
+        scheduled_at: a.scheduled_at,
+        court_label: a.court_label,
+      })),
+      source: "auto",
+    });
+    const report = await validateSchedule(auth, division.id);
+    expect(report.conflicts.filter((c) => c.code === "warn.instruction")).toHaveLength(0);
+    // And the key stays ABSENT rather than defaulted to [] — the schema is
+    // explicit that `hard` is `.optional()`, never `.default([])`. Asserted with
+    // `in` on a constraints object we know is present, so the check cannot be
+    // satisfied by `constraints` being undefined.
+    const settings = await getScheduleSettings(auth, division.id);
+    expect(settings.config.constraints).toBeDefined();
+    expect("hard" in settings.config.constraints!).toBe(false);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-durable-hard.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-durable-hard.test.ts
@@ -1,0 +1,270 @@
+// #447 — a durable `constraints.hard` rule must reach the verifier on the board
+// paths, not only on the AI one.
+//
+// WHAT THE DEFECT WAS. `toSlotConfig` copied every field of the durable
+// `constraints` object except `hard`, and a `SlotConfig` is structurally
+// assignable to a `VerifyConfig` with `tz`, `hard`, `ruleFixtures` and
+// `restByDivision` all `undefined`. So all four board call sites handed
+// `validateAssignments` a config that type-checked perfectly and carried no
+// typed rule at all. `effectiveHard`'s own docstring calls a rule that binds on
+// one entry point and not the other "the worst kind".
+//
+// WHY THESE TESTS BUILD THE CONFIG WITH THE REAL BUILDER. The engine suite
+// already proves the verifier honours `hard`: `calendar-instruction.test.ts`
+// hand-writes `hard: [...]` into a `VerifyConfig` literal. That literal is
+// exactly what the product never produced — it bypasses the one function that
+// dropped the field — so a literal-based test here would score zero. Everything
+// below goes through `ScheduleConfig.parse` (the durable schema, the same one
+// `loadSettings` uses on the stored jsonb) and then through `toVerifyConfig`.
+//
+// No database: every builder under test is pure. The DB round trip through
+// `putScheduleSettings` and the four surfaces lives in
+// `schedule-durable-hard-surfaces.test.ts`.
+import { describe, expect, it } from "vitest";
+import { validateAssignments, type VerifyConfig } from "@seazn/engine/scheduling";
+import { ScheduleConfig } from "@/server/api-v1/schemas";
+import {
+  rowToRuleFixture,
+  toAssignment,
+  toSlotConfig,
+  toVerifyConfig,
+  type FixtureLite,
+  type ScheduleSettingsOut,
+} from "../schedule";
+
+const MIN = 60_000;
+const T0 = Date.parse("2026-08-10T09:00:00.000Z");
+const iso = (t: number) => new Date(t).toISOString();
+
+const DIV_A = "11111111-1111-4111-8111-111111111111";
+const DIV_B = "44444444-4444-4444-8444-444444444444";
+const POOL_A = "22222222-2222-4222-8222-222222222222";
+const F1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const F2 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2";
+
+// A fixtures row exactly as `FIXTURE_LITE_COLS` selects it.
+function row(over: Partial<FixtureLite> = {}): FixtureLite {
+  return {
+    id: F1,
+    stage_id: "s-1",
+    division_id: DIV_A,
+    pool_id: POOL_A,
+    round_no: 0,
+    seq_in_round: 0,
+    ext_key: null,
+    home_entrant_id: "e1",
+    away_entrant_id: "e2",
+    scheduled_at: iso(T0),
+    court_label: "Court 1",
+    venue: null,
+    status: "scheduled",
+    schedule_locked: false,
+    winner_to_fixture: null,
+    loser_to_fixture: null,
+    ...over,
+  };
+}
+
+// Settings as `loadSettings` returns them: the config parsed by the REAL zod
+// schema, so what the runtime stores in `schedule_settings.config` is what is
+// under test — including the `hard` array, which is what #447 is about.
+function settings(constraints: Record<string, unknown>): ScheduleSettingsOut {
+  return {
+    division_id: DIV_A,
+    config: ScheduleConfig.parse({
+      startAt: iso(T0),
+      matchMinutes: 40,
+      gapMinutes: 0,
+      courts: ["Court 1", "Court 2"],
+      perEntrantMinRest: 0,
+      constraints,
+    }),
+    tz: "UTC",
+    orgTz: "UTC",
+    updated_at: iso(T0),
+  };
+}
+
+const people = new Map<string, string[]>();
+const reasons = (c: readonly { reason: string }[]) => c.map((x) => x.reason);
+
+describe("the durable hard-rule seam (#447)", () => {
+  const NOT_BEFORE_TEN = { type: "not_before", time: "10:00", scope: { kind: "competition" } };
+
+  it("toSlotConfig carries the durable rules the copy used to drop", () => {
+    const s = settings({ hard: [NOT_BEFORE_TEN] });
+    // Asserted on the builder itself, not only through a verdict: this is the
+    // exact field that was missing, and a future drop should fail here with a
+    // readable message rather than as a silent absence of conflicts.
+    expect(toSlotConfig(s, 0).constraints?.hard).toEqual([NOT_BEFORE_TEN]);
+  });
+
+  it("leaves `hard` absent when the organiser stored none", () => {
+    // `.optional()`, never `.default([])` — the schema says so, and every
+    // `toSlotConfig` literal the rest of the suite compares against depends on it.
+    expect("hard" in (toSlotConfig(settings({}), 0).constraints ?? {})).toBe(false);
+  });
+
+  it("toVerifyConfig adds the two fields a SlotConfig cannot express", () => {
+    const s = settings({ hard: [NOT_BEFORE_TEN] });
+    const cfg = toVerifyConfig(s, [row()], 0);
+    expect(cfg.constraints?.hard).toEqual([NOT_BEFORE_TEN]);
+    // The ORG zone (#397), never the division's display override.
+    expect(cfg.tz).toBe("UTC");
+    expect(cfg.ruleFixtures).toEqual([
+      { id: F1, extKey: null, divisionId: DIV_A, poolId: POOL_A, winnerTo: null },
+    ]);
+  });
+
+  it("binds a durable wall-clock rule through the real builders", () => {
+    const s = settings({ hard: [NOT_BEFORE_TEN] });
+    const a = toAssignment(row(), 40, people);
+    // 09:00 in the org zone, against a 10:00 floor.
+    expect(reasons(validateAssignments([a], toVerifyConfig(s, [row()], 0)))).toContain("instruction");
+  });
+
+  it("stays silent when the same rule is satisfied", () => {
+    // Guard the guard: without this, an adapter that reported "instruction"
+    // unconditionally would satisfy every assertion above.
+    const s = settings({ hard: [{ type: "not_before", time: "08:00", scope: { kind: "competition" } }] });
+    const a = toAssignment(row(), 40, people);
+    expect(reasons(validateAssignments([a], toVerifyConfig(s, [row()], 0)))).not.toContain("instruction");
+  });
+
+  it("stays silent when the rule is scoped to a different division", () => {
+    const s = settings({
+      hard: [{ type: "not_before", time: "10:00", scope: { kind: "division", divisionId: DIV_B } }],
+    });
+    const a = toAssignment(row(), 40, people);
+    expect(reasons(validateAssignments([a], toVerifyConfig(s, [row()], 0)))).not.toContain("instruction");
+  });
+});
+
+// The trap that would have made the whole fix a no-op that passes review.
+describe("the tz dependency (#447)", () => {
+  const s = settings({
+    hard: [{ type: "max_fixtures_per_day", count: 1, scope: { kind: "competition" } }],
+  });
+  const rows = [row({ id: F1 }), row({ id: F2, court_label: "Court 2", home_entrant_id: "e3", away_entrant_id: "e4" })];
+  const assignments = rows.map((r) => toAssignment(r, 40, people));
+
+  it("binds the day cap when the org zone is carried", () => {
+    expect(reasons(validateAssignments(assignments, toVerifyConfig(s, rows, 0)))).toContain("instruction");
+  });
+
+  // DOCUMENTATION, NOT REGRESSION COVER. The next two hand-degrade a config and
+  // assert an absence, so they pass with the source fix fully reverted — they
+  // cannot fail for the bug this file exists for. They are here to state WHY
+  // `toVerifyConfig` carries what it carries, so the next reader does not
+  // "simplify" it back to `toSlotConfig`. The test above ("binds the day cap
+  // when the org zone is carried") is the one with teeth; do not count these
+  // two as proof of anything.
+  it("SKIPS every typed rule when the zone is absent — the documented behaviour", () => {
+    // `validateInstructionRules` wraps its entire block in `if (tz !== undefined)`
+    // on purpose: a day boundary bucketed in UTC would report a violation the
+    // organiser never expressed. Which is why carrying `hard` WITHOUT `tz` is a
+    // fix that binds nothing, ships, and looks correct in review.
+    const noTz: VerifyConfig = { ...toVerifyConfig(s, rows, 0), tz: undefined };
+    expect(reasons(validateAssignments(assignments, noTz))).not.toContain("instruction");
+  });
+
+  it("is exactly what a bare toSlotConfig cannot supply", () => {
+    // The pre-fix shape, pinned: a SlotConfig is assignable to VerifyConfig with
+    // tz/ruleFixtures undefined, so even a toSlotConfig that DOES carry `hard`
+    // reports nothing. Half a fix is no fix.
+    expect(reasons(validateAssignments(assignments, toSlotConfig(s, 0)))).not.toContain("instruction");
+  });
+});
+
+// The half of `min_rest_minutes` that needs `ruleFixtures`, and the half that
+// does not. Both are durable rules; only one is reported as "instruction".
+describe("durable min_rest_minutes across a feed edge (#447)", () => {
+  // f-1 feeds f-2 by a winner feed. Disjoint entrants on separate courts, so the
+  // feed edge is the only thing in play — no rest pair, no court clash.
+  const feeder = row({ id: F1, winner_to_fixture: F2, ext_key: "SF1" });
+  const dependent = row({
+    id: F2,
+    ext_key: "F",
+    court_label: "Court 2",
+    home_entrant_id: "e3",
+    away_entrant_id: "e4",
+    scheduled_at: iso(T0 + 60 * MIN), // 20 min after the feeder's 09:40 finish
+  });
+  const rows = [feeder, dependent];
+  const assignments = rows.map((r) => toAssignment(r, 40, people));
+  const s = settings({
+    hard: [
+      {
+        type: "min_rest_minutes",
+        minutes: 60,
+        rest_scope: "feeder_to_dependent",
+        scope: { kind: "competition" },
+      },
+    ],
+  });
+
+  it("reports the short turnaround the feed edge owes", () => {
+    const conflicts = validateAssignments(assignments, toVerifyConfig(s, rows, 0));
+    const instruction = conflicts.filter((c) => c.reason === "instruction");
+    expect(instruction).toHaveLength(1);
+    expect(instruction[0]!.fixtureId).toBe(F2);
+    expect(instruction[0]!.detail).toContain("20 min after its feeder");
+  });
+
+  it("binds nothing without ruleFixtures — the join has no left side", () => {
+    // DOCUMENTATION, NOT REGRESSION COVER — same shape as the two in the tz
+    // block: it degrades a config and asserts an absence, so it cannot fail for
+    // this bug. The teeth are in "reports the short turnaround the feed edge
+    // owes" above; this only records WHY `ruleFixtures` is load-bearing.
+    //
+    // The feeder→dependent loop iterates `ruleFixtures`; `assignments` carry no
+    // feed edge at all. So this half of the rule is the one that proves the
+    // fixtures actually reached the verifier, rather than the zone alone.
+    const noFixtures: VerifyConfig = { ...toVerifyConfig(s, rows, 0), ruleFixtures: undefined };
+    expect(reasons(validateAssignments(assignments, noFixtures))).not.toContain("instruction");
+  });
+
+  it("joins the feed edge on the fixture id, never the ext key", () => {
+    // #443's namespace tripwire, on the row adapter this issue added. `extKey`
+    // is nullable text; `winnerTo` is a uuid FK to `fixtures.id`. `RuleFixture`
+    // types both `string | null`, so a swap type-checks and then silently
+    // resolves nothing.
+    const rf = rows.map(rowToRuleFixture);
+    const ids = new Set(rf.map((f) => f.id));
+    const extKeys = new Set(rf.map((f) => f.extKey).filter((k): k is string => k !== null));
+    expect([...ids].some((id) => extKeys.has(id))).toBe(false);
+    const feeds = rf.filter((f) => f.winnerTo !== null);
+    expect(feeds).toHaveLength(1);
+    expect(ids.has(feeds[0]!.winnerTo!)).toBe(true);
+    expect(extKeys.has(feeds[0]!.winnerTo!)).toBe(false);
+  });
+
+  it("raises the PAIR rest bound for a per_person rule, with no zone needed", () => {
+    // The issue's own example. This half never reaches
+    // `validateInstructionRules` — it is folded into `pairRestMinutesWith` so one
+    // short gap is reported once as `rest`, not twice — and it therefore binds
+    // off `constraints.hard` ALONE, with no tz and no ruleFixtures. Carrying the
+    // field is the whole fix for this half.
+    const perPerson = settings({
+      hard: [
+        {
+          type: "min_rest_minutes",
+          minutes: 120,
+          rest_scope: "per_person",
+          scope: { kind: "competition" },
+        },
+      ],
+    });
+    // Same entrant, 45 minutes apart: clears the 0-minute default, breaches 120.
+    const first = toAssignment(row({ id: F1 }), 40, people);
+    const second = toAssignment(
+      row({ id: F2, court_label: "Court 2", scheduled_at: iso(T0 + 85 * MIN) }),
+      40,
+      people,
+    );
+    expect(second.startAt - first.endAt).toBe(45 * MIN);
+    expect(reasons(validateAssignments([second], toVerifyConfig(perPerson, rows, 0), [first]))).toContain("rest");
+    // And it is the durable rule doing it, not the settings tab.
+    expect(reasons(validateAssignments([second], toVerifyConfig(settings({}), rows, 0), [first]))).not.toContain("rest");
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
@@ -1,0 +1,266 @@
+// #446 — pool- and division-targeted rules must survive the apps/web adapters.
+//
+// `constraints.restByGroup` and `constraints.startWindows` target a POOL or a
+// DIVISION. The engine resolves both off two fields on the row being judged:
+// `SchedulableFixture.poolId`/`divisionId` in the placer, and
+// `Assignment.poolId`/`divisionId` in the verifier. Every apps/web adapter
+// stamped the first pair and dropped the second, so a pool rule bound for
+// Auto-schedule and evaporated the moment the same board was verified — a
+// dragged card, an apply gate, an AI proposal.
+//
+// WHY THESE TESTS BUILD NOTHING BY HAND. The engine's own suite already proves
+// the verifier honours `restByGroup` when the field is present: it hand-stamps
+// `{ poolId: "p1" }` onto an `Assignment` literal (calendar-windows.test.ts).
+// That literal is exactly what the product never produced. So every assertion
+// below runs a REAL apps/web adapter over a REAL row shape and asserts on what
+// `validateAssignments` then says. A literal here would score zero.
+//
+// No database: every adapter under test is pure (row/pack in, Assignment out),
+// and the config comes from `toSlotConfig`/`verifyConfig`, the same builders the
+// runtime uses.
+import { describe, expect, it } from "vitest";
+import { makeClock, validateAssignments } from "@seazn/engine/scheduling";
+import { ScheduleConfig } from "@/server/api-v1/schemas";
+import { toAssignment, toSlotConfig, type FixtureLite, type ScheduleSettingsOut } from "../schedule";
+import type { AiSchedulePlan } from "../schedule-ai-prompt";
+import { toEngineAssignments, verifyConfig, type SchedulePack } from "../schedule-ai";
+
+const MIN = 60_000;
+const T0 = Date.parse("2026-08-10T09:00:00.000Z");
+const iso = (t: number) => new Date(t).toISOString();
+
+const DIV_A = "11111111-1111-4111-8111-111111111111";
+const POOL_A = "22222222-2222-4222-8222-222222222222";
+
+// A fixtures row exactly as `FIXTURE_LITE_COLS` selects it.
+function row(over: Partial<FixtureLite> = {}): FixtureLite {
+  return {
+    id: "f-1",
+    stage_id: "s-1",
+    division_id: DIV_A,
+    pool_id: POOL_A,
+    round_no: 0,
+    seq_in_round: 0,
+    ext_key: null,
+    home_entrant_id: "e1",
+    away_entrant_id: "e2",
+    scheduled_at: iso(T0),
+    court_label: "Court 1",
+    venue: null,
+    status: "scheduled",
+    schedule_locked: false,
+    winner_to_fixture: null,
+    loser_to_fixture: null,
+    ...over,
+  };
+}
+
+// Settings as `loadSettings` returns them — the config parsed by the real zod
+// schema, so the defaults the runtime applies are the defaults under test.
+function settings(constraints: Record<string, unknown>): ScheduleSettingsOut {
+  return {
+    division_id: DIV_A,
+    config: ScheduleConfig.parse({
+      startAt: iso(T0),
+      matchMinutes: 40,
+      gapMinutes: 0,
+      courts: ["Court 1", "Court 2"],
+      perEntrantMinRest: 30,
+      constraints,
+    }),
+    tz: "UTC",
+    orgTz: "UTC",
+    updated_at: iso(T0),
+  };
+}
+
+const people = new Map<string, string[]>();
+
+describe("pool-targeted rules through the board adapters (#446)", () => {
+  // The issue's exact scenario: a 180-minute pool rest, a 30-minute default, and
+  // a card sitting 40 minutes after its poolmate. Before the fix `toAssignment`
+  // emitted no `poolId`, `effectiveRestMinutes` fell through to the 30, and the
+  // organiser's move was accepted with no badge.
+  it("a pool-targeted restByGroup binds on an assignment built by toAssignment", () => {
+    const s = settings({ restByGroup: { [POOL_A]: 180 } });
+    const config = toSlotConfig(s, 0);
+    const first = toAssignment(row({ id: "f-1" }), 40, people);
+    const dragged = toAssignment(
+      row({ id: "f-2", home_entrant_id: "e1", away_entrant_id: "e3", scheduled_at: iso(T0 + 80 * MIN) }),
+      40,
+      people,
+    );
+    // The adapter must carry the group identity at all — asserted directly so a
+    // future drop fails here with a readable message and not only via a verdict.
+    expect(dragged.poolId).toBe(POOL_A);
+    expect(dragged.divisionId).toBe(DIV_A);
+
+    // 40 minutes of rest: clears the 30-minute default, breaches the 180.
+    expect(dragged.startAt - first.endAt).toBe(40 * MIN);
+    const conflicts = validateAssignments([dragged], config, [first]);
+    expect(conflicts.map((c) => c.reason)).toContain("rest");
+  });
+
+  // Same board, same adapter, but the rule is keyed by DIVISION and the fixture
+  // is in NO pool — the non-joint path, which had zero coverage (the only
+  // division-keyed test in the suite runs the joint verifier).
+  it("a division-targeted restByGroup binds on the non-joint path", () => {
+    const s = settings({ restByGroup: { [DIV_A]: 180 } });
+    const config = toSlotConfig(s, 0);
+    const first = toAssignment(row({ id: "f-1", pool_id: null }), 40, people);
+    const dragged = toAssignment(
+      row({
+        id: "f-2",
+        pool_id: null,
+        home_entrant_id: "e1",
+        away_entrant_id: "e3",
+        scheduled_at: iso(T0 + 80 * MIN),
+      }),
+      40,
+      people,
+    );
+    // A null pool omits the key rather than setting it to undefined — the
+    // convention `SchedulableFixture` already uses, and what keeps
+    // `restByGroup[undefined]` from ever being asked for.
+    expect("poolId" in dragged).toBe(false);
+    expect(dragged.divisionId).toBe(DIV_A);
+    expect(validateAssignments([dragged], config, [first]).map((c) => c.reason)).toContain("rest");
+  });
+
+  // The other half of the same defect: `startWindows` targets a pool too, and
+  // `startWindowFor` returns (-inf, +inf) for an assignment with no `poolId`.
+  // That unbounded answer is also what emptied the repair solver's
+  // `start_window` family, since `repair-domain` clips to the same call.
+  it("a pool-targeted startWindow binds on an assignment built by toAssignment", () => {
+    const s = settings({
+      startWindows: [{ target: { kind: "pool", id: POOL_A }, notAfter: iso(T0 + 120 * MIN) }],
+    });
+    const config = toSlotConfig(s, 0);
+    const late = toAssignment(row({ id: "f-3", scheduled_at: iso(T0 + 300 * MIN) }), 40, people);
+    expect(validateAssignments([late], config).map((c) => c.reason)).toContain("start_window");
+  });
+
+  // A rule keyed on a DIFFERENT pool must stay silent. Without this the two
+  // tests above are satisfied by an adapter that stamps any non-empty string.
+  it("a rule keyed on another pool does not bind", () => {
+    const s = settings({ restByGroup: { "33333333-3333-4333-8333-333333333333": 180 } });
+    const config = toSlotConfig(s, 0);
+    const first = toAssignment(row({ id: "f-1" }), 40, people);
+    const dragged = toAssignment(
+      row({ id: "f-2", home_entrant_id: "e1", away_entrant_id: "e3", scheduled_at: iso(T0 + 80 * MIN) }),
+      40,
+      people,
+    );
+    expect(validateAssignments([dragged], config, [first]).map((c) => c.reason)).not.toContain("rest");
+  });
+});
+
+// The single-division AI verify seam. `verifyConfig` copies `restByGroup` and
+// `startWindows` off the pack verbatim, so the ONLY reason a pool rule was
+// unenforced on this path is that `toEngineAssignments` emitted no group id.
+describe("pool-targeted rules through the single-division AI adapter (#446)", () => {
+  function pack(constraints: Record<string, unknown>): SchedulePack {
+    return {
+      mode: "generate",
+      division: { id: DIV_A, name: "Div A", sport: "generic", tz: "UTC" },
+      tz: "UTC",
+      clock: makeClock(T0, "UTC"),
+      window: { start: "2026-08-10", end: "2026-08-17" },
+      sessionHours: { start: "08:00", end: "22:00" },
+      settings: {
+        matchMinutes: 40,
+        gapMinutes: 0,
+        perEntrantMinRest: 30,
+        courts: ["Court 1", "Court 2"],
+        sessionWindows: [],
+        blackouts: [],
+        constraints: {
+          noBackToBack: false,
+          startWindows: [],
+          fieldFairness: "off",
+          parallelism: "mixed",
+          crossPersonClash: "warn",
+          ...constraints,
+        },
+      },
+      entrants: [],
+      people: [],
+      participants: { "f-1": [], "f-2": [] },
+      assumptions: [],
+      parsed: { hard: [], soft: [], unparsed: [] },
+      fixtures: {
+        movable: [
+          {
+            id: "f-1",
+            ext_key: null,
+            round: 0,
+            seq: 0,
+            pool: POOL_A,
+            home: "e1",
+            away: "e2",
+            feeds: { winner_to: null, after: [] },
+            current: { at: null, court: null },
+            pinned: false,
+          },
+          {
+            id: "f-2",
+            ext_key: null,
+            round: 1,
+            seq: 0,
+            pool: POOL_A,
+            home: "e1",
+            away: "e3",
+            feeds: { winner_to: null, after: [] },
+            current: { at: null, court: null },
+            pinned: false,
+          },
+        ],
+        obstacles: [],
+      },
+      draft: [],
+      instruction: "",
+      prior: null,
+      officials: [],
+    };
+  }
+
+  const plan: AiSchedulePlan = {
+    assignments: [
+      { fixture_id: "f-1", scheduled_at: iso(T0), court_label: "Court 1" },
+      { fixture_id: "f-2", scheduled_at: iso(T0 + 80 * MIN), court_label: "Court 2" },
+    ],
+    unschedulable: [],
+    explanations: [],
+    summary: "",
+  };
+
+  it("toEngineAssignments carries the pool and division the pack already holds", () => {
+    const p = pack({ restByGroup: { [POOL_A]: 180 } });
+    const [, second] = toEngineAssignments(plan, p);
+    expect(second!.poolId).toBe(POOL_A);
+    expect(second!.divisionId).toBe(DIV_A);
+  });
+
+  it("a pool-targeted restByGroup makes the AI referee report the 40-minute gap", () => {
+    const p = pack({ restByGroup: { [POOL_A]: 180 } });
+    const assignments = toEngineAssignments(plan, p);
+    const conflicts = validateAssignments(assignments, verifyConfig(p));
+    expect(conflicts.map((c) => c.reason)).toContain("rest");
+  });
+
+  // NO startWindow case on THIS path, deliberately, and it is not an oversight
+  // in the fix. `verifyConfig` pins `startWindows: []` outright (schedule-ai.ts,
+  // "the pack's startWindows carry ISO strings … the engine wants epoch ms"), so
+  // the single-division AI referee is blind to EVERY start window, pool-targeted
+  // or not — a second, independent defect that stamping `poolId` cannot reach.
+  // A test here would fail after this fix and mislabel that gap as this bug.
+  // The board path, where `toSlotConfig` does convert the windows, carries the
+  // pool-targeted startWindow assertion instead (above).
+  it("carries the pool id the pinned-empty startWindows cannot yet use", () => {
+    const p = pack({
+      startWindows: [{ target: { kind: "pool", id: POOL_A }, notAfter: iso(T0 + 40 * MIN) }],
+    });
+    expect(verifyConfig(p).constraints?.startWindows).toEqual([]);
+    expect(toEngineAssignments(plan, p)[1]!.poolId).toBe(POOL_A);
+  });
+});

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -565,6 +565,13 @@ export async function buildCompetitionPack(
         // (These assignments are placer input only: the joint verifier rebuilds
         // obstacles through `toJointObstacleAssignments`, so this cannot double
         // a conflict report.)
+        //
+        // No `poolId` (#446). This list is PLACER input: `slotFixtures` reads
+        // `existing` for court, times, entrants and people and never for a
+        // group id — it resolves `restByGroup`/`startWindows` off the
+        // `SchedulableFixture` being placed. `divisionId` below predates that
+        // read and is kept for the draft-accumulation bookkeeping; adding a
+        // pool would mean widening this module's SQL for a field nothing reads.
         people: [
           ...new Set(
             [
@@ -1080,8 +1087,13 @@ export const JOINT_ASSIGNMENT_UNKNOWN = "AI_PLAN_INVALID_ASSIGNMENT";
  *    never reaches (it leaves divisionId unset). Since each division's pass runs
  *    with that division's own constraints, a restByGroup entry keyed by a
  *    division now governs that division's own fixtures — which is what the field
- *    means. `poolId` is deliberately still NOT stamped, matching the
- *    single-division path exactly.
+ *    means.
+ *
+ *    This bullet used to end "`poolId` is deliberately still NOT stamped,
+ *    matching the single-division path exactly." That symmetry was real and the
+ *    conclusion was wrong: the single-division path was not a baseline, it was
+ *    the same bug (#446). `poolId` is stamped now, on both paths, and the pack
+ *    has carried it all along as `PackFixture.pool`.
  *  * An unresolvable assignment THROWS rather than defaulting.
  *
  *  That last one is the important one, and it is why there is no `?? 0` here.
@@ -1131,6 +1143,7 @@ export function toJointEngineAssignments(plan: AiSchedulePlan, pack: Competition
       // this read green on a pack that never computed the map.
       people: pack.participants[a.fixture_id] ?? [],
       divisionId: f.division_id,
+      ...(f.pool != null ? { poolId: f.pool } : {}),
     };
   });
 }
@@ -1143,7 +1156,19 @@ export function toJointEngineAssignments(plan: AiSchedulePlan, pack: Competition
  *  within ONE division's list, and a duplicate id on the joint board is not
  *  inert: `validateAssignments` builds a `byId` map over `existing` +
  *  `assignments` for feed-order resolution, where a collision silently drops an
- *  entry. */
+ *  entry.
+ *
+ *  Carries no `poolId`/`divisionId` DELIBERATELY (#446), even though
+ *  `o.division_id` is right here and used for the id key. These rows are
+ *  occupancy: no entrants, no people, never in `ruleFixtures`. Every read of
+ *  `Assignment.divisionId`/`poolId` is unreachable for them —
+ *  `startWindowFor` runs over `assignments` only, the rest pair needs a shared
+ *  entrant or person, and `validateInstructionRules` counts `existing` only
+ *  where a `RuleFixture` exists, whose own ids win in `scopeCoversFixture`.
+ *  So stamping would be inert today and, the day some rule does start reading
+ *  `existing`, would silently apply a division rule to a booking from OUTSIDE
+ *  the run (`o.division_id === null` — the `"x"` key below) or to a row this run
+ *  is not permitted to move. Occupancy carries no group identity, on purpose. */
 export function toJointObstacleAssignments(pack: CompetitionPack): Assignment[] {
   const indexByDivision = new Map(pack.divisions.map((d, i) => [d.id, String(i)]));
   const counters = new Map<string, number>();

--- a/apps/web/src/server/usecases/competition-schedule-apply.ts
+++ b/apps/web/src/server/usecases/competition-schedule-apply.ts
@@ -453,6 +453,11 @@ export async function applyCompetitionSchedule(
           // What `verifyJoint` partitions on, and what makes a division-keyed
           // `constraints.restByGroup` govern that division's own fixtures.
           divisionId: d.id,
+          // …and the POOL-keyed half of the same field (#446). `restByGroup` and
+          // `startWindows` both target a pool or a division; only the division
+          // half was ever stamped, so a pool-targeted rule bound in the placer
+          // and evaporated here.
+          ...(f.pool_id !== null ? { poolId: f.pool_id } : {}),
         };
       }),
     );
@@ -486,10 +491,12 @@ export async function applyCompetitionSchedule(
       d.input.assignments
         .map((a) => d.byId.get(a.fixture_id)!)
         .filter((f) => f.scheduled_at !== null && f.court_label !== null)
-        .map((f) => ({
-          ...toAssignment(f, d.settings.config.matchMinutes, people),
-          divisionId: d.id,
-        })),
+        // `toAssignment` stamps `divisionId` from the fixture's own
+        // `division_id` (#446), so this pass does NOT re-write it from `d.id`.
+        // The two agree — `d.byId` only holds that division's fixtures — and
+        // one field with one source is the whole point of the fix this file
+        // is part of.
+        .map((f) => toAssignment(f, d.settings.config.matchMinutes, people)),
     );
 
     // ---- one pass per division, over the merged board ---------------------

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -921,6 +921,12 @@ export async function buildSchedulePack(
         // 1970-01-01 as the draft time for every fixture (#397). The honest
         // fallback is the first session hour of the window's first day, in the
         // org zone.
+        // `toSlotConfig`, not `toVerifyConfig`: this is the DRAFT placer, and it
+        // runs before any instruction has been compiled, so the only `hard`
+        // rules that exist here are the durable ones `toSlotConfig` already
+        // forwards (#447). The asymmetry is deliberate rather than the one that
+        // caused #447 — but it is the same shape, so if a compiled rule ever
+        // becomes available at draft time this must move to `toVerifyConfig`.
         config: toSlotConfig(
           settings,
           zonedTimeToUtc(dayKeyInTz(draftAnchorMs, orgTz), DEFAULT_SESSION_HOURS.start, orgTz),
@@ -1503,9 +1509,25 @@ function toObstacleAssignments(pack: SchedulePack): Assignment[] {
   }));
 }
 
+/** Exactly the fields `toRuleFixture` reads, and nothing else — the widened
+ *  parameter that lets a `fixtures` row reach the one builder (#447).
+ *
+ *  Named after what it is rather than where it comes from: `PackFixture`
+ *  satisfies it structurally, and `rowToRuleFixture` in `schedule.ts` builds one
+ *  by renaming a DB row's columns. Keeping it this narrow is the point — a
+ *  parameter that demanded the whole `PackFixture` would have forced the board
+ *  to grow a RuleFixture literal of its own. */
+export interface RuleFixtureSource {
+  id: string;
+  ext_key: string | null;
+  pool: string | null;
+  feeds: { winner_to: string | null };
+}
+
 /**
- * THE one place a `RuleFixture` is built — for the single-division pack here and
- * for both joint producers in `competition-schedule-ai.ts` (#443).
+ * THE one place a `RuleFixture` is built — for the single-division pack here,
+ * for both joint producers in `competition-schedule-ai.ts` (#443), and for the
+ * board paths via `rowToRuleFixture` (#447).
  *
  * It is one function rather than three literals because of what #443 was: two
  * copies of a join drifted onto a shared wrong assumption, and the second copy
@@ -1521,11 +1543,19 @@ function toObstacleAssignments(pack: SchedulePack): Assignment[] {
  * displaying as enforced while binding nothing at all. One producer means one
  * thing to guard, and `schedule-ai-repair.test.ts` guards it.
  *
- * `divisionId` is a parameter because the two packs source it differently: the
+ * `divisionId` is a parameter because the packs source it differently: the
  * single-division pack takes it from the division it is a pack OF, the joint
  * pack from each fixture's own `division_id`.
+ *
+ * The parameter is `RuleFixtureSource`, not `PackFixture`, since #447: the board
+ * paths (`schedule.ts`) hold the same five facts on a `fixtures` ROW under
+ * different column names, and they need a `RuleFixture` too. Widening the
+ * parameter to exactly the fields this function reads lets `rowToRuleFixture`
+ * rename its columns and delegate here, so there is still ONE assignment of
+ * `winnerTo` in the codebase and still one thing to guard — rather than a second
+ * builder in a second module, which is precisely the shape #443 was.
  */
-export function toRuleFixture(f: PackFixture, divisionId: string): RuleFixture {
+export function toRuleFixture(f: RuleFixtureSource, divisionId: string): RuleFixture {
   return {
     id: f.id,
     extKey: f.ext_key,

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -1443,8 +1443,23 @@ function structuralCheck(plan: AiSchedulePlan, movableIds: Set<string>, pack: Sc
 }
 
 /** Map the LLM proposal onto engine assignments (ISO → epoch ms). Entrants and
- *  people come from the pack so the verifier can catch overlaps. */
-function toEngineAssignments(plan: AiSchedulePlan, pack: SchedulePack): Assignment[] {
+ *  people come from the pack so the verifier can catch overlaps.
+ *
+ *  `poolId`/`divisionId` come from the pack too (#446), from the same two pack
+ *  fields `packRuleFixtures` below already reads. They are what makes a
+ *  pool- or division-targeted `restByGroup` entry actually bind on this path.
+ *
+ *  NOT `startWindows`, on this path: `verifyConfig` below pins
+ *  `startWindows: []` outright, so the single-division AI path is blind to
+ *  every start window whatever it targets, and `repair-domain` clips the
+ *  repair domain to that same empty config. Stamping the group identity is
+ *  necessary for that to ever work and is not sufficient — filed separately.
+ *  `schedule-group-targeting.test.ts` asserts the pin, so this comment and
+ *  that test cannot drift apart silently.
+ *
+ *  Exported for the same reason its joint twin `toJointEngineAssignments` is:
+ *  the verify seam is testable without a model round trip. */
+export function toEngineAssignments(plan: AiSchedulePlan, pack: SchedulePack): Assignment[] {
   const fixtureById = new Map(pack.fixtures.movable.map((f) => [f.id, f]));
   const durMs = pack.settings.matchMinutes * MS_PER_MIN;
   return plan.assignments.map((a) => {
@@ -1461,11 +1476,22 @@ function toEngineAssignments(plan: AiSchedulePlan, pack: SchedulePack): Assignme
       // whoever can still advance into it, which is what every person rule
       // needs and what `pack.people` (pairs sharing an entrant) never had.
       people: pack.participants[a.fixture_id] ?? [],
+      ...(f?.pool != null ? { poolId: f.pool } : {}),
+      divisionId: pack.division.id,
     };
   });
 }
 
-/** Fixed court occupancy the proposal must dodge (other stages + siblings). */
+/** Fixed court occupancy the proposal must dodge (other stages + siblings).
+ *
+ *  DELIBERATELY carries no `poolId`/`divisionId` (#446), unlike every other
+ *  adapter in this file. A `PackObstacle` is a court booking — an out-of-run
+ *  division's placement, another stage's decided fixture, an outside hire — and
+ *  it has no entrants and no people, so no rest pair and no start-window bound
+ *  can ever reach it (`startWindowFor` runs over `assignments` only; the rest
+ *  loop needs a shared entrant or person). Stamping a FOREIGN division's id on
+ *  a row this run may not move would be a rule match invented in the opposite
+ *  direction — the pack does not even carry the pool that row sat in. */
 function toObstacleAssignments(pack: SchedulePack): Assignment[] {
   return pack.fixtures.obstacles.map((o, i) => ({
     fixtureId: `obstacle:${i}`,

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -21,13 +21,16 @@ import {
   isBlockingConflict,
   slotFixtures,
   validateAssignments,
+  validateInstructionRules,
   ymdAddDays,
   zonedTimeToUtc,
   type Assignment,
   type Conflict,
   type OrderDependency,
+  type RuleFixture,
   type SchedulableFixture,
   type SlotConfig,
+  type VerifyConfig,
 } from "@seazn/engine/scheduling";
 import { appendDivisionEvent } from "@/server/engine-db";
 import type { AuthCtx } from "@/server/api-v1/auth";
@@ -40,7 +43,7 @@ import {
 import { sendOfficialAssignmentChangedEmail } from "@/lib/email";
 import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { generateStageFixtures } from "./stages";
-import { schedulingAiModel } from "./schedule-ai";
+import { schedulingAiModel, toRuleFixture } from "./schedule-ai";
 
 type Tx = postgres.TransactionSql;
 
@@ -405,9 +408,95 @@ export function toSlotConfig(settings: ScheduleSettingsOut, now: number): SlotCo
             fieldFairness: c.constraints.fieldFairness,
             parallelism: c.constraints.parallelism,
             crossPersonClash: c.constraints.crossPersonClash,
+            // #447: the DURABLE typed rules (#398). This key was the one field
+            // of `constraints` the copy above dropped, and `effectiveHard` reads
+            // exactly it — so a rule an organiser stored through the API bound on
+            // the AI path (which builds its own config) and silently nowhere
+            // else. `effectiveHard`'s own docstring calls that "the worst kind".
+            //
+            // Carried here rather than on the top-level `hard` field because
+            // `effectiveHard` MERGES the two — setting both would count every
+            // durable rule twice — and because `constraints.hard` is the durable
+            // home: the top-level one is where a run puts the stream it COMPILED
+            // from an instruction. It also rides `toSlotConfig` rather than the
+            // wrapper below so every existing caller of this function gets it
+            // without a second place to remember.
+            //
+            // Optional, never defaulted (the schema says so): a `hard: []` on a
+            // config that stored nothing is indistinguishable downstream, but it
+            // would make every `toSlotConfig` output differ from the literals the
+            // rest of the suite compares against.
+            ...(c.constraints.hard !== undefined ? { hard: c.constraints.hard } : {}),
           },
         }
       : {}),
+  };
+}
+
+/** A `fixtures` row as a `RuleFixture`, by renaming its columns onto the ONE
+ *  builder (#447).
+ *
+ *  Deliberately not a second RuleFixture literal. `winnerTo` must carry
+ *  `fixtures.winner_to_fixture` — a uuid FK to `fixtures.id` — and `extKey` must
+ *  carry `fixtures.ext_key`, nullable text in a different namespace with no
+ *  converter. `RuleFixture` types both `string | null`, so a producer that swaps
+ *  them type-checks and then binds NOTHING, silently: that is #443, and #443 was
+ *  invisible precisely because a second copy of the join existed. This function
+ *  therefore does one thing — rename `pool_id`→`pool`, `winner_to_fixture`→
+ *  `feeds.winner_to` — and hands the result to `toRuleFixture`, which stays the
+ *  only assignment of `winnerTo` in the codebase. `schedule-ai-repair.test.ts`
+ *  guards that count across all three modules. */
+export function rowToRuleFixture(
+  f: Pick<FixtureLite, "id" | "ext_key" | "pool_id" | "division_id" | "winner_to_fixture">,
+): RuleFixture {
+  return toRuleFixture(
+    { id: f.id, ext_key: f.ext_key, pool: f.pool_id, feeds: { winner_to: f.winner_to_fixture } },
+    f.division_id,
+  );
+}
+
+/** Everything the VERIFIER reads, for the board paths (#447).
+ *
+ *  `toSlotConfig` answers the placer's question ("where may a card go?") and a
+ *  `SlotConfig` is structurally assignable to a `VerifyConfig` with `tz`, `hard`,
+ *  `ruleFixtures` and `restByDivision` all `undefined` — which is exactly why
+ *  handing one straight to `validateAssignments` compiled clean for four call
+ *  sites while dropping every typed rule on the floor.
+ *
+ *  Two of those fields are load-bearing here and both are traps:
+ *
+ *    tz            `validateInstructionRules` wraps its ENTIRE typed-rule block
+ *                  in `if (tz !== undefined)`, on purpose: every rule in it
+ *                  needs a day boundary or a wall-clock time, and bucketing one
+ *                  in UTC would report a violation the organiser never expressed.
+ *                  So carrying the rules WITHOUT the zone is a fix that binds
+ *                  nothing. It is `orgTz`, never `tz` — the org zone governs
+ *                  every temporal boundary (#397), and the division's display
+ *                  override must not move a rule's calendar day.
+ *    ruleFixtures  the feeder→dependent half of `min_rest_minutes` iterates it,
+ *                  and every `terminal`/`ext_key` selector resolves through it.
+ *                  Without it those rules compile, display as enforced, and bind
+ *                  nothing — the same failure shape as #443.
+ *
+ *  No `restByDivision`: that is the JOINT verifier's field, for the one pass per
+ *  division `verifyJoint` runs. These paths verify one division against a fixed
+ *  sibling board, which is a different question.
+ *
+ *  Returns `SlotConfig & VerifyConfig` so the auto pass can hand ONE object to
+ *  both the placer and the verifier. A second builder for the second consumer is
+ *  how the placer and the verifier drift apart. */
+export function toVerifyConfig(
+  settings: ScheduleSettingsOut,
+  /** The division's own fixture rows — `divisionFixtures`, not just the movable
+   *  ones. A selector may name a fixture this run cannot move, and a day cap
+   *  counts every fixture on the day. */
+  fixtures: readonly FixtureLite[],
+  now: number,
+): SlotConfig & VerifyConfig {
+  return {
+    ...toSlotConfig(settings, now),
+    tz: settings.orgTz,
+    ruleFixtures: fixtures.map(rowToRuleFixture),
   };
 }
 
@@ -551,11 +640,12 @@ export async function autoSchedule(
         : {}),
     }));
 
-    const result = slotFixtures({
-      fixtures: schedulable,
-      config: toSlotConfig(settings, roundToMinute(Date.now())),
-      existing: [...obstacles, ...siblings],
-    });
+    // ONE config for both halves of this pass (#447). The placer reads the
+    // `SlotConfig` side, the typed-rule referee below reads the `VerifyConfig`
+    // side, and neither can drift onto a different idea of the rules.
+    const config = toVerifyConfig(settings, all, roundToMinute(Date.now()));
+    const board = [...obstacles, ...siblings];
+    const result = slotFixtures({ fixtures: schedulable, config, existing: board });
     return {
       assignments: result.assignments.map((a) => ({
         fixture_id: a.fixtureId,
@@ -565,7 +655,20 @@ export async function autoSchedule(
       })),
       // No baseline: the auto pass PROPOSES a board rather than editing one, so
       // every conflict in it is this proposal's own doing (#399).
-      conflicts: mapConflicts(result.conflicts),
+      //
+      // `slotFixtures` PLACES; it does not referee typed rules — it reports only
+      // what it could not fit (`no_slot`, `start_window`, a pinned collision).
+      // So a durable rule the placer has no term for would come back clean from
+      // the one surface an organiser uses to build a board. The AI path answers
+      // this the same way: place, then run the referee over the proposal
+      // (`verifyConfig`). Only `validateInstructionRules` is run here, not the
+      // whole verifier, so this proposal reports exactly the typed rules it was
+      // missing and does not start emitting rest/overlap rows the auto pass has
+      // never emitted.
+      conflicts: mapConflicts([
+        ...result.conflicts,
+        ...validateInstructionRules(result.assignments, config, board),
+      ]),
     };
   });
 }
@@ -654,7 +757,9 @@ export async function applySchedule(
       settings.config.matchMinutes,
     );
 
-    const slotConfig = toSlotConfig(settings, 0);
+    // #447: the VERIFY config, so the durable typed rules an organiser stored
+    // are the rules this gate judges by. Warn-only — see `assertNoNewBlocking`.
+    const slotConfig = toVerifyConfig(settings, all, 0);
     const deps = feedDependencies(all);
     const board = [...untouched, ...siblings];
     // The SAME fixtures where they sit right now (#399). Anything the verifier
@@ -876,7 +981,8 @@ export async function moveFixture(
         fixture.competition_id,
         settings.config.matchMinutes,
       );
-      const slotConfig = toSlotConfig(settings, 0);
+      // #447: the dragged card is judged against the durable typed rules too.
+      const slotConfig = toVerifyConfig(settings, all, 0);
       const deps = feedDependencies(all);
       const board = [...others, ...siblings];
       // Where this card sits right now (#399). An unscheduled fixture has no
@@ -1032,7 +1138,10 @@ export async function validateSchedule(
     return {
       conflicts: [
         ...mapConflicts(
-          validateAssignments(assignments, toSlotConfig(settings, 0), siblings, feedDependencies(all)),
+          // #447: `toVerifyConfig`, so the board's own report shows the durable
+          // typed rules the organiser stored — this is the surface the
+          // constraints panel promises them on.
+          validateAssignments(assignments, toVerifyConfig(settings, all, 0), siblings, feedDependencies(all)),
         ),
         ...officialConflicts.map((c) => ({ fixture_id: c.fixture_id, code: c.code as ScheduleConflict["code"], blocking: false })),
       ],

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -261,6 +261,20 @@ function peopleOf(f: FixtureLite, people: Map<string, string[]>): string[] {
   ];
 }
 
+/** A DB fixture row as the engine's `Assignment`.
+ *
+ *  `poolId`/`divisionId` are stamped (#446). They are not decoration: the
+ *  verifier resolves a pool- or division-targeted `restByGroup` and
+ *  `startWindows` entry off exactly these two fields
+ *  (`effectiveRestMinutes`/`startWindowFor`), and the placer resolves the same
+ *  rules off the twin fields on `SchedulableFixture` (built at :523 from the
+ *  same row). Dropping them here is what made a pool rule bind for
+ *  Auto-schedule and evaporate the moment an organiser dragged a card.
+ *
+ *  Optionality follows the `SchedulableFixture` builder exactly: `division_id`
+ *  is NOT NULL so it is always stamped; `pool_id` is nullable and the key is
+ *  omitted rather than set to `undefined`, because `Assignment.poolId` is an
+ *  optional string and the verifier tests it with `!== undefined`. */
 export function toAssignment(f: FixtureLite, matchMinutes: number, people: Map<string, string[]>): Assignment {
   const start = ms(f.scheduled_at as string | Date);
   return {
@@ -270,6 +284,8 @@ export function toAssignment(f: FixtureLite, matchMinutes: number, people: Map<s
     endAt: start + matchMinutes * MS_PER_MIN,
     entrants: [f.home_entrant_id, f.away_entrant_id].filter((e): e is string => e !== null),
     people: peopleOf(f, people),
+    ...(f.pool_id !== null ? { poolId: f.pool_id } : {}),
+    divisionId: f.division_id,
   };
 }
 
@@ -620,6 +636,11 @@ export async function applySchedule(
         endAt: start + settings.config.matchMinutes * MS_PER_MIN,
         entrants: [f.home_entrant_id, f.away_entrant_id].filter((e): e is string => e !== null),
         people: peopleOf(f, people),
+        // #446: the proposed card's own group identity, so a pool- or
+        // division-targeted rule is applied to the placement being judged and
+        // not only to the board it lands on. Same shape as `toAssignment`.
+        ...(f.pool_id !== null ? { poolId: f.pool_id } : {}),
+        divisionId: f.division_id,
       };
     });
     const listed = new Set(input.assignments.map((a) => a.fixture_id));
@@ -839,6 +860,12 @@ export async function moveFixture(
           (e): e is string => e !== null,
         ),
         people: peopleOf(fixture, people),
+        // #446 — this is the drag/keyboard move the issue describes: without
+        // these two the dragged card resolves its rest to `perEntrantMinRest`
+        // and its start bound to (-inf, +inf), so a pool rule the auto pass
+        // honoured is silently absent at exactly the moment a human overrides it.
+        ...(fixture.pool_id !== null ? { poolId: fixture.pool_id } : {}),
+        divisionId: fixture.division_id,
       };
       const others = all
         .filter((f) => f.id !== fixture.id && f.scheduled_at !== null && f.court_label !== null)

--- a/packages/engine/src/scheduling/calendar-shared-semantics.test.ts
+++ b/packages/engine/src/scheduling/calendar-shared-semantics.test.ts
@@ -7,6 +7,7 @@ import {
   effectiveHard,
   intervalsOverlap,
   pairRestMinutes,
+  slotFixtures,
   startWindowFor,
   validateAssignments,
   type Assignment,
@@ -116,6 +117,74 @@ describe("exported rule semantics", () => {
     // Both movable: the verifier evaluates the pair once per assignment, so the
     // strict direction is reached and the max binds.
     expect(validateAssignments([movable, immovable], config).some((c) => c.reason === "rest")).toBe(true);
+  });
+
+  // #446 — the placer's OWN OUTPUT is the input the verifier is handed next
+  // (Auto-schedule places a board, the organiser drags one card, the board is
+  // re-verified). `slotFixtures` resolves `restByGroup` and `startWindows` off
+  // `SchedulableFixture.poolId`; `validateAssignments` resolves the same two
+  // rules off `Assignment.poolId`. If `commit()` drops the field on the way out,
+  // the rule holds while the placer is looking and evaporates the instant
+  // anything re-reads the result — which is the fork this whole file exists for.
+  //
+  // Asserted on a MOVED card, not on the placer's clean board: a lost group id
+  // can only make the verifier LAXER, so a legal board round-trips clean either
+  // way and proves nothing.
+  describe("a placer placement re-read by the verifier (#446)", () => {
+    const t0 = at("2026-08-10T09:00:00Z");
+    const poolConfig = {
+      ...BASE_CONFIG,
+      startAt: t0,
+      courts: ["C1", "C2"],
+      perEntrantMinRest: 30,
+      constraints: {
+        restByGroup: { "pool-a": 180 },
+        startWindows: [{ target: { kind: "pool", id: "pool-a" }, notAfter: t0 + 600 * MIN }],
+        noBackToBack: false,
+        fieldFairness: "off",
+        parallelism: "mixed",
+      } as never,
+    };
+    const place = () =>
+      slotFixtures({
+        fixtures: [
+          { id: "pa-1", roundNo: 0, home: "e1", away: "e2", poolId: "pool-a", divisionId: "d1" },
+          { id: "pa-2", roundNo: 1, home: "e1", away: "e3", poolId: "pool-a", divisionId: "d1" },
+        ],
+        config: poolConfig,
+      });
+
+    it("the placer honours the pool rest and the verifier agrees on the same board", () => {
+      const { assignments, conflicts } = place();
+      expect(conflicts).toEqual([]);
+      expect(assignments).toHaveLength(2);
+      // The placer really did apply the 180, not the 30 default.
+      expect(assignments[1]!.startAt - assignments[0]!.endAt).toBe(180 * MIN);
+      expect(validateAssignments(assignments, poolConfig)).toEqual([]);
+    });
+
+    it("a placed pool card dragged inside the pool rest is a rest conflict", () => {
+      const [first, second] = place().assignments;
+      // 40 minutes after the first ends: clears the 30-minute default, breaches
+      // the 180 the placer itself just enforced. Only `startAt`/`endAt` change —
+      // everything else is the object the placer emitted.
+      const dragged: Assignment = {
+        ...second!,
+        startAt: first!.endAt + 40 * MIN,
+        endAt: first!.endAt + 80 * MIN,
+      };
+      const conflicts = validateAssignments([dragged], poolConfig, [first!]);
+      expect(conflicts.map((c) => c.reason)).toContain("rest");
+    });
+
+    it("a placed pool card dragged past the pool start window is a start_window conflict", () => {
+      const [, second] = place().assignments;
+      const late = t0 + 700 * MIN; // beyond notAfter = t0 + 600
+      const dragged: Assignment = { ...second!, startAt: late, endAt: late + 40 * MIN };
+      expect(startWindowFor(poolConfig, dragged).notAfter).toBe(t0 + 600 * MIN);
+      const conflicts = validateAssignments([dragged], poolConfig);
+      expect(conflicts.map((c) => c.reason)).toContain("start_window");
+    });
   });
 
   // REGRESSION TRIPWIRE, NOT A BENCHMARK. `pairRestMinutes` is called from an

--- a/packages/engine/src/scheduling/calendar-shared-semantics.test.ts
+++ b/packages/engine/src/scheduling/calendar-shared-semantics.test.ts
@@ -187,6 +187,108 @@ describe("exported rule semantics", () => {
     });
   });
 
+  // #447 — a DURABLE `min_rest_minutes` rule is the one rest source the placer
+  // could not see. `validateInstructionRules` skips `rest_scope: "per_person"`
+  // on purpose (it is folded into the rest bound so one short gap is reported
+  // once as `rest`, not twice), and that fold lived only in
+  // `pairRestMinutesWith`. `slotFixtures` resolved rest through
+  // `effectiveRestMinutes`, which reads the settings/constraints family and
+  // never `hard` — so Auto proposed a board the apply gate warned about, and
+  // re-running Auto could not fix it because the placer did not know the rule
+  // existed. Both sides now read `hardRestMinutesFor`.
+  describe("a durable per_person min_rest across the placer/verifier seam (#447)", () => {
+    const t0 = at("2026-08-10T09:00:00Z");
+    const durable = (hard: unknown[]) => ({
+      ...BASE_CONFIG,
+      startAt: t0,
+      courts: ["C1", "C2"],
+      // A 30-minute floor the rule must RAISE — combining by Math.max, never
+      // replacing. Two courts, so nothing but the rest bound can space the pair.
+      perEntrantMinRest: 30,
+      constraints: {
+        hard,
+        noBackToBack: false,
+        startWindows: [],
+        fieldFairness: "off",
+        parallelism: "mixed",
+        crossPersonClash: "warn",
+      } as never,
+    });
+    // The issue's own example, scope by scope. `entrant` is the one that proves
+    // the placer maps `home`/`away` onto the `entrants` the scope switch reads.
+    const COMPETITION = {
+      type: "min_rest_minutes",
+      minutes: 120,
+      rest_scope: "per_person",
+      scope: { kind: "competition" },
+    };
+    const ENTRANT = { ...COMPETITION, scope: { kind: "entrant", entrantId: "e1" } };
+    // The `division` scope is the one that exercises the `f?.divisionId ?? a.divisionId`
+    // fallback `ScopeRow` exists for: `place` passes no `ruleFixtures`, so `f` is
+    // undefined and the scope switch must read the id off the ROW. If a
+    // `SchedulableFixture` ever stopped carrying `divisionId`, only this case fails.
+    const DIVISION = { ...COMPETITION, scope: { kind: "division", divisionId: "d1" } };
+    // Sharing e1 is what makes them a rest pair at all.
+    const fixtures = [
+      { id: "r-1", roundNo: 0, home: "e1", away: "e2", divisionId: "d1" },
+      { id: "r-2", roundNo: 1, home: "e1", away: "e3", divisionId: "d1" },
+    ];
+    const place = (config: ReturnType<typeof durable>) => slotFixtures({ fixtures, config });
+
+    it.each([
+      ["competition-scoped", COMPETITION],
+      ["entrant-scoped", ENTRANT],
+      ["division-scoped", DIVISION],
+    ])("the placer packs to the same number the verifier enforces (%s)", (_label, rule) => {
+      const config = durable([rule]);
+      const { assignments, conflicts } = place(config);
+      expect(conflicts).toEqual([]);
+      expect(assignments).toHaveLength(2);
+      // THE ASSERTION THAT MATTERS: one number, asked of both sides.
+      const verifierBound = pairRestMinutes(config, assignments[0]!, assignments[1]!);
+      expect(verifierBound).toBe(120);
+      expect(assignments[1]!.startAt - assignments[0]!.endAt).toBe(verifierBound * MIN);
+      // And the placer's own output round-trips clean through the verifier —
+      // before this fix it came back with a `rest` conflict the placer could
+      // never resolve, because re-running it proposed the same board again.
+      expect(validateAssignments(assignments, config as VerifyConfig)).toEqual([]);
+    });
+
+    it("raises the stored floor rather than replacing it", () => {
+      // Guard the guard: without the rule the placer packs at the 30-minute
+      // setting, so the 120 above is the rule doing the work and not the
+      // fixture's own spacing. A rule BELOW the floor may not lower it.
+      expect(place(durable([])).assignments[1]!.startAt - place(durable([])).assignments[0]!.endAt).toBe(30 * MIN);
+      const lax = durable([{ ...COMPETITION, minutes: 10 }]);
+      expect(place(lax).assignments[1]!.startAt - place(lax).assignments[0]!.endAt).toBe(30 * MIN);
+    });
+
+    it("still reports the board a placer that ignored the rule would have built", () => {
+      // The pre-fix output, pinned: the two numbers genuinely disagree, so a
+      // placer that skips `hard` hands the verifier a board it rejects. Without
+      // this, a `hardRestMinutesFor` that always returned 0 would satisfy the
+      // round-trip assertion above by making both sides equally blind.
+      const config = durable([COMPETITION]);
+      const [first] = place(config).assignments;
+      const packedAtTheFloor: Assignment[] = [
+        first!,
+        {
+          fixtureId: "r-2",
+          court: "C1",
+          startAt: first!.endAt + 30 * MIN,
+          endAt: first!.endAt + 70 * MIN,
+          entrants: ["e1", "e3"],
+          people: [],
+          divisionId: "d1",
+        },
+      ];
+      expect(
+        validateAssignments(packedAtTheFloor, config as VerifyConfig).map((c) => c.reason),
+      ).toContain("rest");
+    });
+
+  });
+
   // REGRESSION TRIPWIRE, NOT A BENCHMARK. `pairRestMinutes` is called from an
   // O(n²) loop; deriving `effectiveHard` + the ruleFixtures Map INSIDE it made
   // the per-config work quadratic too. The threshold is deliberately far above

--- a/packages/engine/src/scheduling/calendar-shared-semantics.test.ts
+++ b/packages/engine/src/scheduling/calendar-shared-semantics.test.ts
@@ -287,6 +287,52 @@ describe("exported rule semantics", () => {
       ).toContain("rest");
     });
 
+    // #459, owner ruling 2026-08-04: a pool-keyed `restByGroup` entry RAISES the
+    // floor, it does not override its division. Resolved with `??` before, which
+    // made the more specific key win — and made an explicit `0` erase the
+    // division rule outright, because `0 ?? x` is `0`.
+    describe("restByGroup resolves pool and division by max, not precedence (#459)", () => {
+      const grouped = (restByGroup: Record<string, number>) => ({
+        ...BASE_CONFIG,
+        startAt: t0,
+        courts: ["C1", "C2"],
+        perEntrantMinRest: 30,
+        constraints: {
+          restByGroup,
+          noBackToBack: false,
+          startWindows: [],
+          fieldFairness: "off",
+          parallelism: "mixed",
+          crossPersonClash: "warn",
+        } as never,
+      });
+      // Both fixtures sit in pool-a of d1, so BOTH keys match the same pair.
+      const pooled = [
+        { id: "g-1", roundNo: 0, home: "e1", away: "e2", divisionId: "d1", poolId: "pool-a" },
+        { id: "g-2", roundNo: 1, home: "e1", away: "e3", divisionId: "d1", poolId: "pool-a" },
+      ];
+      const gap = (config: ReturnType<typeof grouped>) => {
+        const { assignments } = slotFixtures({ fixtures: pooled, config });
+        expect(assignments).toHaveLength(2);
+        return assignments[1]!.startAt - assignments[0]!.endAt;
+      };
+
+      it.each([
+        ["a laxer pool entry does not lower the division floor", { d1: 180, "pool-a": 45 }, 180],
+        ["a stricter pool entry raises it", { d1: 60, "pool-a": 150 }, 150],
+        // The `??` case: `0` is not nullish, so it USED to win outright and
+        // erase the 180. Under max it contributes nothing, as an explicit
+        // "no extra rest for this pool" should.
+        ["an explicit pool zero adds nothing rather than erasing the division rule", { d1: 180, "pool-a": 0 }, 180],
+      ])("%s", (_label, restByGroup, expected) => {
+        const config = grouped(restByGroup);
+        expect(gap(config)).toBe(expected * MIN);
+        // Placer and verifier must agree — this file exists to fail when they fork.
+        const { assignments } = slotFixtures({ fixtures: pooled, config });
+        expect(pairRestMinutes(config as VerifyConfig, assignments[0]!, assignments[1]!)).toBe(expected);
+        expect(validateAssignments(assignments, config as VerifyConfig)).toEqual([]);
+      });
+    });
   });
 
   // REGRESSION TRIPWIRE, NOT A BENCHMARK. `pairRestMinutes` is called from an

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -90,10 +90,19 @@ export function effectiveRestMinutes(
   const c = config.constraints;
   let minutes = config.perEntrantMinRest;
   if (c?.restMin !== undefined) minutes = Math.max(minutes, c.restMin);
-  const byGroup =
-    (group?.poolId !== undefined ? c?.restByGroup?.[group.poolId] : undefined) ??
-    (group?.divisionId !== undefined ? c?.restByGroup?.[group.divisionId] : undefined);
-  if (byGroup !== undefined) minutes = Math.max(minutes, byGroup);
+  // MAX, not precedence (#459, owner ruling 2026-08-04). A row can match both a
+  // division-keyed and a pool-keyed entry; a pool entry RAISES the floor and
+  // never lowers it, exactly like `restMin` and `noBackToBack` on the lines
+  // either side of this one. Resolving with `??` instead made the pool entry
+  // shadow the division one — and, because `0 ?? x` is `0`, an explicit pool
+  // entry of zero ERASED a division rule rather than adding nothing.
+  //
+  // Nothing in the UI presents a pool rest as an override of its division, so
+  // "most specific wins" would have been a semantics no surface teaches.
+  for (const key of [group?.poolId, group?.divisionId]) {
+    const v = key !== undefined ? c?.restByGroup?.[key] : undefined;
+    if (v !== undefined) minutes = Math.max(minutes, v);
+  }
   // "One fixture between" is only meaningful once we know how long a fixture
   // is; callers that validate without a match length simply don't get it.
   if (c?.noBackToBack && config.matchMinutes !== undefined) {

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -446,6 +446,14 @@ export function slotFixtures(input: SlotInput): SlotResult {
       endAt: start + durMs,
       entrants: ent,
       people: [...(f.people ?? [])],
+      // Carried through, not dropped (#446). `windowFor`/`restForMs` above read
+      // the fixture's pool and division to honour a pool- or division-targeted
+      // `startWindow`/`restByGroup`; `validateAssignments` reads the SAME two
+      // fields off the Assignment. Emitting a placement that has lost them means
+      // feeding the placer's own output back to the verifier flips the verdict —
+      // the placer/verifier fork this module exists to prevent.
+      ...(f.poolId !== undefined ? { poolId: f.poolId } : {}),
+      ...(f.divisionId !== undefined ? { divisionId: f.divisionId } : {}),
     };
     bookings.push(assignment);
     placed.push(assignment);

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -379,7 +379,32 @@ export function slotFixtures(input: SlotInput): SlotResult {
 
   // Jul3/04 §3 — shared with validateAssignments so the placer and the verifier
   // can never drift apart on what "enough rest" means.
-  const restForMs = (f: SchedulableFixture): number => effectiveRestMinutes(config, f) * MS_PER_MIN;
+  //
+  // #447: `effectiveRestMinutes` reads the settings/constraints family only, so
+  // a durable `min_rest_minutes` rule raised the bound the VERIFIER used and not
+  // the one the placer packed to. Auto then proposed a board the apply gate
+  // warned about, and re-running auto could never fix it. `hardRestMinutesFor`
+  // is the verifier's own fold, called here on the one row this pass is placing
+  // — the same single-direction question `pairRestMinutes(config, movable,
+  // immovable)` asks, and the strongest one the placer's per-entrant `lastEnd`
+  // map can answer. Derived once: the rule list does not vary per fixture.
+  const hard = effectiveHard(config);
+  const scopeRowOf = (f: SchedulableFixture): ScopeRow => ({
+    entrants: entrantsOf(f),
+    people: [...(f.people ?? [])],
+    ...(f.poolId !== undefined ? { poolId: f.poolId } : {}),
+    ...(f.divisionId !== undefined ? { divisionId: f.divisionId } : {}),
+  });
+  const restForMs = (f: SchedulableFixture): number =>
+    (hard.length === 0
+      ? effectiveRestMinutes(config, f)
+      : Math.max(
+          effectiveRestMinutes(config, f),
+          // No `RuleFixture` here on purpose: the placer holds none, and
+          // `scopeCoversFixture` falls back to the row's own pool/division,
+          // which is exactly what a `SchedulableFixture` carries.
+          hardRestMinutesFor(hard, undefined, scopeRowOf(f)),
+        )) * MS_PER_MIN;
 
   // startWindows (Jul3/04 §3): hard lower/upper bounds per entrant/pool/division.
   const windowFor = (f: SchedulableFixture): { notBefore: number; notAfter: number } => {
@@ -592,13 +617,21 @@ export type VerifyConfig = Pick<
     restByDivision?: Readonly<Record<string, number>>;
   };
 
+/** Exactly the fields `scopeCoversFixture` reads. Named (#447) so the PLACER can
+ *  ask the same question the verifier does: `slotFixtures` holds
+ *  `SchedulableFixture`s, which carry the same four facts under `home`/`away`
+ *  rather than `entrants`, and an `Assignment` it has not built yet is not
+ *  available to it. Widening the parameter rather than duplicating the switch is
+ *  what keeps one definition of "does this rule bind this row". */
+export type ScopeRow = Pick<Assignment, "entrants" | "people" | "poolId" | "divisionId">;
+
 /** Does a scoped rule bind this assignment? `person` is the bridge that makes
  *  person-scoped rules expressible at all: `people` is participants (#396), so a
  *  rule about a human reaches the TBD slots they can still advance into. */
 export function scopeCoversFixture(
   scope: ConstraintScope,
   f: RuleFixture | undefined,
-  a: Assignment,
+  a: ScopeRow,
 ): boolean {
   switch (scope.kind) {
     case "competition":
@@ -669,6 +702,46 @@ export function effectiveHard(config: Pick<VerifyConfig, "hard" | "constraints">
   if (stored.length === 0) return compiled;
   if (compiled.length === 0) return stored;
   return [...compiled, ...stored];
+}
+
+/** The rest, in minutes, that the typed rules demand of ONE row.
+ *
+ *  THE PLACER AND THE VERIFIER MUST BOTH READ THIS (#447). `min_rest_minutes`
+ *  with `rest_scope: "per_person"` is deliberately absent from
+ *  `validateInstructionRules` — it is folded into the rest bound instead, so one
+ *  too-short gap is reported once as `rest` and not twice. That fold used to
+ *  live only in `pairRestMinutesWith`, i.e. only in the verifier, while
+ *  `slotFixtures` resolved rest through `effectiveRestMinutes`, which never
+ *  reads `hard`. So the auto pass proposed a board the apply gate immediately
+ *  warned about and re-running auto could not fix it: the placer did not know
+ *  the rule existed. That is a placer/verifier fork, the exact failure
+ *  `calendar-shared-semantics.test.ts` exists to catch.
+ *
+ *  `feeder_to_dependent` is excluded because that half IS reported as its own
+ *  `instruction` rule (it has no rest bound to hide inside); `both` is included,
+ *  since it carries the per-person half too.
+ *
+ *  A lower bound only — every caller combines it with `Math.max`. "At least N
+ *  minutes" may raise a stored setting, never lower it.
+ *
+ *  SCOPE OF THE PLACER HALF, so nobody reads more into it than is there: the
+ *  placer keys `lastEnd` by `EntrantId`, so it applies this bound only to pairs
+ *  that share an ENTRANT. A pair sharing a PERSON but no entrant — which is
+ *  precisely what `validateAssignments` reports below — and any pair against
+ *  `existing` (other divisions' cards, obstacles) are still placer-blind, so
+ *  the auto pass can still propose a board the gate warns about for those.
+ *  Tracked in #463; the verifier half has always covered both. */
+export function hardRestMinutesFor(
+  hard: readonly HardConstraint[],
+  f: RuleFixture | undefined,
+  row: ScopeRow,
+): number {
+  let minutes = 0;
+  for (const h of hard) {
+    if (h.type !== "min_rest_minutes" || h.rest_scope === "feeder_to_dependent") continue;
+    if (scopeCoversFixture(h.scope, f, row)) minutes = Math.max(minutes, h.minutes);
+  }
+  return minutes;
 }
 
 export function validateInstructionRules(
@@ -902,14 +975,23 @@ function pairRestMinutesWith(
   if (otherDivision !== undefined) {
     minutes = Math.max(minutes, config.restByDivision?.[otherDivision] ?? 0);
   }
-  for (const h of hard) {
-    if (h.type !== "min_rest_minutes" || h.rest_scope === "feeder_to_dependent") continue;
-    const covers =
-      scopeCoversFixture(h.scope, fixtureById.get(a.fixtureId), a) ||
-      scopeCoversFixture(h.scope, fixtureById.get(other.fixtureId), other);
-    if (covers) minutes = Math.max(minutes, h.minutes);
-  }
-  return minutes;
+  // THE HOT PATH. This runs once per PAIR — 125k times on the 500-fixture cap —
+  // and the overwhelmingly common case is no typed rules at all. The old inline
+  // `for (const h of hard)` did nothing when `hard` was empty; extracting the
+  // body into a function turned that into two calls and two Map lookups per
+  // pair, which put `repair-scale`'s budget bench over its 7000 ms line. Keep
+  // the early return.
+  if (hard.length === 0) return minutes;
+  // A PAIR is covered when EITHER side is — the same disjunction this loop
+  // always applied, now expressed as the max of the two per-row answers so the
+  // placer can ask for one of them on its own (#447). `hardRestMinutesFor` is
+  // the single definition; nothing here may grow a second copy of the scope
+  // walk, which is how the placer and the verifier forked in the first place.
+  return Math.max(
+    minutes,
+    hardRestMinutesFor(hard, fixtureById.get(a.fixtureId), a),
+    hardRestMinutesFor(hard, fixtureById.get(other.fixtureId), other),
+  );
 }
 
 /** The start bounds `startWindows` impose on an assignment. Exported (#401) so


### PR DESCRIPTION
Three defects in one seam, all "the organiser sets a rule, the product agrees it exists, and then does not enforce it". They ship together because each one is what made the next reachable.

Follows #456 and #457 (the W6 repair follow-ups), same bug class: **a value that exists on one side of a seam and is silently absent on the other.**

## #446 — no adapter stamped `Assignment.poolId` / `divisionId`

The verifier reads both to decide whether a pool- or division-targeted `startWindow` or `restByGroup` covers a card. Nothing stamped them. `SchedulableFixture` carried both and the placer read them — so a group-targeted rule **bound in the placer and evaporated in the verifier**.

An organiser could set a 180-minute rest for one pool, watch auto-schedule honour it, drag a card to a 40-minute turnaround, and get no conflict, no badge, and an accepted write.

The sharper half was in the engine, not the adapters: `slotFixtures`' `commit()` dropped both fields from the placer's **own output**, so feeding a placement straight back to the verifier flipped the verdict — the exact placer/verifier fork that module exists to prevent.

Stamped at the shared `toAssignment` builder (transitively covering the siblings, untouched and current paths in two other files) and at the AI and joint adapters. All 13 construction sites that reach a verifier now carry both.

**Obstacles are deliberately NOT stamped**, reasoned at each site: they carry no entrants and no people, `startWindowFor` runs over `assignments` only, and `validateInstructionRules` filters `existing` to known fixtures whose `RuleFixture` ids win anyway. Stamping is inert today and would, the day some rule reads `existing`, apply a division rule to an out-of-run booking whose `division_id` is null.

## #447 — `toSlotConfig` dropped durable `constraints.hard`

`toSlotConfig` returns a `SlotConfig`; `validateAssignments` takes a `VerifyConfig`, which is a `Pick` of `SlotConfig` **plus** `tz`, `hard`, `ruleFixtures`, `restByDivision`. A `SlotConfig` is structurally assignable with all four `undefined` — which is why this compiled clean for a whole wave.

Result: a durable typed rule was enforced on the AI Schedule path and on none of the other four.

`validateAssignments` already calls `validateInstructionRules`, so the fix is config plumbing, not new call sites — a `toVerifyConfig` at auto-schedule, the apply gate, drag-validate and the conflict report.

Two things that would have made this a silent no-op, and are covered by tests for that reason:

- **`tz` is not optional.** `validateInstructionRules` wraps its whole typed-rule block in `if (tz !== undefined)`. Carrying `hard` without it binds nothing while looking correct.
- **`ruleFixtures` is needed for the feeder half.** Built through the one existing producer — `toRuleFixture` takes a widened `RuleFixtureSource` and `schedule.ts` **delegates** rather than adding a second producer. There is still exactly one `winnerTo:` assignment in the codebase.

### The placer half

Review round 1 caught that #447's **own worked example** was still unbound. A `min_rest_minutes` with `rest_scope: "per_person"` is absent from `validateInstructionRules` by design — it is folded into the rest bound so one short gap reports once, not twice. That fold lived only in the verifier, while `slotFixtures` used `effectiveRestMinutes`, which never reads `hard`.

Binding the rule without fixing that would have made auto-schedule propose a board the apply gate immediately warns about, that re-running auto could never fix.

So the fold is extracted to `hardRestMinutesFor` and **both sides read that one definition**. Review round 2 verified the per-side refactor algebraically: the old code maximised over `{h : coversA ∨ coversB}`, the new over `max(max S_A, max S_B)`; those index sets are `S_A ∪ S_B` and max distributes over union.

Placement is otherwise untouched — `h.type !== "min_rest_minutes"` is the first test in the fold, so no day cap or wall-clock rule can leak into a rest bound.

## #459 — `restByGroup` resolved pool vs division by precedence

`??`, first match wins, while every other rest source in the same function used `Math.max`. `{ division: 180, pool: 45 }` gave 45 and discarded the division floor. Worse, `{ division: 180, pool: 0 }` gave **0**, because `0 ?? x` is `0` — a pool entry of zero erased a division rule.

Owner ruled MAX. Not a regression: before #446 no `Assignment` carried a group id, so this branch was dead on every apps/web path. Stamping the fields is what made it live, which is why it is fixed in the branch that made it reachable.

## Not blocking, by construction

These conflicts are warn-only: `isBlockingConflict` covers `court`, `person_overlap`, `window` and direct `order` — not `instruction` — and the apply gate is a *delta* gate on top of that. **No organiser with an existing board can be locked out of saving.** They gain badges, not a 409. Verified live: apply returns `applied: 6` alongside 6 non-blocking conflicts.

## Verification

| gate | result |
|---|---|
| engine | 2113 pass, 0 fail, 1 pending |
| apps/web | 5213 pass, 0 fail, **50 pending** (the tell that the DB suites ran) |
| tsc | clean, both packages |
| lint | 0 errors, 79 warnings — identical to main's baseline |
| openapi drift | 0 |

Two apps/web suites (`credits-bootstrap-grant`, `credits-monthly-cron`) and `roundrobin.test.ts` fail under machine load with a bare `STACK_TRACE_ERROR` and no assertion text — the vitest timeout signature. Re-run on a quiet box (83–89% measured idle): 14/14 and 9/9. Neither file is touched by this branch.

Every new test was proven red without its fix by reverting source only (never `git stash` — the stash stack is shared with the main checkout here). Sample pre-fix output: `expected undefined to be '2222…'`, `expected [] to include 'rest'`, `expected 1800000 to be 7200000` (the placer packing at the 30-minute floor instead of the 120-minute rule), `expected 2700000 to be 10800000` (#459's laxer-pool case).

Each commit is green in isolation.

## Known gaps, filed rather than widened into this PR

- **#463** — the placer fold reaches only entrant-shared pairs (`lastEnd` is keyed by `EntrantId`), so a `per_person` rule between fixtures sharing a person but no entrant is still placer-blind; and the greedy pass still cannot place around day caps or wall-clock windows.
- **#461** — the drag path computes conflicts and discards them.
- **#462** — a competition-scoped day cap undercounts cross-division fixtures.
- **#458** — `verifyConfig` pins `startWindows: []`, so the single-division AI path is blind to every start window. This PR asserts the pin rather than working around it, so it cannot be silently "fixed" by a comment drifting out of date.

## No e2e or smoke coverage, honestly

`scripts/smoke.ts` drives `schedule-settings` PUTs but contains zero `constraints` occurrences and has no pool-bearing division, so neither fix is reachable there. No UI anywhere writes `constraints.hard` — the field is API-only — so e2e would need new seeded fixtures. Tracked as **#452**. The e2e workflow is untouched and stays disabled.