### PR TITLE
Bucket the officials maxPerDay cap on the org's calendar day, not UTC

### DIFF
--- a/apps/web/e2e/schedule-panels.spec.ts
+++ b/apps/web/e2e/schedule-panels.spec.ts
@@ -57,6 +57,107 @@ test("officials (PROMPT-22): propose → apply an auto-assignment", async ({ pag
   await expect(page.getByText(/failed/i)).toHaveCount(0);
 });
 
+// #448 — the auto-assign cap must count the ORGANISATION's calendar day. Drive
+// it through the panel a user actually clicks: an org in America/Los_Angeles,
+// one referee capped at 2/day, and four fixtures on ONE local Saturday whose
+// evening half is already Sunday in UTC. Bucketing on UTC sees 2 + 2 and offers
+// to apply all six; the org's own day allows 2 there, so it offers four and
+// reports the two it could not fill.
+test("officials (#448): maxPerDay caps on the org day across a UTC midnight", async ({
+  page,
+  request,
+}) => {
+  const org = await apiJson<{ id: string }>(request, "/api/orgs", "POST", {
+    name: `TZ448 ${TAG}-${Math.random().toString(36).slice(2, 6)}`,
+  });
+  await setOrgPlanBySql({ orgId: org.data!.id }, "pro_plus");
+  const activated = await apiJson(request, "/api/orgs/active", "POST", { org_id: org.data!.id });
+  expect(activated.status).toBeLessThan(300);
+
+  // The governing clock. Everything below is chosen against this zone.
+  const tzSet = await apiJson(request, `/api/orgs/${org.data!.id}`, "PATCH", {
+    timezone: "America/Los_Angeles",
+  });
+  expect(tzSet.status).toBeLessThan(300);
+
+  const comp = await apiJson<{ id: string }>(request, "/api/v1/competitions", "POST", {
+    name: `TZ448 ${TAG}-${Math.random().toString(36).slice(2, 6)}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    {
+      name: "Open",
+      sport_key: "generic",
+      variant_key: "score",
+      config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    },
+  );
+  const divisionId = div.data!.id;
+  await apiJson(
+    request,
+    `/api/v1/divisions/${divisionId}/entrants`,
+    "POST",
+    ["A", "B", "C", "D"].map((n, i) => ({ kind: "individual", display_name: n, seed: i + 1 })),
+  );
+  const stage = await apiJson<{ id: string }>(request, `/api/v1/divisions/${divisionId}/stages`, "POST", {
+    seq: 1,
+    kind: "league",
+    name: "League",
+  });
+  const gen = await apiJson<{ fixtures: { id: string }[] }>(
+    request,
+    `/api/v1/stages/${stage.data!.id}/generate`,
+    "POST",
+  );
+  const fixtures = gen.data!.fixtures;
+  expect(fixtures.length).toBe(6); // 4 entrants, round robin
+
+  // 2026-07-11 in Los Angeles (PDT, UTC-7). 10:00 and 12:00 local are still
+  // Saturday in UTC; 18:00 and 20:00 local are Sunday 01:00Z and 03:00Z.
+  const localSaturday = [
+    "2026-07-11T17:00:00.000Z",
+    "2026-07-11T19:00:00.000Z",
+    "2026-07-12T01:00:00.000Z",
+    "2026-07-12T03:00:00.000Z",
+  ];
+  for (const [i, at] of localSaturday.entries()) {
+    await apiJson(request, `/api/v1/fixtures/${fixtures[i]!.id}`, "PATCH", {
+      scheduled_at: at,
+      court_label: "1",
+    });
+  }
+  // The remaining two sit on their own days well clear of the Saturday, so they
+  // consume none of its cap and are expected to fill.
+  for (const [i, f] of fixtures.slice(4).entries()) {
+    await apiJson(request, `/api/v1/fixtures/${f.id}`, "PATCH", {
+      scheduled_at: `2026-09-2${i}T18:00:00.000Z`,
+      court_label: "1",
+    });
+  }
+  await apiJson(request, `/api/v1/divisions/${divisionId}/start`, "POST");
+
+  // Exactly ONE referee, capped at 2 a day — no one else can absorb the
+  // overflow, so the cap is what decides the outcome.
+  await apiJson(request, "/api/v1/officials", "POST", {
+    display_name: `Capped Ref ${TAG}`,
+    role_keys: ["referee"],
+    max_per_day: 2,
+  });
+
+  await page.goto(`/divisions/${divisionId}/schedule?tab=officials`);
+  await page.getByRole("button", { name: /^Propose$/ }).click();
+
+  // 2 on the local Saturday + 1 on each September day = 4, not 6.
+  await expect(page.getByRole("button", { name: "Apply 4 assignments" })).toBeVisible({
+    timeout: 20_000,
+  });
+  // and the two slots the cap refused are reported, not silently dropped
+  await expect(page.getByText(/role_unfilled/)).toHaveCount(2);
+});
+
 test("history (PROMPT-23): undo then redo round-trips without error", async ({ page, request }) => {
   const { divisionId } = await seedScoredDivision(request);
   await page.goto(`/divisions/${divisionId}/schedule?tab=history`);

--- a/apps/web/src/server/usecases/__tests__/__snapshots__/officials-ai-pack.test.ts.snap
+++ b/apps/web/src/server/usecases/__tests__/__snapshots__/officials-ai-pack.test.ts.snap
@@ -5,6 +5,7 @@ exports[`buildOfficialsPack (v4/03 §2) > pack is deterministic and matches the 
   "division": {
     "id": "<id:1>",
     "name": "Open",
+    "org_tz": "UTC",
     "sport": "generic",
     "tz": "Europe/London",
   },

--- a/apps/web/src/server/usecases/__tests__/officials-ai-pack.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-pack.test.ts
@@ -260,6 +260,9 @@ describe.skipIf(!HAS_DB)("buildOfficialsPack (v4/03 §2)", () => {
     expect(ref.max_per_day).toBe(3);
     // Every fixture carries a time with the division tz offset (BST = +01:00).
     expect(a.fixtures.length).toBe(RR);
+    // `tz` is the DIVISION override; `org_tz` is the governing clock (#448).
+    expect(a.division.tz).toBe(TZ);
+    expect(typeof a.division.org_tz).toBe("string");
     expect(a.fixtures.every((f) => /[+-]\d{2}:\d{2}$/.test(f.start_at))).toBe(true);
     expect(a.fixtures.some((f) => f.start_at.endsWith("+01:00"))).toBe(true);
     // The solver draft is present and only ever assigns a referee.
@@ -268,6 +271,23 @@ describe.skipIf(!HAS_DB)("buildOfficialsPack (v4/03 §2)", () => {
     expect(a.match_minutes).toBe(30);
     expect(a.policy.roles).toEqual(["referee"]);
     expect(a.prior).toBeNull();
+  });
+
+  it("org_tz is the ORG zone and the division override never leaks into it (#448)", async () => {
+    // This division pins schedule_settings.tz = Europe/London. Point the ORG
+    // somewhere else: the pack must keep rendering in the division zone while
+    // reporting the org zone as the governing clock for day math.
+    const board = await seedOfficialsBoard();
+    await sql`
+      update organizations set timezone = 'America/Los_Angeles' where id = ${board.auth.orgId}`;
+    const p = await buildOfficialsPack(board.auth, board.divisionId, {
+      instruction: "x",
+      policy: POLICY,
+    });
+    expect(p.division.tz).toBe(TZ); // display, unchanged by the org zone
+    expect(p.division.org_tz).toBe("America/Los_Angeles");
+    // timestamps still carry the DISPLAY offset (BST), not the org's
+    expect(p.fixtures.some((f) => f.start_at.endsWith("+01:00"))).toBe(true);
   });
 
   it("a dry-run schedule overrides the persisted slot for a fixture", async () => {

--- a/apps/web/src/server/usecases/__tests__/officials-ai-provider.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-provider.test.ts
@@ -22,7 +22,13 @@ const refA = REF_A;
 
 function makePack(): import("../officials-ai").OfficialsPack {
   return {
-    division: { id: "d1", name: "Open", sport: "generic", tz: "Europe/London" },
+    division: {
+      id: "d1",
+      name: "Open",
+      sport: "generic",
+      tz: "Europe/London",
+      org_tz: "Europe/London",
+    },
     match_minutes: 30,
     policy: {
       roles: ["referee"],

--- a/apps/web/src/server/usecases/__tests__/officials-ai-referee.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-referee.test.ts
@@ -20,7 +20,7 @@ const POLICY = {
 
 function pack(over: Partial<OfficialsPack>): OfficialsPack {
   return {
-    division: { id: "div", name: "Open", sport: "generic", tz: "UTC" },
+    division: { id: "div", name: "Open", sport: "generic", tz: "UTC", org_tz: "UTC" },
     match_minutes: 30,
     policy: POLICY,
     fixtures: [],
@@ -189,6 +189,80 @@ describe("refereeOfficialsPlan (v4/03 §7 decision 8)", () => {
       conflicts.some(
         (c) =>
           c.kind === "ineligible" && c.officialId === "o1" && /locked/i.test(c.detail),
+      ),
+    ).toBe(true);
+  });
+
+  // -- one calendar, and it is the ORG's (#448) ------------------------------
+  //
+  // A Los Angeles org whose division overrides its display zone to Berlin, so
+  // `start_at` is rendered at +02:00 exactly as buildOfficialsPack writes it.
+  // Both fixtures fall on local Saturday 2026-08-01 in the ORG zone, but the
+  // evening one reads 2026-08-02 in UTC *and* at the division offset — so the
+  // two readings this function used to hold (UTC slice for the recount,
+  // division-offset slice for blackouts) are BOTH wrong here, and differently.
+  const LA = "America/Los_Angeles";
+  const BERLIN_DIV = {
+    id: "div",
+    name: "Open",
+    sport: "generic",
+    tz: "Europe/Berlin",
+    org_tz: LA,
+  };
+  // 2026-08-01T19:00+02:00 = 17:00Z = Sat 10:00 in Los Angeles.
+  const SAT_MORNING = "2026-08-01T19:00:00+02:00";
+  // 2026-08-02T03:00+02:00 = 01:00Z = Sat 18:00 in Los Angeles — still Saturday
+  // for the organiser, already Sunday for UTC and for the division's own clock.
+  const SAT_EVENING = "2026-08-02T03:00:00+02:00";
+
+  it("maxPerDay recount buckets on the ORG day, not the UTC day (#448)", () => {
+    const p = pack({
+      division: BERLIN_DIV,
+      fixtures: [fixture("morning", SAT_MORNING), fixture("evening", SAT_EVENING)],
+      officials: [official("o1", { max_per_day: 1 })],
+    });
+    // Guard the guard: both discarded readings really do split these two apart,
+    // so this test cannot pass by accident.
+    expect(p.fixtures.map((f) => f.start_at.slice(0, 10))).toEqual([
+      "2026-08-01",
+      "2026-08-02",
+    ]);
+    expect(
+      p.fixtures.map((f) => new Date(f.start_at).toISOString().slice(0, 10)),
+    ).toEqual(["2026-08-01", "2026-08-02"]);
+
+    const { conflicts } = refereeOfficialsPlan(
+      p,
+      plan({
+        assignments: [
+          { fixture_id: "morning", official_id: "o1", role_key: "referee" },
+          { fixture_id: "evening", official_id: "o1", role_key: "referee" },
+        ],
+      }),
+    );
+    const breach = conflicts.filter((c) => c.kind === "ineligible" && /max/i.test(c.detail));
+    expect(breach).toHaveLength(1);
+    // and it names the ORG day — the one the organiser actually capped
+    expect(breach[0]!.detail).toContain("2026-08-01");
+  });
+
+  it("blackout check reads the ORG day, agreeing with the recount (#448)", () => {
+    // The official blacked out local Saturday 2026-08-01. Slicing `start_at`
+    // yields 2026-08-02 and would MISS this; so would the UTC slice.
+    const p = pack({
+      division: BERLIN_DIV,
+      fixtures: [fixture("evening", SAT_EVENING)],
+      officials: [official("o1", { blackout_dates: ["2026-08-01"] })],
+    });
+    expect(p.fixtures[0]!.start_at.slice(0, 10)).toBe("2026-08-02"); // guard the guard
+
+    const { conflicts } = refereeOfficialsPlan(
+      p,
+      plan({ assignments: [{ fixture_id: "evening", official_id: "o1", role_key: "referee" }] }),
+    );
+    expect(
+      conflicts.some(
+        (c) => c.kind === "ineligible" && c.officialId === "o1" && /blackout/i.test(c.detail),
       ),
     ).toBe(true);
   });

--- a/apps/web/src/server/usecases/__tests__/officials.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials.test.ts
@@ -269,6 +269,61 @@ describe.skipIf(!HAS_DB)("officials assignment (Jul3/02)", () => {
     }
   });
 
+  it("maxPerDay caps on the ORG's calendar day, not the UTC day (#448)", async () => {
+    const { auth } = await seedOrg("pro_plus");
+    // An org west of Greenwich: a Saturday evening there is already Sunday UTC.
+    await sql`
+      update organizations set timezone = 'America/Los_Angeles' where id = ${auth.orgId}`;
+    const { division, fixtures } = await seedScheduledDivision(auth);
+
+    // Four fixtures on ONE local Saturday (2026-07-11 PDT, UTC-7):
+    // 10:00 and 12:00 are still Saturday UTC; 18:00 and 20:00 are Sunday UTC.
+    const local = ["17:00", "19:00", "01:00", "03:00"]; // the same times in UTC
+    const utcDay = ["11", "11", "12", "12"];
+    const picked = fixtures.slice(0, 4) as { id: string }[];
+    expect(picked).toHaveLength(4);
+    for (const [i, f] of picked.entries()) {
+      await sql`
+        update fixtures
+        set scheduled_at = ${`2026-07-${utcDay[i]}T${local[i]}:00.000Z`}, court_label = 'Court 1'
+        where id = ${f.id}`;
+    }
+    // Park the rest well clear so they cannot compete for the capped official.
+    for (const [i, f] of (fixtures.slice(4) as { id: string }[]).entries()) {
+      await sql`
+        update fixtures set scheduled_at = ${`2026-09-${String(i + 1).padStart(2, "0")}T18:00:00.000Z`}
+        where id = ${f.id}`;
+    }
+
+    await createOfficial(auth, {
+      display_name: "Capped Ref",
+      role_keys: ["referee"],
+      max_per_day: 2,
+    });
+
+    const proposal = await autoAssignOfficials(auth, division.id, {
+      policy: {
+        roles: ["referee"],
+        poolLock: false,
+        blockStay: false,
+        fairness: "tournament",
+        teamRefKeepDivision: false,
+        restMinMinutes: 0,
+        blockGapMinutes: 30,
+      },
+      rng_seed: "t",
+    });
+
+    const pickedIds = new Set(picked.map((f) => f.id));
+    const onLocalSaturday = proposal.assignments.filter((a) => pickedIds.has(a.fixtureId));
+    // Bucketing on UTC sees 2 + 2 and fills all four; the org's calendar day
+    // allows only 2, leaving the other two slots unfilled.
+    expect(onLocalSaturday).toHaveLength(2);
+    expect(
+      proposal.conflicts.filter((c) => c.kind === "role_unfilled" && pickedIds.has(c.fixtureId!)),
+    ).toHaveLength(2);
+  });
+
   it("locked assignments survive apply; re-apply keeps them", async () => {
     const { auth } = await seedOrg("pro_plus");
     const { division, fixtures } = await seedScheduledDivision(auth);

--- a/apps/web/src/server/usecases/__tests__/schedule-durable-hard.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-durable-hard.test.ts
@@ -79,7 +79,7 @@ function settings(constraints: Record<string, unknown>): ScheduleSettingsOut {
       perEntrantMinRest: 0,
       constraints,
     }),
-    tz: "UTC",
+    displayTz: "UTC",
     orgTz: "UTC",
     updated_at: iso(T0),
   };

--- a/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
@@ -68,7 +68,7 @@ function settings(constraints: Record<string, unknown>): ScheduleSettingsOut {
       perEntrantMinRest: 30,
       constraints,
     }),
-    tz: "UTC",
+    displayTz: "UTC",
     orgTz: "UTC",
     updated_at: iso(T0),
   };

--- a/apps/web/src/server/usecases/__tests__/schedule-settings-wire.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-settings-wire.test.ts
@@ -1,0 +1,142 @@
+// The WIRE contract of GET/PUT /api/v1/divisions/{id}/schedule-settings.
+//
+// The route returns `getScheduleSettings` / `putScheduleSettings` unmapped, so
+// whatever key those two functions emit IS the public payload. That payload is
+// pinned twice over: by the `ScheduleSettings` response schema in
+// api-v1/schemas.ts, and by openapi/v1.json, which documents GET's `data` as
+// exactly { division_id, config, tz, updated_at }.
+//
+// The INTERNAL settings object (`ScheduleSettingsOut`, what `loadSettings`
+// returns) carries TWO zones one letter apart — `displayTz` (rendering) and
+// `orgTz` (the governing clock, #397/#448). Renaming the internal display field
+// is a good idea; renaming the PUBLIC key along with it is a breaking change
+// that nothing else in this repo would catch — the pages read `.tz` off the
+// same object and would simply follow the rename. This suite is the tripwire:
+// it fails if either boundary function stops emitting `tz`, starts emitting an
+// extra field, or stops putting the DISPLAY zone in it.
+//
+// Real Postgres required; skipped without DATABASE_URL (CI runs them).
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { ScheduleSettings } from "@/server/api-v1/schemas";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { getScheduleSettings, putScheduleSettings } from "../schedule";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+/** Exactly what openapi/v1.json documents for this route's `data`. */
+const WIRE_KEYS = ["config", "division_id", "tz", "updated_at"];
+
+const DIVISION_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+const CONFIG = {
+  startAt: "2026-08-01T09:00:00.000Z",
+  matchMinutes: 30,
+  gapMinutes: 0,
+  courts: ["Court 1"],
+  perEntrantMinRest: 0,
+  blackouts: [],
+  sessionWindows: [],
+};
+
+/** Org zone and division zone must DIFFER, or "tz carries the display zone"
+ *  and "tz carries the governing zone" agree and the assertion is vacuous. */
+const ORG_TZ = "Europe/London";
+const DIVISION_TZ = "Europe/Madrid";
+
+async function seedOrg(): Promise<AuthCtx> {
+  const suffix = randomUUID().slice(0, 8);
+  const [{ id: orgId }] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug, timezone)
+    values (${"Wire Org " + suffix}, ${"wire-org-" + suffix}, ${ORG_TZ})
+    returning id`;
+  await sql`
+    insert into sports (key, name, module_version, position_catalog)
+    values ('generic', 'Generic', '1.0.0', ${sql.json({ groups: [], lineup: { size: 1, benchMax: 0 } })})
+    on conflict (key) do nothing`;
+  await sql`
+    insert into sport_variants (sport_key, key, name, config, is_system)
+    values ('generic', 'score', 'Score', ${sql.json(DIVISION_CONFIG)}, true)
+    on conflict do nothing`;
+  return { orgId, via: "session", userId: null, role: "owner", keyId: null };
+}
+
+/** A division pinned to its own zone — the case where display and governing
+ *  zones disagree, which is the whole reason the two fields exist. */
+async function seedDivision(auth: AuthCtx): Promise<string> {
+  const competition = await createCompetition(auth, {
+    name: "Wire Cup",
+    visibility: "public",
+    branding: {},
+  });
+  const division = await createDivision(auth, competition.id, {
+    name: "Open",
+    slug: "open",
+    sport_key: "generic",
+    variant_key: "score",
+    config: { points: { w: 3, d: 1, l: 0 }, progressScore: false },
+    eligibility: [],
+  });
+  await sql`
+    insert into schedule_settings (division_id, config, tz, updated_at)
+    values (${division.id}, ${sql.json(CONFIG as never)}, ${DIVISION_TZ}, now())
+    on conflict (division_id) do update set tz = excluded.tz`;
+  return division.id;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("schedule-settings wire contract", () => {
+  it("GET emits exactly { division_id, config, tz, updated_at }", async () => {
+    const auth = await seedOrg();
+    const divisionId = await seedDivision(auth);
+
+    const wire = await getScheduleSettings(auth, divisionId);
+    expect(Object.keys(wire).sort()).toEqual(WIRE_KEYS);
+  });
+
+  it("PUT emits the same key set — it must not leak the internal shape", async () => {
+    const auth = await seedOrg();
+    const divisionId = await seedDivision(auth);
+
+    const wire = await putScheduleSettings(auth, divisionId, { config: CONFIG });
+    expect(Object.keys(wire).sort()).toEqual(WIRE_KEYS);
+  });
+
+  it("`tz` carries the DISPLAY zone, not the governing org zone", async () => {
+    const auth = await seedOrg();
+    const divisionId = await seedDivision(auth);
+
+    // The division overrides; the org is elsewhere. `tz` is the override.
+    expect((await getScheduleSettings(auth, divisionId)).tz).toBe(DIVISION_TZ);
+    expect((await putScheduleSettings(auth, divisionId, { config: CONFIG })).tz).toBe(DIVISION_TZ);
+  });
+
+  it("round-trips through the ScheduleSettings response schema unchanged", async () => {
+    const auth = await seedOrg();
+    const divisionId = await seedDivision(auth);
+
+    // zod STRIPS unknown keys, so an extra field on the payload makes the
+    // parsed object differ from the emitted one — this is what catches a new
+    // undocumented field sneaking onto the wire.
+    const wire = await getScheduleSettings(auth, divisionId);
+    expect(ScheduleSettings.parse(wire)).toEqual(wire);
+
+    const put = await putScheduleSettings(auth, divisionId, { config: CONFIG });
+    expect(ScheduleSettings.parse(put)).toEqual(put);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/schedule.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule.test.ts
@@ -7,7 +7,7 @@
 import { afterAll, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
 import { EngineError } from "@seazn/engine/core";
-import { sql } from "@/lib/db";
+import { sql, withTenant } from "@/lib/db";
 import { PaymentRequiredError } from "@/lib/errors";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { createCompetition } from "../competitions";
@@ -17,6 +17,7 @@ import { createStages, generateStageFixtures } from "../stages";
 import {
   putScheduleSettings,
   getScheduleSettings,
+  loadSettings,
   autoSchedule,
   applySchedule,
   moveFixture,
@@ -576,27 +577,36 @@ describe.skipIf(!HAS_DB)("loadSettings resolves the organisation zone separately
     return { auth, divisionId: division.id };
   }
 
-  it("returns the org zone in orgTz even when the division overrides tz", async () => {
+  // Driven through `loadSettings` directly, not the HTTP boundary: `orgTz` is
+  // an INTERNAL field. `getScheduleSettings`/`putScheduleSettings` map to the
+  // wire shape and deliberately drop it — that boundary is pinned separately in
+  // schedule-settings-wire.test.ts.
+  const load = (auth: AuthCtx, divisionId: string) =>
+    withTenant(auth.orgId, (tx) => loadSettings(tx, divisionId));
+
+  it("returns the org zone in orgTz even when the division overrides displayTz", async () => {
     const { auth, divisionId } = await seedDivisionWithOrgTz("Europe/London");
     await sql`
       insert into schedule_settings (division_id, config, tz, updated_at)
       values (${divisionId}, ${sql.json({})}, 'Europe/Madrid', now())
       on conflict (division_id) do update set tz = excluded.tz`;
 
-    const settings = await getScheduleSettings(auth, divisionId);
-    expect(settings.tz).toBe("Europe/Madrid"); // display lane, unchanged
+    const settings = await load(auth, divisionId);
+    expect(settings.displayTz).toBe("Europe/Madrid"); // display lane, unchanged
     expect(settings.orgTz).toBe("Europe/London"); // governing lane, new
+    // And the same division over the wire still renders in the display zone.
+    expect((await getScheduleSettings(auth, divisionId)).tz).toBe("Europe/Madrid");
   });
 
   it("falls back to UTC when the organisation has no timezone", async () => {
     const { auth, divisionId } = await seedDivisionWithOrgTz(null);
-    const settings = await getScheduleSettings(auth, divisionId);
+    const settings = await load(auth, divisionId);
     expect(settings.orgTz).toBe("UTC");
   });
 
   it("falls back to UTC when the organisation timezone is not a valid IANA id", async () => {
     const { auth, divisionId } = await seedDivisionWithOrgTz("Pacific/Atlantis");
-    const settings = await getScheduleSettings(auth, divisionId);
+    const settings = await load(auth, divisionId);
     expect(settings.orgTz).toBe("UTC");
   });
 });

--- a/apps/web/src/server/usecases/competition-schedule-apply.ts
+++ b/apps/web/src/server/usecases/competition-schedule-apply.ts
@@ -271,7 +271,7 @@ const packDivisionOf = (d: LoadedDivision): CompetitionPackDivision => ({
   id: d.id,
   name: d.name,
   sport: d.sport,
-  tz: d.settings.tz,
+  tz: d.settings.displayTz,
   settings: packSettingsOf(d.settings.config),
   movableIds: d.input.assignments.map((a) => a.fixture_id),
   draftPlaced: d.input.assignments.length,

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -162,7 +162,7 @@ export async function buildOfficialsPack(
     if (!division) throw new HttpError(404, "division not found");
 
     const settings = await loadSettings(tx, divisionId);
-    const tz = settings.tz; // display/rendering only
+    const tz = settings.displayTz; // display/rendering only
     const orgTz = settings.orgTz; // governing clock for every day bucket (#448)
     const matchMinutes = settings.config.matchMinutes;
 

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -33,6 +33,7 @@ import {
   type OfficialFixture,
   type OfficialSpec,
 } from "@seazn/engine/officials";
+import { dayKeyInTz } from "@seazn/engine/scheduling";
 import { withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { requireFeature } from "@/lib/entitlements";
@@ -80,7 +81,10 @@ const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
 
 export interface OfficialsPackFixture {
   id: string;
-  /** ISO-8601 with the division tz offset (dry-run schedule time when given). */
+  /** ISO-8601 with the DIVISION tz offset — display rendering for the model
+   *  (dry-run schedule time when given). Its date is NOT the authority on which
+   *  calendar day this fixture falls on: that is `dayKeyInTz(start, org_tz)`
+   *  (#448). Slicing the offset out of this string reads the DIVISION's day. */
   start_at: string;
   court: string | null;
   /** Pool id — the engine's poolLock target. */
@@ -104,7 +108,18 @@ export interface OfficialsPackOfficial {
 }
 
 export interface OfficialsPack {
-  division: { id: string; name: string; sport: string; tz: string };
+  /**
+   * `tz` is the DIVISION zone — display metadata, the offset every timestamp in
+   * this pack is rendered with, and nothing else.
+   *
+   * `org_tz` is the ORGANISATION zone (#397, design §2.1): the governing clock
+   * for every calendar-day decision — the engine's `maxPerDay` cap, `per_day`
+   * fairness, the referee's max_per_day recount and the blackout-date check.
+   * The two are equal unless the division overrides `schedule_settings.tz`;
+   * where they differ, day math must use `org_tz` or two divisions of one
+   * competition disagree about which Saturday a fixture is on (#448).
+   */
+  division: { id: string; name: string; sport: string; tz: string; org_tz: string };
   /** Fixed match length — the referee derives each fixture's end from this. */
   match_minutes: number;
   policy: AssignPolicy;
@@ -147,7 +162,8 @@ export async function buildOfficialsPack(
     if (!division) throw new HttpError(404, "division not found");
 
     const settings = await loadSettings(tx, divisionId);
-    const tz = settings.tz;
+    const tz = settings.tz; // display/rendering only
+    const orgTz = settings.orgTz; // governing clock for every day bucket (#448)
     const matchMinutes = settings.config.matchMinutes;
 
     // Officials roster (soft context). An empty roster cannot be planned.
@@ -323,6 +339,7 @@ export async function buildOfficialsPack(
       })),
       policy: opts.policy,
       rngSeed: "officials-draft",
+      tz: orgTz,
     });
     const draft = sortAssignments(
       solved.assignments.map((a) => ({
@@ -381,7 +398,13 @@ export async function buildOfficialsPack(
       );
 
     return {
-      division: { id: division.id, name: division.name, sport: division.sport_key, tz },
+      division: {
+        id: division.id,
+        name: division.name,
+        sport: division.sport_key,
+        tz,
+        org_tz: orgTz,
+      },
       match_minutes: matchMinutes,
       policy: opts.policy,
       fixtures: packFixtures,
@@ -439,9 +462,14 @@ const rowKey = (a: { fixtureId: string; roleKey: string; officialId: string }): 
  *    elsewhere — signals the engine cannot see). A declared-unfilled slot the
  *    pass also cannot fill surfaces as the engine's `role_unfilled` (confirmed).
  * 3. Supplement (`ineligible`, block): wrong role, maxPerDay exceeded (recounted
- *    per official per UTC day over locked+plan), assignment on a blackout date,
- *    assignment overlapping a busy-elsewhere time, and any locked row missing /
- *    altered in the proposal.
+ *    per official per ORG calendar day over locked+plan), assignment on a
+ *    blackout date, assignment overlapping a busy-elsewhere time, and any
+ *    locked row missing / altered in the proposal.
+ *
+ * Every calendar day here — the recount and the blackout check — comes from
+ * `dayOf()` below, which reads `pack.division.org_tz` (#448). This function used
+ * to hold two different answers to "what day is this fixture on": a UTC slice
+ * for the recount and a division-offset string slice for blackouts.
  */
 export function refereeOfficialsPlan(
   pack: OfficialsPack,
@@ -450,6 +478,11 @@ export function refereeOfficialsPlan(
   const matchMs = pack.match_minutes * MS_PER_MIN;
   const fixtureById = new Map(pack.fixtures.map((f) => [f.id, f]));
   const officialById = new Map(pack.officials.map((o) => [o.id, o]));
+
+  // THE day key for this whole function (#448) — the org zone, matching what
+  // the engine buckets maxPerDay and per_day fairness on.
+  const dayOf = (f: OfficialsPackFixture): string =>
+    dayKeyInTz(new Date(f.start_at).getTime(), pack.division.org_tz);
 
   const engineFixtures: OfficialFixture[] = pack.fixtures.map((f) => {
     const startAt = new Date(f.start_at).getTime();
@@ -489,6 +522,7 @@ export function refereeOfficialsPlan(
     locked: engineLocked,
     policy: pack.policy,
     rngSeed: "referee",
+    tz: pack.division.org_tz,
   });
 
   // Greedy fills = the solver's assignments on slots the plan left uncovered.
@@ -499,8 +533,11 @@ export function refereeOfficialsPlan(
   }
 
   const onBlackout = (o: OfficialsPackOfficial, f: OfficialsPackFixture): boolean =>
-    // start_at carries the division offset, so its date is the local calendar day.
-    o.blackout_dates.includes(f.start_at.slice(0, 10));
+    // The ORG calendar day, same key the maxPerDay recount uses (#448). Slicing
+    // `start_at` would read the DIVISION's day, which differs whenever a
+    // division overrides schedule_settings.tz — and would put this check and
+    // the recount back on two different calendars.
+    o.blackout_dates.includes(dayOf(f));
   const busyOverlap = (o: OfficialsPackOfficial, f: OfficialsPackFixture): boolean => {
     const fStart = new Date(f.start_at).getTime();
     const fEnd = fStart + matchMs;
@@ -561,13 +598,14 @@ export function refereeOfficialsPlan(
     }
   }
 
-  // maxPerDay recount per official per UTC day (the engine never checks locked).
+  // maxPerDay recount per official per ORG calendar day (the engine never
+  // checks locked). Same key as the engine's own cap and as onBlackout (#448).
   const byOfficialDay = new Map<string, FixtureOfficial[]>();
   for (const a of engineLocked) {
     const o = officialById.get(a.officialId);
     const f = fixtureById.get(a.fixtureId);
     if (!o || !f || o.max_per_day === null) continue;
-    const day = new Date(f.start_at).toISOString().slice(0, 10); // UTC day
+    const day = dayOf(f);
     const k = `${a.officialId}${SEP}${day}`;
     (byOfficialDay.get(k) ?? byOfficialDay.set(k, []).get(k)!).push(a);
   }

--- a/apps/web/src/server/usecases/officials.ts
+++ b/apps/web/src/server/usecases/officials.ts
@@ -23,6 +23,7 @@ import { AiApplyMeta } from "@/server/api-v1/schemas";
 import { sendOfficialAssignedEmail } from "@/lib/email";
 import { createClaimInvite, type ClaimRow } from "./person-claims";
 import { parseUpload } from "./import-parse";
+import { loadSettings } from "./schedule";
 
 type Tx = postgres.TransactionSql;
 
@@ -301,10 +302,21 @@ export async function loadOfficialsWithEntrants(tx: Tx): Promise<OfficialWithEnt
 async function engineInput(
   tx: Tx,
   divisionId: string,
-): Promise<{ fixtures: OfficialFixture[]; officials: OfficialSpec[]; locked: FixtureOfficial[] }> {
+): Promise<{
+  fixtures: OfficialFixture[];
+  officials: OfficialSpec[];
+  locked: FixtureOfficial[];
+  tz: string;
+}> {
   const [settings] = await tx<{ config: { matchMinutes?: number } }[]>`
     select config from schedule_settings where division_id = ${divisionId}`;
   const matchMinutes = settings?.config?.matchMinutes ?? DEFAULT_MATCH_MINUTES;
+
+  // The ORG zone governs which calendar day a fixture falls on, so it is what
+  // the engine's maxPerDay cap and per_day fairness bucket on (#397, #448).
+  // Deliberately NOT the division's display tz: a division override must not
+  // move a fixture to a different day than its sibling divisions see.
+  const tz = (await loadSettings(tx, divisionId)).orgTz;
 
   const fixtureRows = await tx<{
     id: string; scheduled_at: string; court_label: string | null; pool_id: string | null;
@@ -354,7 +366,7 @@ async function engineInput(
     roleKey: r.role_key,
     locked: true,
   }));
-  return { fixtures, officials, locked };
+  return { fixtures, officials, locked, tz };
 }
 
 export const AutoAssignInput = z.object({
@@ -373,13 +385,14 @@ export async function autoAssignOfficials(
   return withTenant(auth.orgId, async (tx) => {
     const [division] = await tx`select 1 from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
-    const { fixtures, officials, locked } = await engineInput(tx, divisionId);
+    const { fixtures, officials, locked, tz } = await engineInput(tx, divisionId);
     return assignOfficials({
       fixtures,
       officials,
       locked,
       policy: input.policy,
       rngSeed: input.rng_seed,
+      tz,
     });
   });
 }

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -557,11 +557,11 @@ export async function buildSchedulePack(
     if (!division) throw new HttpError(404, "division not found");
     const settings = await loadSettings(tx, divisionId);
     const config = settings.config;
-    // ONE clock (#397, design §2.1). `settings.tz` stays available as the
+    // ONE clock (#397, design §2.1). `settings.displayTz` stays available as the
     // division's DISPLAY zone — it is what `pack.division.tz` carries — but
     // every instant below is rendered in, and every calendar question answered
     // in, the ORGANISATION zone.
-    const tz = settings.tz;
+    const tz = settings.displayTz;
     const orgTz = settings.orgTz;
     const clock = makeClock(opts.now, orgTz);
     const courts = [...config.courts];

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -2042,7 +2042,16 @@ function coveragePreview(
     ...(o.entrant_ids.length > 0 ? { entrantIds: o.entrant_ids } : {}),
     homeDivisionId: pack.division.id,
   }));
-  const { conflicts } = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: "coverage" });
+  // `pack.tz` is the ORG zone (see SchedulePack.tz) — the day bucket the
+  // maxPerDay cap and per_day fairness are counted on (#448).
+  const { conflicts } = assignOfficials({
+    fixtures,
+    officials,
+    locked: [],
+    policy,
+    rngSeed: "coverage",
+    tz: pack.tz,
+  });
   const unfilled = conflicts
     .filter((c) => c.kind === "role_unfilled")
     .map((c) => ({ fixture_id: c.fixtureId ?? "", role_key: c.roleKey ?? "" }));

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -80,17 +80,50 @@ export const OCCUPYING = ["scheduled", "in_play", "decided", "finalized", "forfe
 // Settings
 // ---------------------------------------------------------------------------
 
+/** The INTERNAL settings object. Its two zones are deliberately NOT one letter
+ *  apart: `displayTz` vs `orgTz` reads as a choice, `tz` vs `orgTz` reads as a
+ *  typo, and #448 was exactly that typo shipped. Anything doing calendar-day
+ *  math wants `orgTz`; anything rendering a timestamp wants `displayTz`.
+ *
+ *  This is NOT the wire shape — see `ScheduleSettingsWire`. */
 export interface ScheduleSettingsOut {
   division_id: string;
   config: ScheduleConfig;
-  /** RESOLVED venue zone (V305): stored division tz → org timezone → 'UTC'. */
-  tz: string;
+  /** RESOLVED venue zone (V305): stored division tz → org timezone → 'UTC'.
+   *  DISPLAY ONLY. Never use it to decide which calendar day something is on. */
+  displayTz: string;
   /** The ORGANISATION zone, resolved independently of the division's own (#397).
    *  W2 makes this the one clock all temporal math runs in — day boundaries,
-   *  weekday targets, session hours, output offsets — while `tz` above stays the
-   *  display lane a division may override. */
+   *  weekday targets, session hours, output offsets — while `displayTz` above
+   *  stays the display lane a division may override. */
   orgTz: string;
   updated_at: string;
+}
+
+/** The PUBLIC payload of GET/PUT /api/v1/divisions/{id}/schedule-settings.
+ *
+ *  The route returns the two boundary functions below unmapped, so this shape
+ *  IS the wire. The key is `tz` — not `displayTz` — because it is pinned by the
+ *  `ScheduleSettings` response schema and documented in openapi/v1.json;
+ *  renaming it would break every existing client. `orgTz` is deliberately NOT
+ *  here: it was only ever serialised as an undocumented extra.
+ *  Pinned by `__tests__/schedule-settings-wire.test.ts`. */
+export interface ScheduleSettingsWire {
+  division_id: string;
+  config: ScheduleConfig;
+  /** RESOLVED venue zone (V305) — the DISPLAY lane, `ScheduleSettingsOut.displayTz`. */
+  tz: string;
+  updated_at: string;
+}
+
+/** Internal → wire. The one place the display zone is renamed back to `tz`. */
+function toWire(s: ScheduleSettingsOut): ScheduleSettingsWire {
+  return {
+    division_id: s.division_id,
+    config: s.config,
+    tz: s.displayTz,
+    updated_at: s.updated_at,
+  };
 }
 
 /** Does a config use the Pro constraint solver (doc 12 §5)? Community keeps
@@ -110,7 +143,7 @@ export async function putScheduleSettings(
   auth: AuthCtx,
   divisionId: string,
   input: PutScheduleSettings,
-): Promise<ScheduleSettingsOut> {
+): Promise<ScheduleSettingsWire> {
   if (usesConstraints(input.config)) {
     await requireFeature(auth.orgId, "scheduling.constraints");
   }
@@ -130,18 +163,18 @@ export async function putScheduleSettings(
         set config = excluded.config,
             tz = case when ${tzTouched} then excluded.tz else schedule_settings.tz end,
             updated_at = now()`;
-    return loadSettings(tx, divisionId);
+    return toWire(await loadSettings(tx, divisionId));
   });
 }
 
 export async function getScheduleSettings(
   auth: AuthCtx,
   divisionId: string,
-): Promise<ScheduleSettingsOut> {
+): Promise<ScheduleSettingsWire> {
   return withTenant(auth.orgId, async (tx) => {
     const [division] = await tx`select 1 from divisions where id = ${divisionId}`;
     if (!division) throw new HttpError(404, "division not found");
-    return loadSettings(tx, divisionId);
+    return toWire(await loadSettings(tx, divisionId));
   });
 }
 
@@ -168,12 +201,18 @@ export async function loadSettings(tx: Tx, divisionId: string): Promise<Schedule
     config: ScheduleConfig.parse(row?.config ?? {}),
     // A division that already holds its own tz keeps winning, silently and
     // forever — the console can no longer set one, but it must never move.
-    tz: resolveVenueTz(row?.tz, row?.org_tz),
+    displayTz: resolveVenueTz(row?.tz, row?.org_tz),
     // Deliberately NOT resolveVenueTz(row?.tz, …): the division override must not
     // leak into the governing clock, or two divisions of one competition would
     // disagree about which calendar day a fixture is on (#397, design §2.1).
     orgTz: resolveVenueTz(null, row?.org_tz),
-    updated_at: row?.updated_at ?? new Date(0).toISOString(),
+    // postgres hands timestamptz back as a Date, so the declared `string` was a
+    // lie the wire hid (JSON.stringify(Date) already emits this exact ISO
+    // string). Normalise here so `ScheduleSettings.parse` actually accepts it.
+    updated_at:
+      row?.updated_at !== null && row?.updated_at !== undefined
+        ? new Date(row.updated_at).toISOString()
+        : new Date(0).toISOString(),
   };
 }
 
@@ -1129,7 +1168,7 @@ export async function validateSchedule(
         -- venue lane (V305): settings already carries the RESOLVED zone
         -- (division override → org timezone → UTC), and this whole query is
         -- scoped to one division, so bind it rather than re-joining.
-        and oa.date = (f.scheduled_at at time zone ${settings.tz})::date`;
+        and oa.date = (f.scheduled_at at time zone ${settings.displayTz})::date`;
 
     // A REPORT of the board as it stands. `blocking` here says "impossible", not
     // "refused" (#399) — the board paints those cards red, and it must keep

--- a/packages/engine/src/officials/assign.property.test.ts
+++ b/packages/engine/src/officials/assign.property.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import fc from "fast-check";
 import { assignOfficials } from "./assign.ts";
+import { dayKeyInTz } from "../scheduling/tz.ts";
 import {
   AssignPolicy,
   type FixtureOfficial,
@@ -16,6 +17,13 @@ const T0 = Date.UTC(2026, 6, 4, 9, 0, 0);
 const ENTRANTS = ["e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8"];
 const POOLS = ["pA", "pB"];
 
+/** Zones chosen so the generated board straddles a UTC midnight from BOTH
+ *  sides (#448): west of Greenwich a local evening is already the next UTC day,
+ *  east of it a local morning is still the previous one. "UTC" stays in the
+ *  set so the degenerate case keeps its coverage. */
+const TIMEZONES = ["UTC", "America/Los_Angeles", "Pacific/Auckland", "Asia/Kolkata"];
+const arbitraryTz = fc.constantFrom(...TIMEZONES);
+
 const arbitraryFixtures = fc
   .integer({ min: 1, max: 64 })
   .chain((n) =>
@@ -23,7 +31,9 @@ const arbitraryFixtures = fc
       ...Array.from({ length: n }, (_, i) =>
         fc
           .record({
-            slot: fc.integer({ min: 0, max: 15 }),
+            // 48 half-hour slots from 09:00Z = a full 24h span, so fixtures
+            // land on both sides of a UTC midnight AND of a local one.
+            slot: fc.integer({ min: 0, max: 47 }),
             court: fc.constantFrom("C1", "C2", "C3"),
             pool: fc.option(fc.constantFrom(...POOLS), { nil: undefined }),
             pair: fc.integer({ min: 0, max: ENTRANTS.length - 2 }),
@@ -72,19 +82,21 @@ const arbitraryPolicy = fc
   .map((p) => AssignPolicy.parse({ roles: ["referee"], ...p }));
 
 describe("assignOfficials properties (PROMPT-22)", () => {
-  it("no official is double-booked; team-ref never officiates own or parallel-play fixtures; poolLock holds", () => {
+  it("no official is double-booked; team-ref never officiates own or parallel-play fixtures; poolLock holds; maxPerDay holds per ORG day", () => {
     fc.assert(
       fc.property(
         arbitraryFixtures,
         arbitraryOfficials,
         arbitraryPolicy,
-        (fixtures, officials, policy) => {
+        arbitraryTz,
+        (fixtures, officials, policy, tz) => {
           const { assignments } = assignOfficials({
             fixtures,
             officials,
             locked: [],
             policy,
             rngSeed: "prop",
+            tz,
           });
           const fixtureById = new Map(fixtures.map((f) => [f.id, f]));
           const officialById = new Map(officials.map((o) => [o.id, o]));
@@ -119,6 +131,20 @@ describe("assignOfficials properties (PROMPT-22)", () => {
               expect(o.homePoolId).toBe(f.poolId);
             }
           }
+
+          // maxPerDay is a HARD cap, counted on the calendar day in the org
+          // zone (#448) — never the UTC day, which used to let an official
+          // west of Greenwich work two "days" in one local evening.
+          const perOfficialDay = new Map<string, number>();
+          for (const a of assignments) {
+            const f = fixtureById.get(a.fixtureId)!;
+            const key = `${a.officialId}|${dayKeyInTz(f.startAt, tz)}`;
+            perOfficialDay.set(key, (perOfficialDay.get(key) ?? 0) + 1);
+          }
+          for (const [key, n] of perOfficialDay) {
+            const cap = officialById.get(key.slice(0, key.indexOf("|")))!.maxPerDay;
+            if (cap !== undefined) expect(n).toBeLessThanOrEqual(cap);
+          }
         },
       ),
       { numRuns: 150 },
@@ -131,13 +157,15 @@ describe("assignOfficials properties (PROMPT-22)", () => {
         arbitraryFixtures,
         arbitraryOfficials,
         arbitraryPolicy,
-        (fixtures, officials, policy) => {
+        arbitraryTz,
+        (fixtures, officials, policy, tz) => {
           const first = assignOfficials({
             fixtures,
             officials,
             locked: [],
             policy,
             rngSeed: "prop",
+            tz,
           });
           const locked: FixtureOfficial[] = first.assignments.map((a) => ({
             ...a,
@@ -149,6 +177,7 @@ describe("assignOfficials properties (PROMPT-22)", () => {
             locked,
             policy,
             rngSeed: "prop",
+            tz,
           });
           const fresh = second.assignments.filter((a) => !a.locked);
           expect(fresh).toEqual([]);
@@ -166,10 +195,10 @@ describe("assignOfficials properties (PROMPT-22)", () => {
 
   it("determinism: same inputs ⇒ identical result", () => {
     fc.assert(
-      fc.property(arbitraryFixtures, arbitraryOfficials, (fixtures, officials) => {
+      fc.property(arbitraryFixtures, arbitraryOfficials, arbitraryTz, (fixtures, officials, tz) => {
         const policy = AssignPolicy.parse({ roles: ["referee"], blockStay: true });
-        const a = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: "x" });
-        const b = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: "x" });
+        const a = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: "x", tz });
+        const b = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: "x", tz });
         expect(b).toEqual(a);
       }),
       { numRuns: 80 },

--- a/packages/engine/src/officials/assign.test.ts
+++ b/packages/engine/src/officials/assign.test.ts
@@ -44,6 +44,7 @@ describe("assignOfficials golden (Jul3/02 §3)", () => {
       locked: [],
       policy: AssignPolicy.parse({ roles: ["referee"], blockStay: true }),
       rngSeed: "golden-24",
+      tz: "UTC",
     });
     expect(assignments).toHaveLength(24);
     expect(conflicts).toEqual([]); // full coverage, spread ≤ 1 → no warns
@@ -119,6 +120,7 @@ describe("assignOfficials rules", () => {
       locked: [],
       policy: POLICY,
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(assignments).toEqual([]);
     expect(conflicts).toEqual([
@@ -136,6 +138,7 @@ describe("assignOfficials rules", () => {
       locked: [],
       policy: POLICY,
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(assignments).toEqual([]); // parallel slot → busy playing
   });
@@ -154,6 +157,7 @@ describe("assignOfficials rules", () => {
       locked: [],
       policy: AssignPolicy.parse({ roles: ["referee"], poolLock: true }),
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(conflicts).toEqual([]);
     const byFixture = new Map(assignments.map((a) => [a.fixtureId, a.officialId]));
@@ -169,6 +173,7 @@ describe("assignOfficials rules", () => {
       locked: [{ fixtureId: "f1", officialId: "only", roleKey: "referee", locked: true }],
       policy: POLICY,
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(assignments).toEqual([
       { fixtureId: "f1", officialId: "only", roleKey: "referee", locked: true },
@@ -186,6 +191,7 @@ describe("assignOfficials rules", () => {
       locked: [],
       policy: POLICY,
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(assignments).toHaveLength(2);
     expect(conflicts).toContainEqual(
@@ -203,6 +209,7 @@ describe("assignOfficials rules", () => {
       locked: [],
       policy: AssignPolicy.parse({ roles: ["referee", "judge"] }),
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(assignments).toEqual(
       expect.arrayContaining([
@@ -210,6 +217,89 @@ describe("assignOfficials rules", () => {
         expect.objectContaining({ officialId: "judge", roleKey: "judge" }),
       ]),
     );
+  });
+
+  it("maxPerDay counts the ORG calendar day, not the UTC day (#448)", () => {
+    // One local Saturday in America/Los_Angeles (PDT, UTC-7). The evening pair
+    // is already Sunday in UTC, which is exactly what used to double the cap.
+    const at = (hhmm: string): number => Date.parse(`2026-07-04T${hhmm}:00-07:00`);
+    const fixtures: OfficialFixture[] = ["10:00", "12:00", "18:00", "20:00"].map((t, i) => ({
+      id: `sat-${t}`,
+      startAt: at(t),
+      endAt: at(t) + 30 * MIN,
+      court: "C1",
+      entrants: [`e${i}a`, `e${i}b`],
+    }));
+    // Guard the guard: the last two really are a different UTC day, so a UTC
+    // bucket sees 2 + 2 and this test cannot pass by accident.
+    expect(fixtures.map((f) => new Date(f.startAt).toISOString().slice(0, 10))).toEqual([
+      "2026-07-04",
+      "2026-07-04",
+      "2026-07-05",
+      "2026-07-05",
+    ]);
+
+    const { assignments, conflicts } = assignOfficials({
+      fixtures,
+      officials: [official("capped", { maxPerDay: 2 })],
+      locked: [],
+      policy: POLICY,
+      rngSeed: "s",
+      tz: "America/Los_Angeles",
+    });
+
+    expect(assignments).toHaveLength(2);
+    expect(assignments.map((a) => a.fixtureId)).toEqual(["sat-10:00", "sat-12:00"]);
+    for (const id of ["sat-18:00", "sat-20:00"]) {
+      expect(conflicts).toContainEqual(
+        expect.objectContaining({ kind: "role_unfilled", severity: "block", fixtureId: id }),
+      );
+    }
+  });
+
+  it("per_day fairness buckets on the ORG calendar day (#448)", () => {
+    // Four fixtures on ONE local Saturday straddling UTC midnight. o2 plays in
+    // both evening fixtures, so o1 must take them: the load ends 3/1 and the
+    // spread warning names the basis it was measured in. Bucketing on UTC
+    // splits that into two bases and reports the spread against 07-05.
+    const at = (hhmm: string): number => Date.parse(`2026-07-04T${hhmm}:00-07:00`);
+    const mk = (t: string, entrants: string[]): OfficialFixture => ({
+      id: `sat-${t}`,
+      startAt: at(t),
+      endAt: at(t) + 30 * MIN,
+      court: "C1",
+      entrants,
+    });
+    const fixtures = [
+      mk("10:00", ["eX", "eY"]),
+      mk("12:00", ["eX", "eY"]),
+      mk("18:00", ["ePlay", "eY"]),
+      mk("20:00", ["ePlay", "eY"]),
+    ];
+    const { assignments, conflicts } = assignOfficials({
+      fixtures,
+      officials: [official("o1"), official("o2", { entrantIds: ["ePlay"] })],
+      locked: [],
+      policy: AssignPolicy.parse({ roles: ["referee"], fairness: "per_day" }),
+      rngSeed: "s",
+      tz: "America/Los_Angeles",
+    });
+    expect(assignments).toHaveLength(4);
+    const perOfficial = new Map<string, number>();
+    for (const a of assignments) {
+      perOfficial.set(a.officialId, (perOfficial.get(a.officialId) ?? 0) + 1);
+    }
+    expect(perOfficial.get("o1")).toBe(3);
+    expect(perOfficial.get("o2")).toBe(1);
+    // ONE basis for the whole local day, and it is the LOCAL date — under a UTC
+    // bucket this is two bases and the warning would name 2026-07-05.
+    expect(conflicts.filter((c) => c.kind === "fairness")).toEqual([
+      expect.objectContaining({
+        kind: "fairness",
+        severity: "warn",
+        detail: "assignment spread 2 within basis 2026-07-04",
+      }),
+    ]);
   });
 
   it("teamRefKeepDivision: same-division team-ref preferred; leaving warns", () => {
@@ -223,6 +313,7 @@ describe("assignOfficials rules", () => {
       locked: [],
       policy: AssignPolicy.parse({ roles: ["referee"], teamRefKeepDivision: true }),
       rngSeed: "s",
+      tz: "UTC",
     });
     expect(assignments).toHaveLength(2);
     expect(conflicts).toEqual([

--- a/packages/engine/src/officials/assign.ts
+++ b/packages/engine/src/officials/assign.ts
@@ -3,6 +3,7 @@
 // candidates (never assigned in violation), locked assignments are validated
 // obstacles, soft objectives (fairness, block-stay, travel) order candidates.
 import { mulberry32 } from "../core/rng.ts";
+import { dayKeyInTz } from "../scheduling/tz.ts";
 import type {
   AssignInput,
   AssignResult,
@@ -35,13 +36,37 @@ function overlaps(busy: readonly Busy[], from: number, to: number): Busy | undef
 }
 
 // Fairness basis key (Jul3/02 §3, 29 May): whole tournament or per day.
-// Days bucket on UTC — times are injected epoch ms, the caller owns zones.
-function basisKey(basis: "tournament" | "per_day", startAt: number): string {
-  return basis === "tournament" ? "T" : new Date(startAt).toISOString().slice(0, 10);
+//
+// A day is the calendar day in the ORG zone the caller injects (#397/#448) —
+// the single source of truth for what "a day" means here. The hard maxPerDay
+// cap, per_day fairness and the fairness-spread warning ALL route through this
+// one function, so they can never disagree about which day a fixture is on.
+// It used to bucket on UTC, which split one local evening across two days and
+// doubled the cap for every org west of Greenwich.
+function basisKey(
+  basis: "tournament" | "per_day",
+  startAt: number,
+  dayKey: (startAt: number) => string,
+): string {
+  return basis === "tournament" ? "T" : dayKey(startAt);
 }
 
 export function assignOfficials(input: AssignInput): AssignResult {
-  const { policy, rngSeed } = input;
+  const { policy, rngSeed, tz } = input;
+
+  // `dayKeyInTz` builds an Intl.DateTimeFormat per call and basisKey sits in
+  // the inner candidate loop (fixtures × roles × officials), so memoise on the
+  // instant. Fixtures share start times heavily, and the cache is per-call, so
+  // this cannot leak state between runs or make the pass non-deterministic.
+  const dayKeyCache = new Map<number, string>();
+  const dayKey = (startAt: number): string => {
+    let key = dayKeyCache.get(startAt);
+    if (key === undefined) {
+      key = dayKeyInTz(startAt, tz);
+      dayKeyCache.set(startAt, key);
+    }
+    return key;
+  };
   const conflicts: OfficialConflict[] = [];
   const byId = new Map<string, OfficialSpec>(input.officials.map((o) => [o.id, o]));
   const fixtureById = new Map<string, OfficialFixture>(input.fixtures.map((f) => [f.id, f]));
@@ -100,7 +125,7 @@ export function assignOfficials(input: AssignInput): AssignResult {
   // Track both bases: "T" (tournament) for fairness, the day for maxPerDay.
   function bump(officialId: string, startAt: number): void {
     const m = counts.get(officialId)!;
-    for (const key of ["T", basisKey("per_day", startAt)]) {
+    for (const key of ["T", basisKey("per_day", startAt, dayKey)]) {
       m.set(key, (m.get(key) ?? 0) + 1);
     }
   }
@@ -201,15 +226,15 @@ export function assignOfficials(input: AssignInput): AssignResult {
         // hard: max assignments per day (29 May) — always day-based,
         // independent of the fairness distribution basis
         if (official.maxPerDay !== undefined) {
-          const dayKey = basisKey("per_day", fixture.startAt);
-          const dayCount = counts.get(official.id)!.get(dayKey) ?? 0;
+          const fixtureDay = basisKey("per_day", fixture.startAt, dayKey);
+          const dayCount = counts.get(official.id)!.get(fixtureDay) ?? 0;
           if (dayCount >= official.maxPerDay) continue;
         }
 
         // soft score, minimised lexicographically:
         // [fairness count, block-stay miss, travel penalty, seeded tiebreak]
         const count =
-          counts.get(official.id)!.get(basisKey(policy.fairness, fixture.startAt)) ?? 0;
+          counts.get(official.id)!.get(basisKey(policy.fairness, fixture.startAt, dayKey)) ?? 0;
         const last = lastOnCourt.get(official.id);
         // stay = the official's previous assignment sits in the SAME
         // court-block as this fixture (29 Jun "before break", not across it)

--- a/packages/engine/src/officials/types.ts
+++ b/packages/engine/src/officials/types.ts
@@ -75,6 +75,21 @@ export interface AssignInput {
   locked: readonly FixtureOfficial[];
   policy: AssignPolicy;
   rngSeed: string;
+  /**
+   * The ORGANISATION zone (#397, design §2.1) — the governing clock for every
+   * calendar day this pass buckets on: the `maxPerDay` cap, `per_day` fairness
+   * and the fairness-spread warning all share it. NOT the division's display
+   * zone: a division override must not decide which day a fixture falls on, or
+   * two divisions of one competition would disagree about the same Saturday.
+   *
+   * REQUIRED on purpose (#448). This field exists because the pass used to
+   * bucket days on UTC, which silently doubled a `maxPerDay: 2` cap for any
+   * evening fixture west of Greenwich. An optional field defaulting to UTC
+   * would reinstate exactly that failure for every caller that forgot it, and
+   * a caller forgetting it is the whole defect. Making it required turns each
+   * un-updated call site into a compile error instead.
+   */
+  tz: string;
 }
 
 export interface AssignResult {

--- a/packages/engine/src/testkit/scenarios.ts
+++ b/packages/engine/src/testkit/scenarios.ts
@@ -318,7 +318,16 @@ export function runOfficialsScenario(seed: number): OfficialsStats {
     restMinMinutes: 0,
     blockGapMinutes: 30,
   };
-  const result = assignOfficials({ fixtures, officials, locked: [], policy, rngSeed: `sim-${seed}` });
+  // Fixtures are laid out from epoch 0, so "UTC" keeps this sim's day bucket
+  // identical to what it has always been (#448 made the zone explicit).
+  const result = assignOfficials({
+    fixtures,
+    officials,
+    locked: [],
+    policy,
+    rngSeed: `sim-${seed}`,
+    tz: "UTC",
+  });
 
   // Hard invariant: no official on two overlapping fixtures.
   const byOfficial = new Map<string, { from: number; to: number }[]>();

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1573,10 +1573,16 @@ async function smokePlanMatrix(): Promise<void> {
   // the org west of Greenwich and lay four fixtures across one LOCAL Saturday
   // whose evening half is already Sunday in UTC: a UTC bucket sees 2 + 2 and
   // fills all four, the org's own day allows only 2.
-  const tzOrg = await call(plus, `/api/orgs/${plusOrg}`, "PATCH", {
+  // `call` returns json.data and THROWS on ok:false — it has no .status, so
+  // assert the value actually landed. The two checks below are meaningless if
+  // this org is still on UTC, so this must fail loudly rather than silently.
+  const tzOrg = (await call(plus, `/api/orgs/${plusOrg}`, "PATCH", {
     timezone: "America/Los_Angeles",
-  });
-  check("matrix/pro_plus #448: org timezone set to America/Los_Angeles", tzOrg.status === 200);
+  })) as { timezone: string };
+  check(
+    "matrix/pro_plus #448: org timezone set to America/Los_Angeles",
+    tzOrg.timezone === "America/Los_Angeles",
+  );
 
   // 2026-07-11 in Los Angeles (PDT, UTC-7): 10:00 & 12:00 local are still
   // Saturday UTC; 18:00 & 20:00 local are already Sunday UTC.

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1552,7 +1552,9 @@ async function smokePlanMatrix(): Promise<void> {
       name: "League",
     }),
   );
-  await v1(plus, `/api/v1/stages/${plusStage.id}/generate`, "POST");
+  const plusFixtures = v1data<{ fixtures: { id: string }[] }>(
+    await v1(plus, `/api/v1/stages/${plusStage.id}/generate`, "POST"),
+  ).fixtures;
   await v1(plus, `/api/v1/divisions/${plusDiv.id}/start`, "POST");
   await v1(plus, "/api/v1/officials", "POST", {
     display_name: `Matrix Ref ${tag}`,
@@ -1565,6 +1567,70 @@ async function smokePlanMatrix(): Promise<void> {
     "matrix/pro_plus: officials.auto is allowed (200, assignments proposed)",
     plusAuto.status === 200 &&
       Array.isArray(v1data<{ assignments: unknown[] }>(plusAuto).assignments),
+  );
+
+  // #448 — maxPerDay is capped on the ORG's calendar day, not the UTC day. Put
+  // the org west of Greenwich and lay four fixtures across one LOCAL Saturday
+  // whose evening half is already Sunday in UTC: a UTC bucket sees 2 + 2 and
+  // fills all four, the org's own day allows only 2.
+  const tzOrg = await call(plus, `/api/orgs/${plusOrg}`, "PATCH", {
+    timezone: "America/Los_Angeles",
+  });
+  check("matrix/pro_plus #448: org timezone set to America/Los_Angeles", tzOrg.status === 200);
+
+  // 2026-07-11 in Los Angeles (PDT, UTC-7): 10:00 & 12:00 local are still
+  // Saturday UTC; 18:00 & 20:00 local are already Sunday UTC.
+  const localSaturday = [
+    "2026-07-11T17:00:00.000Z",
+    "2026-07-11T19:00:00.000Z",
+    "2026-07-12T01:00:00.000Z",
+    "2026-07-12T03:00:00.000Z",
+  ];
+  const capIds = plusFixtures.slice(0, 4).map((f) => f.id);
+  for (const [i, id] of capIds.entries()) {
+    await v1(plus, `/api/v1/fixtures/${id}`, "PATCH", {
+      scheduled_at: localSaturday[i],
+      court_label: "Court 1",
+    });
+  }
+  // Park every other fixture far away so it cannot compete for the capped ref.
+  for (const [i, f] of plusFixtures.slice(4).entries()) {
+    await v1(plus, `/api/v1/fixtures/${f.id}`, "PATCH", {
+      scheduled_at: `2026-09-${String(i + 1).padStart(2, "0")}T18:00:00.000Z`,
+      court_label: "Court 1",
+    });
+  }
+
+  // The cap only binds if NO other official can absorb the overflow, so give
+  // this one a role nobody else on the roster holds ("Matrix Ref" is referee).
+  const cappedRef = v1data<{ id: string }>(
+    await v1(plus, "/api/v1/officials", "POST", {
+      display_name: `Capped Judge ${tag}`,
+      role_keys: ["judge"],
+      max_per_day: 2,
+    }),
+  );
+  const capAuto = await v1(plus, `/api/v1/divisions/${plusDiv.id}/officials/auto`, "POST", {
+    policy: { roles: ["judge"] },
+    rng_seed: "tz448",
+  });
+  const capBody = v1data<{
+    assignments: { fixtureId: string; officialId: string; roleKey: string }[];
+    conflicts: { kind: string; fixtureId?: string }[];
+  }>(capAuto);
+  const capSet = new Set(capIds);
+  const cappedOnSaturday = capBody.assignments.filter(
+    (a) => capSet.has(a.fixtureId) && a.officialId === cappedRef.id,
+  );
+  check(
+    "matrix/pro_plus #448: maxPerDay caps on the ORG day across a UTC midnight",
+    capAuto.status === 200 && cappedOnSaturday.length === 2,
+  );
+  check(
+    "matrix/pro_plus #448: the two over-cap local-Saturday slots report role_unfilled",
+    capBody.conflicts.filter(
+      (c) => c.kind === "role_unfilled" && capSet.has(c.fixtureId ?? ""),
+    ).length === 2,
   );
 
   // === PERSONA 4 — event_pass (community org + a single-comp pass) ======


### PR DESCRIPTION
Closes #448

## The defect

`packages/engine/src/officials/assign.ts` built its day key with
`new Date(startAt).toISOString().slice(0, 10)` — the **UTC** calendar day — and
bucketed three things on it: the hard `maxPerDay` cap, `fairness: "per_day"`,
and the fairness-spread warning. The comment claimed the caller owned time
zones. No caller passed one; `OfficialFixture` and `AssignPolicy` had no tz
field at all.

Concretely: an org in `America/Los_Angeles`, an official capped at 2/day, and
Saturday fixtures at 10:00 / 12:00 / 18:00 / 20:00 local. The evening two land
on **Sunday UTC**, so the cap counted 2 + 2 and assigned all four with zero
conflicts. Four games on one local Saturday against a cap of two. Every org west
of UTC with evening fixtures was exposed, and every org east of it with
early-morning ones.

The codebase also disagreed with itself *inside one function*: in
`refereeOfficialsPlan`, `onBlackout` sliced the offset string (the **local**
day) while the `maxPerDay` recount used `toISOString()` (the **UTC** day) — on
the same `start_at` field.

## The fix

One day key, from one source. `AssignInput` carries a **required** `tz`, routed
through the engine's existing DST-correct `dayKeyInTz`. All four consumers in
`assign.ts` and both consumers in `officials-ai.ts` derive from it.

`tz` is deliberately on `AssignInput` and **not** `AssignPolicy`: the latter is
the over-the-wire request schema, so putting it there would drift OpenAPI and
let a client choose the zone. It is required rather than optional because an
optional field defaulting to UTC reinstates the bug for every caller that
forgets it — and a caller forgetting it *is* the defect. Required turns each
un-updated call site into a compile error, which is the only mechanism that
catches this class.

The zone is the **org** zone, never the division's display zone. A division
override must not decide which calendar day a fixture falls on, or two divisions
of one competition disagree about the same Saturday.

## Also in this PR

- `refactor(schedule)`: the internal display zone is now `displayTz`, so
  grabbing the wrong one of two same-typed fields is a compile error. **The wire
  key stays `tz`** — `ScheduleSettingsOut` is the API payload, and the response
  schema pins `tz: z.string()`. A new test asserts the boundary payload
  directly, because `openapi:gen` regenerates from the zod schema and would not
  have caught a breaking rename. This also fixed a pre-existing bug:
  `loadSettings` declared `updated_at: string` while postgres returns a `Date`,
  so `ScheduleSettings.parse()` rejected the payload it describes.
- `test(smoke)`: the #448 org-timezone check asserted `.status === 200` on a
  helper that returns `json.data` and throws on error — it had no `.status` and
  could never pass. Now asserts the timezone actually landed.

## Verification

All run locally against a fresh DB (schema 348) after rebasing onto `main`.

| gate | result |
| --- | --- |
| engine unit | 2298 passed / **0 failed** / 2299 total / 92 suites / 0 empty |
| apps/web unit | 5339 passed / **0 failed** / 5389 total / 602 suites / 0 empty |
| smoke | **750 passed / 0 failed**, against a real standalone server |
| e2e | **7/7** in `schedule-panels.spec.ts` (prod build, `E2E_PROD_TARGET`) |
| lint | root `0 errors, 79 warnings` (baseline); `@seazn/engine#lint` clean |
| drift | `openapi:gen` + `i18n:gen-keys` → `git status --porcelain` empty; `openapi/v1.json` unchanged |

Regression coverage fails without the fix: the unit test crosses a real UTC
midnight, the property test now runs across `America/Los_Angeles`,
`Pacific/Auckland`, `Asia/Kolkata` and UTC, and
`officials-ai-referee.test.ts` asserts a three-way divergence (org LA vs
division Berlin vs UTC) — a two-way test would not have caught the near-miss of
using the display zone. The smoke case discriminates by construction: 2 assigned
+ 2 `role_unfilled` with the fix, 4 + 0 under the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)