### PR TITLE
Coverage for the rules an organiser actually stored: smoke + e2e for the scheduling constraint surface (#452)

### DIFF
--- a/apps/web/e2e/ai-architect.spec.ts
+++ b/apps/web/e2e/ai-architect.spec.ts
@@ -14,6 +14,8 @@ import {
 import {
   startAiFixtureServer,
   FIXTURE_CLASH,
+  FIXTURE_CLASH_SECONDS,
+  FIXTURE_CLASH_OFFSET_MS,
   FIXTURE_REFUSE,
   FIXTURE_COMPILE_BRIEF,
   FIXTURE_COMPILE_SOFT,
@@ -971,6 +973,102 @@ test("a double-booked plan is repaired by the solver before the organiser sees i
   );
   expect(overflow).toBeLessThanOrEqual(0);
   await shot(page, "13-repair-strip-375");
+});
+
+/**
+ * #452 — the same repair, on a board that is not on the minute grid.
+ *
+ * The test above cannot reach this. Every instant the deterministic draft
+ * produces is minute-aligned, so the encoder's minutes and the verifier's
+ * milliseconds agree on that board by construction — which is precisely why
+ * #457 (an obstacle ending at 10:00:20 rounded DOWN to 10:00, letting z3 permit
+ * a 20-second overlap the verifier rejects) shipped past a green suite.
+ * `FIXTURE_CLASH_SECONDS` pushes the four cards that are NOT in the clash off
+ * the minute, so the card the solver has to move is routed around real
+ * sub-minute occupancy; see that constant for why it is those cards and not
+ * the clashing pair.
+ *
+ * What this pins that nothing else does: sub-minute instants crossing every
+ * layer of the real stack — model plan → engine verifier → z3 repair → the
+ * repair's own re-verification → the apply gate → `timestamptz`. A repair whose
+ * encoding drifts does not come back merely wrong; `repairAndVerify` throws
+ * `RepairVerificationError` and the run drops through to the PAID LLM repair
+ * round, so both the CLEAN board and the "exactly one schedule call" assertion
+ * below are load-bearing.
+ *
+ * HONEST LIMIT, so nobody over-claims this later: it is not proven that this
+ * board would have gone red on the pre-#457 encoder. z3 is free to choose any
+ * minimal repair, and only some of those choices put the moved card adjacent
+ * enough to a rounded obstacle for the old `roundMin` to matter. What IS true
+ * is that no minute-aligned board can go red on it at all, so this is the first
+ * e2e that can.
+ *
+ * Deliberately kept ALONGSIDE the whole-minute test rather than replacing it:
+ * that one is the minimal-repair proof on a wholly aligned board, and the two
+ * agreeing on `data-moved="1"` / `proved` is itself an assertion.
+ */
+test("a clash off the minute boundary is repaired without losing its seconds (#452)", async ({
+  page,
+  request,
+}) => {
+  fixture.reset();
+  await activateFreshProPlusOrg(page, request);
+  const { divisionId } = await seedAiDivision(request);
+
+  await page.goto(`/divisions/${divisionId}/schedule?tab=board`);
+  await openConsole(page);
+
+  await page.locator("#ai-instruction").fill(`${FIXTURE_CLASH_SECONDS} — squeeze the order.`);
+  await compileAndConfirm(page);
+
+  // Same organiser-facing outcome as the whole-minute case. If the encoder and
+  // the verifier disagree about the extra 20 seconds, the solver's answer fails
+  // its own re-verification and this never renders.
+  await expect(page.getByText(/CLEAN · 0 blocking/)).toBeVisible({ timeout: 30_000 });
+  const strip = page.locator('[data-testid="ai-repair-strip"]');
+  await expect(strip).toBeVisible();
+  // The SAME verdict the whole-minute clash produces — one move, proved minimal,
+  // nothing given up. That parity is the point: putting four off-minute cards on
+  // the board must not degrade the repair. (It does when the CLASH pair is the
+  // off-minute one: measured `data-moved="2"`, `data-minimality="upper_bound"`.
+  // See `FIXTURE_CLASH_SECONDS`.)
+  await expect(strip).toHaveAttribute("data-moved", "1");
+  await expect(strip).toHaveAttribute("data-minimality", "proved");
+  await expect(strip).toHaveAttribute("data-unresolved", "0");
+  await shot(page, "14-repair-strip-offminute");
+
+  // One schedule call. A repair that failed verification is not a silent
+  // downgrade — it costs a second, chargeable model round, so this is the
+  // assertion that separates "the solver answered" from "the solver was
+  // overruled".
+  expect(fixture.calls.filter((c) => c.phase === "schedule").length).toBe(1);
+
+  // Through the apply gate and into the column, because a truncation anywhere
+  // downstream would be invisible on the board (which renders to the minute).
+  // "Skip to apply", not "Review & apply": this division seeds no officials, so
+  // the officials step is skipped and its own onward button never renders.
+  await page.getByRole("button", { name: "Skip to apply" }).click();
+  await page.getByRole("button", { name: "Apply schedule only" }).click();
+  await expect(page.getByText("Applied. The board is updated.")).toBeVisible({ timeout: 20_000 });
+
+  const placed = (await getFixtureScheduleSources(divisionId)).filter(
+    (r) => r.scheduled_at !== null,
+  );
+  expect(placed).toHaveLength(6);
+  const seconds = placed.map((r) => new Date(r.scheduled_at!).getUTCSeconds());
+  const offMinute = FIXTURE_CLASH_OFFSET_MS / 1000;
+  // FOUR off-minute cards in, four out. The fixture server offsets every draft
+  // card from the third on; none of them is in the clash, so a minimal repair
+  // leaves all four exactly where they were, to the millisecond. Fewer than four
+  // means something between the model and the `timestamptz` column truncated to
+  // the minute — the failure #457 was about, and the one no minute-aligned
+  // board can show.
+  expect(seconds.filter((s) => s === offMinute)).toHaveLength(4);
+  // The clash pair: one card never moved, one was repaired back onto the minute
+  // grid. Pinned so a future fixture-server edit that started offsetting the
+  // pair too (which measurably costs the minimal repair) fails here rather than
+  // quietly changing what this test covers.
+  expect(seconds.filter((s) => s === 0)).toHaveLength(2);
 });
 
 test("blackout injected over a scheduled fixture surfaces the repair nudge", async ({

--- a/apps/web/e2e/ai-fixture-server.ts
+++ b/apps/web/e2e/ai-fixture-server.ts
@@ -74,6 +74,53 @@ export const FIXTURE_REFUSE = "FIXTURE_REFUSE";
 export const FIXTURE_CLASH = "FIXTURE_CLASH";
 
 /**
+ * #452 — the same clash, on a board whose OTHER cards sit off the minute.
+ *
+ * Every instant the deterministic draft produces is minute-aligned, so
+ * `FIXTURE_CLASH` can only ever build a board on which the repair encoder's
+ * minutes and `validateAssignments`'s milliseconds agree by construction. That
+ * is precisely the blind spot #457 lived in: an obstacle ending at 10:00:20
+ * rounded DOWN to 10:00, so z3 permitted a start that overlapped it by twenty
+ * seconds and the verifier rejected the board the solver had just proved clean.
+ * No minute-aligned board can express that disagreement.
+ *
+ * WHAT IS OFFSET, AND WHY IT IS NOT THE CLASH PAIR. The clash stays byte-for-byte
+ * what `FIXTURE_CLASH` produces; every draft card FROM THE THIRD ON is shifted
+ * instead. Two reasons, both measured rather than assumed:
+ *
+ *   * The cards that are not in the clash have no reason to move, so they are
+ *     what the solver has to route the repaired card AROUND — the obstacle
+ *     rounding that #457 was actually about. They also come out the far end
+ *     still carrying their seconds, which is what makes the spec's assertion on
+ *     the applied board deterministic rather than a coin flip on which of two
+ *     interchangeable cards z3 picked.
+ *   * Offsetting the clash pair itself was tried first and is worse in a way
+ *     worth recording: the board then repairs with `data-moved="2"` and
+ *     `data-minimality="upper_bound"` (both clash cards land in the free tail
+ *     of the day, minute-aligned, and no sub-minute value survives at all),
+ *     where the whole-minute clash proves a single move. So that variant tests
+ *     neither minimal repair nor sub-minute survival.
+ *
+ * Sub-minute instants are reachable from the product, not invented here:
+ * `AddFixture.scheduled_at` is a client-supplied RFC-3339 string with no
+ * seconds restriction, the single-move PATCH stores it verbatim, and the AI
+ * usecase feeds `Date.parse` straight into `Assignment.startAt`.
+ *
+ * The sentinel deliberately CONTAINS `FIXTURE_CLASH`, so a body carrying it
+ * takes the clash path too; the offset is the only difference.
+ */
+export const FIXTURE_CLASH_SECONDS = `${FIXTURE_CLASH}_SECONDS`;
+
+/** How far off the minute `FIXTURE_CLASH_SECONDS` pushes the non-clashing cards.
+ *  Small enough that it moves no minute bucket, weekday or day boundary — the
+ *  only thing under test is the sub-minute remainder itself. */
+export const FIXTURE_CLASH_OFFSET_MS = 20_000;
+
+/** The first draft index `FIXTURE_CLASH_OFFSET_MS` applies to. 0 and 1 are the
+ *  clash pair and are left exactly where `FIXTURE_CLASH` puts them. */
+const CLASH_OFFSET_FROM_INDEX = 2;
+
+/**
  * W5 (#400) — the one brief this server actually COMPILES.
  *
  * Stage 1 is a model call like any other, so against the canned `{}` below
@@ -135,7 +182,7 @@ interface ParseRequestLite {
   context?: { divisions?: unknown[] };
 }
 
-function buildSchedulePlan(pack: SchedulePackLite, clash = false): unknown {
+function buildSchedulePlan(pack: SchedulePackLite, clashOffsetMs: number | null = null): unknown {
   const draft = Array.isArray(pack.draft) ? pack.draft : [];
   const assignments = draft.map((d) => ({
     fixture_id: d.fixture_id,
@@ -146,12 +193,26 @@ function buildSchedulePlan(pack: SchedulePackLite, clash = false): unknown {
   // `court` conflict, on a board whose remaining slots are free — so the minimal
   // repair is a single move, and a solver that moved more than one fixture is
   // visibly wrong rather than merely slower.
-  if (clash && assignments.length >= 2) {
+  //
+  if (clashOffsetMs !== null && assignments.length >= 2) {
     assignments[1] = {
       ...assignments[1]!,
       scheduled_at: assignments[0]!.scheduled_at,
       court_label: assignments[0]!.court_label,
     };
+    // #452: the rest of the board goes off the minute, leaving the clash exactly
+    // where it was. See `FIXTURE_CLASH_SECONDS` for why it is these cards and
+    // not the clashing pair. `clashOffsetMs === 0` touches nothing, so
+    // `FIXTURE_CLASH` behaviour is unchanged rather than round-tripped
+    // through Date.
+    if (clashOffsetMs > 0) {
+      for (let i = CLASH_OFFSET_FROM_INDEX; i < assignments.length; i++) {
+        assignments[i] = {
+          ...assignments[i]!,
+          scheduled_at: new Date(Date.parse(assignments[i]!.scheduled_at) + clashOffsetMs).toISOString(),
+        };
+      }
+    }
   }
   const placed = new Set(assignments.map((a) => a.fixture_id));
   const movable = !Array.isArray(pack.fixtures) && pack.fixtures?.movable ? pack.fixtures.movable : [];
@@ -231,7 +292,9 @@ interface GeneratedPlan {
 function generatePlan(
   body: { model?: string; messages?: { role?: string; content?: unknown }[] },
   fallbackModel: string,
-  clash = false,
+  /** null = no clash; 0 = the whole-minute clash; >0 = that many ms off the
+   *  minute (#452). */
+  clashOffsetMs: number | null = null,
 ): GeneratedPlan {
   let phase: FixtureCall["phase"] = "unknown";
   const model = body.model ?? fallbackModel;
@@ -253,7 +316,7 @@ function generatePlan(
     } else {
       phase = "schedule";
       movable = pack.fixtures?.movable?.length ?? 0;
-      plan = buildSchedulePlan(pack as SchedulePackLite, clash);
+      plan = buildSchedulePlan(pack as SchedulePackLite, clashOffsetMs);
     }
   } catch {
     /* leave defaults; a malformed pack becomes an empty-plan response */
@@ -284,10 +347,19 @@ export async function startAiFixtureServer(port = AI_FIXTURE_PORT): Promise<AiFi
       } catch {
         /* malformed body becomes an empty-plan response, same as before */
       }
+      // Order matters: `FIXTURE_CLASH_SECONDS` contains `FIXTURE_CLASH`, so the
+      // more specific sentinel has to be tested first or every off-minute run
+      // silently degrades to the whole-minute clash and passes for the wrong
+      // reason.
+      const clashOffsetMs = raw.includes(FIXTURE_CLASH_SECONDS)
+        ? FIXTURE_CLASH_OFFSET_MS
+        : raw.includes(FIXTURE_CLASH)
+          ? 0
+          : null;
       const { phase, model, plan, movable } = generatePlan(
         body,
         isAnthropic ? "claude-sonnet-5" : "anthropic/claude-sonnet-5",
-        raw.includes(FIXTURE_CLASH),
+        clashOffsetMs,
       );
       const planLike = plan as { assignments?: unknown[] } | null;
       calls.push({ phase, refusal, movable, assignments: planLike?.assignments?.length ?? 0 });

--- a/apps/web/e2e/scheduling-constraints.spec.ts
+++ b/apps/web/e2e/scheduling-constraints.spec.ts
@@ -1,0 +1,321 @@
+import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+import { TAG, apiJson, addEntrantsViaApi } from "./helpers";
+
+/**
+ * The scheduling rules an organiser STORES, proven on the board (#452).
+ *
+ * Why this file exists at all. Four defects — #443, #446, #447 and the #457
+ * repair rounding — shipped past a fully green suite, and every one of them had
+ * the same shape: a rule that compiles, displays as enforced, and binds
+ * nothing. None was reachable from e2e, for two structural reasons:
+ *
+ *   1. **No UI writes `constraints.hard`.** Verified again while writing this
+ *      file: `grep -a -rn "constraints.hard"` over `src/components` and
+ *      `src/app` returns nothing. `constraints-panel.tsx` writes
+ *      `crossPersonClash: "hard" | "warn"`, a different field entirely. So the
+ *      rule has to be seeded through `PUT /api/v1/divisions/{id}/schedule-settings`
+ *      and then ASSERTED on what the board renders. That split is deliberate:
+ *      an API-only assertion would re-test the same usecase the unit suite
+ *      already covers, and the surface the organiser is actually promised is
+ *      the board's conflicts badge.
+ *   2. **No spec created a pool-bearing stage.** `kind: "group"` with
+ *      `config.pools.count > 1` is the only kind that writes `fixtures.pool_id`,
+ *      and until this file nothing in `e2e/` created one — so a pool-targeted
+ *      rule (#446) was unreachable.
+ *
+ * EVERY TEST HERE IS TWO-SIDED, and that is the whole design. A one-sided
+ * "the badge appears" assertion is satisfied by a rule that binds nothing as
+ * long as SOMETHING else on the board conflicts, and it is satisfied by a
+ * board-wide rest floor that ignores the rule's scope entirely. So each test
+ * renders the SAME board twice and changes exactly one thing — the stored rule
+ * — and requires the badge to follow it in both directions.
+ *
+ * These conflicts are WARN-ONLY by design (`isBlockingConflict` in
+ * packages/engine/src/scheduling/calendar.ts covers `court`, `person_overlap`,
+ * `window` and direct `order` — not `rest`, not `instruction`). So nothing here
+ * asserts a refused save, and each test additionally pins that no RED row
+ * appears: a rest rule that started blocking writes would be a regression this
+ * file should fail on.
+ */
+
+/** Mon 12 Oct 2026, 09:00 UTC — a fixed weekday instant so nothing here can
+ *  drift with the calendar. */
+const START = Date.UTC(2026, 9, 12, 9, 0);
+const MATCH_MINUTES = 45;
+const MIN = 60_000;
+
+/** Enough rest that a back-to-back pair cannot possibly satisfy it, and far
+ *  enough from any core setting that a stray default cannot supply it. */
+const REST_MINUTES = 240;
+
+interface FixtureRow {
+  id: string;
+  pool_id: string | null;
+  home_entrant_id: string | null;
+  away_entrant_id: string | null;
+}
+
+const rand = () => Math.random().toString(36).slice(2, 6);
+
+/** A private competition + one generic division, its entrants, and one stage's
+ *  generated fixtures. Returns the FULL fixture rows, not just ids: the pool
+ *  test needs `pool_id` and both tests need the entrant pair. */
+async function seedDivision(
+  request: APIRequestContext,
+  opts: {
+    entrants: string[];
+    stage: { kind: string; name: string; config?: Record<string, unknown> };
+  },
+): Promise<{ divisionId: string; stageId: string; fixtures: FixtureRow[] }> {
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Constraints ${TAG}-${rand()}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    {
+      name: "Constraints",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    },
+  );
+  const divisionId = div.data!.id;
+  await addEntrantsViaApi(request, divisionId, opts.entrants);
+  const stage = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/divisions/${divisionId}/stages`,
+    "POST",
+    { seq: 1, ...opts.stage },
+  );
+  const stageId = stage.data!.id;
+  const gen = await apiJson<{ fixtures: FixtureRow[] }>(
+    request,
+    `/api/v1/stages/${stageId}/generate`,
+    "POST",
+  );
+  expect(gen.status).toBeLessThan(300);
+  return { divisionId, stageId, fixtures: gen.data?.fixtures ?? [] };
+}
+
+/**
+ * The board's calendar inputs, with `constraints` as the ONLY variable.
+ *
+ * `perEntrantMinRest: 0` is load-bearing. It is the one setting that can
+ * produce a `rest` conflict without any stored rule at all, so leaving it at
+ * zero means a rest row on this board has exactly one possible author: the
+ * `constraints` object passed in here.
+ */
+async function putSettings(
+  request: APIRequestContext,
+  divisionId: string,
+  constraints: Record<string, unknown>,
+): Promise<void> {
+  const res = await apiJson(request, `/api/v1/divisions/${divisionId}/schedule-settings`, "PUT", {
+    tz: "UTC",
+    config: {
+      startAt: new Date(START).toISOString(),
+      matchMinutes: MATCH_MINUTES,
+      gapMinutes: 0,
+      courts: ["Court A", "Court B"],
+      perEntrantMinRest: 0,
+      blackouts: [],
+      sessionWindows: [],
+      constraints,
+    },
+  });
+  // A 402 here means the org lost `scheduling.constraints` and the whole file
+  // would then "pass" its negative halves for the wrong reason.
+  expect(res.status, "schedule-settings PUT must be accepted").toBe(200);
+}
+
+/** Two fixtures that share an entrant, butted end-to-start on DIFFERENT courts.
+ *  Different courts on purpose: same court + same time is a `court` clash,
+ *  which blocks, and would mask the warn-only rest row this file is about. */
+async function placeBackToBack(
+  request: APIRequestContext,
+  stageId: string,
+  pair: [FixtureRow, FixtureRow],
+): Promise<void> {
+  const res = await apiJson<{ applied: number }>(
+    request,
+    `/api/v1/stages/${stageId}/schedule/apply`,
+    "POST",
+    {
+      assignments: [
+        {
+          fixture_id: pair[0].id,
+          scheduled_at: new Date(START).toISOString(),
+          court_label: "Court A",
+        },
+        {
+          fixture_id: pair[1].id,
+          scheduled_at: new Date(START + MATCH_MINUTES * MIN).toISOString(),
+          court_label: "Court B",
+        },
+      ],
+      source: "manual",
+    },
+  );
+  expect(res.status, "a warn-only board must still apply").toBe(200);
+  expect(res.data!.applied).toBe(2);
+}
+
+/** Two fixtures sharing an entrant, optionally restricted to one pool. */
+function sharedEntrantPair(fixtures: FixtureRow[], poolId?: string): [FixtureRow, FixtureRow] {
+  const pool = poolId === undefined ? fixtures : fixtures.filter((f) => f.pool_id === poolId);
+  for (const a of pool) {
+    const ents = [a.home_entrant_id, a.away_entrant_id].filter((e): e is string => e !== null);
+    for (const b of pool) {
+      if (b.id === a.id) continue;
+      if (ents.some((e) => e === b.home_entrant_id || e === b.away_entrant_id)) return [a, b];
+    }
+  }
+  throw new Error("seed produced no two fixtures sharing an entrant");
+}
+
+/**
+ * The conflicts badge and its panel.
+ *
+ * Located by ARIA role + accessible name, matching the convention board-v3.spec
+ * already uses — `conflicts-panel.tsx` exposes no `data-*` state at all, so
+ * there is nothing more stable to hold onto here (noted in the #452 report; a
+ * `data-conflict-code` hook would let every assertion below drop the copy).
+ * Everything the tests actually MEASURE — how many rows, and whether any is
+ * blocking — is read structurally rather than from rendered English.
+ */
+const badge = (page: Page) => page.getByRole("button", { name: /conflicts? — open the list/ });
+const panel = (page: Page) => page.getByRole("region", { name: "Schedule conflicts" });
+
+/**
+ * The board is up, and it is showing the fixtures we seeded.
+ *
+ * Every "no badge" assertion below is an ABSENCE, and an absence is satisfied
+ * by a page that failed to render, by a 404, and by a redirect to the org
+ * picker. So each one is anchored on a name this test itself chose — product
+ * copy could change, `Ada` cannot.
+ */
+async function openBoard(page: Page, divisionId: string, anchorEntrant: string): Promise<void> {
+  await page.goto(`/divisions/${divisionId}/schedule?tab=board`);
+  await expect(page.getByText(anchorEntrant).first()).toBeVisible({ timeout: 20_000 });
+}
+
+test("a durable min_rest_minutes rule the API stored binds on the board — and only when stored (#447)", async ({
+  page,
+  request,
+}) => {
+  const { divisionId, stageId, fixtures } = await seedDivision(request, {
+    entrants: ["Ada", "Bay", "Cy", "Dot"],
+    stage: { kind: "league", name: "League" },
+  });
+  expect(fixtures).toHaveLength(6);
+  const pair = sharedEntrantPair(fixtures);
+
+  // ---- Direction 1: the rule is NOT stored. -------------------------------
+  // Same board, same zero rest between the same two cards. If this half shows
+  // a conflict then the board has some other reason to complain and direction
+  // 2 proves nothing about the rule.
+  await putSettings(request, divisionId, { hard: [] });
+  await placeBackToBack(request, stageId, pair);
+  await openBoard(page, divisionId, "Ada");
+  await expect(badge(page)).toHaveCount(0);
+
+  // ---- Direction 2: store the rule, change nothing else. ------------------
+  // `min_rest_minutes` / `per_person` is deliberately folded into the rest
+  // bound rather than reported as its own rule (calendar.ts,
+  // `hardRestMinutesFor`), so the row this raises is `rest` — the SAME code
+  // `perEntrantMinRest` produces. That is exactly why direction 1 has to pin
+  // `perEntrantMinRest: 0`: it is what makes the row unambiguously the stored
+  // rule's doing.
+  await putSettings(request, divisionId, {
+    hard: [
+      {
+        type: "min_rest_minutes",
+        minutes: REST_MINUTES,
+        rest_scope: "per_person",
+        scope: { kind: "division", divisionId },
+      },
+    ],
+  });
+  await openBoard(page, divisionId, "Ada");
+  await expect(badge(page)).toBeVisible({ timeout: 20_000 });
+
+  await badge(page).click();
+  const list = panel(page);
+  await expect(list).toBeVisible();
+  // TWO rows, not one: `validateAssignments` walks ordered pairs and reports
+  // the shortfall on each side, so one too-short gap is one row per card. The
+  // exact number is pinned rather than `>= 1` because it is also the assertion
+  // that the rule bound the PAIR and not the whole board — six fixtures are
+  // seeded and only two are placed, and a rule that had escaped its scope would
+  // have more to say than this.
+  await expect(list.getByRole("listitem")).toHaveCount(2);
+  // Warn-only, on purpose (`isBlockingConflict` does not cover `rest`). The
+  // panel paints a blocking row red and a warning amber, so a red row here
+  // would mean a stored rest rule had started refusing writes.
+  await expect(list.locator("li.border-red-200")).toHaveCount(0);
+  await expect(list.locator("li.border-amber-200")).toHaveCount(2);
+
+  // 375px: the panel is a bottom sheet at phone widths and nothing it adds may
+  // push the page sideways. No mobile PROJECT runs this spec — playwright.config
+  // scopes `mobile-se`/`mobile-14` to mobile.spec.ts — so the viewport is set
+  // here or the width is never exercised at all.
+  await page.setViewportSize({ width: 375, height: 800 });
+  await expect(list).toBeVisible();
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});
+
+test("a pool-targeted restByGroup binds the pool it names, and no other (#446)", async ({
+  page,
+  request,
+}) => {
+  // The first pool-bearing stage in the e2e suite. `kind: "group"` with
+  // `pools.count: 2` is the only shape that writes `fixtures.pool_id`
+  // (stages.ts `poolCount`), and `pool_id` is precisely what #446 was about:
+  // the placer carried it, the Assignment handed to the verifier did not, so a
+  // pool-keyed rule bound during placement and evaporated during verification.
+  const { divisionId, stageId, fixtures } = await seedDivision(request, {
+    entrants: ["Ada", "Bay", "Cy", "Dot", "Eve", "Fay"],
+    stage: { kind: "group", name: "Groups", config: { pools: { count: 2 } } },
+  });
+  const poolIds = [...new Set(fixtures.map((f) => f.pool_id))].filter(
+    (p): p is string => p !== null,
+  );
+  // If this is 1, the stage did not actually pool and every assertion below
+  // would be about a division-keyed rule wearing a pool's name.
+  expect(poolIds).toHaveLength(2);
+  const [poolA, poolB] = poolIds as [string, string];
+  const pair = sharedEntrantPair(fixtures, poolA);
+  expect(pair[0].pool_id).toBe(poolA);
+  expect(pair[1].pool_id).toBe(poolA);
+
+  // ---- Direction 1: the rule names the OTHER pool. ------------------------
+  // Not "no rule at all". A `restByGroup` that is present but keyed elsewhere
+  // is the only control that distinguishes "the pool key was matched" from
+  // "any restByGroup entry raises rest for everybody" — which is what a
+  // dropped `poolId` would look like if the fallback happened to hit.
+  await putSettings(request, divisionId, { restByGroup: { [poolB]: REST_MINUTES } });
+  await placeBackToBack(request, stageId, pair);
+  await openBoard(page, divisionId, "Ada");
+  await expect(badge(page)).toHaveCount(0);
+
+  // ---- Direction 2: re-key the SAME value onto this pair's pool. ----------
+  await putSettings(request, divisionId, { restByGroup: { [poolA]: REST_MINUTES } });
+  await openBoard(page, divisionId, "Ada");
+  await expect(badge(page)).toBeVisible({ timeout: 20_000 });
+
+  await badge(page).click();
+  const list = panel(page);
+  await expect(list).toBeVisible();
+  // One row per card of the pair (see the note in the #447 test). Pinned, so a
+  // pool rule that had leaked onto the other pool's cards would fail here even
+  // if direction 1 above somehow passed.
+  await expect(list.getByRole("listitem")).toHaveCount(2);
+  await expect(list.locator("li.border-red-200")).toHaveCount(0);
+  await expect(list.locator("li.border-amber-200")).toHaveCount(2);
+});

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -650,6 +650,12 @@ async function main() {
   // seq-tokened reschedule + stale 409, SZ refs + /r/[ref] on pro AND free.
   await schedRegV3Suite(admin, renamed.slug, org2.id);
 
+  // --- #452 scheduling CONSTRAINT surface: a durable `constraints.hard` rule
+  // on a real bracket and a pool-targeted `restByGroup` on a `group` stage,
+  // asserted on auto / apply / board report / drag. Keyless (no model), own Pro
+  // org, so it runs on every smoke invocation.
+  await schedulingConstraintsSuite();
+
   // --- v10 sponsor CRM: tiers + placement + tracked clicks + Connect rail
   // on the pro org; flat free strip + 402 gates on a fresh community owner.
   await sponsorsSuite(admin, org2.id, renamed.slug);
@@ -6409,6 +6415,479 @@ interface AiPreviewLite {
     assumptions: string[];
   };
   window: { start: string; end: string; tz: string } | null;
+}
+
+// ---------------------------------------------------------------------------
+// #452 — the scheduling CONSTRAINT surface over real HTTP.
+//
+// Four defects (#443, #446, #447, #459) shipped past a fully green suite
+// because nothing outside the unit tests ever stored a durable rule or a
+// pool-bearing fixture. Before this suite `grep -c constraints scripts/smoke.ts`
+// was 0 and `kind: "group"` appeared zero times, so `constraints.hard` and a
+// pool-targeted `restByGroup` were both UNREACHABLE from an end-to-end run.
+// ---------------------------------------------------------------------------
+
+/** A conflict row as `mapConflicts` returns it. */
+interface ScheduleConflictLite {
+  fixture_id: string;
+  code: string;
+  rule?: string;
+  detail?: string;
+  blocking: boolean;
+}
+/** As much of a `fixtures` row as this suite reads. */
+interface ConstraintFixtureLite {
+  id: string;
+  pool_id: string | null;
+  round_no: number;
+  seq_in_round: number;
+  home_entrant_id: string | null;
+  away_entrant_id: string | null;
+  scheduled_at: string | null;
+}
+
+const idsWithCode = (rows: readonly ScheduleConflictLite[], code: string): Set<string> =>
+  new Set(rows.filter((c) => c.code === code).map((c) => c.fixture_id));
+
+/**
+ * #452: a durable `constraints.hard` rule and a pool-targeted `restByGroup`,
+ * asserted on every surface the smoke harness can reach.
+ *
+ * ITS OWN ORG, and deliberately NOT bolted onto `seedBracketAiDivision`'s PUT
+ * (see the report for the deviation): that seed sits behind TWO gates, not one —
+ * `aiConfigured` (SCHEDULING_AI_BASE_URL) and then the `if (fixture)` block,
+ * i.e. the fixture server having actually started. Hanging this coverage off it
+ * would make the whole thing skip whenever EITHER is unmet — the same
+ * "green run that asserted nothing" this issue exists to end. Its division is
+ * also the subject of the #401 solver assertions (`repair.moved === 1`), and the
+ * repair solver reads `effectiveHard`, so storing a rule there would have moved
+ * an existing check's answer.
+ *
+ * EVERY "the rule fires" check below is paired with a "the rule stays silent
+ * when it is satisfied" twin on the SAME board and the SAME stored rule. A
+ * one-sided assertion passes when the rule binds nothing at all, which is
+ * precisely #443/#446.
+ *
+ * Conflicts here are WARN-ONLY. `isBlockingConflict` covers court /
+ * person_overlap / window / direct order — not `instruction` and not `rest` — so
+ * an apply carrying them still returns 200 and still writes. The assertions
+ * therefore read the returned `conflicts` array, never the status code.
+ */
+async function schedulingConstraintsSuite(): Promise<void> {
+  const s = newSession();
+  // `scheduling.constraints` (the whole constraints v2 family, `hard` included)
+  // is Pro, and so is the board apply path.
+  const orgId = (await signIn(s, `smoke-sched-constraints-${tag}@example.com`)).org_id;
+  await setPlan(orgId, "pro", s);
+
+  // ======================================================================
+  // 1. A durable feeder→dependent rest rule on a real bracket (#443, #447)
+  // ======================================================================
+  const cupComp = v1data<{ id: string }>(
+    await v1(s, "/api/v1/competitions", "POST", { name: `Sched Constraints ${tag}` }),
+  );
+  const cupDiv = v1data<{ id: string }>(
+    await v1(s, `/api/v1/competitions/${cupComp.id}/divisions`, "POST", {
+      name: "Cup",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    }),
+  );
+  await v1(
+    s,
+    `/api/v1/divisions/${cupDiv.id}/entrants`,
+    "POST",
+    ["A", "B", "C", "D"].map((n, i) => ({
+      kind: "individual",
+      display_name: `Cup ${n}${tag}`,
+      seed: i + 1,
+    })),
+  );
+  const cupStage = v1data<{ id: string }>(
+    await v1(s, `/api/v1/divisions/${cupDiv.id}/stages`, "POST", {
+      seq: 1,
+      kind: "knockout",
+      name: "Cup",
+      config: { thirdPlace: true },
+    }),
+  );
+
+  // `scope: competition` on purpose: the narrower scopes are unit-tested, and a
+  // scope that failed to match would make every assertion below vacuous in the
+  // same direction — the failure mode this suite exists to catch.
+  const FEEDER_REST_MIN = 60;
+  const feederRule = [
+    {
+      type: "min_rest_minutes",
+      minutes: FEEDER_REST_MIN,
+      rest_scope: "feeder_to_dependent",
+      scope: { kind: "competition" },
+    },
+  ];
+  const cupSettings = (gapMinutes: number) => ({
+    config: {
+      startAt: "2026-11-05T09:00:00.000Z",
+      matchMinutes: 30,
+      gapMinutes,
+      courts: ["A", "B"],
+      perEntrantMinRest: 0,
+      blackouts: [],
+      sessionWindows: [],
+      constraints: { hard: feederRule },
+    },
+    tz: "UTC",
+  });
+  const storedCup = v1data<{ config: { constraints?: { hard?: { rest_scope?: string }[] } } }>(
+    await v1(s, `/api/v1/divisions/${cupDiv.id}/schedule-settings`, "PUT", cupSettings(0)),
+  );
+  check(
+    // The field is API-only — no UI in the repo writes `constraints.hard` — so
+    // this round trip is the first end-to-end proof it survives a save at all.
+    "#452 constraints: a durable constraints.hard rule stores and reads back through the API",
+    storedCup?.config?.constraints?.hard?.length === 1 &&
+      storedCup.config.constraints.hard[0]?.rest_scope === "feeder_to_dependent",
+  );
+
+  const cupFixtures = v1data<{ fixtures: ConstraintFixtureLite[] }>(
+    await v1(s, `/api/v1/stages/${cupStage.id}/generate`, "POST"),
+  ).fixtures;
+  // The semis carry both entrants; round 2 (final + third place) carries
+  // neither, and `winner_to_fixture` from BOTH semis names the final — the feed
+  // edge the rule joins on. Only the final is a dependent, so exactly one
+  // round-2 fixture can ever be reported.
+  const semis = cupFixtures.filter(
+    (f) => f.home_entrant_id !== null && f.away_entrant_id !== null,
+  );
+  const round2 = cupFixtures.filter(
+    (f) => f.home_entrant_id === null && f.away_entrant_id === null,
+  );
+  check(
+    "#452 constraints: the bracket generated 2 fed semis + 2 TBD round-2 fixtures",
+    cupFixtures.length === 4 && semis.length === 2 && round2.length === 2,
+  );
+
+  interface AutoOut {
+    assignments: { fixture_id: string; scheduled_at: string; court_label: string }[];
+    conflicts: ScheduleConflictLite[];
+  }
+  // ---- Surface 1: the AUTO pass ----
+  // gapMinutes 0 packs round 2 straight onto the court the semi just vacated,
+  // so the dependent starts 0 minutes after its feeder.
+  const autoTight = v1data<AutoOut>(
+    await v1(s, `/api/v1/stages/${cupStage.id}/schedule/auto`, "POST", {}),
+  );
+  const autoTightHits = idsWithCode(autoTight?.conflicts ?? [], "warn.instruction");
+  check(
+    "#452 auto: a stored feeder→dependent rest rule is REPORTED by the auto pass (#447)",
+    (autoTight?.assignments ?? []).length === 4 &&
+      autoTightHits.size === 1 &&
+      round2.some((f) => autoTightHits.has(f.id)),
+  );
+  // The twin, on the same stored rule: a 90-minute court turnaround pushes round
+  // 2 to exactly the 60 minutes the rule asks for, and the rule goes quiet.
+  await v1(s, `/api/v1/divisions/${cupDiv.id}/schedule-settings`, "PUT", cupSettings(90));
+  const autoLoose = v1data<AutoOut>(
+    await v1(s, `/api/v1/stages/${cupStage.id}/schedule/auto`, "POST", {}),
+  );
+  check(
+    "#452 auto: ...and stays SILENT once the turnaround gives the dependent its rest",
+    (autoLoose?.assignments ?? []).length === 4 &&
+      idsWithCode(autoLoose?.conflicts ?? [], "warn.instruction").size === 0,
+  );
+  await v1(s, `/api/v1/divisions/${cupDiv.id}/schedule-settings`, "PUT", cupSettings(0));
+
+  // ---- Surfaces 2 & 3: the APPLY gate and the board's own conflict report ----
+  interface ApplyOut {
+    applied: number;
+    conflicts: ScheduleConflictLite[];
+  }
+  const cupBoard = (round2At: string) => ({
+    assignments: [
+      { fixture_id: semis[0]!.id, scheduled_at: "2026-11-05T09:00:00.000Z", court_label: "A" },
+      { fixture_id: semis[1]!.id, scheduled_at: "2026-11-05T09:00:00.000Z", court_label: "B" },
+      { fixture_id: round2[0]!.id, scheduled_at: round2At, court_label: "A" },
+      { fixture_id: round2[1]!.id, scheduled_at: round2At, court_label: "B" },
+    ],
+  });
+  const validateCup = async (): Promise<ScheduleConflictLite[]> =>
+    v1data<{ conflicts: ScheduleConflictLite[] }>(
+      await v1(s, `/api/v1/divisions/${cupDiv.id}/schedule/validate`, "POST"),
+    )?.conflicts ?? [];
+
+  // Semis end 09:30; the final starts 09:45 — 15 minutes, against a 60 rule.
+  const tightRes = await v1(
+    s,
+    `/api/v1/stages/${cupStage.id}/schedule/apply`,
+    "POST",
+    cupBoard("2026-11-05T09:45:00.000Z"),
+  );
+  const tightApply = v1data<ApplyOut>(tightRes);
+  const tightRows = (tightApply?.conflicts ?? []).filter((c) => c.code === "warn.instruction");
+  check(
+    // 200, not 409: `instruction` is not in `isBlockingConflict`, so the gate
+    // warns and still writes. A test that expected a 409 here would fail and
+    // teach the next reader the wrong model.
+    "#452 apply: the gate WARNS on a 15-min feeder gap and still writes it (warn-only, no 409)",
+    tightRes.status === 200 &&
+      tightApply?.applied === 4 &&
+      // One row per FEEDER — both semis feed the same final.
+      tightRows.length === 2 &&
+      new Set(tightRows.map((r) => r.fixture_id)).size === 1 &&
+      round2.some((f) => tightRows[0]!.fixture_id === f.id) &&
+      tightRows.every((r) => r.blocking === false && r.rule === "H8"),
+  );
+  const tightReport = idsWithCode(await validateCup(), "warn.instruction");
+  check(
+    "#452 board report: the same durable rule shows on the board's own report (#447)",
+    tightReport.size === 1 && tightReport.has(tightRows[0]!.fixture_id),
+  );
+
+  // The twin: 11:00 is 90 minutes after the semis end, clearing the 60-min rule.
+  const looseRes = await v1(
+    s,
+    `/api/v1/stages/${cupStage.id}/schedule/apply`,
+    "POST",
+    cupBoard("2026-11-05T11:00:00.000Z"),
+  );
+  const looseApply = v1data<ApplyOut>(looseRes);
+  check(
+    "#452 apply: ...and is SILENT once the dependent starts 90 minutes after its feeder",
+    looseRes.status === 200 &&
+      looseApply?.applied === 4 &&
+      idsWithCode(looseApply?.conflicts ?? [], "warn.instruction").size === 0,
+  );
+  check(
+    "#452 board report: ...and the board report goes quiet with it",
+    idsWithCode(await validateCup(), "warn.instruction").size === 0,
+  );
+
+  // ======================================================================
+  // 2. A pool-bearing division and a two-keyed restByGroup (#446, #459)
+  // ======================================================================
+  const poolComp = v1data<{ id: string }>(
+    await v1(s, "/api/v1/competitions", "POST", { name: `Sched Pools ${tag}` }),
+  );
+  const poolDiv = v1data<{ id: string }>(
+    await v1(s, `/api/v1/competitions/${poolComp.id}/divisions`, "POST", {
+      name: "Pools",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    }),
+  );
+  // SIX entrants, not four. Two pools of three give each pool a three-fixture
+  // round robin in which EVERY pair shares exactly one entrant — so any two
+  // fixtures of a pool are rest-checked against each other, whatever order the
+  // generator emits them in. Two pools of two would be one fixture each and no
+  // pair to rest at all: a seed that asserts nothing.
+  await v1(
+    s,
+    `/api/v1/divisions/${poolDiv.id}/entrants`,
+    "POST",
+    ["A", "B", "C", "D", "E", "F"].map((n, i) => ({
+      kind: "individual",
+      display_name: `Pool ${n}${tag}`,
+      seed: i + 1,
+    })),
+  );
+  const poolStage = v1data<{ id: string }>(
+    await v1(s, `/api/v1/divisions/${poolDiv.id}/stages`, "POST", {
+      seq: 1,
+      kind: "group",
+      name: "Groups",
+      // `group` is the pool-bearing kind — `poolCount(cfg)` reads exactly this,
+      // and it is what writes a non-null `fixtures.pool_id`.
+      config: { pools: { count: 2 } },
+    }),
+  );
+  const poolFixtures = v1data<{ fixtures: ConstraintFixtureLite[] }>(
+    await v1(s, `/api/v1/stages/${poolStage.id}/generate`, "POST"),
+  ).fixtures;
+  const poolIds = [
+    ...new Set(poolFixtures.map((f) => f.pool_id).filter((p): p is string => p !== null)),
+  ].sort();
+  check(
+    "#452 pools: a `group` stage populates pool_id on every fixture (the shape #446 needs)",
+    poolFixtures.length === 6 &&
+      poolIds.length === 2 &&
+      poolFixtures.every((f) => f.pool_id !== null),
+  );
+  const ofPool = (p: string): ConstraintFixtureLite[] =>
+    poolFixtures
+      .filter((f) => f.pool_id === p)
+      .sort((a, b) => a.round_no - b.round_no || a.seq_in_round - b.seq_in_round);
+  const strictPool = poolIds[0]!;
+  const laxPool = poolIds[1]!;
+  const sf = ofPool(strictPool);
+  const lf = ofPool(laxPool);
+
+  // The #459 configuration in one object: a division floor, a pool entry ABOVE
+  // it, and a pool entry of exactly zero. Under the shipped MAX rule the first
+  // pool resolves to 90 and the second to 30 (the division floor, unchanged);
+  // under the `??` precedence it replaced, the second would have resolved to 0
+  // and ERASED the division rule.
+  const DIVISION_REST = 30;
+  const STRICT_POOL_REST = 90;
+  const poolSettings = {
+    config: {
+      startAt: "2026-11-12T09:00:00.000Z",
+      matchMinutes: 30,
+      gapMinutes: 0,
+      courts: ["A", "B"],
+      perEntrantMinRest: 0,
+      blackouts: [],
+      sessionWindows: [],
+      constraints: {
+        restByGroup: {
+          [poolDiv.id]: DIVISION_REST,
+          [strictPool]: STRICT_POOL_REST,
+          [laxPool]: 0,
+        },
+      },
+    },
+    tz: "UTC",
+  };
+  const storedPool = v1data<{ config: { constraints?: { restByGroup?: Record<string, number> } } }>(
+    await v1(s, `/api/v1/divisions/${poolDiv.id}/schedule-settings`, "PUT", poolSettings),
+  );
+  check(
+    "#452 pools: a restByGroup carrying BOTH a division-keyed and a pool-keyed entry stores (#459)",
+    storedPool?.config?.constraints?.restByGroup?.[poolDiv.id] === DIVISION_REST &&
+      storedPool.config.constraints.restByGroup[strictPool] === STRICT_POOL_REST &&
+      storedPool.config.constraints.restByGroup[laxPool] === 0,
+  );
+
+  // ---- Surface 1: the AUTO pass, both directions in ONE run ----
+  // The placer resolves rest per fixture through `effectiveRestMinutes`, so the
+  // strict pool must come out ≥ 90 minutes apart and the lax pool ≥ 30. Both
+  // halves are asserted: the second is what fails if the pool entry were applied
+  // division-wide, the first if it were dropped.
+  const poolAuto = v1data<AutoOut>(
+    await v1(s, `/api/v1/stages/${poolStage.id}/schedule/auto`, "POST", {}),
+  );
+  const MATCH_MS = 30 * 60 * 1000;
+  const minPoolGapMinutes = (ids: readonly string[]): number => {
+    const times = (poolAuto?.assignments ?? [])
+      .filter((a) => ids.includes(a.fixture_id))
+      .map((a) => Date.parse(a.scheduled_at))
+      .sort((a, b) => a - b);
+    let min = Infinity;
+    for (let i = 1; i < times.length; i++) {
+      min = Math.min(min, (times[i]! - (times[i - 1]! + MATCH_MS)) / 60000);
+    }
+    return min;
+  };
+  const strictAutoGap = minPoolGapMinutes(sf.map((f) => f.id));
+  const laxAutoGap = minPoolGapMinutes(lf.map((f) => f.id));
+  check(
+    "#452 pools/auto: the placer honours the POOL rest (≥90) and not division-wide (lax pool <90)",
+    (poolAuto?.assignments ?? []).length === 6 &&
+      strictAutoGap >= STRICT_POOL_REST &&
+      laxAutoGap >= DIVISION_REST &&
+      laxAutoGap < STRICT_POOL_REST,
+  );
+
+  // ---- Surfaces 2 & 3: the APPLY gate and the board report ----
+  const at = (hhmm: string) => `2026-11-12T${hhmm}:00.000Z`;
+  // One court per pool, so nothing here can produce a court clash and every row
+  // reported is a rest row. The third fixture of each pool sits at 14:00, clear
+  // of both the others under either rule — so it is never expected to appear,
+  // and its absence is what proves the reported set is the PAIR and not the pool.
+  const poolBoard = (strictSecond: string, laxSecond: string) => ({
+    assignments: [
+      { fixture_id: sf[0]!.id, scheduled_at: at("09:00"), court_label: "A" },
+      { fixture_id: sf[1]!.id, scheduled_at: strictSecond, court_label: "A" },
+      { fixture_id: sf[2]!.id, scheduled_at: at("14:00"), court_label: "A" },
+      { fixture_id: lf[0]!.id, scheduled_at: at("09:00"), court_label: "B" },
+      { fixture_id: lf[1]!.id, scheduled_at: laxSecond, court_label: "B" },
+      { fixture_id: lf[2]!.id, scheduled_at: at("14:00"), court_label: "B" },
+    ],
+  });
+  const validatePools = async (): Promise<ScheduleConflictLite[]> =>
+    v1data<{ conflicts: ScheduleConflictLite[] }>(
+      await v1(s, `/api/v1/divisions/${poolDiv.id}/schedule/validate`, "POST"),
+    )?.conflicts ?? [];
+
+  // Strict pool: 60 minutes apart — clears the 30 division floor, short of the
+  // 90 pool rule. Lax pool: 15 minutes — short of the 30 division floor.
+  const shortRes = await v1(
+    s,
+    `/api/v1/stages/${poolStage.id}/schedule/apply`,
+    "POST",
+    poolBoard(at("10:30"), at("09:45")),
+  );
+  const shortApply = v1data<ApplyOut>(shortRes);
+  const shortRest = idsWithCode(shortApply?.conflicts ?? [], "warn.rest");
+  check(
+    "#452 pools/apply: a POOL-keyed rest BINDS — 60 min inside a 90-min pool is short (#446)",
+    shortRes.status === 200 &&
+      shortApply?.applied === 6 &&
+      shortRest.has(sf[0]!.id) &&
+      shortRest.has(sf[1]!.id),
+  );
+  check(
+    // The `??` precedence this replaced resolved the lax pool to 0 and dropped
+    // the division rule entirely, so this pair came back clean.
+    "#452 pools/apply: an explicit pool `0` ADDS NOTHING — the 30-min division floor still bites (#459)",
+    shortRest.has(lf[0]!.id) && shortRest.has(lf[1]!.id),
+  );
+  check(
+    "#452 pools/apply: ...and only the two short PAIRS are rested, not the whole pool",
+    shortRest.size === 4 && !shortRest.has(sf[2]!.id) && !shortRest.has(lf[2]!.id),
+  );
+  const shortReport = idsWithCode(await validatePools(), "warn.rest");
+  check(
+    "#452 pools/board report: the board's own report names the same four cards",
+    shortReport.size === 4 &&
+      [sf[0]!, sf[1]!, lf[0]!, lf[1]!].every((f) => shortReport.has(f.id)),
+  );
+
+  // The twin. Strict pool at exactly 90 (a floor is `<`, so equal is legal), lax
+  // pool at 60 — which the 90 rule would flag if it had leaked out of its pool.
+  const clearRes = await v1(
+    s,
+    `/api/v1/stages/${poolStage.id}/schedule/apply`,
+    "POST",
+    poolBoard(at("11:00"), at("10:30")),
+  );
+  const clearApply = v1data<ApplyOut>(clearRes);
+  const clearRest = idsWithCode(clearApply?.conflicts ?? [], "warn.rest");
+  check(
+    "#452 pools/apply: the pool rule is SILENT at exactly its 90 minutes (raises the floor, #459)",
+    clearRes.status === 200 &&
+      clearApply?.applied === 6 &&
+      !clearRest.has(sf[0]!.id) &&
+      !clearRest.has(sf[1]!.id),
+  );
+  check(
+    "#452 pools/apply: the 90-min pool rule does NOT leak onto the other pool (60 clears its 30)",
+    clearRest.size === 0,
+  );
+
+  // ---- Surface 4: the drag/keyboard move (PATCH → moveFixture) ----
+  // `moveFixture` computes the conflicts but the PATCH response is the fixture
+  // ROW, so the rule cannot be read off the drag's own reply. What the console
+  // does after a drag is re-validate, and that is what is asserted here: the
+  // drag is real (it moves the card and it is not refused, because rest never
+  // blocks), and the pool rule follows the card in both directions.
+  await v1(s, `/api/v1/fixtures/${sf[1]!.id}`, "PATCH", {
+    scheduled_at: at("10:30"),
+    court_label: "A",
+  });
+  const draggedIn = idsWithCode(await validatePools(), "warn.rest");
+  check(
+    "#452 pools/drag: dragging a card inside its pool's 90-min rest surfaces on re-validate (#446)",
+    draggedIn.size === 2 && draggedIn.has(sf[0]!.id) && draggedIn.has(sf[1]!.id),
+  );
+  await v1(s, `/api/v1/fixtures/${sf[1]!.id}`, "PATCH", {
+    scheduled_at: at("11:00"),
+    court_label: "A",
+  });
+  check(
+    "#452 pools/drag: ...and dragging it back out clears it again",
+    idsWithCode(await validatePools(), "warn.rest").size === 0,
+  );
 }
 
 /** design/v4 (Task 18): the AI Schedule Architect end-to-end over HTTP.


### PR DESCRIPTION
Closes #452.

Four defects shipped past a fully green unit suite this cycle — #443, the repair rounding bug, #446 and #447. **Every one was caught by reading code or by a reviewer, never by a gate.** They share a failure mode: a fixture that sets both sides of a comparison equal by construction, so the assertion passes whether or not the rule binds anything.

Neither harness could have caught any of them, and not because the tests were weak — because **the surface did not exist in either one**.

No product source is touched. This is coverage only.

## What was actually missing

The issue's original premise was wrong and is corrected in a comment: smoke already builds a `kind: "knockout"` division with schedule settings, and `/generate` really does populate `winner_to_fixture` (`stages.ts:957`, `:1074`). A bracket was never the blocker.

| gap | evidence |
|---|---|
| No durable rule of any kind in smoke | `grep -c constraints scripts/smoke.ts` → **0**, across all seven `schedule-settings` PUTs |
| No pool-bearing stage anywhere | `kind: "group"` (the pool-bearing kind — `poolCount(cfg)` → `pool_id` at `stages.ts:1480`) used **zero** times in smoke or e2e |
| No off-minute instant reachable in e2e | the clash generator copies one card's `scheduled_at` onto another verbatim; every seeded instant is minute-aligned |

## Smoke — 657 → 676 checks, ~3.8s

Stores real rules and asserts they bind, on auto-schedule, the apply gate and the board conflict report, **each in both directions**:

- a durable `constraints.hard` `min_rest_minutes` with `rest_scope: "feeder_to_dependent"` on a real bracket (#443);
- a `kind: "group"` division so `pool_id` is populated and a pool-targeted `restByGroup` is reachable at all (#446);
- both a division-keyed and a pool-keyed entry on one board, so the pool entry is seen to RAISE the division floor rather than replace it, and an explicit pool `0` adds nothing (#459);
- a check that the rule does **not** bind on a different pool.

Every "the rule fires" check is paired with a "stays silent when satisfied" twin on the same board and the **same stored rule**, toggling an orthogonal knob — the gap, the round-2 time, the drag target.

**Teeth.** With `constraints.hard` emptied and the strict pool entry deleted: **10 failures, every one a "fires" check, while all six twins still passed.** That asymmetry is the point — the twins alone would have proved nothing, which is exactly the shape of the bugs being guarded against.

## e2e — 39 passed, 0 failed against a real standalone prod build

- **An off-minute clash.** New `FIXTURE_CLASH_SECONDS` sentinel. The existing `#401` whole-minute test is unchanged in behaviour: the new branch is guarded on `clashOffsetMs > 0` and the plain path resolves it to 0, so it takes exactly the old two-field overwrite (verified in review by reading, not assumed).
- **A durable rule seeded via the API, asserted on the board.** No UI writes `constraints.hard` — the field is API-only — so it is stored through the route and the assertion is on what the board paints. Both directions.
- **The first `kind: "group"` stage in the e2e suite**, asserting a pool-targeted `restByGroup` binds the pool it names and no other.

Teeth: `hard: []` → the #447 test fails; wrong pool key → the #446 test fails; offset `20_000 → 0` → the off-minute test fails.

### What the off-minute test does NOT prove

**It is not a claim that this would have caught the pre-#457 rounding bug**, and a comment in the test says so. z3 may pick any minimal repair and only some choices sit adjacent to a rounded obstacle. What is established is weaker and still worth having: no minute-aligned board can express an encoder/verifier disagreement measured in seconds, so this is the first e2e whose board *can*, and 4 of 6 applied instants come back from `timestamptz` carrying `:20`.

## Warn-only, throughout

`isBlockingConflict` excludes `instruction` and `rest`, so every apply here returns 200 (`applied: 2`). Assertions are on the returned conflicts and the rendered badges, never on a refused write. A check expecting a 409 would fail and mislead the next reader.

## Mobile

The rule test sets 375px itself and asserts zero horizontal overflow with the panel open, measured as `scrollWidth - clientWidth` — a real DOM measurement, not a screenshot.

## Verification

| gate | result |
|---|---|
| engine | 2287 pass / 0 fail / 1 pending |
| apps/web | 5277 pass / 0 fail / **50 pending** |
| apps/web lint | 0 errors, 79 warnings (= main's baseline) |
| engine lint | clean |
| `typecheck:scripts` | clean |
| openapi drift | 0 |

Both halves went through an independent review round. Neither found a blocker; the smoke NIT (a comment understating that the AI seed sits behind **two** gates, not one) is fixed.

## Filed, not fixed here

- **#465** — `conflicts-panel.tsx` exposes no `data-*` hooks, so the e2e must locate rows by ARIA name and Tailwind border classes. That couples a correctness test to presentation: a restyle would break it and read as a scheduling regression. Not a blocker — the assertions are structural — but it should not stay that way.
- **#463** (comment) — a `feeder_to_dependent` rule can never fire on the drag path at all: `validateInstructionRules` keys `placedById` off the assignments array and `moveFixture` passes only the dragged card, so the rule is structurally unevaluable there. Distinct from #461, and it survives #461's fix.

## Not enabled

`.github/workflows/e2e.yml` is untouched and stays disabled. e2e was verified locally against a standalone prod build, per the standing rule.