### PR TITLE
Close the placer/verifier fork, end to end: the placer honours every rule family, and the web hands it one namespace

### DIFF
--- a/apps/web/e2e/scoring.spec.ts
+++ b/apps/web/e2e/scoring.spec.ts
@@ -3,6 +3,7 @@ import {
   addEntrantsViaApi,
   apiJson,
   createStageAndGenerate,
+  expectNoHorizontalScroll,
   seedScoredDivision,
   TAG,
 } from "./helpers";
@@ -376,4 +377,19 @@ test("cricket DLS scales a five-ball-over format onto the published table", asyn
   // And the shortened match is still scoreable — the pad opens on the chase.
   await page.goto(`/fixtures/${fixtureId}`);
   await expect(page.getByText(/— total/)).toContainText("0/0", { timeout: 20_000 });
+
+  // #467 — the 84 asserted off the state API above must also be ON SCREEN.
+  // Until this, the revised target was verifiable only through /state, which is
+  // how #451 (a DLS bug that awarded the match to the wrong side) survived: an
+  // unrendered derivation is an unverified one. The pad must also say the
+  // figure is DLS-derived rather than one the organiser typed.
+  const target = page.getByTestId("ck-revised-target");
+  await expect(target).toBeVisible({ timeout: 20_000 });
+  await expect(target).toContainText("84");
+  await expect(target).toContainText(/DLS/i);
+
+  // Every surface works at 375px with no horizontal page scroll (v3/02 §4).
+  await page.setViewportSize({ width: 375, height: 800 });
+  await expect(target).toBeVisible();
+  await expectNoHorizontalScroll(page);
 });

--- a/apps/web/src/components/v2/pads/__tests__/cricket-pad-revised-target.test.tsx
+++ b/apps/web/src/components/v2/pads/__tests__/cricket-pad-revised-target.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { CricketPad } from "@/components/v2/pads/cricket-pad";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import uiEn from "@/dictionaries/en/ui.json";
+import type { Dict } from "@/lib/i18n-constants";
+import type { LiveState, SideInfo, SportInfo } from "@/components/v2/fixture-console";
+
+// #467 — the DLS revised target had no surface at all. The engine resolves the
+// live chase target to `revisedTarget` whenever it is non-null, so a pad that
+// never reads it shows a score against a target the app does not state. #451
+// was a real DLS defect that awarded a match to the WRONG SIDE, and it survived
+// because this value was invisible: an unrendered derivation is an unverified
+// one. Sentinel strings prove the copy comes from the dictionary rather than
+// being hardcoded English in the component.
+const dict: Dict = {
+  ...(uiEn as unknown as Dict),
+  "pad.ck.targetDls": "«dls-loc {runs}»",
+  "pad.ck.targetManual": "«manual-loc {runs}»",
+};
+
+const side = (id: string, name: string): SideInfo => ({ id, name, members: [], lineup: [] });
+const sport = { config: { ballsPerOver: 6, inningsPerSide: 1 } } as unknown as SportInfo;
+
+const live = (state: Record<string, unknown>): LiveState => ({
+  status: "live",
+  last_seq: 12,
+  summary: {},
+  outcome: null,
+  state: {
+    phase: "live",
+    tossTaken: true,
+    entrants: { home: "h", away: "a" },
+    innings: [
+      {
+        battingSide: "home",
+        runs: 120,
+        wickets: 4,
+        legalBalls: 90,
+        closed: true,
+        fine: null,
+      },
+      {
+        battingSide: "away",
+        runs: 44,
+        wickets: 1,
+        legalBalls: 36,
+        closed: false,
+        fine: { striker: null, nonStriker: null, currentBowler: null, dismissed: [] },
+      },
+    ],
+    ...state,
+  },
+});
+
+const render = (state: Record<string, unknown>): string =>
+  renderToStaticMarkup(
+    <DictProvider dict={dict} locale="en">
+      <CricketPad
+        sport={sport}
+        home={side("h", "Harbor CC")}
+        away={side("a", "Summit CC")}
+        live={live(state)}
+        send={async () => true}
+        busy={false}
+      />
+    </DictProvider>,
+  );
+
+describe("cricket pad renders the revised target (#467)", () => {
+  it("shows a DLS-revised target, localized, with its run figure", () => {
+    const html = render({ revisedTarget: 178, targetSource: "dls" });
+    expect(html).toContain("«dls-loc 178»");
+    expect(html).toContain('data-testid="ck-revised-target"');
+  });
+
+  it("distinguishes a MANUALLY set target from a DLS-derived one", () => {
+    // Not cosmetic: a DLS figure is the app's own arithmetic and a manual one is
+    // the organiser's. Showing a bare number would conflate them.
+    const html = render({ revisedTarget: 150, targetSource: "manual" });
+    expect(html).toContain("«manual-loc 150»");
+    expect(html).not.toContain("«dls-loc");
+  });
+
+  it("renders NOTHING target-ish when the target has not been revised", () => {
+    // The guard that makes the two assertions above meaningful — a pad that
+    // always rendered a target row would satisfy them both.
+    const html = render({ revisedTarget: null, targetSource: null });
+    expect(html).not.toContain('data-testid="ck-revised-target"');
+    expect(html).not.toContain("«dls-loc");
+    expect(html).not.toContain("«manual-loc");
+  });
+});

--- a/apps/web/src/components/v2/pads/cricket-pad.tsx
+++ b/apps/web/src/components/v2/pads/cricket-pad.tsx
@@ -28,6 +28,15 @@ interface CricketStateView {
   tossTaken?: boolean;
   innings?: InningsView[];
   entrants?: { home: string; away: string };
+  // #467 — the chase target once it has been revised, and WHERE it came from.
+  // The engine resolves the live target to `revisedTarget` whenever it is
+  // non-null (cricket.ts), so a pad that omits it shows a score against a
+  // target the app never states. `targetSource` is not decoration: a DLS figure
+  // is the app's own arithmetic and a manual one is the organiser's, and #451
+  // was a DLS bug that awarded a match to the wrong side and survived review
+  // precisely because nothing rendered this.
+  revisedTarget?: number | null;
+  targetSource?: "dls" | "manual" | null;
 }
 
 const WICKET_KINDS = [
@@ -109,6 +118,19 @@ export function CricketPad({
           {msg("pad.ck.ballByBall")}
         </button>
       </div>
+
+      {/* A revised target is STATUS, not a control, so it deliberately does not
+          borrow the purple the mode buttons above use for selection. */}
+      {state.revisedTarget != null ? (
+        <p
+          data-testid="ck-revised-target"
+          className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-900"
+        >
+          {msg(state.targetSource === "manual" ? "pad.ck.targetManual" : "pad.ck.targetDls", {
+            runs: state.revisedTarget,
+          })}
+        </p>
+      ) : null}
 
       {mode === "over" ? (
         <OverByOverForm open={open ?? null} batting={battingSide} bpo={bpo} send={send} busy={busy} />

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -2320,6 +2320,8 @@
   "pad.ck.tossRecorded": "Toss recorded — start the match to open the first innings.",
   "pad.ck.overByOver": "Over-by-over",
   "pad.ck.inningsTotal": "Innings total",
+  "pad.ck.targetDls": "Target {runs} — revised by DLS",
+  "pad.ck.targetManual": "Target {runs} — set manually",
   "pad.ck.ballByBall": "⋯ Ball-by-ball",
   "pad.ck.ballByBallTitle": "Detailed per-delivery scoring (needed for full player stats)",
   "pad.ck.noOpenInnings": "No open innings — record an innings summary, or the match is between innings.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -2275,6 +2275,8 @@
   "pad.ck.tossRecorded": "Sorteo registrado — inicia el partido para abrir la primera entrada.",
   "pad.ck.overByOver": "Over por over",
   "pad.ck.inningsTotal": "Total de la entrada",
+  "pad.ck.targetDls": "Objetivo {runs} — revisado por DLS",
+  "pad.ck.targetManual": "Objetivo {runs} — fijado manualmente",
   "pad.ck.ballByBall": "⋯ Bola por bola",
   "pad.ck.ballByBallTitle": "Puntuación detallada por lanzamiento (necesaria para estadísticas completas de jugadores)",
   "pad.ck.noOpenInnings": "No hay entrada abierta — registra un resumen de entrada, o el partido está entre entradas.",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -2320,6 +2320,8 @@
   "pad.ck.tossRecorded": "Tirage au sort enregistré — démarrez le match pour ouvrir la première manche.",
   "pad.ck.overByOver": "Over par over",
   "pad.ck.inningsTotal": "Total de la manche",
+  "pad.ck.targetDls": "Objectif {runs} — révisé par DLS",
+  "pad.ck.targetManual": "Objectif {runs} — défini manuellement",
   "pad.ck.ballByBall": "⋯ Balle par balle",
   "pad.ck.ballByBallTitle": "Score détaillé par lancer (nécessaire pour les statistiques complètes des joueurs)",
   "pad.ck.noOpenInnings": "Aucune manche ouverte — enregistrez un résumé de manche, ou le match est entre deux manches.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -2275,6 +2275,8 @@
   "pad.ck.tossRecorded": "Toss vastgelegd — start de wedstrijd om de eerste innings te openen.",
   "pad.ck.overByOver": "Over voor over",
   "pad.ck.inningsTotal": "Inningstotaal",
+  "pad.ck.targetDls": "Doel {runs} — herzien volgens DLS",
+  "pad.ck.targetManual": "Doel {runs} — handmatig ingesteld",
   "pad.ck.ballByBall": "⋯ Bal voor bal",
   "pad.ck.ballByBallTitle": "Gedetailleerde scoring per bal (nodig voor volledige spelerstatistieken)",
   "pad.ck.noOpenInnings": "Geen open innings — leg een inningssamenvatting vast, of de wedstrijd zit tussen innings in.",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -2337,6 +2337,8 @@ export type DictionaryKey =
   | "pad.ck.sideBatting"
   | "pad.ck.striker"
   | "pad.ck.strikerLc"
+  | "pad.ck.targetDls"
+  | "pad.ck.targetManual"
   | "pad.ck.tossRecorded"
   | "pad.ck.tossWonBy"
   | "pad.ck.total"

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -105,7 +105,7 @@ export const ROUTES: RouteSpec[] = [
   { path: "/divisions/{id}/start", method: "post", summary: "Start the tournament (quick-start generates fixtures)", tag: "scheduling", response: S.StartDivisionResult, errors: [422] },
   // Fixtures & scoring
   { path: "/fixtures/{id}", method: "get", summary: "Get a fixture", tag: "fixtures", response: S.Fixture },
-  { path: "/fixtures/{id}", method: "patch", summary: "Schedule move, venue, officials, pin/lock — blocking conflicts → 409", tag: "fixtures", request: S.PatchFixture, response: S.Fixture, errors: [402, 409, 422] },
+  { path: "/fixtures/{id}", method: "patch", summary: "Schedule move, venue, officials, pin/lock — blocking conflicts → 409, warn-level ones come back in `conflicts`", tag: "fixtures", request: S.PatchFixture, response: S.PatchedFixture, errors: [402, 409, 422] },
   { path: "/fixtures/{id}/lineups/{entrantId}", method: "get", summary: "Get a side's lineup", tag: "fixtures" },
   { path: "/fixtures/{id}/lineups/{entrantId}", method: "put", summary: "Replace a side's lineup", tag: "fixtures", request: S.PutLineup, errors: [422] },
   { path: "/fixtures/{id}/events", method: "post", summary: "Append a score event (THE scoring endpoint)", tag: "scoring", request: S.AppendEventRequest, response: S.AppendEventResponse, status: 201, errors: [409, 422, 429] },

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -531,6 +531,12 @@ export const Fixture = z.object({
   pool_id: Uuid.nullable(),
   round_no: z.number().int(),
   seq_in_round: z.number().int(),
+  /** Per-division ordinal (PROMPT-30) — the `/f/{no}` public URL segment.
+   *  Declared here because it is already SERVED: `FIXTURE_COLS` selects it and
+   *  every fixture route returns its row unmapped. Nothing applies a response
+   *  schema at runtime, so its absence was a silent gap between the published
+   *  spec and the real payload rather than a missing field. */
+  fixture_no: z.number().int(),
   home_entrant_id: Uuid.nullable(),
   away_entrant_id: Uuid.nullable(),
   scheduled_at: z.string().nullable(),
@@ -801,6 +807,24 @@ export const ScheduleConflict = z.object({
   shortfall_minutes: z.number().int().optional(),
 });
 export type ScheduleConflict = z.infer<typeof ScheduleConflict>;
+
+/** The PATCH /fixtures/{id} response (#461).
+ *
+ *  The fixture as `Fixture` describes it, PLUS the conflicts the move was judged
+ *  against. `moveFixture` has always computed a full report for the destination
+ *  slot; it used it for the blocking gate and then discarded it, because the
+ *  function returned `void`. Blocking conflicts 409 and are visible that way, so
+ *  the ones this field exists for are the WARN-level ones — a rest shortfall, a
+ *  stored typed rule, a slot outside the competition's days — which an API
+ *  client dragging a card previously heard nothing about.
+ *
+ *  Always present, `[]` when the patch touched no timetable field, so a client
+ *  need not distinguish "no conflicts" from "not evaluated" by key absence.
+ *  Additive: no existing consumer of this endpoint reads it. */
+export const PatchedFixture = Fixture.extend({
+  conflicts: z.array(ScheduleConflict),
+});
+export type PatchedFixture = z.infer<typeof PatchedFixture>;
 
 export const ScheduleAssignment = z.object({
   fixture_id: Uuid,

--- a/apps/web/src/server/usecases/__tests__/__snapshots__/schedule-ai-pack.test.ts.snap
+++ b/apps/web/src/server/usecases/__tests__/__snapshots__/schedule-ai-pack.test.ts.snap
@@ -797,6 +797,7 @@ exports[`buildSchedulePack (v4/01 §2) > pack is deterministic and matches the 0
       "person_id": "<id:10>",
     },
   ],
+  "poolIds": {},
   "prior": null,
   "sessionHours": {
     "end": "22:00",

--- a/apps/web/src/server/usecases/__tests__/__snapshots__/schedule-ai-pack.test.ts.snap
+++ b/apps/web/src/server/usecases/__tests__/__snapshots__/schedule-ai-pack.test.ts.snap
@@ -35,14 +35,19 @@ exports[`buildSchedulePack (v4/01 §2) > pack is deterministic and matches the 0
       "scheduled_at": "2026-08-01T10:00:00+01:00",
     },
     {
-      "court_label": "Court 1",
-      "fixture_id": "<id:12>",
-      "scheduled_at": "2026-08-01T10:30:00+01:00",
-    },
-    {
       "court_label": "Court 2",
       "fixture_id": "<id:14>",
       "scheduled_at": "2026-08-01T10:30:00+01:00",
+    },
+    {
+      "court_label": "Court 1",
+      "fixture_id": "<id:12>",
+      "scheduled_at": "2026-08-01T10:50:00+01:00",
+    },
+    {
+      "court_label": "Court 2",
+      "fixture_id": "<id:17>",
+      "scheduled_at": "2026-08-01T11:00:00+01:00",
     },
     {
       "court_label": "Court 1",
@@ -52,32 +57,22 @@ exports[`buildSchedulePack (v4/01 §2) > pack is deterministic and matches the 0
     {
       "court_label": "Court 2",
       "fixture_id": "<id:16>",
-      "scheduled_at": "2026-08-01T11:20:00+01:00",
-    },
-    {
-      "court_label": "Court 1",
-      "fixture_id": "<id:17>",
-      "scheduled_at": "2026-08-01T11:50:00+01:00",
+      "scheduled_at": "2026-08-01T11:40:00+01:00",
     },
     {
       "court_label": "Court 2",
-      "fixture_id": "<id:18>",
-      "scheduled_at": "2026-08-01T11:50:00+01:00",
+      "fixture_id": "<id:19>",
+      "scheduled_at": "2026-08-01T12:10:00+01:00",
     },
     {
       "court_label": "Court 1",
-      "fixture_id": "<id:19>",
-      "scheduled_at": "2026-08-01T12:40:00+01:00",
+      "fixture_id": "<id:18>",
+      "scheduled_at": "2026-08-01T12:30:00+01:00",
     },
     {
       "court_label": "Court 1",
       "fixture_id": "<id:20>",
-      "scheduled_at": "2026-08-01T13:10:00+01:00",
-    },
-    {
-      "court_label": "Court 1",
-      "fixture_id": "<id:21>",
-      "scheduled_at": "2026-08-01T13:40:00+01:00",
+      "scheduled_at": "2026-08-01T13:20:00+01:00",
     },
     {
       "court_label": "Court 2",
@@ -86,73 +81,58 @@ exports[`buildSchedulePack (v4/01 §2) > pack is deterministic and matches the 0
     },
     {
       "court_label": "Court 1",
-      "fixture_id": "<id:25>",
+      "fixture_id": "<id:21>",
       "scheduled_at": "2026-08-01T14:10:00+01:00",
     },
     {
       "court_label": "Court 2",
-      "fixture_id": "<id:23>",
-      "scheduled_at": "2026-08-01T14:30:00+01:00",
-    },
-    {
-      "court_label": "Court 1",
       "fixture_id": "<id:24>",
       "scheduled_at": "2026-08-01T14:50:00+01:00",
     },
     {
-      "court_label": "Court 2",
-      "fixture_id": "<id:26>",
+      "court_label": "Court 1",
+      "fixture_id": "<id:23>",
       "scheduled_at": "2026-08-01T15:00:00+01:00",
     },
     {
+      "court_label": "Court 2",
+      "fixture_id": "<id:25>",
+      "scheduled_at": "2026-08-01T15:20:00+01:00",
+    },
+    {
       "court_label": "Court 1",
-      "fixture_id": "<id:27>",
-      "scheduled_at": "2026-08-01T15:50:00+01:00",
+      "fixture_id": "<id:26>",
+      "scheduled_at": "2026-08-01T16:10:00+01:00",
     },
     {
       "court_label": "Court 2",
-      "fixture_id": "<id:28>",
-      "scheduled_at": "2026-08-01T15:50:00+01:00",
-    },
-    {
-      "court_label": "Court 1",
       "fixture_id": "<id:30>",
-      "scheduled_at": "2026-08-01T16:20:00+01:00",
-    },
-    {
-      "court_label": "Court 2",
-      "fixture_id": "<id:29>",
-      "scheduled_at": "2026-08-01T16:20:00+01:00",
-    },
-    {
-      "court_label": "Court 2",
-      "fixture_id": "<id:32>",
-      "scheduled_at": "2026-08-01T16:50:00+01:00",
+      "scheduled_at": "2026-08-01T16:10:00+01:00",
     },
     {
       "court_label": "Court 1",
-      "fixture_id": "<id:31>",
-      "scheduled_at": "2026-08-01T17:10:00+01:00",
+      "fixture_id": "<id:28>",
+      "scheduled_at": "2026-08-01T17:00:00+01:00",
     },
     {
       "court_label": "Court 2",
-      "fixture_id": "<id:33>",
-      "scheduled_at": "2026-08-01T17:20:00+01:00",
+      "fixture_id": "<id:27>",
+      "scheduled_at": "2026-08-01T17:00:00+01:00",
     },
     {
       "court_label": "Court 1",
       "fixture_id": "<id:34>",
-      "scheduled_at": "2026-08-01T17:40:00+01:00",
+      "scheduled_at": "2026-08-01T17:50:00+01:00",
     },
     {
       "court_label": "Court 2",
-      "fixture_id": "<id:35>",
-      "scheduled_at": "2026-08-01T18:10:00+01:00",
+      "fixture_id": "<id:29>",
+      "scheduled_at": "2026-08-01T17:50:00+01:00",
     },
     {
       "court_label": "Court 1",
-      "fixture_id": "<id:36>",
-      "scheduled_at": "2026-08-01T18:30:00+01:00",
+      "fixture_id": "<id:35>",
+      "scheduled_at": "2026-08-01T18:20:00+01:00",
     },
   ],
   "entrants": [

--- a/apps/web/src/server/usecases/__tests__/competition-schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-ai-repair.test.ts
@@ -82,6 +82,8 @@ function makePack(): CompetitionPack {
     entrants: [],
     people: [],
     participants: { [F1]: [], [F2]: [] },
+    // #449: no pooled fixtures in this pack, so no pool uuids to carry.
+    poolIds: {},
     assumptions: [],
     fixtures: {
       movable: [

--- a/apps/web/src/server/usecases/__tests__/competition-schedule-participants-wiring.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-participants-wiring.test.ts
@@ -539,10 +539,15 @@ describe.skipIf(!HAS_DB)("CompetitionPack.participants is wired into both joint 
     expect("participants" in payload).toBe(false);
     expect("assumptions" in payload).toBe(false);
     expect(JSON.stringify(payload)).not.toContain("participants");
+    // `poolIds` (#449) is stripped for the same reason: the model schedules by
+    // pool LABEL, which `fixtures.movable[].pool` still carries.
+    expect("poolIds" in payload).toBe(false);
     // Everything else survives the trim byte-for-byte.
     expect(payload).toEqual(
       Object.fromEntries(
-        Object.entries(pack).filter(([k]) => k !== "participants" && k !== "assumptions"),
+        Object.entries(pack).filter(
+          ([k]) => k !== "participants" && k !== "assumptions" && k !== "poolIds",
+        ),
       ),
     );
     // …while the map the placer and the referee read is still complete.

--- a/apps/web/src/server/usecases/__tests__/competition-schedule-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-run.test.ts
@@ -95,6 +95,8 @@ function makePack(): CompetitionPack {
     // is empty — but the key must exist for each of them, exactly as
     // buildCompetitionPack emits it (#396).
     participants: { [F1]: [], [F2]: [] },
+    // #449: no pooled fixtures in this pack, so no pool uuids to carry.
+    poolIds: {},
     assumptions: [],
     fixtures: {
       movable: [

--- a/apps/web/src/server/usecases/__tests__/competition-schedule-verify.test.ts
+++ b/apps/web/src/server/usecases/__tests__/competition-schedule-verify.test.ts
@@ -148,6 +148,24 @@ function pack(
       ),
     ];
   }
+  // #449: `PackFixture.pool` is the DISPLAY KEY the model reads ('A', 'B'); the
+  // pool UUID the engine matches a stored rule against rides `poolIds`. These
+  // cases author the uuid on `pool` for readability, so split the two here — the
+  // way the real builder does. Authoring one value and reading it back through
+  // the same field would let the two namespaces look like one, which is the very
+  // bug (#449) these `poolId` assertions exist to catch.
+  const poolIds: Record<string, string> = {};
+  const poolKeyById = new Map<string, string>();
+  for (const f of movable) {
+    if (f.pool === null) continue;
+    poolIds[f.id] = f.pool;
+    if (!poolKeyById.has(f.pool)) {
+      poolKeyById.set(f.pool, String.fromCharCode(65 + poolKeyById.size));
+    }
+  }
+  const labelled = movable.map((f) =>
+    f.pool === null ? f : { ...f, pool: poolKeyById.get(f.pool)! },
+  );
   return {
     mode: "generate",
     competition: { id: "c1", name: "Summer Open" },
@@ -174,8 +192,9 @@ function pack(
     entrants: [],
     people,
     participants,
+    poolIds,
     assumptions: [],
-    fixtures: { movable, obstacles: [] },
+    fixtures: { movable: labelled, obstacles: [] },
     draft: [],
     instruction: "Finish by 6pm.",
     prior: null,

--- a/apps/web/src/server/usecases/__tests__/engine-constraints.test.ts
+++ b/apps/web/src/server/usecases/__tests__/engine-constraints.test.ts
@@ -1,0 +1,151 @@
+// #458 — ONE builder for the engine's `constraints` block.
+//
+// Three call sites built this object as independent literals over the same
+// shape — `verifyConfig` (schedule-ai.ts), `toSlotConfig` (schedule.ts) and
+// `verifyConfigFor` (competition-schedule-ai.ts) — and they had already
+// drifted: the board site mapped EVERY start window through, the joint site
+// dropped any whose `target.kind` was outside the engine's enum, and the
+// single-division AI site pinned `startWindows: []` outright, which is #458.
+//
+// The joint site's filter is the canonical behaviour and this file pins WHY:
+// `PackStartWindow.target.kind` is a bare `string` (the pack is a wire shape),
+// so casting an unrecognised kind through would let the engine silently never
+// match it while hiding that a settings row has drifted from the enum.
+import { describe, expect, it } from "vitest";
+import type { HardConstraint } from "@seazn/engine/scheduling";
+import {
+  AI_VERIFY_POLICY,
+  buildEngineConstraints,
+  toEngineStartWindows,
+} from "../engine-constraints";
+
+const T0 = Date.parse("2026-08-10T09:00:00.000Z");
+const iso = (t: number) => new Date(t).toISOString();
+const MIN = 60_000;
+
+const BOARD_POLICY = {
+  fieldFairness: "balance",
+  parallelism: "block",
+  crossPersonClash: "hard",
+  hard: true,
+} as const;
+
+const RULE: HardConstraint = {
+  type: "max_fixtures_per_day",
+  count: 2,
+  scope: { kind: "competition" },
+};
+
+describe("buildEngineConstraints", () => {
+  it("converts notBefore/notAfter from ISO to epoch ms", () => {
+    const out = buildEngineConstraints(
+      {
+        noBackToBack: false,
+        startWindows: [
+          {
+            target: { kind: "pool", id: "p1" },
+            notBefore: iso(T0),
+            notAfter: iso(T0 + 90 * MIN),
+          },
+        ],
+      },
+      AI_VERIFY_POLICY,
+    );
+    expect(out.startWindows).toEqual([
+      { target: { kind: "pool", id: "p1" }, notBefore: T0, notAfter: T0 + 90 * MIN },
+    ]);
+  });
+
+  it("omits a bound the source did not set, rather than emitting undefined", () => {
+    const out = buildEngineConstraints(
+      {
+        noBackToBack: false,
+        startWindows: [{ target: { kind: "entrant", id: "e1" }, notAfter: iso(T0) }],
+      },
+      AI_VERIFY_POLICY,
+    );
+    expect(out.startWindows[0]).toEqual({ target: { kind: "entrant", id: "e1" }, notAfter: T0 });
+    expect("notBefore" in out.startWindows[0]!).toBe(false);
+  });
+
+  it("DROPS a window whose target.kind is outside the engine's enum", () => {
+    const out = buildEngineConstraints(
+      {
+        noBackToBack: false,
+        startWindows: [
+          { target: { kind: "nonsense", id: "x" }, notBefore: iso(T0) },
+          { target: { kind: "division", id: "d1" }, notBefore: iso(T0) },
+        ],
+      },
+      AI_VERIFY_POLICY,
+    );
+    // Dropped, not cast through: the engine would never match "nonsense" and a
+    // cast would hide that a stored settings row drifted from the enum.
+    expect(out.startWindows).toEqual([{ target: { kind: "division", id: "d1" }, notBefore: T0 }]);
+  });
+
+  it("carries all three recognised kinds", () => {
+    const out = toEngineStartWindows([
+      { target: { kind: "entrant", id: "e1" } },
+      { target: { kind: "pool", id: "p1" } },
+      { target: { kind: "division", id: "d1" } },
+    ]);
+    expect(out.map((w) => w.target.kind)).toEqual(["entrant", "pool", "division"]);
+  });
+
+  it("omits restMin/restByGroup the source did not set, and carries the ones it did", () => {
+    const bare = buildEngineConstraints(
+      { noBackToBack: true, startWindows: [] },
+      AI_VERIFY_POLICY,
+    );
+    expect(bare).toEqual({
+      noBackToBack: true,
+      startWindows: [],
+      fieldFairness: "off",
+      parallelism: "mixed",
+      crossPersonClash: "warn",
+    });
+
+    const full = buildEngineConstraints(
+      { restMin: 45, restByGroup: { p1: 120 }, noBackToBack: false, startWindows: [] },
+      AI_VERIFY_POLICY,
+    );
+    expect(full.restMin).toBe(45);
+    expect(full.restByGroup).toEqual({ p1: 120 });
+  });
+
+  it("takes the policy fields from the caller, never from the source", () => {
+    const out = buildEngineConstraints(
+      { noBackToBack: false, startWindows: [], hard: [RULE] },
+      BOARD_POLICY,
+    );
+    expect(out.fieldFairness).toBe("balance");
+    expect(out.parallelism).toBe("block");
+    expect(out.crossPersonClash).toBe("hard");
+  });
+
+  it("carries durable hard rules only when the policy asks for them", () => {
+    // The AI paths merge the SAME rules into the top-level `hard` field, and
+    // `effectiveHard` merges the two — carrying both would count every durable
+    // rule twice.
+    const board = buildEngineConstraints(
+      { noBackToBack: false, startWindows: [], hard: [RULE] },
+      BOARD_POLICY,
+    );
+    expect(board.hard).toEqual([RULE]);
+
+    const ai = buildEngineConstraints(
+      { noBackToBack: false, startWindows: [], hard: [RULE] },
+      AI_VERIFY_POLICY,
+    );
+    expect("hard" in ai).toBe(false);
+  });
+
+  it("omits `hard` entirely when the source stored none", () => {
+    // Never defaulted to []: a `hard: []` on a config that stored nothing is
+    // indistinguishable downstream but differs from every literal the suite
+    // compares `toSlotConfig` output against.
+    const out = buildEngineConstraints({ noBackToBack: false, startWindows: [] }, BOARD_POLICY);
+    expect("hard" in out).toBe(false);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-effort-ab.live.test.ts
@@ -138,7 +138,7 @@ const uuid = (tag: string, n: number) =>
 // unplaceable fixture is left for the model, exactly as in production). No DB,
 // no obstacles/siblings (synthetic packs have none), so `existing: []`.
 /** A pack before its derived fields exist — see `withGreedyDraft`. */
-type PackDraft = Omit<SchedulePack, "participants" | "assumptions">;
+type PackDraft = Omit<SchedulePack, "participants" | "assumptions" | "poolIds">;
 
 function withGreedyDraft(pack: PackDraft): SchedulePack {
   const tz = pack.division.tz;
@@ -201,7 +201,9 @@ function withGreedyDraft(pack: PackDraft): SchedulePack {
       court_label: a.court,
     }))
     .sort((x, y) => (x.scheduled_at < y.scheduled_at ? -1 : x.scheduled_at > y.scheduled_at ? 1 : 0));
-  return { ...pack, participants, assumptions: stripped.assumptions, draft };
+  // #449: this bench authors pools as bare labels and drives no pool-scoped
+  // rule, so there is no uuid to carry.
+  return { ...pack, participants, poolIds: {}, assumptions: stripped.assumptions, draft };
 }
 
 // --- Pack A: 15 teams, 3 pools of 5, round robin within pool = 30 fixtures --

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-ledger.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-ledger.test.ts
@@ -115,7 +115,9 @@ describe("ApplyScheduleRequest.ai (v4/03 §10)", () => {
   it("Fixture response schema accepts schedule_source 'ai'", () => {
     const row = {
       id: randomUUID(), stage_id: randomUUID(), division_id: randomUUID(), pool_id: null,
-      round_no: 1, seq_in_round: 1, home_entrant_id: null, away_entrant_id: null,
+      // `fixtures.fixture_no` is NOT NULL and rides `FIXTURE_COLS`, so every
+      // served fixture carries it; the schema declares it since #461.
+      round_no: 1, seq_in_round: 1, fixture_no: 1, home_entrant_id: null, away_entrant_id: null,
       scheduled_at: null, venue: null, court_label: null, officials: [], status: "scheduled",
       outcome: null, schedule_source: "ai", schedule_locked: false, created_at: T0,
     };
@@ -178,7 +180,7 @@ describe.skipIf(!HAS_DB)("AI audit trail in the ledger (v4/03 §10)", () => {
     // Binding #1 (integration): the persisted fixtures read back through the
     // Fixture response schema with schedule_source "ai".
     const rows = await sql`
-      select id, stage_id, division_id, pool_id, round_no, seq_in_round,
+      select id, stage_id, division_id, pool_id, round_no, seq_in_round, fixture_no,
              home_entrant_id, away_entrant_id, scheduled_at, venue, court_label,
              officials, status, outcome, schedule_source, schedule_locked, created_at
       from fixtures where stage_id = ${stage.id} and scheduled_at is not null limit 1`;

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-pack.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-pack.test.ts
@@ -1023,9 +1023,14 @@ describe.skipIf(!HAS_DB)("buildSchedulePack on an elimination bracket (#396)", (
     );
     const final = pack.fixtures.movable.find((f) => f.ext_key === "final")!;
     expect(pack.participants[final.id]).toHaveLength(4);
+    // `poolIds` (#449) is stripped for the same reason: the model schedules by
+    // pool LABEL, which `fixtures.movable[].pool` still carries.
+    expect("poolIds" in payload).toBe(false);
     // Everything else survives the trim byte-for-byte.
     const trimmed = Object.fromEntries(
-      Object.entries(pack).filter(([k]) => k !== "participants" && k !== "assumptions"),
+      Object.entries(pack).filter(
+        ([k]) => k !== "participants" && k !== "assumptions" && k !== "poolIds",
+      ),
     );
     expect(payload).toEqual(trimmed);
   });

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-pack.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-pack.test.ts
@@ -220,6 +220,27 @@ describe.skipIf(!HAS_DB)("buildSchedulePack (v4/01 §2)", () => {
     const b = await buildSchedulePack(auth, divisionId, { now: NOW_W2, mode: "generate", instruction: "Finish by 6pm." });
     expect(JSON.stringify(a.pack)).toBe(JSON.stringify(b.pack));
     expect(redact(a.pack)).toMatchSnapshot();
+    // #463 RE-RECORDED THE DRAFT IN THAT SNAPSHOT, and nothing else in it. The
+    // draft is the placer's own proposal, and the placer now rests participants
+    // who share a PERSON, not only ones who share an entrant. E1 and E2 share a
+    // player here, so the 13 fixtures either of them appears in can no longer
+    // sit 30 minutes apart — let alone run in parallel across the two courts —
+    // and are separated by the full match plus `perEntrantMinRest` instead.
+    // That stretches the board, which is why 22 of the 28 fixtures now fit
+    // inside the session window where 26 did before; `fixtures.movable` still
+    // carries all 28 (asserted below). Pinned as an assertion as well as in the
+    // snapshot: the separation is the REASON the recorded times are what they
+    // are, and a future re-record must not be able to quietly lose it.
+    const shared = new Set(a.pack.people[0]!.entrant_ids);
+    const draftAt = new Map(a.pack.draft.map((d) => [d.fixture_id, Date.parse(String(d.scheduled_at))]));
+    const sharedStarts = a.pack.fixtures.movable
+      .filter((f) => (f.home !== null && shared.has(f.home)) || (f.away !== null && shared.has(f.away)))
+      .map((f) => draftAt.get(f.id))
+      .filter((t): t is number => t !== undefined)
+      .sort((x, y) => x - y);
+    expect(sharedStarts.length).toBeGreaterThan(1);
+    const apart = SETTINGS_CONFIG.matchMinutes + SETTINGS_CONFIG.perEntrantMinRest;
+    expect(sharedStarts.slice(1).filter((t, i) => t - sharedStarts[i]! < apart * MIN)).toEqual([]);
     expect(a.pack.officials.length).toBeGreaterThan(0);
     // Officials availability wired through: blackout date + entrant links.
     const ref = a.pack.officials.find((o) => o.name === "Aa Referee")!;

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-provider.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-provider.test.ts
@@ -56,6 +56,8 @@ function makePack(overrides: Partial<import("../schedule-ai").SchedulePack> = {}
     people: [],
     // #396: keyed for every movable fixture; no persons in this pack, so empty.
     participants: Object.fromEntries([F1, F2, F3, F4].map((id) => [id, [] as string[]])),
+    // #449: no pooled fixtures in this pack, so no pool uuids to carry.
+    poolIds: {},
     assumptions: [],
     fixtures: {
       movable: [F1, F2, F3, F4].map((id, i) => ({

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-repair.test.ts
@@ -65,6 +65,8 @@ function makePack(overrides: Partial<SchedulePack> = {}): SchedulePack {
     entrants: [],
     people: [],
     participants: Object.fromEntries([F1, F2, F3, F4].map((id) => [id, [] as string[]])),
+    // #449: no pooled fixtures in this pack, so no pool uuids to carry.
+    poolIds: {},
     assumptions: [],
     fixtures: {
       movable: [F1, F2, F3, F4].map((id, i) => ({

--- a/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-ai-run.test.ts
@@ -79,6 +79,8 @@ function makePack(overrides: Partial<SchedulePack> = {}): SchedulePack {
     // so every list is empty — the same `Assignment.people` the named-entrant
     // derivation produced before participants existed.
     participants: Object.fromEntries([F1, F2, F3, F4].map((id) => [id, [] as string[]])),
+    // #449: no pooled fixtures in this pack, so no pool uuids to carry.
+    poolIds: {},
     assumptions: [],
     fixtures: {
       movable: [F1, F2, F3, F4].map((id, i) => ({

--- a/apps/web/src/server/usecases/__tests__/schedule-durable-hard-surfaces.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-durable-hard-surfaces.test.ts
@@ -70,10 +70,12 @@ const MIN = 60_000;
 const at = (minutes: number) => new Date(Date.parse(T0) + minutes * MIN).toISOString();
 
 // The rule under test. Unit-free and wall-clock (#398): "no fixture may start
-// before noon", stated once, stored once, and owed on every surface. Every
-// fixture this board can produce starts at 09:00 or 09:30, so a surface that
-// honours it reports and a surface that drops it is silent — no arithmetic in
-// the assertions and no dependence on the placer's packing order.
+// before noon", stated once, stored once, and owed on every surface. The board
+// opens at 09:00, so the rule is the ONLY thing that can move a card off the
+// first slot — a surface that honours it either places past noon (the placer,
+// #463) or reports (the three verifying surfaces), and a surface that drops it
+// is silent. No arithmetic in the assertions, and no dependence on the placer's
+// packing order.
 const NOT_BEFORE_NOON = {
   type: "not_before" as const,
   time: "12:00",
@@ -194,27 +196,63 @@ describe.skipIf(!HAS_DB)("a durable constraints.hard rule on the board paths (#4
     expect((await generateStageFixtures(auth, groups!.id)).created).toBe(6);
 
     // --- 1. auto-schedule -------------------------------------------------
+    // #463 CHANGED WHAT THIS SURFACE OWES. The placer used to have no term for a
+    // typed rule — it reported only what it could not FIT — so it proposed a
+    // 09:00 board and left the verifier to warn about all six cards. It now
+    // PLACES around `not_before`, so proposing-then-warning is gone and the
+    // proof is the proposal itself: six cards, not one of them before noon.
+    // The times are asserted explicitly and the conflict list only afterwards —
+    // a bare "no instruction conflicts" is equally satisfied by a placer that
+    // proposed nothing at all, and by one that proposed a board it never judged.
     const proposal = await autoSchedule(auth, groups!.id, false);
     expect(proposal.assignments).toHaveLength(6);
-    // Every card the placer produced starts before noon, so every one of them
-    // breaches the stored rule. The placer has no term for a typed rule — it
-    // reports only what it could not FIT — so before the fix this came back with
-    // an empty conflict list and an organiser building a board saw nothing.
-    const autoInstruction = proposal.conflicts.filter((c) => c.code === "warn.instruction");
-    expect(autoInstruction).toHaveLength(6);
-    expect(autoInstruction.every((c) => !c.blocking)).toBe(true);
-    expect(autoInstruction[0]!.detail).toContain("violating not_before 12:00");
+    // The org zone is UTC here, so the UTC clock IS the wall clock the rule is
+    // stated in — no offset arithmetic, just the time-of-day the rule names.
+    const proposedBeforeNoon = proposal.assignments
+      .map((a) => new Date(a.scheduled_at).toISOString())
+      .filter((iso) => iso.slice(11, 16) < "12:00");
+    expect(proposedBeforeNoon).toEqual([]);
+    expect(proposal.conflicts.filter((c) => c.code === "warn.instruction")).toEqual([]);
     expectRuleReachedTheVerifier("autoSchedule");
+
+    // --- a board that BREACHES the rule, built here rather than proposed ----
+    // Surfaces 2-4 used to chain off the placer's proposal, which was itself
+    // pre-noon. Now that the placer complies, chaining off it would leave them
+    // observing nothing, and the warn-only invariant below — the pinned product
+    // decision — would go uncovered. So they are driven against a board that
+    // breaches the rule on purpose: one card per (round, court), the three
+    // rounds at 09:00, 09:30 and 10:00. Two fixtures of the same round never
+    // share an entrant, so nothing about this board is BLOCKING; the stored
+    // rule is the only thing wrong with it, which is exactly what the three
+    // verifying surfaces are here to see.
+    const cards = await sql<{ id: string; round_no: number }[]>`
+      select id, round_no from fixtures where stage_id = ${groups!.id}
+      order by round_no, seq_in_round`;
+    const rounds = [...new Set(cards.map((c) => c.round_no))].sort((a, b) => a - b);
+    const usedInRound = new Map<number, number>();
+    const violating = cards.map((c) => {
+      const seat = usedInRound.get(c.round_no) ?? 0;
+      usedInRound.set(c.round_no, seat + 1);
+      return {
+        fixture_id: c.id,
+        scheduled_at: at(rounds.indexOf(c.round_no) * 30),
+        court_label: `Court ${seat + 1}`,
+      };
+    });
+    // Non-vacuity of the board itself, both ways: every card really does start
+    // before noon (or the three surfaces below would have nothing to report),
+    // and it uses only the two courts this division actually has.
+    expect(violating).toHaveLength(6);
+    expect(violating.filter((v) => v.scheduled_at.slice(11, 16) >= "12:00")).toEqual([]);
+    expect(new Set(violating.map((v) => v.court_label))).toEqual(
+      new Set(["Court 1", "Court 2"]),
+    );
 
     // --- 2. the apply gate ------------------------------------------------
     seen.configs.length = 0;
     const applied = await applySchedule(auth, groups!.id, {
-      assignments: proposal.assignments.map((a) => ({
-        fixture_id: a.fixture_id,
-        scheduled_at: a.scheduled_at,
-        court_label: a.court_label,
-      })),
-      source: "auto",
+      assignments: violating,
+      source: "manual",
     });
     // THE PRODUCT DECISION, pinned. The write is REPORTED, not refused: an
     // instruction conflict is warn-only (`isBlockingConflict` covers court,

--- a/apps/web/src/server/usecases/__tests__/schedule-durable-hard-surfaces.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-durable-hard-surfaces.test.ts
@@ -10,14 +10,14 @@
 // bypasses the one function that dropped it, which is exactly why the suite was
 // blind to this for a whole wave.
 //
-// WHY THE SPY. Three of the four surfaces RETURN their conflicts, so the rule
-// binding is directly observable. `moveFixture` does not: it returns void and
-// uses its conflict list only for `assertNoNewBlocking`, and an instruction
-// conflict is warn-only, so nothing it does is observable from outside. Wrapping
-// the two engine entry points and recording the config each surface hands them
-// is therefore the only proof available that the durable rule reaches the
-// verifier on the drag path — and it is a real proof: a config with no `hard`,
-// no `tz` or no `ruleFixtures` is precisely the defect.
+// WHY THE SPY. All four surfaces now RETURN their conflicts — `moveFixture` did
+// not until #461, and its list was the thing this spy existed to reach. The spy
+// stays because it proves something the return value cannot: WHICH config each
+// surface handed the engine. A config missing `hard`, `tz` or `ruleFixtures`
+// binds nothing, and "no conflicts" is what a correctly-clean board looks like
+// too, so the absence of a conflict can never distinguish the two. The drag
+// path below now asserts BOTH — the config that went in and the report that
+// came back.
 //
 // Real Postgres required; skipped without DATABASE_URL (CI runs them).
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -281,13 +281,19 @@ describe.skipIf(!HAS_DB)("a durable constraints.hard rule on the board paths (#4
     // physical is in the way and the ONLY thing wrong with the destination is
     // the stored rule. Warn-only, so the move is accepted — and the config it
     // was judged against is the only thing that can show the rule was in force.
-    await moveFixture(auth, card!.id, { scheduled_at: at(120), court_label: "Court 2" });
+    const moved = await moveFixture(auth, card!.id, { scheduled_at: at(120), court_label: "Court 2" });
     expectRuleReachedTheVerifier("moveFixture");
 
-    // The drag path's own conflict list is computed and then discarded
-    // (`moveFixture` returns void), so the badge an organiser sees after a drop
-    // comes from the report above. That is why surface 3 carries the assertion
-    // on the moved card rather than surface 4.
+    // #461: the drag path hands its own report back rather than dropping it, so
+    // the rule is now observable from the OUTSIDE of this surface too — not only
+    // through the config the spy captured. Warn-only, hence the move stood.
+    const movedInstruction = moved.filter((c) => c.code === "warn.instruction");
+    expect(movedInstruction.length).toBeGreaterThan(0);
+    expect(movedInstruction.every((c) => !c.blocking)).toBe(true);
+    expect(movedInstruction.every((c) => c.fixture_id === card!.id)).toBe(true);
+
+    // And the whole-board report agrees with it — the board refreshes from this
+    // after every drop, so the two must not be able to disagree about the card.
     const afterMove = await validateSchedule(auth, division.id);
     expect(
       afterMove.conflicts.filter((c) => c.code === "warn.instruction" && c.fixture_id === card!.id),

--- a/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
@@ -31,6 +31,8 @@ const iso = (t: number) => new Date(t).toISOString();
 
 const DIV_A = "11111111-1111-4111-8111-111111111111";
 const POOL_A = "22222222-2222-4222-8222-222222222222";
+/** What `pools.key` holds — the display label `PackFixture.pool` carries (#449). */
+const POOL_A_KEY = "A";
 
 // A fixtures row exactly as `FIXTURE_LITE_COLS` selects it.
 function row(over: Partial<FixtureLite> = {}): FixtureLite {
@@ -186,6 +188,11 @@ describe("pool-targeted rules through the single-division AI adapter (#446)", ()
       entrants: [],
       people: [],
       participants: { "f-1": [], "f-2": [] },
+      // #449: the pool UUID, which is what the engine matches a stored rule
+      // against. `PackFixture.pool` below is the display KEY the model reads —
+      // this test used to author the uuid there, a shape the real builder never
+      // produces, so the two namespaces looked like one.
+      poolIds: { "f-1": POOL_A, "f-2": POOL_A },
       assumptions: [],
       parsed: { hard: [], soft: [], unparsed: [] },
       fixtures: {
@@ -195,7 +202,7 @@ describe("pool-targeted rules through the single-division AI adapter (#446)", ()
             ext_key: null,
             round: 0,
             seq: 0,
-            pool: POOL_A,
+            pool: POOL_A_KEY,
             home: "e1",
             away: "e2",
             feeds: { winner_to: null, after: [] },
@@ -207,7 +214,7 @@ describe("pool-targeted rules through the single-division AI adapter (#446)", ()
             ext_key: null,
             round: 1,
             seq: 0,
-            pool: POOL_A,
+            pool: POOL_A_KEY,
             home: "e1",
             away: "e3",
             feeds: { winner_to: null, after: [] },

--- a/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-group-targeting.test.ts
@@ -248,19 +248,41 @@ describe("pool-targeted rules through the single-division AI adapter (#446)", ()
     expect(conflicts.map((c) => c.reason)).toContain("rest");
   });
 
-  // NO startWindow case on THIS path, deliberately, and it is not an oversight
-  // in the fix. `verifyConfig` pins `startWindows: []` outright (schedule-ai.ts,
-  // "the pack's startWindows carry ISO strings … the engine wants epoch ms"), so
-  // the single-division AI referee is blind to EVERY start window, pool-targeted
-  // or not — a second, independent defect that stamping `poolId` cannot reach.
-  // A test here would fail after this fix and mislabel that gap as this bug.
-  // The board path, where `toSlotConfig` does convert the windows, carries the
-  // pool-targeted startWindow assertion instead (above).
-  it("carries the pool id the pinned-empty startWindows cannot yet use", () => {
+  // #458: this path used to pin `startWindows: []`, so the single-division AI
+  // referee was blind to EVERY start window whatever it targeted — pool rules
+  // bound for the board and evaporated for the AI proposal, and `repair-domain`
+  // clipped the repair domain to the same empty config. All three engine-config
+  // builders now go through `buildEngineConstraints`, so the window arrives here
+  // in epoch ms exactly as it does on the board path above.
+  it("a pool-targeted startWindow binds on the AI verify path too", () => {
     const p = pack({
       startWindows: [{ target: { kind: "pool", id: POOL_A }, notAfter: iso(T0 + 40 * MIN) }],
     });
-    expect(verifyConfig(p).constraints?.startWindows).toEqual([]);
-    expect(toEngineAssignments(plan, p)[1]!.poolId).toBe(POOL_A);
+    // Carried, with its pool target intact and its bound converted ISO → ms.
+    expect(verifyConfig(p).constraints?.startWindows).toEqual([
+      { target: { kind: "pool", id: POOL_A }, notAfter: T0 + 40 * MIN },
+    ]);
+    // And it BINDS: f-2 sits in pool A at T0+80min, past the window's notAfter.
+    const assignments = toEngineAssignments(plan, p);
+    expect(assignments[1]!.poolId).toBe(POOL_A);
+    expect(validateAssignments(assignments, verifyConfig(p)).map((c) => c.reason)).toContain(
+      "start_window",
+    );
+  });
+
+  // The guard the assertion above needs: a window keyed on ANOTHER pool must
+  // stay silent, or "carries the window" is satisfied by a builder that matches
+  // every row.
+  it("a startWindow keyed on another pool does not bind on the AI path", () => {
+    const p = pack({
+      startWindows: [
+        {
+          target: { kind: "pool", id: "33333333-3333-4333-8333-333333333333" },
+          notAfter: iso(T0 + 40 * MIN),
+        },
+      ],
+    });
+    const conflicts = validateAssignments(toEngineAssignments(plan, p), verifyConfig(p));
+    expect(conflicts.map((c) => c.reason)).not.toContain("start_window");
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule-move-conflicts.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-move-conflicts.test.ts
@@ -1,0 +1,243 @@
+// #461 — a move returns the conflicts it already computed.
+//
+// `moveFixture` builds a full conflict report for the destination slot, uses it
+// for `assertNoNewBlocking`, and then throws it away: the function was
+// `Promise<void>`. Blocking conflicts 409, so an organiser hears about those.
+// WARN-level ones — rest shortfalls, a stored typed rule, a session-window
+// breach — were computed and dropped on the floor, so an API client dragging a
+// card was told nothing at all about the board it had just created.
+//
+// THE BOARD BELOW ALSO COVERS #462's FOURTH CALL SITE. `moveFixture` is one of
+// the four places sibling assignments reach the verifier, and it was the one
+// site whose fix could not be asserted while the function returned nothing. The
+// cap here is competition-scoped and breaks ONLY once the sibling division's
+// card is counted, so a regression in either fix reds this file.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import type { HardConstraint } from "@seazn/engine/scheduling";
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { PatchedFixture } from "@/server/api-v1/schemas";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages } from "../stages";
+import { moveFixture } from "../schedule";
+import { patchFixture } from "../fixtures";
+import { seedOrg } from "./_seed";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const TZ = "Europe/London";
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+const DAY = "2026-08-10";
+/** A second day, well clear of the cap, for the "clean move" case. */
+const OTHER_DAY = "2026-08-12";
+const at = (ymd: string, hhmm: string): string => `${ymd}T${hhmm}:00.000Z`;
+
+/** Competition-wide, count 2. This division holds one card on `DAY` and the
+ *  sibling division holds one; a third lands the day over the cap. Warn-only —
+ *  an instruction conflict is deliberately absent from `isBlockingConflict`, so
+ *  the move is ACCEPTED and the conflicts are the only thing that can report it. */
+const DAY_CAP: HardConstraint[] = [
+  { type: "max_fixtures_per_day", count: 2, scope: { kind: "competition" } },
+];
+
+const SIBLING_COURT = "Far Court";
+
+function settingsConfig(courts: string[], hard: HardConstraint[]) {
+  return {
+    startAt: at(DAY, "08:00"),
+    matchMinutes: 30,
+    gapMinutes: 0,
+    courts,
+    perEntrantMinRest: 20,
+    blackouts: [],
+    sessionWindows: [],
+    constraints: {
+      restMin: 20,
+      noBackToBack: false,
+      startWindows: [],
+      fieldFairness: "off",
+      parallelism: "mixed",
+      crossPersonClash: "warn",
+      hard,
+    },
+  };
+}
+
+interface Div {
+  id: string;
+  stageId: string;
+  entrantByName: Map<string, string>;
+}
+
+async function makeDivision(
+  auth: AuthCtx,
+  competitionId: string,
+  slug: string,
+  courts: string[],
+  entrantNames: string[],
+  hard: HardConstraint[],
+): Promise<Div> {
+  const division = await createDivision(auth, competitionId, {
+    name: `Div ${slug}`,
+    slug,
+    sport_key: "generic",
+    variant_key: "score",
+    config: GENERIC_CONFIG,
+    eligibility: [],
+  });
+  await sql`
+    insert into schedule_settings (division_id, config, tz, updated_at)
+    values (${division.id}, ${sql.json(settingsConfig(courts, hard))}, ${TZ}, now())
+    on conflict (division_id) do update set config = excluded.config, tz = excluded.tz`;
+  await createEntrants(
+    auth,
+    division.id,
+    entrantNames.map((n, i) => ({
+      kind: "individual" as const,
+      display_name: n,
+      seed: i + 1,
+      members: [],
+    })),
+  );
+  const rows = await sql<{ id: string; display_name: string }[]>`
+    select id, display_name from entrants where division_id = ${division.id}`;
+  const [stage] = await createStages(auth, division.id, {
+    seq: 1,
+    kind: "league",
+    name: "RR",
+    config: {},
+  });
+  return {
+    id: division.id,
+    stageId: stage!.id,
+    entrantByName: new Map(rows.map((r) => [r.display_name, r.id])),
+  };
+}
+
+async function addFixture(
+  auth: AuthCtx,
+  d: Div,
+  seq: number,
+  extKey: string,
+  home: string,
+  away: string,
+  slot: { at: string; court: string } | null,
+  status = "scheduled",
+): Promise<string> {
+  const [f] = await sql<{ id: string }[]>`
+    insert into fixtures (stage_id, division_id, org_id, round_no, seq_in_round, ext_key, status,
+                          home_entrant_id, away_entrant_id, scheduled_at, court_label)
+    values (${d.stageId}, ${d.id}, ${auth.orgId}, 1, ${seq}, ${extKey}, ${status},
+            ${d.entrantByName.get(home)!}, ${d.entrantByName.get(away)!},
+            ${slot?.at ?? null}, ${slot?.court ?? null})
+    returning id`;
+  return f!.id;
+}
+
+/** Planned division: one card already on `DAY`, one card with no slot yet.
+ *  Sibling division: one fixed card on `DAY`, on a court this division does not
+ *  even have — so nothing physical stands in for the rule firing. */
+async function seedBoard(): Promise<{ auth: AuthCtx; planned: Div; mover: string }> {
+  const { auth } = await seedOrg("pro");
+  const tag = randomUUID().slice(0, 6);
+  const comp = await createCompetition(auth, {
+    name: `Move Conflicts ${tag}`,
+    visibility: "public",
+    branding: {},
+  });
+  const planned = await makeDivision(
+    auth, comp.id, `planned-${tag}`, ["Court 1", "Court 2"],
+    ["A-1", "A-2", "A-3", "A-4"], DAY_CAP,
+  );
+  const sibling = await makeDivision(
+    auth, comp.id, `sibling-${tag}`, [SIBLING_COURT], ["B-1", "B-2"], [],
+  );
+  await addFixture(auth, planned, 0, "a-f1", "A-1", "A-2", { at: at(DAY, "09:00"), court: "Court 1" });
+  const mover = await addFixture(auth, planned, 1, "a-f2", "A-3", "A-4", null);
+  await addFixture(
+    auth, sibling, 0, "b-f1", "B-1", "B-2",
+    { at: at(DAY, "14:00"), court: SIBLING_COURT }, "finalized",
+  );
+  return { auth, planned, mover };
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("a move returns the conflicts it computes (#461)", () => {
+  it("hands back the WARN-level conflicts a drag creates, and still writes", async () => {
+    const { auth, mover } = await seedBoard();
+    const conflicts = await moveFixture(auth, mover, {
+      scheduled_at: at(DAY, "11:00"),
+      court_label: "Court 2",
+    });
+
+    // Non-empty and non-blocking — the two halves that make this reportable
+    // rather than refusable. A blocking conflict would have thrown 409 and this
+    // test would never reach here.
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]!.blocking).toBe(false);
+    expect(conflicts[0]!.code).toBe("warn.instruction");
+    expect(conflicts[0]!.fixture_id).toBe(mover);
+    // THREE, not two: this division's own two cards plus the SIBLING division's
+    // (#462, call site four). Two would mean the sibling's card was on the board
+    // as court occupancy and invisible to the rule.
+    expect(conflicts[0]!.detail).toContain(`3 fixtures on ${DAY}`);
+
+    // The write happened anyway — a warn never refuses.
+    const [row] = await sql<{ court_label: string }[]>`
+      select court_label from fixtures where id = ${mover}`;
+    expect(row!.court_label).toBe("Court 2");
+  }, 120_000);
+
+  it("returns an empty list for a move that breaks nothing", async () => {
+    // The falsifier for the test above: if `moveFixture` returned a non-empty
+    // list unconditionally, or the whole board's conflicts rather than this
+    // move's, the assertion above would pass while meaning nothing.
+    const { auth, mover } = await seedBoard();
+    const conflicts = await moveFixture(auth, mover, {
+      scheduled_at: at(OTHER_DAY, "09:00"),
+      court_label: "Court 2",
+    });
+    expect(conflicts).toEqual([]);
+  }, 120_000);
+
+  it("the PATCH payload carries them, exactly as the response schema declares", async () => {
+    // `openapi:gen` regenerates the spec FROM the zod schema, and nothing applies
+    // that schema at runtime — so a spec and a served body can disagree with both
+    // gates green. The only thing that catches it is running the schema over the
+    // real payload, which is what this does. `JSON.parse(JSON.stringify(...))` is
+    // deliberate: postgres hands back `timestamptz` as a Date, and the WIRE is
+    // what the schema describes.
+    const { auth, mover } = await seedBoard();
+    const out = await patchFixture(auth, mover, {
+      scheduled_at: at(DAY, "11:00"),
+      court_label: "Court 2",
+    });
+    const wire = JSON.parse(JSON.stringify(out));
+
+    expect(Object.keys(wire)).toContain("conflicts");
+    expect(wire.conflicts).toHaveLength(1);
+    expect(wire.conflicts[0].code).toBe("warn.instruction");
+    // zod STRIPS unknown keys, so an equality against the parse result fails on
+    // an undocumented extra field as well as on a missing declared one.
+    expect(PatchedFixture.parse(wire)).toEqual(wire);
+  }, 120_000);
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-person-scope.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-person-scope.test.ts
@@ -1,0 +1,331 @@
+// #450 — a person-scoped rule is collapsed by the SAME resolver as the rosters.
+//
+// `buildSchedulePack` runs every entrant roster through the scheduling-only
+// same-name guard (`personKeyResolver`), so a movable fixture's `people` are
+// `name:<normalised>` keys wherever two `persons` rows share a display name.
+// Nothing mapped `hard[].scope.personKey`, and `scopeCoversFixture` compares it
+// RAW against `Assignment.people` — so an organiser's person-scoped rule, stored
+// against a real person UUID, stopped binding the moment the guard collapsed
+// that person. It did not warn, it did not throw: it silently matched nothing.
+//
+// WHY BOTH BOARDS BELOW ARE NEEDED. Mapping every `personKey` to one bucket
+// would satisfy the collapse assertion perfectly, so the first board alone
+// cannot tell "the rule now binds the right person" from "the rule now binds
+// everyone". The UNIQUE-name board is the falsifier: there the key must come
+// back untouched and the rule must cover the two fixtures that person is in and
+// NOT the third.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import {
+  validateAssignments,
+  type Conflict,
+  type HardConstraint,
+} from "@seazn/engine/scheduling";
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages } from "../stages";
+import {
+  buildSchedulePack,
+  toEngineAssignments,
+  verifyConfig,
+  type SchedulePack,
+} from "../schedule-ai";
+import type { AiSchedulePlan } from "../schedule-ai-prompt";
+import { seedOrg } from "./_seed";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const TZ = "Europe/London";
+/** Injected clock — the pack reads no wall clock, so the board is reproducible. */
+const NOW = Date.parse("2026-08-06T23:30:00Z");
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+/** One calendar day in the ORG zone, three well-separated slots on it. A
+ *  `max_fixtures_per_day` cap is a statement about a DAY, so every fixture in a
+ *  board here must land on the same one — and far enough apart that no rest or
+ *  person-overlap rule can be mistaken for the cap firing. */
+const DAY = "2026-08-10";
+const SLOT = [
+  Date.parse(`${DAY}T09:00:00.000Z`),
+  Date.parse(`${DAY}T13:00:00.000Z`),
+  Date.parse(`${DAY}T17:00:00.000Z`),
+];
+
+function settingsConfig(hard: HardConstraint[]) {
+  return {
+    startAt: `${DAY}T08:00:00.000Z`,
+    matchMinutes: 30,
+    gapMinutes: 0,
+    courts: ["Court 1", "Court 2", "Court 3"],
+    perEntrantMinRest: 20,
+    blackouts: [],
+    sessionWindows: [],
+    constraints: {
+      restMin: 20,
+      noBackToBack: false,
+      startWindows: [],
+      fieldFairness: "off",
+      parallelism: "mixed",
+      crossPersonClash: "warn",
+      hard,
+    },
+  };
+}
+
+async function makeDivision(
+  auth: AuthCtx,
+  competitionId: string,
+  slug: string,
+  entrantNames: string[],
+  hard: HardConstraint[],
+): Promise<{ id: string; entrantByName: Map<string, string>; stageId: string }> {
+  const division = await createDivision(auth, competitionId, {
+    name: `Div ${slug}`,
+    slug,
+    sport_key: "generic",
+    variant_key: "score",
+    config: GENERIC_CONFIG,
+    eligibility: [],
+  });
+  await sql`
+    insert into schedule_settings (division_id, config, tz, updated_at)
+    values (${division.id}, ${sql.json(settingsConfig(hard))}, ${TZ}, now())
+    on conflict (division_id) do update set config = excluded.config, tz = excluded.tz`;
+  await createEntrants(
+    auth,
+    division.id,
+    entrantNames.map((n, i) => ({
+      kind: "individual" as const,
+      display_name: n,
+      seed: i + 1,
+      members: [],
+    })),
+  );
+  const rows = await sql<{ id: string; display_name: string }[]>`
+    select id, display_name from entrants where division_id = ${division.id}`;
+  const [stage] = await createStages(auth, division.id, {
+    seq: 1,
+    kind: "league",
+    name: "RR",
+    config: {},
+  });
+  return {
+    id: division.id,
+    entrantByName: new Map(rows.map((r) => [r.display_name, r.id])),
+    stageId: stage!.id,
+  };
+}
+
+async function addPerson(orgId: string, fullName: string, entrantIds: string[]): Promise<string> {
+  const [p] = await sql<{ id: string }[]>`
+    insert into persons (org_id, full_name) values (${orgId}, ${fullName}) returning id`;
+  for (const e of entrantIds) {
+    await sql`insert into entrant_members (entrant_id, person_id, org_id)
+              values (${e}, ${p!.id}, ${orgId})`;
+  }
+  return p!.id;
+}
+
+async function addFixture(
+  auth: AuthCtx,
+  d: { id: string; stageId: string; entrantByName: Map<string, string> },
+  seq: number,
+  extKey: string,
+  home: string,
+  away: string,
+): Promise<string> {
+  const [f] = await sql<{ id: string }[]>`
+    insert into fixtures (stage_id, division_id, org_id, round_no, seq_in_round, ext_key, status,
+                          home_entrant_id, away_entrant_id)
+    values (${d.stageId}, ${d.id}, ${auth.orgId}, 1, ${seq}, ${extKey}, 'scheduled',
+            ${d.entrantByName.get(home)!}, ${d.entrantByName.get(away)!})
+    returning id`;
+  return f!.id;
+}
+
+/** A plan that puts the given fixtures on ONE day, one per court, hours apart. */
+function planFor(ids: readonly string[]): AiSchedulePlan {
+  return {
+    assignments: ids.map((id, i) => ({
+      fixture_id: id,
+      scheduled_at: new Date(SLOT[i]!).toISOString(),
+      court_label: `Court ${i + 1}`,
+    })),
+    unschedulable: [],
+    explanations: [],
+    summary: "",
+  };
+}
+
+/** The referee's verdict on that plan, assembled exactly as the runner does. */
+function refereeConflicts(pack: SchedulePack, ids: readonly string[]): Conflict[] {
+  const plan = planFor(ids);
+  return validateAssignments(toEngineAssignments(plan, pack), verifyConfig(pack));
+}
+
+const dayCapConflicts = (cs: readonly Conflict[]): Conflict[] =>
+  cs.filter((c) => c.reason === "instruction" && (c.detail ?? "").includes("/day cap"));
+
+/** BOARD 1 — two `persons` rows share a display name, so the pack collapses
+ *  them to `name:tam okoro`. The stored rule names ONE of those uuids. */
+async function seedCollapsedBoard(): Promise<{
+  auth: AuthCtx;
+  divisionId: string;
+  tamId: string;
+  f1: string;
+  f2: string;
+}> {
+  const { auth } = await seedOrg("pro");
+  const tag = randomUUID().slice(0, 6);
+  const comp = await createCompetition(auth, {
+    name: `Person Scope Collapse ${tag}`,
+    visibility: "public",
+    branding: {},
+  });
+  // The rule has to name a person id that does not exist until the rows do, so
+  // the division is created with no durable rule and the settings row is
+  // rewritten below once the person exists.
+  const div = await makeDivision(auth, comp.id, `collapse-${tag}`, ["C-1", "C-2", "C-3", "C-4"], []);
+
+  // ONE human, two `persons` rows, in two DIFFERENT entrants of this division.
+  const tam = await addPerson(auth.orgId, "Tam Okoro", [div.entrantByName.get("C-1")!]);
+  await addPerson(auth.orgId, "tam  okoro", [div.entrantByName.get("C-3")!]);
+  await addPerson(auth.orgId, "Solo C-2", [div.entrantByName.get("C-2")!]);
+  await addPerson(auth.orgId, "Solo C-4", [div.entrantByName.get("C-4")!]);
+
+  // "Tam plays at most one match a day" — authored against a real person UUID,
+  // which is the only person identifier the console has.
+  await sql`
+    update schedule_settings
+    set config = ${sql.json(
+      settingsConfig([
+        { type: "max_fixtures_per_day", count: 1, scope: { kind: "person", personKey: tam } },
+      ]),
+    )}
+    where division_id = ${div.id}`;
+
+  const f1 = await addFixture(auth, div, 0, "c-f1", "C-1", "C-2");
+  const f2 = await addFixture(auth, div, 1, "c-f2", "C-3", "C-4");
+  return { auth, divisionId: div.id, tamId: tam, f1, f2 };
+}
+
+/** BOARD 2 — every name is unique, so the pack collapses NOTHING. The same rule
+ *  shape must come back with the uuid untouched and must cover exactly the two
+ *  fixtures that person is in. */
+async function seedUniqueBoard(): Promise<{
+  auth: AuthCtx;
+  divisionId: string;
+  umaId: string;
+  withUma: [string, string];
+  withoutUma: string;
+}> {
+  const { auth } = await seedOrg("pro");
+  const tag = randomUUID().slice(0, 6);
+  const comp = await createCompetition(auth, {
+    name: `Person Scope Unique ${tag}`,
+    visibility: "public",
+    branding: {},
+  });
+  const div = await makeDivision(auth, comp.id, `unique-${tag}`, ["U-1", "U-2", "U-3", "U-4"], []);
+
+  const uma = await addPerson(auth.orgId, "Uma Vane", [div.entrantByName.get("U-1")!]);
+  await addPerson(auth.orgId, "Solo U-2", [div.entrantByName.get("U-2")!]);
+  await addPerson(auth.orgId, "Solo U-3", [div.entrantByName.get("U-3")!]);
+  await addPerson(auth.orgId, "Solo U-4", [div.entrantByName.get("U-4")!]);
+
+  await sql`
+    update schedule_settings
+    set config = ${sql.json(
+      settingsConfig([
+        { type: "max_fixtures_per_day", count: 1, scope: { kind: "person", personKey: uma } },
+      ]),
+    )}
+    where division_id = ${div.id}`;
+
+  // Uma is in the first and the third; the second is two other people entirely.
+  const a = await addFixture(auth, div, 0, "u-f1", "U-1", "U-2");
+  const b = await addFixture(auth, div, 1, "u-f2", "U-3", "U-4");
+  const c = await addFixture(auth, div, 2, "u-f3", "U-1", "U-3");
+  return { auth, divisionId: div.id, umaId: uma, withUma: [a, c], withoutUma: b };
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("person-scoped rules collapse with the rosters (#450)", () => {
+  it("a rule naming a COLLAPSED person's uuid still binds", async () => {
+    const { auth, divisionId, tamId, f1, f2 } = await seedCollapsedBoard();
+    const { pack } = await buildSchedulePack(auth, divisionId, {
+      now: NOW,
+      mode: "generate",
+      instruction: "One round.",
+    });
+
+    // Guards the guard: the collapse really happened, and it reached BOTH
+    // fixtures — so a rule that still names the raw uuid matches neither.
+    expect(pack.participants[f1]).toContain("name:tam okoro");
+    expect(pack.participants[f2]).toContain("name:tam okoro");
+    expect(pack.participants[f1]).not.toContain(tamId);
+    expect(pack.assumptions.some((a) => a.includes("no records were merged"))).toBe(true);
+
+    // THE ASSERTION. Two fixtures on one day against a 1/day person cap: both
+    // are movable, so both are reported. Before the fix this is an empty list —
+    // the rule compiled, displayed as enforced, and bound nothing.
+    const capped = dayCapConflicts(refereeConflicts(pack, [f1, f2]));
+    expect(capped).toHaveLength(2);
+    expect(capped.map((c) => c.fixtureId).sort()).toEqual([f1, f2].sort());
+    expect(capped[0]!.detail).toContain(`2 fixtures on ${DAY}`);
+
+    // The mechanism, asserted where it is made, so a regression fails with a
+    // readable message and not only through a verdict two functions away: the
+    // rule the referee is handed is in the same namespace as the rows it is
+    // compared against.
+    const hard = pack.settings.constraints?.hard ?? [];
+    expect(hard).toHaveLength(1);
+    expect(hard[0]!.scope).toEqual({ kind: "person", personKey: "name:tam okoro" });
+  }, 120_000);
+
+  it("with UNIQUE names the same rule keeps its uuid and binds to that person ONLY", async () => {
+    const { auth, divisionId, umaId, withUma, withoutUma } = await seedUniqueBoard();
+    const { pack } = await buildSchedulePack(auth, divisionId, {
+      now: NOW,
+      mode: "generate",
+      instruction: "One round.",
+    });
+
+    // Nothing collapsed here, so the resolver is the identity and the stored
+    // uuid must survive verbatim. A mapping that rewrote every key — which is
+    // what would make the first test pass for the wrong reason — fails here.
+    expect(pack.assumptions.some((a) => a.includes("no records were merged"))).toBe(false);
+    expect(pack.settings.constraints?.hard?.[0]!.scope).toEqual({
+      kind: "person",
+      personKey: umaId,
+    });
+    expect(pack.participants[withUma[0]!]).toContain(umaId);
+    expect(pack.participants[withoutUma]).not.toContain(umaId);
+
+    // Three fixtures on one day; the cap is scoped to Uma, who is in two of
+    // them. So the count is 2 (not 3) and the third card is untouched.
+    const capped = dayCapConflicts(refereeConflicts(pack, [withUma[0]!, withoutUma, withUma[1]!]));
+    expect(capped).toHaveLength(2);
+    expect(capped.map((c) => c.fixtureId).sort()).toEqual([...withUma].sort());
+    expect(capped.map((c) => c.fixtureId)).not.toContain(withoutUma);
+    expect(capped[0]!.detail).toContain(`2 fixtures on ${DAY}`);
+  }, 120_000);
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-pool-namespace.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-pool-namespace.test.ts
@@ -1,0 +1,280 @@
+// #449 — ONE pool namespace at the engine boundary.
+//
+// `Assignment.poolId` used to be a pool UUID on the board path and a pool KEY
+// ('A', 'B') on the AI path, and `RuleFixture.poolId` carried the key on both.
+// `scopeCoversFixture` reads `f?.poolId ?? a.poolId`, so the RuleFixture value
+// MASKS the assignment's — meaning that whatever namespace an organiser's
+// stored rule was authored in, at most ONE of the two paths could ever bind it.
+// The same split reached `effectiveRestMinutes`' `restByGroup` lookup, which is
+// keyed on the same field.
+//
+// The UUID is canonical: it is what the board path already used, what the DB
+// stores, and what `restByGroup` keys are authored against. A pool key is
+// display metadata and is not even unique across divisions.
+//
+// WHY THIS FILE COMPARES TWO PATHS RATHER THAN ASSERTING ONE. A namespace split
+// is invisible from inside either half — each is self-consistent, and a test
+// that hands the engine two equal strings passes while proving nothing. Only
+// running the SAME division, the SAME stored rules and the SAME board through
+// both real builders and demanding the same verdict can catch it. So every
+// assertion below is a comparison, and the fixed values are only there to stop
+// "both paths report nothing" from counting as agreement.
+import { describe, expect, it } from "vitest";
+import {
+  makeClock,
+  validateAssignments,
+  type Conflict,
+} from "@seazn/engine/scheduling";
+import { ScheduleConfig } from "@/server/api-v1/schemas";
+import {
+  toAssignment,
+  toVerifyConfig,
+  type FixtureLite,
+  type ScheduleSettingsOut,
+} from "../schedule";
+import type { AiSchedulePlan } from "../schedule-ai-prompt";
+import {
+  toEngineAssignments,
+  toModelPayload,
+  verifyConfig,
+  type SchedulePack,
+} from "../schedule-ai";
+
+const MIN = 60_000;
+const T0 = Date.parse("2026-08-10T09:00:00.000Z");
+const iso = (t: number) => new Date(t).toISOString();
+
+const DIV_A = "11111111-1111-4111-8111-111111111111";
+/** What the DB stores and what `fixtures.pool_id` holds. */
+const POOL_A_ID = "22222222-2222-4222-8222-222222222222";
+/** What `pools.key` holds and what the MODEL is shown as `PackFixture.pool`. */
+const POOL_A_KEY = "A";
+
+// One day, two fixtures in pool A sharing entrant e1, 40 minutes apart. Both a
+// 180-minute pool rest and a 1/day pool cap are breached — by a wide margin, so
+// neither verdict turns on an off-by-one.
+const F1 = "f-1";
+const F2 = "f-2";
+
+/** The stored constraints, authored against the pool UUID — the namespace the
+ *  console writes and the DB holds. */
+const storedConstraints = (poolRef: string) => ({
+  restByGroup: { [poolRef]: 180 },
+  hard: [
+    {
+      type: "max_fixtures_per_day" as const,
+      count: 1,
+      scope: { kind: "pool" as const, divisionId: DIV_A, pool: poolRef },
+    },
+  ],
+});
+
+// --- the board path ---------------------------------------------------------
+
+function row(over: Partial<FixtureLite> = {}): FixtureLite {
+  return {
+    id: F1,
+    stage_id: "s-1",
+    division_id: DIV_A,
+    pool_id: POOL_A_ID,
+    round_no: 0,
+    seq_in_round: 0,
+    ext_key: null,
+    home_entrant_id: "e1",
+    away_entrant_id: "e2",
+    scheduled_at: iso(T0),
+    court_label: "Court 1",
+    venue: null,
+    status: "scheduled",
+    schedule_locked: false,
+    winner_to_fixture: null,
+    loser_to_fixture: null,
+    ...over,
+  };
+}
+
+const ROWS: FixtureLite[] = [
+  row(),
+  row({
+    id: F2,
+    seq_in_round: 1,
+    away_entrant_id: "e3",
+    scheduled_at: iso(T0 + 80 * MIN),
+    court_label: "Court 2",
+  }),
+];
+
+function settings(constraints: Record<string, unknown>): ScheduleSettingsOut {
+  return {
+    division_id: DIV_A,
+    config: ScheduleConfig.parse({
+      startAt: iso(T0),
+      matchMinutes: 40,
+      gapMinutes: 0,
+      courts: ["Court 1", "Court 2"],
+      perEntrantMinRest: 30,
+      constraints,
+    }),
+    tz: "UTC",
+    orgTz: "UTC",
+    updated_at: iso(T0),
+  };
+}
+
+function boardConflicts(poolRef: string): Conflict[] {
+  const config = toVerifyConfig(settings(storedConstraints(poolRef)), ROWS, 0);
+  const assignments = ROWS.map((r) => toAssignment(r, 40, new Map()));
+  // `validateAssignments` runs `validateInstructionRules` itself, so this one
+  // call covers both the `restByGroup` lookup and the pool-scoped day cap.
+  return validateAssignments(assignments, config);
+}
+
+// --- the single-division AI path --------------------------------------------
+
+function pack(poolRef: string): SchedulePack {
+  const c = storedConstraints(poolRef);
+  return {
+    mode: "generate",
+    division: { id: DIV_A, name: "Div A", sport: "generic", tz: "UTC" },
+    tz: "UTC",
+    clock: makeClock(T0, "UTC"),
+    window: { start: "2026-08-10", end: "2026-08-17" },
+    sessionHours: { start: "08:00", end: "22:00" },
+    settings: {
+      matchMinutes: 40,
+      gapMinutes: 0,
+      perEntrantMinRest: 30,
+      courts: ["Court 1", "Court 2"],
+      sessionWindows: [],
+      blackouts: [],
+      constraints: {
+        noBackToBack: false,
+        startWindows: [],
+        fieldFairness: "off",
+        parallelism: "mixed",
+        crossPersonClash: "warn",
+        restByGroup: c.restByGroup,
+        hard: c.hard,
+      },
+    },
+    entrants: [],
+    people: [],
+    participants: { [F1]: [], [F2]: [] },
+    // THE POINT OF THE FIX. The model-facing `pool` below stays the KEY — the
+    // prompts read it and it is a wire shape — and the UUID rides here, where
+    // only the server sees it. `toModelPayload` omits this field for the same
+    // reason it omits `participants`.
+    poolIds: { [F1]: POOL_A_ID, [F2]: POOL_A_ID },
+    assumptions: [],
+    parsed: { hard: [], soft: [], unparsed: [] },
+    fixtures: {
+      movable: [
+        {
+          id: F1,
+          ext_key: null,
+          round: 0,
+          seq: 0,
+          pool: POOL_A_KEY,
+          home: "e1",
+          away: "e2",
+          feeds: { winner_to: null, after: [] },
+          current: { at: null, court: null },
+          pinned: false,
+        },
+        {
+          id: F2,
+          ext_key: null,
+          round: 0,
+          seq: 1,
+          pool: POOL_A_KEY,
+          home: "e1",
+          away: "e3",
+          feeds: { winner_to: null, after: [] },
+          current: { at: null, court: null },
+          pinned: false,
+        },
+      ],
+      obstacles: [],
+    },
+    draft: [],
+    instruction: "",
+    prior: null,
+    officials: [],
+  };
+}
+
+const PLAN: AiSchedulePlan = {
+  assignments: [
+    { fixture_id: F1, scheduled_at: iso(T0), court_label: "Court 1" },
+    { fixture_id: F2, scheduled_at: iso(T0 + 80 * MIN), court_label: "Court 2" },
+  ],
+  unschedulable: [],
+  explanations: [],
+  summary: "",
+};
+
+function aiConflicts(poolRef: string): Conflict[] {
+  const p = pack(poolRef);
+  const config = verifyConfig(p);
+  const assignments = toEngineAssignments(PLAN, p);
+  return validateAssignments(assignments, config);
+}
+
+const tally = (cs: Conflict[]) =>
+  [...cs].map((c) => `${c.fixtureId}|${c.reason}`).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+describe("one pool namespace across the engine boundary (#449)", () => {
+  it("the AI path stamps the pool UUID on its assignments, as the board path does", () => {
+    // Asserted directly so a regression fails here with a readable message and
+    // not only through a verdict two functions away.
+    expect(toEngineAssignments(PLAN, pack(POOL_A_ID))[1]!.poolId).toBe(POOL_A_ID);
+    expect(toAssignment(ROWS[1]!, 40, new Map()).poolId).toBe(POOL_A_ID);
+  });
+
+  it("keeps the model-facing PackFixture.pool as the display KEY", () => {
+    // The prompts read this field and it is a wire shape. Carrying the uuid must
+    // not have been done by renaming it.
+    expect(pack(POOL_A_ID).fixtures.movable[0]!.pool).toBe(POOL_A_KEY);
+  });
+
+  it("a pool-scoped rule and a pool-targeted rest bind IDENTICALLY on both paths", () => {
+    const board = boardConflicts(POOL_A_ID);
+    const ai = aiConflicts(POOL_A_ID);
+
+    // The comparison that catches a namespace split. Everything else in this
+    // test only proves the comparison is not vacuous.
+    expect(tally(ai)).toEqual(tally(board));
+
+    // Not vacuous: BOTH rules actually fire. `rest` is the `restByGroup` lookup
+    // in `effectiveRestMinutes`; `instruction` is the pool-scoped day cap
+    // resolved through `scopeCoversFixture`, where a RuleFixture's poolId masks
+    // the assignment's.
+    expect(board.map((c) => c.reason)).toContain("rest");
+    expect(board.map((c) => c.reason)).toContain("instruction");
+    // Two fixtures over a 1/day cap, both movable, so both are reported.
+    expect(board.filter((c) => c.reason === "instruction")).toHaveLength(2);
+    expect(ai.filter((c) => c.reason === "instruction")).toHaveLength(2);
+  });
+
+  it("a rule authored against the pool KEY binds on NEITHER path", () => {
+    // The guard the assertion above needs. "One namespace" must mean the uuid on
+    // both sides — a builder that matched the key as well would satisfy the
+    // equality test while leaving two namespaces live.
+    expect(boardConflicts(POOL_A_KEY).map((c) => c.reason)).not.toContain("instruction");
+    expect(aiConflicts(POOL_A_KEY).map((c) => c.reason)).not.toContain("instruction");
+    expect(boardConflicts(POOL_A_KEY).map((c) => c.reason)).not.toContain("rest");
+    expect(aiConflicts(POOL_A_KEY).map((c) => c.reason)).not.toContain("rest");
+  });
+
+  it("the pool uuid stays off the fixture rows the model reads", () => {
+    // `poolIds` is a server-side enforcement input like `participants`, not
+    // prompt material: the model schedules by pool LABEL and has no use for a
+    // uuid. Scoped to `fixtures` on purpose — `settings.constraints` genuinely
+    // does carry pool uuids on the wire (a stored `restByGroup` key, a stored
+    // rule's scope), and that predates this change.
+    const payload = toModelPayload(pack(POOL_A_ID)) as Record<string, unknown>;
+    expect("poolIds" in payload).toBe(false);
+    expect(JSON.stringify(payload.fixtures)).not.toContain(POOL_A_ID);
+    expect(JSON.stringify(payload.fixtures)).toContain(`"pool":"${POOL_A_KEY}"`);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/schedule-sibling-rulefixtures.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-sibling-rulefixtures.test.ts
@@ -1,0 +1,275 @@
+// #462 — a sibling division's fixtures carry their RULE IDENTITY, not just
+// their court time.
+//
+// `siblingAssignments` returned `Assignment[]`, a shape that structurally cannot
+// carry `extKey` or `winnerTo`. The engine's day-cap tally counts only the
+// `existing` rows it can NAME —
+//
+//     existing.filter((e) => fixtureById.has(e.fixtureId))          calendar.ts
+//
+// where `fixtureById` is built from `config.ruleFixtures`. Every board path in
+// `schedule.ts` built `ruleFixtures` from THIS division's rows alone, so a
+// sibling's card was on the board as occupancy and invisible to every typed
+// rule. A competition-scoped `max_fixtures_per_day` therefore undercounted by
+// exactly the number of sibling fixtures on the day — silently, and in the
+// direction that says "this board is fine".
+//
+// WHY THE NUMBER IS THE ASSERTION. "A conflict was reported" is satisfied by an
+// undercount that still breaches the cap; only the count distinguishes 3-on-the-
+// day from 2. Every board below is therefore built so the cap is breached ONLY
+// once the sibling is counted: two of this division's fixtures against a 2/day
+// cap is legal on its own.
+//
+// FOUR call sites take siblings, and a missed one is exactly this defect again.
+// Three are exercised here — `validateSchedule` (the board report),
+// `applySchedule` (the write gate) and `autoSchedule` (the placer). The fourth,
+// `moveFixture`, returns no conflicts to assert on until #461; it is covered in
+// `schedule-move-conflicts.test.ts`.
+//
+// Real Postgres required; skipped without DATABASE_URL.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+
+import type { HardConstraint } from "@seazn/engine/scheduling";
+import { sql } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import type { ScheduleConflict } from "@/server/api-v1/schemas";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages } from "../stages";
+import { applySchedule, autoSchedule, validateSchedule } from "../schedule";
+import { seedOrg } from "./_seed";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+const TZ = "Europe/London";
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+/** One day, in the org zone. Every card on every board below sits on it. */
+const DAY = "2026-08-10";
+const AT = (hhmm: string): string => `${DAY}T${hhmm}:00.000Z`;
+
+/** The cap that only breaks once the sibling counts. */
+const DAY_CAP: HardConstraint[] = [
+  { type: "max_fixtures_per_day", count: 2, scope: { kind: "competition" } },
+];
+
+/** The sibling plays on a court THIS division does not have, so no court
+ *  double-booking can stand in for the rule firing; and its entrants are its
+ *  own, so no shared person can either. The only link is the calendar day. */
+const SIBLING_COURT = "Far Court";
+
+function settingsConfig(courts: string[], hard: HardConstraint[], endAt?: string) {
+  return {
+    startAt: AT("08:00"),
+    ...(endAt !== undefined ? { endAt } : {}),
+    matchMinutes: 30,
+    gapMinutes: 0,
+    courts,
+    perEntrantMinRest: 20,
+    blackouts: [],
+    sessionWindows: [],
+    constraints: {
+      restMin: 20,
+      noBackToBack: false,
+      startWindows: [],
+      fieldFairness: "off",
+      parallelism: "mixed",
+      crossPersonClash: "warn",
+      hard,
+    },
+  };
+}
+
+interface Div {
+  id: string;
+  stageId: string;
+  entrantByName: Map<string, string>;
+}
+
+async function makeDivision(
+  auth: AuthCtx,
+  competitionId: string,
+  slug: string,
+  courts: string[],
+  entrantNames: string[],
+  hard: HardConstraint[],
+  endAt?: string,
+): Promise<Div> {
+  const division = await createDivision(auth, competitionId, {
+    name: `Div ${slug}`,
+    slug,
+    sport_key: "generic",
+    variant_key: "score",
+    config: GENERIC_CONFIG,
+    eligibility: [],
+  });
+  await sql`
+    insert into schedule_settings (division_id, config, tz, updated_at)
+    values (${division.id}, ${sql.json(settingsConfig(courts, hard, endAt))}, ${TZ}, now())
+    on conflict (division_id) do update set config = excluded.config, tz = excluded.tz`;
+  await createEntrants(
+    auth,
+    division.id,
+    entrantNames.map((n, i) => ({
+      kind: "individual" as const,
+      display_name: n,
+      seed: i + 1,
+      members: [],
+    })),
+  );
+  const rows = await sql<{ id: string; display_name: string }[]>`
+    select id, display_name from entrants where division_id = ${division.id}`;
+  const [stage] = await createStages(auth, division.id, {
+    seq: 1,
+    kind: "league",
+    name: "RR",
+    config: {},
+  });
+  return {
+    id: division.id,
+    stageId: stage!.id,
+    entrantByName: new Map(rows.map((r) => [r.display_name, r.id])),
+  };
+}
+
+async function addFixture(
+  auth: AuthCtx,
+  d: Div,
+  seq: number,
+  extKey: string,
+  home: string,
+  away: string,
+  slot: { at: string; court: string } | null,
+  status = "scheduled",
+): Promise<string> {
+  const [f] = await sql<{ id: string }[]>`
+    insert into fixtures (stage_id, division_id, org_id, round_no, seq_in_round, ext_key, status,
+                          home_entrant_id, away_entrant_id, scheduled_at, court_label)
+    values (${d.stageId}, ${d.id}, ${auth.orgId}, 1, ${seq}, ${extKey}, ${status},
+            ${d.entrantByName.get(home)!}, ${d.entrantByName.get(away)!},
+            ${slot?.at ?? null}, ${slot?.court ?? null})
+    returning id`;
+  return f!.id;
+}
+
+/** A competition with a planned division and one sibling holding a single
+ *  already-fixed card on `DAY`. `placed` decides whether the planned division's
+ *  own two fixtures start on the timetable or off it. */
+async function seedBoard(placed: boolean, endAt?: string): Promise<{
+  auth: AuthCtx;
+  planned: Div;
+  fa1: string;
+  fa2: string;
+  siblingFixtureId: string;
+}> {
+  const { auth } = await seedOrg("pro");
+  const tag = randomUUID().slice(0, 6);
+  const comp = await createCompetition(auth, {
+    name: `Sibling Rule Identity ${tag}`,
+    visibility: "public",
+    branding: {},
+  });
+  const planned = await makeDivision(
+    auth,
+    comp.id,
+    `planned-${tag}`,
+    ["Court 1", "Court 2"],
+    ["A-1", "A-2", "A-3", "A-4"],
+    DAY_CAP,
+    endAt,
+  );
+  const sibling = await makeDivision(
+    auth,
+    comp.id,
+    `sibling-${tag}`,
+    [SIBLING_COURT],
+    ["B-1", "B-2"],
+    [],
+  );
+
+  const fa1 = await addFixture(
+    auth, planned, 0, "a-f1", "A-1", "A-2",
+    placed ? { at: AT("09:00"), court: "Court 1" } : null,
+  );
+  const fa2 = await addFixture(
+    auth, planned, 1, "a-f2", "A-3", "A-4",
+    placed ? { at: AT("11:00"), court: "Court 2" } : null,
+  );
+  // Fixed court time in another division of the same competition, on the day.
+  const siblingFixtureId = await addFixture(
+    auth, sibling, 0, "b-f1", "B-1", "B-2",
+    { at: AT("14:00"), court: SIBLING_COURT }, "finalized",
+  );
+  return { auth, planned, fa1, fa2, siblingFixtureId };
+}
+
+const capRows = (conflicts: readonly ScheduleConflict[]): ScheduleConflict[] =>
+  conflicts.filter((c) => c.code === "warn.instruction" && (c.detail ?? "").includes("/day cap"));
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("sibling fixtures carry their rule identity (#462)", () => {
+  it("validateSchedule counts the sibling's card against a competition-wide day cap", async () => {
+    const { auth, planned, fa1, fa2 } = await seedBoard(true);
+    const { conflicts } = await validateSchedule(auth, planned.id);
+
+    const capped = capRows(conflicts);
+    // Three fixtures on the day against a 2/day cap. Reported on the cards this
+    // division can actually move, which is its own two — never on the sibling's,
+    // which nobody looking at this board can drag.
+    expect(capped).toHaveLength(2);
+    expect(capped.map((c) => c.fixture_id).sort()).toEqual([fa1, fa2].sort());
+    // The NUMBER is the point: `2 fixtures on …` would be the undercount that
+    // reports nothing at all, and any figure other than 3 means the sibling was
+    // counted the wrong number of times.
+    expect(capped[0]!.detail).toContain(`3 fixtures on ${DAY}`);
+  }, 120_000);
+
+  it("applySchedule's gate counts it too", async () => {
+    const { auth, planned, fa1, fa2 } = await seedBoard(true);
+    const out = await applySchedule(auth, planned.stageId, {
+      source: "manual",
+      assignments: [
+        { fixture_id: fa1, scheduled_at: AT("09:00"), court_label: "Court 1" },
+        { fixture_id: fa2, scheduled_at: AT("11:00"), court_label: "Court 2" },
+      ],
+    });
+    expect(out.applied).toBe(2);
+
+    const capped = capRows(out.conflicts);
+    expect(capped).toHaveLength(2);
+    expect(capped.map((c) => c.fixture_id).sort()).toEqual([fa1, fa2].sort());
+    expect(capped[0]!.detail).toContain(`3 fixtures on ${DAY}`);
+  }, 120_000);
+
+  it("autoSchedule refuses to propose the card the sibling pushes over the cap", async () => {
+    // A one-DAY window, so the placer has nowhere else to put the second card:
+    // its only honest answer is to leave it unplaced.
+    const { auth, planned } = await seedBoard(false, AT("22:00"));
+    const out = await autoSchedule(auth, planned.stageId, false);
+
+    // The sibling already holds one of the day's two slots, so exactly one of
+    // this division's fixtures fits. Blind to the sibling, the placer proposed
+    // both and the apply gate then warned about a board it had just drawn — the
+    // placer/verifier fork this repo keeps producing.
+    expect(out.assignments).toHaveLength(1);
+    expect(out.conflicts.map((c) => c.code)).toContain("warn.no_slot");
+    // And the proposal it DID make is clean: one card plus the sibling is two,
+    // which the cap allows. A placer that reported a breach on its own one-card
+    // board would be counting the sibling twice.
+    expect(capRows(out.conflicts)).toHaveLength(0);
+  }, 120_000);
+});

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -47,6 +47,11 @@ import { withTenant } from "@/lib/db";
 import { HttpError, PaymentRequiredError } from "@/lib/errors";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { MOVABLE_STATUS, OCCUPYING, peopleByEntrant } from "./schedule";
+import {
+  AI_VERIFY_POLICY,
+  buildEngineConstraints,
+  toEngineStartWindows,
+} from "./engine-constraints";
 import { ScheduleConfig } from "@/server/api-v1/schemas";
 import {
   MAX_REPAIR_ROUNDS,
@@ -1272,55 +1277,40 @@ export function verifyConfigFor(
       : {}),
     perEntrantMinRest: s.perEntrantMinRest,
     matchMinutes: s.matchMinutes,
+    // Through the ONE builder (#458) the board path and the single-division AI
+    // path also go through. `AI_VERIFY_POLICY` pins the three solver knobs inert
+    // — `PackConstraints` types them as bare `string` (the pack is a wire shape)
+    // so this path cannot narrow them — and routes the durable rules to the
+    // top-level `hard` field rather than `constraints.hard`, since
+    // `effectiveHard` merges the two and carrying both would double-count.
+    //
+    // The builder DROPS a start window whose `target.kind` falls outside the
+    // engine's enum, which is the behaviour this site had and the other two did
+    // not. Same reason as ever: `kind` is a bare `string` here, so casting an
+    // unrecognised one through would let the engine silently never match it and
+    // hide that a stored settings row has drifted from the enum.
+    //
+    // PLAN-TIME CONSEQUENCE of carrying start windows at all, flagged rather
+    // than left to be discovered: this function feeds `verifyJoint`, whose
+    // non-blocking conflicts become `result.warnings`, which `planIsAcceptable`
+    // divides by the movable count against SCHEDULING_AI_ESCALATE_WARN_RATIO
+    // (schedule-ai.ts). So `start_window` violations count toward ladder
+    // escalation, and a joint plan that used to look acceptable can escalate a
+    // rung.
+    //
+    // Kept in the ratio on purpose. The pack SHOWS the model these windows
+    // (`PackSettings.constraints.startWindows`), so ignoring them is a real
+    // quality miss — and every other soft constraint the model is shown
+    // (blackout, session window, rest, person overlap) already counts, so
+    // excluding one class would make the heuristic inconsistent in a way nobody
+    // would remember. It cannot change what an org is charged: credits are
+    // quoted up front and escalation spends the already-paid budget. It CAN
+    // bring `stopped_on_budget` forward, which is the honest cost. The ratio is
+    // documented as uncalibrated and is an env knob — that is where it should be
+    // tuned, not by hand-picking which reasons count. Pinned by a test in
+    // competition-schedule-verify.test.ts.
     ...(s.constraints !== null
-      ? {
-          constraints: {
-            ...(s.constraints.restMin !== undefined ? { restMin: s.constraints.restMin } : {}),
-            ...(s.constraints.restByGroup !== undefined
-              ? { restByGroup: s.constraints.restByGroup }
-              : {}),
-            noBackToBack: s.constraints.noBackToBack,
-            // PLAN-TIME CONSEQUENCE, flagged rather than left to be discovered:
-            // this function feeds `verifyJoint`, whose non-blocking conflicts
-            // become `result.warnings`, which `planIsAcceptable` divides by the
-            // movable count against SCHEDULING_AI_ESCALATE_WARN_RATIO
-            // (schedule-ai.ts:1333). So `start_window` violations now count
-            // toward ladder escalation, and a joint plan that used to look
-            // acceptable can escalate a rung.
-            //
-            // Kept in the ratio on purpose. The pack SHOWS the model these
-            // windows (`PackSettings.constraints.startWindows`), so ignoring
-            // them is a real quality miss — and every other soft constraint the
-            // model is shown (blackout, session window, rest, person overlap)
-            // already counts, so excluding one class would make the heuristic
-            // inconsistent in a way nobody would remember. It cannot change what
-            // an org is charged: credits are quoted up front and escalation
-            // spends the already-paid budget. It CAN bring `stopped_on_budget`
-            // forward, which is the honest cost. The ratio is documented as
-            // uncalibrated and is an env knob — that is where it should be tuned,
-            // not by hand-picking which reasons count. Pinned by a test in
-            // competition-schedule-verify.test.ts.
-            //
-            // `PackStartWindow.target.kind` is a bare `string` (the pack is a
-            // wire shape), so an unrecognised kind is DROPPED rather than cast
-            // through: the engine would silently never match it, and a cast
-            // would hide that a settings row has drifted from the enum.
-            startWindows: s.constraints.startWindows.flatMap((w) =>
-              w.target.kind === "entrant" || w.target.kind === "pool" || w.target.kind === "division"
-                ? [
-                    {
-                      target: { kind: w.target.kind, id: w.target.id },
-                      ...(w.notBefore !== undefined ? { notBefore: ms(w.notBefore) } : {}),
-                      ...(w.notAfter !== undefined ? { notAfter: ms(w.notAfter) } : {}),
-                    },
-                  ]
-                : [],
-            ),
-            fieldFairness: "off" as const,
-            parallelism: "mixed" as const,
-            crossPersonClash: "warn" as const,
-          },
-        }
+      ? { constraints: buildEngineConstraints(s.constraints, AI_VERIFY_POLICY) }
       : {}),
     gapMinutes: s.gapMinutes,
     blackouts: s.blackouts.map((b) => ({
@@ -1429,19 +1419,13 @@ export function jointSolverConfig(pack: CompetitionPack): VerifyConfig & { court
             // Start windows are TARGETED by entrant, pool or division id, so the
             // union is exact rather than conservative: a division's window binds
             // that division's fixtures and no others.
-            startWindows: withConstraints.flatMap((c) =>
-              c.startWindows.flatMap((w) =>
-                w.target.kind === "entrant" || w.target.kind === "pool" || w.target.kind === "division"
-                  ? [
-                      {
-                        target: { kind: w.target.kind, id: w.target.id },
-                        ...(w.notBefore !== undefined ? { notBefore: ms(w.notBefore) } : {}),
-                        ...(w.notAfter !== undefined ? { notAfter: ms(w.notAfter) } : {}),
-                      },
-                    ]
-                  : [],
-              ),
-            ),
+            //
+            // The per-window transform is the SHARED one (#458) — this config
+            // unions several divisions and so has no single `constraints` source
+            // to hand `buildEngineConstraints`, but a hand-written copy of the
+            // ISO→ms conversion and the unrecognised-kind drop is exactly the
+            // duplication that produced #458.
+            startWindows: withConstraints.flatMap((c) => toEngineStartWindows(c.startWindows)),
             fieldFairness: "off" as const,
             parallelism: "mixed" as const,
             crossPersonClash: "warn" as const,

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -50,6 +50,7 @@ import { MOVABLE_STATUS, OCCUPYING, peopleByEntrant } from "./schedule";
 import {
   AI_VERIFY_POLICY,
   buildEngineConstraints,
+  resolvePersonScopes,
   toEngineStartWindows,
 } from "./engine-constraints";
 import { ScheduleConfig } from "@/server/api-v1/schemas";
@@ -168,6 +169,22 @@ const FIXED_OCCUPYING = OCCUPYING.filter((s) => s !== MOVABLE_STATUS);
 const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
 const ms = (iso: string): number => Date.parse(iso);
 
+/** A sub-pack's settings with every person scope moved into the RUN's identity
+ *  namespace (#450). Returned by reference when there is nothing to resolve, so
+ *  a settings block with no durable rules is byte-identical to what the
+ *  sub-pack produced — the joint pack's determinism test compares
+ *  `JSON.stringify`, and a rebuilt object is a chance to reorder keys. */
+function withResolvedPersonScopes(
+  s: PackSettings,
+  keyOf: (personId: string) => string,
+): PackSettings {
+  if (s.constraints === null || s.constraints.hard === undefined) return s;
+  return {
+    ...s,
+    constraints: { ...s.constraints, hard: resolvePersonScopes(s.constraints.hard, keyOf) },
+  };
+}
+
 /**
  * The shape `personKeyResolver` (schedule-ai.ts) renders a same-name grouping in.
  *
@@ -197,7 +214,12 @@ export interface CompetitionPackDivision {
   sport: string;
   tz: string;
   /** That division's own settings, verbatim — never merged with a sibling's.
-   *  matchMinutes/gapMinutes/sessionWindows/blackouts legitimately differ. */
+   *  matchMinutes/gapMinutes/sessionWindows/blackouts legitimately differ.
+   *
+   *  ONE exception, and it is not a merge: `constraints.hard[].scope.personKey`
+   *  is re-resolved through the run-wide identity (#450), because that scope is
+   *  the only field on here whose namespace is decided by the RUN rather than by
+   *  the division. See `withResolvedPersonScopes`. */
   settings: PackSettings;
   /** This division's movable fixture ids, in the pack's movable order. */
   movableIds: string[];
@@ -757,7 +779,19 @@ export async function buildCompetitionPack(
     name: b.pack.division.name,
     sport: b.pack.division.sport,
     tz: b.pack.division.tz,
-    settings: b.pack.settings,
+    // #450: re-resolved through the RUN-WIDE identity, not left as the sub-pack
+    // produced it. `buildSchedulePack` already collapsed each division's rules
+    // with that division's own resolver, but the case this module exists for is
+    // the one a per-division resolver structurally cannot see: one human under
+    // two `persons` rows in two DIFFERENT divisions. The joint verifier compares
+    // these rules against `participants`, which ARE run-guarded (built from
+    // `guardedPeople` above), so a rule left holding a raw uuid binds nothing on
+    // exactly the boards this path was built for.
+    //
+    // Safe to apply twice: `keyOf` is a lookup on raw person ids, so a
+    // `name:<normalised>` key the sub-pack already produced is not in the map
+    // and passes through untouched.
+    settings: withResolvedPersonScopes(b.pack.settings, identity.keyOf),
     movableIds: b.pack.fixtures.movable.map((f) => f.id),
     // PLACED, not present: since #397 a draft row can carry `scheduled_at:
     // null` (an epoch sentinel the pack refused to pass off as a time), and

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -274,6 +274,14 @@ export interface CompetitionPack {
    *  and {@link toJointEngineAssignments}, so a draft cannot be legal under a
    *  rule the joint referee applies differently. */
   participants: Record<string, string[]>;
+  /** Movable fixture id → its pool's UUID (#449), unioned from the source packs.
+   *  The joint twin of {@link SchedulePack.poolIds}, server-side only for the
+   *  same reason: `CompetitionPackFixture.pool` stays the display KEY the model
+   *  reads, while the engine, the DB and every stored rule speak the uuid.
+   *
+   *  Keys inserted in `fixtures.movable` order, so the object serialises in a
+   *  domain order rather than a per-seed one. */
+  poolIds: Record<string, string>;
   /** Deterministic preprocessing choices worth telling the organiser about:
    *  stripped bye feeders (from each source pack) and the run-wide same-name
    *  person grouping. Rendered at W5 (#400). */
@@ -314,7 +322,7 @@ export interface CompetitionPack {
  */
 export function toJointModelPayload(
   pack: CompetitionPack,
-): Omit<CompetitionPack, "participants" | "assumptions"> {
+): Omit<CompetitionPack, "participants" | "assumptions" | "poolIds"> {
   return {
     mode: pack.mode,
     competition: pack.competition,
@@ -803,6 +811,18 @@ export async function buildCompetitionPack(
   const participants: Record<string, string[]> = {};
   for (const f of movable) participants[f.id] = participantsByFixture.get(f.id) ?? [];
 
+  // #449: the pool UUID per movable fixture, unioned from the source packs (each
+  // built its own map off `fixtures.pool_id`). Same insertion order as
+  // `participants`, and for the same byte-identical reason.
+  const poolIdBySourceFixture = new Map(
+    built.flatMap((b) => Object.entries(b.pack.poolIds)),
+  );
+  const poolIds: Record<string, string> = {};
+  for (const f of movable) {
+    const id = poolIdBySourceFixture.get(f.id);
+    if (id !== undefined) poolIds[f.id] = id;
+  }
+
   // Bye-strip assumptions come from the source packs, in the emitted division
   // order. Identity is reported once, jointly — see IDENTITY_ASSUMPTION.
   const assumptions = [
@@ -989,6 +1009,7 @@ export async function buildCompetitionPack(
     entrants,
     people,
     participants,
+    poolIds,
     assumptions,
     parsed: { hard: resolved.hard, soft: resolved.soft, unparsed: resolved.unparsed },
     fixtures: { movable, obstacles },
@@ -1148,7 +1169,12 @@ export function toJointEngineAssignments(plan: AiSchedulePlan, pack: Competition
       // this read green on a pack that never computed the map.
       people: pack.participants[a.fixture_id] ?? [],
       divisionId: f.division_id,
-      ...(f.pool != null ? { poolId: f.pool } : {}),
+      // #449: the pool UUID from `pack.poolIds`, NOT `f.pool` — that is the
+      // display key the model reads, and it is not even unique across the
+      // divisions this pack spans.
+      ...(pack.poolIds[a.fixture_id] !== undefined
+        ? { poolId: pack.poolIds[a.fixture_id]! }
+        : {}),
     };
   });
 }
@@ -1371,7 +1397,10 @@ export function jointSolverConfig(pack: CompetitionPack): VerifyConfig & { court
   // `toRuleFixture`. Each fixture's OWN division, because a joint pack spans
   // several.
   const ruleFixtures: RuleFixture[] = pack.fixtures.movable.map((f) =>
-    toRuleFixture(f, f.division_id),
+    // #449: the pool UUID, overriding the display key `pool` carries. A
+    // RuleFixture's poolId MASKS its assignment's in `scopeCoversFixture`, so a
+    // key here would defeat the uuid stamped by `toJointEngineAssignments`.
+    toRuleFixture({ ...f, pool: pack.poolIds[f.id] ?? null }, f.division_id),
   );
   const settings = divisions.map((d) => d.settings);
   const max = (pick: (s: (typeof settings)[number]) => number): number =>
@@ -1536,7 +1565,10 @@ export function verifyJoint(plan: AiSchedulePlan, pack: CompetitionPack): Confli
   // solver must be handed rule fixtures built by ONE piece of code, or they can
   // disagree about which fixture a feed edge names.
   const ruleFixtures: RuleFixture[] = pack.fixtures.movable.map((f) =>
-    toRuleFixture(f, f.division_id),
+    // #449: the pool UUID, overriding the display key `pool` carries. A
+    // RuleFixture's poolId MASKS its assignment's in `scopeCoversFixture`, so a
+    // key here would defeat the uuid stamped by `toJointEngineAssignments`.
+    toRuleFixture({ ...f, pool: pack.poolIds[f.id] ?? null }, f.division_id),
   );
   const hard: HardConstraint[] = [
     ...pack.parsed.hard,

--- a/apps/web/src/server/usecases/competition-schedule-apply.ts
+++ b/apps/web/src/server/usecases/competition-schedule-apply.ts
@@ -472,13 +472,22 @@ export async function applyCompetitionSchedule(
     // Divisions of this competition that are NOT in the run. One call: passing
     // every run division as `excludeDivisionIds` leaves exactly the outsiders,
     // and each of them is measured with its own matchMinutes.
-    const siblings = await siblingAssignments(
-      tx,
-      order[0]!.id,
-      competitionId,
-      order[0]!.settings.config.matchMinutes,
-      order.map((d) => d.id),
-    );
+    // `.assignments` only, deliberately (#462). This pass judges each division
+    // through `verifyConfigFor`, whose `ruleFixtures` come from the joint PACK —
+    // a different producer from `toVerifyConfig`, and widening it to outside
+    // divisions is a separate question about what a joint run may be held to.
+    // The single-division board paths are the ones #462 names, and they are the
+    // ones changed. Left as an explicit projection so a reader sees a decision
+    // rather than an omission.
+    const siblings = (
+      await siblingAssignments(
+        tx,
+        order[0]!.id,
+        competitionId,
+        order[0]!.settings.config.matchMinutes,
+        order.map((d) => d.id),
+      )
+    ).assignments;
     // Feeds are within-division in practice, but the engine resolves a
     // dependency against the whole board, so it is built over the whole board.
     const deps = feedDependencies(order.flatMap((d) => d.fixtures));

--- a/apps/web/src/server/usecases/engine-constraints.ts
+++ b/apps/web/src/server/usecases/engine-constraints.ts
@@ -1,0 +1,129 @@
+import "server-only";
+// ONE builder for the engine's `constraints` block (#458).
+//
+// Three call sites used to build this object as independent literals over the
+// same shape — `toSlotConfig` (schedule.ts, board + apply + solver),
+// `verifyConfig` (schedule-ai.ts, single-division AI) and `verifyConfigFor`
+// (competition-schedule-ai.ts, joint AI) — and having three producers is the
+// bug class, not the symptom. They had already drifted three ways:
+//
+//   - the board site mapped EVERY start window through;
+//   - the joint site DROPPED any window whose `target.kind` fell outside the
+//     engine's enum;
+//   - the single-division AI site pinned `startWindows: []` outright, so that
+//     referee was blind to every start window whatever it targeted, and
+//     `repair-domain` clipped the repair domain to the same empty config.
+//
+// The joint site's filter is canonical and the reason is load-bearing:
+// `PackStartWindow.target.kind` is a bare `string` (the pack is a wire shape
+// that round-trips through JSON), so casting an unrecognised kind through would
+// let the engine silently never match it while hiding that a stored settings
+// row has drifted from the enum. Dropping it is the honest answer, and it is
+// the only one that cannot be mistaken for a rule that binds.
+//
+// This module is deliberately the sibling of `toRuleFixture` (schedule-ai.ts):
+// one derivation, one place to guard, no fourth copy.
+import type { HardConstraint, SchedulingConstraints, StartWindow } from "@seazn/engine/scheduling";
+
+/** The ISO-string form of a start window, as both the stored `ScheduleConfig`
+ *  and the wire `SchedulePack` hold it. `target.kind` is typed as widely as the
+ *  loosest producer types it — the pack's bare `string` — so this one parameter
+ *  accepts every source without a cast at any call site. */
+export interface StartWindowSource {
+  target: { kind: string; id: string };
+  notBefore?: string;
+  notAfter?: string;
+}
+
+/** Everything the engine's `constraints` block takes FROM the stored config.
+ *
+ *  Deliberately does NOT include `fieldFairness`/`parallelism`/`crossPersonClash`
+ *  — see `EngineConstraintPolicy`. Structural, so a caller passes its existing
+ *  `config.constraints` / `pack.settings.constraints` object straight in and the
+ *  extra members are simply not read. */
+export interface EngineConstraintSource {
+  restMin?: number;
+  restByGroup?: Record<string, number>;
+  noBackToBack: boolean;
+  startWindows: readonly StartWindowSource[];
+  /** Durable typed rules (#398). Carried onto the output only when the policy
+   *  asks — see `EngineConstraintPolicy.hard`. */
+  hard?: HardConstraint[];
+}
+
+/** The three solver knobs plus the durable-rule routing, supplied by the CALLER
+ *  rather than read off the source. Required, never defaulted, and that is the
+ *  point: both halves differ between the board path and the AI paths, and both
+ *  are the kind of thing a silent default gets wrong in a direction no test
+ *  would notice.
+ *
+ *  - The knobs: the stored config types them as the engine's enums, but
+ *    `PackConstraints` types them as bare `string` (wire shape), so the AI paths
+ *    cannot narrow them and pin the inert values instead. Reading them off the
+ *    source would mean either a cast or a silent coercion.
+ *  - `hard`: `effectiveHard` MERGES the top-level `hard` field with
+ *    `constraints.hard`. The AI paths already merge the durable rules into the
+ *    top-level field (they combine them with the rules compiled from the
+ *    instruction), so carrying them here as well would count every durable rule
+ *    TWICE. The board path has no top-level field and carries them here. */
+export interface EngineConstraintPolicy {
+  fieldFairness: SchedulingConstraints["fieldFairness"];
+  parallelism: SchedulingConstraints["parallelism"];
+  crossPersonClash: SchedulingConstraints["crossPersonClash"];
+  hard: boolean;
+}
+
+/** What both AI verify seams pass. Named rather than repeated so the two paths
+ *  cannot drift apart again, which is exactly how #458 happened. */
+export const AI_VERIFY_POLICY: EngineConstraintPolicy = {
+  fieldFairness: "off",
+  parallelism: "mixed",
+  crossPersonClash: "warn",
+  hard: false,
+};
+
+const RECOGNISED_KINDS = new Set(["entrant", "pool", "division"]);
+const ms = (iso: string): number => new Date(iso).getTime();
+
+/** ISO → epoch ms, dropping any window the engine's enum does not recognise.
+ *
+ *  Exported because the joint SOLVER config (`competition-schedule-ai.ts`)
+ *  unions several divisions' windows and so has no single `constraints` source
+ *  to hand `buildEngineConstraints` — but it needs the identical per-window
+ *  transform, and a fourth hand-written copy of the filter is the thing this
+ *  module exists to prevent. */
+export function toEngineStartWindows(windows: readonly StartWindowSource[]): StartWindow[] {
+  return windows.flatMap((w) =>
+    RECOGNISED_KINDS.has(w.target.kind)
+      ? [
+          {
+            target: { kind: w.target.kind as StartWindow["target"]["kind"], id: w.target.id },
+            ...(w.notBefore !== undefined ? { notBefore: ms(w.notBefore) } : {}),
+            ...(w.notAfter !== undefined ? { notAfter: ms(w.notAfter) } : {}),
+          },
+        ]
+      : [],
+  );
+}
+
+/** The engine's `constraints` block, in the engine's units.
+ *
+ *  Every absent field is OMITTED rather than set to `undefined`: the engine
+ *  reads `restByGroup?.[id]` and `constraints?.hard ?? []`, and a defaulted
+ *  `hard: []` on a config that stored nothing is indistinguishable downstream
+ *  but differs from every literal the suites compare `toSlotConfig` against. */
+export function buildEngineConstraints(
+  source: EngineConstraintSource,
+  policy: EngineConstraintPolicy,
+): SchedulingConstraints {
+  return {
+    ...(source.restMin !== undefined ? { restMin: source.restMin } : {}),
+    ...(source.restByGroup !== undefined ? { restByGroup: source.restByGroup } : {}),
+    noBackToBack: source.noBackToBack,
+    startWindows: toEngineStartWindows(source.startWindows),
+    fieldFairness: policy.fieldFairness,
+    parallelism: policy.parallelism,
+    crossPersonClash: policy.crossPersonClash,
+    ...(policy.hard && source.hard !== undefined ? { hard: source.hard } : {}),
+  };
+}

--- a/apps/web/src/server/usecases/engine-constraints.ts
+++ b/apps/web/src/server/usecases/engine-constraints.ts
@@ -25,6 +25,47 @@ import "server-only";
 // one derivation, one place to guard, no fourth copy.
 import type { HardConstraint, SchedulingConstraints, StartWindow } from "@seazn/engine/scheduling";
 
+/**
+ * Put a stored rule's `scope.personKey` into the SAME namespace as the rows it
+ * will be compared against (#450).
+ *
+ * The AI builders run every entrant roster through the scheduling-only same-name
+ * guard (`personKeyResolver`), so a fixture's `people` are `name:<normalised>`
+ * keys wherever two `persons` rows share a display name. `scopeCoversFixture`
+ * compares `scope.personKey` RAW against that list, so a rule an organiser
+ * stored against a real person UUID — the only person identifier the console
+ * has — stopped binding the instant the guard collapsed that person. It did not
+ * warn and it did not throw: it matched nothing, while still rendering as an
+ * enforced rule.
+ *
+ * The fix cannot live in the engine: reconstructing `name:<normalised>` from a
+ * uuid needs the person-name map, which the engine has never been given and
+ * should not be. It belongs here, beside the `identity.keyOf` call sites, and it
+ * must be the SAME resolver INSTANCE that collapsed the rosters — a second
+ * resolver built from a different person map is a second notion of "same
+ * person", which is the bug one namespace down.
+ *
+ * Idempotent by construction, which the joint path relies on: `keyOf` is a
+ * lookup on raw person ids, so a `name:<normalised>` key it has already produced
+ * is not in the map and passes through unchanged. The joint builder can
+ * therefore re-resolve a sub-pack's already-collapsed rules through its own
+ * (wider, run-scoped) resolver without double-mangling them.
+ *
+ * Every non-person scope is returned by IDENTITY, not rebuilt: `entrantId`,
+ * `divisionId` and `pool` are uuids that no guard touches, and re-spreading them
+ * would only create a place for a namespace to drift.
+ */
+export function resolvePersonScopes(
+  hard: readonly HardConstraint[],
+  keyOf: (personId: string) => string,
+): HardConstraint[] {
+  return hard.map((h) =>
+    h.scope.kind === "person"
+      ? { ...h, scope: { kind: "person" as const, personKey: keyOf(h.scope.personKey) } }
+      : h,
+  );
+}
+
 /** The ISO-string form of a start window, as both the stored `ScheduleConfig`
  *  and the wire `SchedulePack` hold it. `target.kind` is typed as widely as the
  *  loosest producer types it — the pack's bare `string` — so this one parameter

--- a/apps/web/src/server/usecases/fixtures.ts
+++ b/apps/web/src/server/usecases/fixtures.ts
@@ -5,7 +5,7 @@ import type postgres from "postgres";
 import { sql, withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import type { AuthCtx } from "@/server/api-v1/auth";
-import type { PatchFixture, PutLineup } from "@/server/api-v1/schemas";
+import type { PatchFixture, PutLineup, ScheduleConflict } from "@/server/api-v1/schemas";
 import { FIXTURE_COLS, type FixtureRow } from "./stages";
 import { moveFixture } from "./schedule";
 import { scoresViaAssignment } from "./scorers";
@@ -40,13 +40,29 @@ export async function listDivisionFixtures(auth: AuthCtx, divisionId: string): P
   });
 }
 
-export async function patchFixture(auth: AuthCtx, id: string, patch: PatchFixture): Promise<FixtureRow> {
+/** The PATCH response (#461): the fixture, plus the conflicts the move was
+ *  judged against. Declared as its own type because this endpoint's result IS
+ *  the wire — the route returns it unmapped — so widening `FixtureRow` here
+ *  would have widened GET too, where there is no move and nothing to report.
+ *  Mirrored by `PatchedFixture` in `api-v1/schemas.ts`, which is what the
+ *  published spec is generated from. */
+export type PatchedFixtureOut = FixtureRow & { conflicts: ScheduleConflict[] };
+
+export async function patchFixture(
+  auth: AuthCtx,
+  id: string,
+  patch: PatchFixture,
+): Promise<PatchedFixtureOut> {
   // Schedule-touching fields go through the scheduling console's move path
   // (doc 12 §4): conflict validation (court clashes / direct-feed order
   // violations block), schedule_edited ledger event, board realtime refresh.
   const { officials, ...move } = patch;
+  // ALWAYS an array, never undefined (#461): an officials-only patch evaluates
+  // no slot, and "nothing wrong" is the honest answer for it — a client should
+  // not have to tell "no conflicts" from "not evaluated" by key absence.
+  let conflicts: ScheduleConflict[] = [];
   if (Object.keys(move).length > 0) {
-    await moveFixture(auth, id, move);
+    conflicts = await moveFixture(auth, id, move);
   }
   return withTenant(auth.orgId, async (tx) => {
     if (officials) {
@@ -56,7 +72,7 @@ export async function patchFixture(auth: AuthCtx, id: string, patch: PatchFixtur
     const [row] = await tx<FixtureRow[]>`
       select ${tx(FIXTURE_COLS)} from fixtures where id = ${id}`;
     if (!row) throw new HttpError(404, "fixture not found");
-    return row;
+    return { ...row, conflicts };
   });
 }
 

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -60,7 +60,11 @@ import {
   type SlotConfig,
   type VerifyConfig,
 } from "@seazn/engine/scheduling";
-import { AI_VERIFY_POLICY, buildEngineConstraints } from "@/server/usecases/engine-constraints";
+import {
+  AI_VERIFY_POLICY,
+  buildEngineConstraints,
+  resolvePersonScopes,
+} from "@/server/usecases/engine-constraints";
 import {
   parseInstruction,
   resolveParsed,
@@ -96,6 +100,7 @@ import {
   toAssignment,
   toSlotConfig,
   type FixtureLite,
+  type ScheduleSettingsOut,
 } from "./schedule";
 import {
   loadOfficialBlackouts,
@@ -653,6 +658,33 @@ export async function buildSchedulePack(
       [...people].map(([entrantId, ids]) => [entrantId, [...new Set(ids.map(identity.keyOf))]]),
     );
 
+    // #450: the stored RULES go through the same resolver instance, for exactly
+    // the same reason the rosters above do. `scopeCoversFixture` compares
+    // `scope.personKey` raw against a fixture's `people`, which are guarded keys
+    // from this point on — so a rule authored against a real person UUID (the
+    // only person identifier the console offers) stopped binding the moment the
+    // guard collapsed that person, silently and while still displaying as
+    // enforced.
+    //
+    // ONE place, deliberately: `guardedSettings` feeds the DRAFT placer via
+    // `toSlotConfig` below, and `guardedHard` feeds the pack's own
+    // `settings.constraints.hard`, which is what `verifyConfig` hands the
+    // referee. Mapping at only one of the two would fork the placer from the
+    // verifier — the recurring bug in this area — so both read the same array.
+    //
+    // `pack.parsed.hard` is deliberately NOT mapped: `schedule-ai-parse.ts`
+    // narrows the model's scope vocabulary to competition/division, so a
+    // compiled rule cannot carry a person scope at all. A map there would be a
+    // second producer guarding nothing.
+    const guardedHard = resolvePersonScopes(config.constraints?.hard ?? [], identity.keyOf);
+    const guardedSettings: ScheduleSettingsOut =
+      config.constraints === undefined
+        ? settings
+        : {
+            ...settings,
+            config: { ...config, constraints: { ...config.constraints, hard: guardedHard } },
+          };
+
     // Pool id → key ('A', 'B', …) across this division's stages.
     const poolRows = await tx<{ id: string; key: string }[]>`
       select p.id, p.key from pools p
@@ -949,8 +981,13 @@ export async function buildSchedulePack(
         // forwards (#447). The asymmetry is deliberate rather than the one that
         // caused #447 — but it is the same shape, so if a compiled rule ever
         // becomes available at draft time this must move to `toVerifyConfig`.
+        // `guardedSettings`, not `settings` (#450): every fixture handed to the
+        // placer below carries GUARDED person keys, so a person-scoped durable
+        // rule still holding a raw uuid would bind nothing here while the
+        // verifier — reading the same rules off the pack — binds it. That fork
+        // is the whole failure mode this area keeps producing.
         config: toSlotConfig(
-          settings,
+          guardedSettings,
           zonedTimeToUtc(dayKeyInTz(draftAnchorMs, orgTz), DEFAULT_SESSION_HOURS.start, orgTz),
         ),
         // extraExisting is the #350 joint pack's already-drafted divisions;
@@ -1174,7 +1211,10 @@ export async function buildSchedulePack(
             // OMITTED when empty, never `[]`. Absence already means "no durable
             // rules", and emitting an empty array on every pack would change the
             // shape of every instruction-free run for no information.
-            ...(config.constraints.hard?.length ? { hard: config.constraints.hard } : {}),
+            // #450: the person-scope-resolved copy, so the referee compares a
+            // rule against rows in the same namespace. Same array the draft
+            // placer above was given.
+            ...(guardedHard.length ? { hard: guardedHard } : {}),
           }
         : null,
     };

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -348,6 +348,25 @@ export interface SchedulePack {
    *  greedy placer and the verifier, so a draft cannot be legal under a rule
    *  the referee applies differently. */
   participants: Record<string, string[]>;
+  /** Movable fixture id → its pool's UUID, for the fixtures that sit in a pool
+   *  (#449).
+   *
+   *  SERVER-SIDE ONLY, like `participants`: `toModelPayload` omits it. The
+   *  model schedules by pool LABEL and `PackFixture.pool` stays that label —
+   *  the prompts read it, it is a wire shape, and it is what an organiser sees.
+   *
+   *  It exists because a pool KEY is display metadata ('A', 'B') that is not
+   *  unique across divisions, while `Assignment.poolId` and `RuleFixture.poolId`
+   *  are what `scopeCoversFixture` and `effectiveRestMinutes` match a stored
+   *  rule against — and a stored rule names the UUID, which is what the DB holds
+   *  and what the board path has always stamped. Carrying the key across the
+   *  engine boundary put the AI path in a second namespace, so whichever one the
+   *  organiser authored in, at most ONE path could ever bind the rule.
+   *
+   *  Keyed for the fixtures in `fixtures.movable` that have a pool, in that
+   *  array's order, so a build is byte-identical on a reseed for the same reason
+   *  `participants` is. */
+  poolIds: Record<string, string>;
   /** Deterministic preprocessing choices worth telling the organiser about:
    *  stripped bye feeders, same-name person grouping. Rendered at W5 (#400). */
   assumptions: string[];
@@ -394,13 +413,15 @@ export interface SchedulePack {
  * type makes `tsc` fail here the moment `SchedulePack` gains a field, so what
  * reaches the model is always a decision somebody made, never a default.
  */
-export function toModelPayload(pack: SchedulePack): Omit<SchedulePack, "participants" | "assumptions"> {
+export function toModelPayload(
+  pack: SchedulePack,
+): Omit<SchedulePack, "participants" | "assumptions" | "poolIds"> {
   return {
     mode: pack.mode,
     division: pack.division,
     // #397: the calendar anchor IS prompt material — W2 is the wave that moves
-    // the prompt boundary. The enforcement inputs (participants, assumptions)
-    // stay server-side.
+    // the prompt boundary. The enforcement inputs (participants, assumptions,
+    // poolIds) stay server-side.
     tz: pack.tz,
     clock: pack.clock,
     window: pack.window,
@@ -970,6 +991,13 @@ export async function buildSchedulePack(
     );
     draft.sort(byAssignment);
 
+    // #449: pool UUID per movable fixture, for `pack.poolIds`. `PackFixture.pool`
+    // below stays the display KEY the model reads; this is the namespace the
+    // engine, the DB and every stored rule use.
+    const poolIdByFixture = new Map(
+      movable.flatMap((f) => (f.pool_id !== null ? [[f.id, f.pool_id] as const] : [])),
+    );
+
     const packMovable: PackFixture[] = movable
       .map((f) => ({
         id: f.id,
@@ -1168,6 +1196,17 @@ export async function buildSchedulePack(
       entrants: packEntrants,
       people: packPeople,
       participants,
+      // #449: the pool UUID for engine use, alongside the display key on
+      // `PackFixture.pool`. Built from `packMovable` so the key order follows the
+      // pack's own board order rather than a per-seed row order, exactly as
+      // `participants` does — the byte-identical test compares `JSON.stringify`,
+      // where insertion order is load-bearing.
+      poolIds: Object.fromEntries(
+        packMovable.flatMap((f) => {
+          const id = poolIdByFixture.get(f.id);
+          return id !== undefined ? [[f.id, id] as const] : [];
+        }),
+      ),
       assumptions,
       fixtures: { movable: packMovable, obstacles: packObstacles },
       draft,
@@ -1483,7 +1522,13 @@ export function toEngineAssignments(plan: AiSchedulePlan, pack: SchedulePack): A
       // whoever can still advance into it, which is what every person rule
       // needs and what `pack.people` (pairs sharing an entrant) never had.
       people: pack.participants[a.fixture_id] ?? [],
-      ...(f?.pool != null ? { poolId: f.pool } : {}),
+      // #449: the pool UUID from `pack.poolIds`, NOT `f.pool` — that is the
+      // display key the model reads, and stamping it here put this path in a
+      // different namespace from the board path, `RuleFixture.poolId` and every
+      // stored rule.
+      ...(pack.poolIds[a.fixture_id] !== undefined
+        ? { poolId: pack.poolIds[a.fixture_id]! }
+        : {}),
       divisionId: pack.division.id,
     };
   });
@@ -1570,7 +1615,13 @@ export function toRuleFixture(f: RuleFixtureSource, divisionId: string): RuleFix
  *  `winnerTo` is the ONLY definition of terminal — never a round number, which
  *  is a display label an elimination bracket numbers sparsely. */
 export function packRuleFixtures(pack: SchedulePack): RuleFixture[] {
-  return pack.fixtures.movable.map((f) => toRuleFixture(f, pack.division.id));
+  // #449: the pool UUID, overriding the display key `PackFixture.pool` carries.
+  // `scopeCoversFixture` reads `f?.poolId ?? a.poolId`, so a RuleFixture MASKS
+  // its assignment's value — a key here would defeat the uuid stamped by
+  // `toEngineAssignments` and put the whole AI path back in a second namespace.
+  return pack.fixtures.movable.map((f) =>
+    toRuleFixture({ ...f, pool: pack.poolIds[f.id] ?? null }, pack.division.id),
+  );
 }
 
 /** Exported for the same reason the joint twin `verifyConfigFor` is: it is a

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -60,6 +60,7 @@ import {
   type SlotConfig,
   type VerifyConfig,
 } from "@seazn/engine/scheduling";
+import { AI_VERIFY_POLICY, buildEngineConstraints } from "@/server/usecases/engine-constraints";
 import {
   parseInstruction,
   resolveParsed,
@@ -1455,13 +1456,13 @@ function structuralCheck(plan: AiSchedulePlan, movableIds: Set<string>, pack: Sc
  *  fields `packRuleFixtures` below already reads. They are what makes a
  *  pool- or division-targeted `restByGroup` entry actually bind on this path.
  *
- *  NOT `startWindows`, on this path: `verifyConfig` below pins
- *  `startWindows: []` outright, so the single-division AI path is blind to
- *  every start window whatever it targets, and `repair-domain` clips the
- *  repair domain to that same empty config. Stamping the group identity is
- *  necessary for that to ever work and is not sufficient — filed separately.
- *  `schedule-group-targeting.test.ts` asserts the pin, so this comment and
- *  that test cannot drift apart silently.
+ *  `startWindows` too, since #458: `verifyConfig` below used to pin
+ *  `startWindows: []`, so this path was blind to every start window whatever it
+ *  targeted and `repair-domain` clipped the repair domain to that same empty
+ *  config. It now goes through `buildEngineConstraints`, which converts them.
+ *  Stamping the group identity here is what makes a pool-targeted one bind at
+ *  all; `schedule-group-targeting.test.ts` asserts both halves end to end, so
+ *  this comment and that test cannot drift apart silently.
  *
  *  Exported for the same reason its joint twin `toJointEngineAssignments` is:
  *  the verify seam is testable without a model round trip. */
@@ -1589,26 +1590,19 @@ export function verifyConfig(pack: SchedulePack): VerifyConfig {
     // effectiveRestMinutes takes the strictest, exactly as the solver does.
     perEntrantMinRest: pack.settings.perEntrantMinRest,
     matchMinutes: pack.settings.matchMinutes,
-    // Only the rest-bearing fields: the pack's startWindows carry ISO strings
-    // (the model reads them), while the engine wants epoch ms. Window
-    // validation is a separate piece of work — carrying them across here would
-    // silently compare the wrong units.
+    // #458: the ONE builder the board path and the joint path also go through.
+    // This site used to pin `startWindows: []` — the pack carries them as ISO
+    // strings for the model while the engine wants epoch ms, and rather than
+    // convert, the copy here dropped them. So this referee was blind to EVERY
+    // start window whatever it targeted, and `repair-domain` clipped the repair
+    // domain to the same empty config. The builder converts them.
+    //
+    // `AI_VERIFY_POLICY` (`hard: false`): the durable rules already ride the
+    // TOP-LEVEL `hard` field above, merged with the compiled instruction stream.
+    // `effectiveHard` merges the two, so carrying them here as well would count
+    // every durable rule twice.
     ...(pack.settings.constraints !== null
-      ? {
-          constraints: {
-            ...(pack.settings.constraints.restMin !== undefined
-              ? { restMin: pack.settings.constraints.restMin }
-              : {}),
-            ...(pack.settings.constraints.restByGroup !== undefined
-              ? { restByGroup: pack.settings.constraints.restByGroup }
-              : {}),
-            noBackToBack: pack.settings.constraints.noBackToBack,
-            startWindows: [],
-            fieldFairness: "off" as const,
-            parallelism: "mixed" as const,
-            crossPersonClash: "warn" as const,
-          },
-        }
+      ? { constraints: buildEngineConstraints(pack.settings.constraints, AI_VERIFY_POLICY) }
       : {}),
     gapMinutes: pack.settings.gapMinutes,
     blackouts: pack.settings.blackouts.map((b) => ({

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -698,13 +698,21 @@ export async function buildSchedulePack(
       (f) => !movableSet.has(f.id) && f.scheduled_at !== null && f.court_label !== null,
     );
     const obstacleAssignments = obstacleFixtures.map((f) => toAssignment(f, matchMinutes, guardedPeople));
-    const siblingsRaw = await siblingAssignments(
-      tx,
-      divisionId,
-      division.competition_id,
-      matchMinutes,
-      opts.excludeDivisionIds ?? [],
-    );
+    // `.assignments` only (#462): this list becomes `pack.fixtures.obstacles`,
+    // which is a COURT BOOKING shape carrying no ids at all — the pack cannot
+    // express a sibling's rule identity, and the AI verify seam builds its
+    // `ruleFixtures` from `pack.fixtures.movable` instead. The board paths in
+    // `schedule.ts` are the ones that both hold siblings AND build the config
+    // from rows, and they are the ones changed.
+    const siblingsRaw = (
+      await siblingAssignments(
+        tx,
+        divisionId,
+        division.competition_id,
+        matchMinutes,
+        opts.excludeDivisionIds ?? [],
+      )
+    ).assignments;
     // BOTH the raw person id and its guarded key, deliberately — the same shape
     // `buildCompetitionPack` uses for `fixedOccupancy`, and for the same reason.
     // `siblingAssignments` reads `peopleByEntrant` directly, so it emits raw

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -308,6 +308,27 @@ export function feedDependencies(fixtures: readonly FixtureLite[]): OrderDepende
   return deps;
 }
 
+/** A sibling division's board, in the TWO shapes the engine needs it in (#462).
+ *
+ *  `assignments` is the court occupancy — what it has always been. `ruleFixtures`
+ *  is the rule identity of those same rows, and it is not decoration: the day-cap
+ *  tally counts only the `existing` entries it can NAME
+ *  (`existing.filter((e) => fixtureById.has(e.fixtureId))`, where `fixtureById`
+ *  comes from `config.ruleFixtures`), and every `terminal`/`ext_key` selector
+ *  resolves through the same list. An `Assignment` cannot carry `extKey` or
+ *  `winnerTo` — the fields are not on the type — so serving occupancy alone made
+ *  a competition-scoped rule undercount by exactly the number of cross-division
+ *  fixtures involved, in the direction that reports a breached board as clean.
+ *
+ *  Returned as a pair rather than as a second exported query on purpose: the two
+ *  halves describe the same rows, and a caller that fetched one without the
+ *  other is the defect. Both must reach `validateAssignments` — the occupancy as
+ *  `existing`, the identity through `toVerifyConfig`'s `extraRuleFixtures`. */
+export interface SiblingBoard {
+  assignments: Assignment[];
+  ruleFixtures: RuleFixture[];
+}
+
 // Sibling divisions' timetables (doc 06 §4.3): fixed court occupancy for the
 // pass, and the source of cross-division person-overlap warnings. Durations
 // use each sibling's own matchMinutes when it has settings.
@@ -327,7 +348,7 @@ export async function siblingAssignments(
    *  them at the source is what makes "this obstacle is from outside the run" a
    *  fact instead of a slot-key guess. */
   excludeDivisionIds: readonly string[] = [],
-): Promise<Assignment[]> {
+): Promise<SiblingBoard> {
   const excluded = [...new Set([divisionId, ...excludeDivisionIds])];
   const rows = await tx<FixtureLite[]>`
     select ${tx(FIXTURE_LITE_COLS)} from fixtures
@@ -335,7 +356,7 @@ export async function siblingAssignments(
                           where competition_id = ${competitionId} and id not in ${tx(excluded)})
       and scheduled_at is not null and court_label is not null
       and status in ${tx(OCCUPYING)}`;
-  if (rows.length === 0) return [];
+  if (rows.length === 0) return { assignments: [], ruleFixtures: [] };
   const settings = await tx<{ division_id: string; config: unknown }[]>`
     select division_id, config from schedule_settings
     where division_id in ${tx([...new Set(rows.map((r) => r.division_id))])}`;
@@ -346,9 +367,16 @@ export async function siblingAssignments(
     ...new Set(rows.flatMap((r) => [r.home_entrant_id, r.away_entrant_id])),
   ].filter((e): e is string => e !== null);
   const people = await peopleByEntrant(tx, entrantIds);
-  return rows.map((r) =>
-    toAssignment(r, minutes.get(r.division_id) ?? fallbackMatchMinutes, people),
-  );
+  return {
+    assignments: rows.map((r) =>
+      toAssignment(r, minutes.get(r.division_id) ?? fallbackMatchMinutes, people),
+    ),
+    // Through the ONE builder (#447/#443), like every other RuleFixture in the
+    // codebase — `winnerTo` and `extKey` are different namespaces that both type
+    // as `string | null`, so a literal here would type-check and bind nothing.
+    // `FIXTURE_LITE_COLS` already selects all five columns it reads.
+    ruleFixtures: rows.map(rowToRuleFixture),
+  };
 }
 
 export function toSlotConfig(settings: ScheduleSettingsOut, now: number): SlotConfig {
@@ -475,11 +503,23 @@ export function toVerifyConfig(
    *  counts every fixture on the day. */
   fixtures: readonly FixtureLite[],
   now: number,
+  /** Rule identity for rows that are NOT this division's (#462) — in practice
+   *  `siblingAssignments(...).ruleFixtures`.
+   *
+   *  Every caller that puts sibling assignments on the board must pass this, and
+   *  the reason is asymmetric: omitting it does not disable a rule, it makes the
+   *  rule QUIETLY UNDERCOUNT. A competition-scoped day cap tallies only the
+   *  `existing` rows named in `ruleFixtures`, so an unnamed sibling card is on
+   *  the board for court purposes and absent for rule purposes — a board that
+   *  breaches the cap reports clean. There is no signal anywhere; that is why
+   *  `siblingAssignments` returns the two halves together rather than leaving
+   *  this to a second call a caller can simply not make. */
+  extraRuleFixtures: readonly RuleFixture[] = [],
 ): SlotConfig & VerifyConfig {
   return {
     ...toSlotConfig(settings, now),
     tz: settings.orgTz,
-    ruleFixtures: fixtures.map(rowToRuleFixture),
+    ruleFixtures: [...fixtures.map(rowToRuleFixture), ...extraRuleFixtures],
   };
 }
 
@@ -626,8 +666,12 @@ export async function autoSchedule(
     // ONE config for both halves of this pass (#447). The placer reads the
     // `SlotConfig` side, the typed-rule referee below reads the `VerifyConfig`
     // side, and neither can drift onto a different idea of the rules.
-    const config = toVerifyConfig(settings, all, roundToMinute(Date.now()));
-    const board = [...obstacles, ...siblings];
+    // #462: the siblings' rule identity rides along with their court time. The
+    // placer's day tally and the referee below both count only the `existing`
+    // rows `ruleFixtures` names, so without this the auto pass proposes a board
+    // that breaches a competition-scoped cap and then reports it clean.
+    const config = toVerifyConfig(settings, all, roundToMinute(Date.now()), siblings.ruleFixtures);
+    const board = [...obstacles, ...siblings.assignments];
     const result = slotFixtures({ fixtures: schedulable, config, existing: board });
     return {
       assignments: result.assignments.map((a) => ({
@@ -742,9 +786,9 @@ export async function applySchedule(
 
     // #447: the VERIFY config, so the durable typed rules an organiser stored
     // are the rules this gate judges by. Warn-only — see `assertNoNewBlocking`.
-    const slotConfig = toVerifyConfig(settings, all, 0);
+    const slotConfig = toVerifyConfig(settings, all, 0, siblings.ruleFixtures);
     const deps = feedDependencies(all);
-    const board = [...untouched, ...siblings];
+    const board = [...untouched, ...siblings.assignments];
     // The SAME fixtures where they sit right now (#399). Anything the verifier
     // already says about this board is history, not this apply's doing — an
     // organiser whose board carries a pre-existing person overlap must still be
@@ -965,9 +1009,9 @@ export async function moveFixture(
         settings.config.matchMinutes,
       );
       // #447: the dragged card is judged against the durable typed rules too.
-      const slotConfig = toVerifyConfig(settings, all, 0);
+      const slotConfig = toVerifyConfig(settings, all, 0, siblings.ruleFixtures);
       const deps = feedDependencies(all);
-      const board = [...others, ...siblings];
+      const board = [...others, ...siblings.assignments];
       // Where this card sits right now (#399). An unscheduled fixture has no
       // baseline, so every blocking conflict its first placement causes is
       // introduced — which is exactly what it is.
@@ -1124,7 +1168,12 @@ export async function validateSchedule(
           // #447: `toVerifyConfig`, so the board's own report shows the durable
           // typed rules the organiser stored — this is the surface the
           // constraints panel promises them on.
-          validateAssignments(assignments, toVerifyConfig(settings, all, 0), siblings, feedDependencies(all)),
+          validateAssignments(
+            assignments,
+            toVerifyConfig(settings, all, 0, siblings.ruleFixtures),
+            siblings.assignments,
+            feedDependencies(all),
+          ),
         ),
         ...officialConflicts.map((c) => ({ fixture_id: c.fixture_id, code: c.code as ScheduleConflict["code"], blocking: false })),
       ],

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -932,12 +932,25 @@ export async function assertFreshSeq(
  * Schedule-aware single-fixture move: blocks on conflict.court / direct
  * warn.order (409 with the conflicts), otherwise persists and appends
  * `schedule_edited {fixture, from, to}` (doc 12 §2).
+ *
+ * RETURNS the conflict report it judged the destination by (#461). It always
+ * computed one — the blocking gate needs it — and used to drop it, so the
+ * WARN-level half was invisible to every caller: a drag that put a card into a
+ * rest shortfall, past a stored typed rule or outside the competition's days
+ * wrote silently and said nothing. The blocking half still throws, so anything
+ * returned here is by construction non-blocking (or pre-existing, which the
+ * delta gate deliberately allows). `[]` when the patch touched no timetable
+ * field, so absence and emptiness are the same answer rather than two.
+ *
+ * These are THIS MOVE's conflicts, not the board's: `validateAssignments` is run
+ * over the single proposed card. The whole-board report is `validateSchedule`,
+ * and the console board refreshes from it after every drop.
  */
 export async function moveFixture(
   auth: AuthCtx,
   fixtureId: string,
   patch: MoveInput,
-): Promise<void> {
+): Promise<ScheduleConflict[]> {
   if (patch.schedule_locked !== undefined) {
     await requireFeature(auth.orgId, "scheduling.board");
   }
@@ -1084,6 +1097,7 @@ export async function moveFixture(
     return {
       divisionId: fixture.division_id,
       competitionId: fixture.competition_id,
+      conflicts,
       changeNotices,
       change: {
         prevAt: fixture.scheduled_at !== null ? iso(ms(fixture.scheduled_at)) : null,
@@ -1107,6 +1121,7 @@ export async function moveFixture(
     }).catch(() => {});
   }
   afterScheduleWrite(out.divisionId, out.competitionId, "schedule");
+  return out.conflicts;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -41,6 +41,7 @@ import {
   type ScheduleConflict,
 } from "@/server/api-v1/schemas";
 import { sendOfficialAssignmentChangedEmail } from "@/lib/email";
+import { buildEngineConstraints } from "./engine-constraints";
 import { assertCompetitionNotFrozen } from "./entitlement-freeze";
 import { generateStageFixtures } from "./stages";
 import { schedulingAiModel, toRuleFixture } from "./schedule-ai";
@@ -391,43 +392,25 @@ export function toSlotConfig(settings: ScheduleSettingsOut, now: number): SlotCo
       to: ms(b.to),
     })),
     sessionWindows: c.sessionWindows.map((w) => ({ from: ms(w.from), to: ms(w.to) })),
-    // constraints v2 (Jul3/04 §3): ISO → epoch ms for the pure pass
+    // constraints v2 (Jul3/04 §3): ISO → epoch ms for the pure pass, through the
+    // ONE builder (#458) the AI verify seams also go through, so this config and
+    // the config a proposal is judged against cannot drift apart again.
+    //
+    // `hard: true` — the DURABLE typed rules (#398) ride `constraints.hard` on
+    // this path, never the top-level `hard` field, because `effectiveHard`
+    // MERGES the two and setting both would count every durable rule twice
+    // (#447). The top-level field is where a run puts the stream it COMPILED
+    // from an instruction, which is why the AI seams route them the other way.
+    // Riding `toSlotConfig` rather than the wrapper below is deliberate too:
+    // every existing caller gets them with no second place to remember.
     ...(c.constraints !== undefined
       ? {
-          constraints: {
-            ...(c.constraints.restMin !== undefined ? { restMin: c.constraints.restMin } : {}),
-            ...(c.constraints.restByGroup !== undefined
-              ? { restByGroup: c.constraints.restByGroup }
-              : {}),
-            noBackToBack: c.constraints.noBackToBack,
-            startWindows: c.constraints.startWindows.map((w) => ({
-              target: w.target,
-              ...(w.notBefore !== undefined ? { notBefore: ms(w.notBefore) } : {}),
-              ...(w.notAfter !== undefined ? { notAfter: ms(w.notAfter) } : {}),
-            })),
+          constraints: buildEngineConstraints(c.constraints, {
             fieldFairness: c.constraints.fieldFairness,
             parallelism: c.constraints.parallelism,
             crossPersonClash: c.constraints.crossPersonClash,
-            // #447: the DURABLE typed rules (#398). This key was the one field
-            // of `constraints` the copy above dropped, and `effectiveHard` reads
-            // exactly it — so a rule an organiser stored through the API bound on
-            // the AI path (which builds its own config) and silently nowhere
-            // else. `effectiveHard`'s own docstring calls that "the worst kind".
-            //
-            // Carried here rather than on the top-level `hard` field because
-            // `effectiveHard` MERGES the two — setting both would count every
-            // durable rule twice — and because `constraints.hard` is the durable
-            // home: the top-level one is where a run puts the stream it COMPILED
-            // from an instruction. It also rides `toSlotConfig` rather than the
-            // wrapper below so every existing caller of this function gets it
-            // without a second place to remember.
-            //
-            // Optional, never defaulted (the schema says so): a `hard: []` on a
-            // config that stored nothing is indistinguishable downstream, but it
-            // would make every `toSlotConfig` output differ from the literals the
-            // rest of the suite compares against.
-            ...(c.constraints.hard !== undefined ? { hard: c.constraints.hard } : {}),
-          },
+            hard: true,
+          }),
         }
       : {}),
   };

--- a/docs/superpowers/plans/2026-08-05-wave-1a-placer-convergence.md
+++ b/docs/superpowers/plans/2026-08-05-wave-1a-placer-convergence.md
@@ -43,7 +43,38 @@ Only `min_rest_minutes` is placed around today. The other five are reported by t
 
 ---
 
-### Task 1: Normalise both sides of every scoped comparison
+### Task 1: WITHDRAWN — #449 and #450 do not live in this file
+
+**Executed 2026-08-05. All three tests passed as written, so the stop condition
+fired and no change was made to `scopeCoversFixture`.** The function is correct:
+it compares the strings it is given. The divergence is in the BUILDERS, in
+`apps/web`, exactly as the bug class predicts — two producers, one comparison.
+
+Verified against `origin/main` @ `14b8e5f6`:
+
+- **#449 (pool).** `schedule-ai.ts:902` builds the placer's input as
+  `poolId: f.pool_id` — a **uuid**. `schedule-ai.ts:978` builds the pack as
+  `pool: poolKey.get(f.pool_id)` — the **`pools.key`** (`"A"`, `"B"`), which
+  becomes `Assignment.poolId`. `toRuleFixture` (`:1563`) stamps that same key
+  onto `RuleFixture.poolId`, and because `scopeCoversFixture` reads
+  `f?.poolId ?? a.poolId`, the RuleFixture value MASKS the assignment's. One
+  division, two namespaces, at most one side ever binding. The same field keys
+  `restByGroup`. The joint twin is `competition-schedule-ai.ts:1146`.
+- **#450 (person).** `personKeyResolver` collapses roster rows to
+  `name:<normalised>` and `schedule-ai.ts:631` maps every roster through it, so
+  the placer's and verifier's ROWS already agree. Nothing maps
+  `hard[].scope.personKey`. A rule authored against a person uuid stops binding
+  the moment that person collapses. **This is not fixable inside the engine:**
+  rebuilding `name:<normalised>` from a uuid needs the person-name map, which
+  the engine does not have and should not be given. The fix belongs beside the
+  `identity.keyOf` call sites in `apps/web`.
+
+Both therefore move to **Wave 1b**, whose plan must cover them. Note
+`schedule-ai-parse.ts:50` narrows the model to competition/division scopes, so
+pool- and person-scoped rules reach the engine only via durable
+`schedule_settings` config — which is why no AI-path test ever caught this.
+
+The original Task 1 text follows for the record; do not execute it.
 
 Closes #449 (pool key vs uuid) and #450 (person name vs uuid). `scopeCoversFixture` compares `scope.pool` against `a.poolId`, and `scope.personKey` against `a.people` — but the two sides are produced by different builders, so one may hold a uuid while the other holds a pool key or a `name:<normalised>` collapse key.
 
@@ -300,8 +331,9 @@ describe("placer honours max_fixtures_per_day on the ORG day (#463)", () => {
         constraints: {
           hard: [
             {
+              // `count`, NOT `max` — verified at constraints.ts:70.
               type: "max_fixtures_per_day",
-              max: 2,
+              count: 2,
               scope: { kind: "entrant", entrantId: "e1" },
             },
           ],
@@ -519,7 +551,7 @@ import { slotFixtures, validateAssignments } from "./calendar.ts";
 // Feed the placer's OWN OUTPUT back to the verifier. Any family the placer
 // does not honour shows up here as a violation the placer just created.
 const FAMILIES = [
-  { type: "max_fixtures_per_day", max: 2, scope: { kind: "entrant", entrantId: "e1" } },
+  { type: "max_fixtures_per_day", count: 2, scope: { kind: "entrant", entrantId: "e1" } },
   { type: "not_before", time: "09:00", scope: { kind: "division", divisionId: "d1" } },
   { type: "not_after", time: "20:00", scope: { kind: "division", divisionId: "d1" } },
   { type: "fixture_on_weekday", weekday: 6, scope: { kind: "division", divisionId: "d1" } },

--- a/docs/superpowers/plans/2026-08-05-wave-1a-placer-convergence.md
+++ b/docs/superpowers/plans/2026-08-05-wave-1a-placer-convergence.md
@@ -1,0 +1,612 @@
+# Wave 1a — Engine Placer/Verifier Convergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the greedy placer honour every constraint family the verifier already checks, and resolve both sides of every scoped comparison through one normaliser, so `slotFixtures` and `validateAssignments` can no longer disagree.
+
+**Architecture:** One file, `packages/engine/src/scheduling/calendar.ts`. Task 1 lands the normaliser inside the already-shared `scopeCoversFixture`. Tasks 2-5 extend `slotFixtures` one rule family at a time, each with its own failing-first test. Task 6 adds the parity test that makes a future fork fail the suite.
+
+**Tech Stack:** TypeScript, vitest, zod. The engine's only runtime dependency is `z3-solver`. No new dependencies.
+
+## Global Constraints
+
+- Target file: `packages/engine/src/scheduling/calendar.ts`. Do NOT modify `packages/engine/src/scheduling/tz.ts`.
+- Day bucketing uses the existing `dayKeyInTz(instantMs, tz)` from `./tz.ts`. Never write another day helper; never use `toISOString().slice(0, 10)`.
+- The governing zone is the **org** zone, supplied as `VerifyConfig.tz` / `SlotConfig` tz. A division's display zone must never decide which calendar day a fixture falls on.
+- A rule that needs a `tz` is SKIPPED when `tz` is absent, matching the existing documented behaviour at the `VerifyConfig.tz` declaration — reporting a violation the organiser never expressed is worse than reporting none.
+- Never run `UPDATE_GOLDEN=1`. Never modify any `*.golden.json`.
+- Never `git stash` in this worktree — the stash stack is shared with the main checkout, and a no-op push+pop pops a foreign stash and leaves `package.json` unmerged, blocking every commit. To prove a test red, use `git show HEAD:<path> > <path>` or a `cp` backup.
+- Prefix `cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence &&` in the SAME call as every command you judge. The shell cwd resets to the main checkout between calls.
+- Judge vitest ONLY from `--reporter=json --outputFile`. `rtk` prints `PASS(0) FAIL(0)` for a suite that failed to COLLECT. A drop in `numTotalTests` is a failure, not a pass.
+- Run `repair-scale` and `calendar-shared-semantics` ALONE when judging them — both carry wall-clock assertions that fail under machine load.
+- Do not file GitHub issues. Anything found gets fixed here with its own failing-first test.
+
+## Verified Starting State
+
+Read from `origin/main` @ `14b8e5f6` on 2026-08-05. Every line number below was read this session.
+
+| Location | What is there |
+| --- | --- |
+| `calendar.ts:47-56` | `SchedulableFixture` — carries `people?: readonly string[]`, `poolId?`, `divisionId?` |
+| `calendar.ts:255-259` | `SlotInput { fixtures, config, existing? }` |
+| `calendar.ts:365` | `slotFixtures(input: SlotInput): SlotResult` |
+| `calendar.ts:384` | `const lastEnd = new Map<EntrantId, number>()` |
+| `calendar.ts:494` | `for (const e of ent) lastEnd.set(e, …)` — the only write |
+| `calendar.ts:529` | `for (const e of ent) ready = Math.max(ready, (lastEnd.get(e) ?? -Infinity) + restF)` — the only read |
+| `calendar.ts:~640` | `scopeCoversFixture(scope, f, a)` — already SHARED by placer and verifier (#447); `ScopeRow` exists for exactly that |
+| `constraints.ts:61-88` | `HardConstraint` union: `min_rest_minutes`, `max_fixtures_per_day`, `fixture_on_weekday`, `fixture_on_date`, `not_before`, `not_after` |
+| `constraints.ts:30-36` | `ConstraintScope`: `competition`, `division`, `entrant`, `person` (`personKey`), `pool` (`divisionId` + `pool`) |
+
+Only `min_rest_minutes` is placed around today. The other five are reported by the verifier and never placed around.
+
+**Before writing code**, confirm the exact signature of `validateAssignments` and how existing tests build a config, by reading `packages/engine/src/scheduling/calendar-shared-semantics.test.ts`. Tasks 1-6 below give the assertions; match that file's construction style rather than inventing one.
+
+---
+
+### Task 1: Normalise both sides of every scoped comparison
+
+Closes #449 (pool key vs uuid) and #450 (person name vs uuid). `scopeCoversFixture` compares `scope.pool` against `a.poolId`, and `scope.personKey` against `a.people` — but the two sides are produced by different builders, so one may hold a uuid while the other holds a pool key or a `name:<normalised>` collapse key.
+
+**Files:**
+- Modify: `packages/engine/src/scheduling/calendar.ts` (the `scopeCoversFixture` function, ~:640)
+- Test: `packages/engine/src/scheduling/calendar-scope-identity.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `ConstraintScope` and `ScopeRow`, both already exported.
+- Produces: `scopeCoversFixture` keeps its exact existing signature `(scope: ConstraintScope, f: RuleFixture | undefined, a: ScopeRow) => boolean`. No caller changes.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { scopeCoversFixture } from "./calendar.ts";
+
+describe("scopeCoversFixture normalises both sides (#449, #450)", () => {
+  const row = {
+    entrants: ["ent-1"],
+    people: ["name:jordan lee"], // collapsed identity key, not a uuid
+    poolId: "11111111-1111-4111-8111-111111111111", // uuid
+    divisionId: "div-1",
+  };
+
+  it("binds a person-scoped rule when the row carries a collapse key", () => {
+    // The rule was authored against the person's uuid; the row carries the
+    // collapsed key. Both name the same human, so the rule must bind.
+    expect(
+      scopeCoversFixture({ kind: "person", personKey: "name:jordan lee" }, undefined, row),
+    ).toBe(true);
+  });
+
+  it("binds a pool-scoped rule when the scope names the pool KEY and the row a uuid", () => {
+    expect(
+      scopeCoversFixture(
+        { kind: "pool", divisionId: "div-1", pool: "11111111-1111-4111-8111-111111111111" },
+        undefined,
+        row,
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT bind a pool rule from another division", () => {
+    expect(
+      scopeCoversFixture(
+        { kind: "pool", divisionId: "div-2", pool: "11111111-1111-4111-8111-111111111111" },
+        undefined,
+        row,
+      ),
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm which cases fail**
+
+Run:
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npx vitest run packages/engine/src/scheduling/calendar-scope-identity.test.ts --reporter=json --outputFile=/tmp/t1.json > /tmp/t1.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/t1.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests)"
+```
+
+Expected: `total 3` with at least one `fail`. **If all three pass, STOP.** That means the mismatch does not reproduce at this level, and the real divergence is in the BUILDERS that produce `scope` and `ScopeRow`, not in the comparison. Grep the builders (`identity.keyOf` call sites and wherever `poolKey` is assigned) and rewrite this test against the actual mismatch before implementing anything. Do not "fix" a function that is already correct.
+
+- [ ] **Step 3: Implement the normaliser**
+
+Add one module-local function above `scopeCoversFixture` and route both sides through it. Keep the existing collapse semantics — #450 is that BOTH sides must apply the resolution, not that it should stop:
+
+```ts
+/** One resolution for both sides of a scoped comparison (#449, #450). The scope
+ *  and the row are built by different producers, so comparing them raw asks
+ *  whether two namespaces happen to coincide. Both sides resolve here. */
+const sameKey = (a: string | undefined, b: string | undefined): boolean =>
+  a !== undefined && b !== undefined && normaliseKey(a) === normaliseKey(b);
+```
+
+Implement `normaliseKey` to match the collapse rule already used for `people` (the `name:<normalised>` form). Then rewrite the `pool` and `person` branches of the switch to use `sameKey` / a `sameKey`-based `includes`. Leave `competition`, `division` and `entrant` semantics unchanged.
+
+- [ ] **Step 4: Run the test and the full engine suite**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm test --workspace packages/engine -- --reporter=json --outputFile=/tmp/eng1.json > /tmp/eng1.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/eng1.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'empty',r.testResults.filter(s=>!s.assertionResults||!s.assertionResults.length).length)"
+```
+
+Expected: `fail 0`, `empty 0`, and `total` = the pre-change total + 3. Rerun any wall-clock failure ALONE before believing it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && git add packages/engine/src/scheduling/calendar.ts packages/engine/src/scheduling/calendar-scope-identity.test.ts && git commit -m "fix(engine): resolve both sides of a scoped comparison through one key (#449, #450)
+
+scopeCoversFixture compared a scope built by one producer against a row built
+by another, so a pool key met a pool uuid and a person uuid met a collapsed
+name key. Both sides now resolve through one function, which is the normaliser
+this comparison never had.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Gate rest on people, not only entrants
+
+Closes the central case of #463. `lastEnd` is keyed by `EntrantId`, so a `per_person` rest rule between two fixtures that share a **person** but no **entrant** is invisible to the placer while the verifier reports it.
+
+**Files:**
+- Modify: `packages/engine/src/scheduling/calendar.ts:384`, `:494`, `:529`
+- Test: `packages/engine/src/scheduling/calendar-person-rest.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `sameKey` / `normaliseKey` from Task 1.
+- Produces: no signature changes. `lastEnd` becomes keyed by a resolved participant key covering both entrants and people.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { slotFixtures } from "./calendar.ts";
+
+const T0 = Date.UTC(2026, 6, 4, 9, 0);
+
+describe("placer rests on shared PEOPLE, not only shared entrants (#463)", () => {
+  it("separates two fixtures that share a person but no entrant", () => {
+    const res = slotFixtures({
+      fixtures: [
+        { id: "a", home: "e1", away: "e2", people: ["p-shared"], divisionId: "d1" },
+        { id: "b", home: "e3", away: "e4", people: ["p-shared"], divisionId: "d1" },
+      ],
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 60, // one hour of rest is owed to a shared participant
+        courts: ["C1", "C2"], // two courts, so nothing forces them apart
+        blackouts: [],
+        sessionWindows: [],
+      },
+    });
+
+    expect(res.assignments).toHaveLength(2);
+    const [a, b] = res.assignments.sort((x, y) => x.startAt - y.startAt);
+    // Without the fix both are placed at T0 on different courts: they share no
+    // entrant, so `lastEnd` never saw the overlap.
+    expect(b.startAt - a.endAt).toBeGreaterThanOrEqual(60 * 60_000);
+  });
+
+  it("still packs fixtures that share nothing", () => {
+    const res = slotFixtures({
+      fixtures: [
+        { id: "a", home: "e1", away: "e2", people: ["p1"], divisionId: "d1" },
+        { id: "b", home: "e3", away: "e4", people: ["p2"], divisionId: "d1" },
+      ],
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 60,
+        courts: ["C1", "C2"],
+        blackouts: [],
+        sessionWindows: [],
+      },
+    });
+    expect(res.assignments.every((a) => a.startAt === T0)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run and verify it fails on the first case only**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npx vitest run packages/engine/src/scheduling/calendar-person-rest.test.ts --reporter=json --outputFile=/tmp/t2.json > /tmp/t2.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/t2.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests)"
+```
+
+Expected: `total 2`, `fail 1` — the shared-person case fails, the unrelated-fixtures case passes. The second case is the guard that the fix does not simply separate everything.
+
+- [ ] **Step 3: Implement**
+
+Widen the rest map to cover both participant kinds:
+
+```ts
+// Rest is owed to a PARTICIPANT, and a participant is an entrant or a person
+// (#463). Keying only by EntrantId made a per_person rule invisible to the
+// placer while the verifier still reported it — the placer/verifier fork.
+const lastEnd = new Map<string, number>();
+const restKeysOf = (f: SchedulableFixture): string[] => [
+  ...entrantsOf(f).map(normaliseKey),
+  ...(f.people ?? []).map(normaliseKey),
+];
+```
+
+At `:494` write every key from `restKeysOf(f)`; at `:529` read every key from `restKeysOf(f)`. Leave `courtUse` and `lastCourt` keyed by entrant — field fairness is an entrant-level concept and widening it would change unrelated behaviour.
+
+- [ ] **Step 4: Run the test and the full engine suite**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm test --workspace packages/engine -- --reporter=json --outputFile=/tmp/eng2.json > /tmp/eng2.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/eng2.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'empty',r.testResults.filter(s=>!s.assertionResults||!s.assertionResults.length).length)"
+```
+
+Expected: `fail 0`. Boards get strictly more separated, so if an existing test asserts an exact packed start time it may legitimately need updating — but read it first and confirm the new spacing is the CORRECT answer before changing any assertion. An existing test that breaks is evidence, not an obstacle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && git add packages/engine/src/scheduling/calendar.ts packages/engine/src/scheduling/calendar-person-rest.test.ts && git commit -m "fix(engine): rest the placer on shared people, not only shared entrants (#463)
+
+lastEnd was keyed by EntrantId, so two fixtures sharing a person but no
+entrant were packed adjacent while the verifier reported the rest violation.
+SchedulableFixture already carried people; the placer simply never read it.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Place around `max_fixtures_per_day`
+
+**Files:**
+- Modify: `packages/engine/src/scheduling/calendar.ts` (`slotFixtures` placement loop, ~:520-560)
+- Test: `packages/engine/src/scheduling/calendar-day-cap-placement.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `sameKey`/`normaliseKey` (Task 1), `restKeysOf` (Task 2), `dayKeyInTz` from `./tz.ts`, `scopeCoversFixture`.
+- Produces: a module-local `dayCountsFor` map used by Tasks 3-5.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { slotFixtures } from "./calendar.ts";
+
+// 2026-07-11 in Los Angeles: 17:00Z and 19:00Z are Saturday local; 01:00Z and
+// 03:00Z on the 12th are still Saturday LOCAL but Sunday UTC. A UTC bucket
+// sees 2 + 2 and fills all four.
+const SAT_1000_LOCAL = Date.UTC(2026, 6, 11, 17, 0);
+
+describe("placer honours max_fixtures_per_day on the ORG day (#463)", () => {
+  it("refuses to place a fourth fixture for a capped entrant on one local day", () => {
+    const res = slotFixtures({
+      fixtures: [1, 2, 3, 4].map((n) => ({
+        id: `f${n}`,
+        home: "e1",
+        away: `e${n + 10}`,
+        divisionId: "d1",
+      })),
+      config: {
+        startAt: SAT_1000_LOCAL,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 0,
+        courts: ["C1"],
+        blackouts: [],
+        sessionWindows: [],
+        tz: "America/Los_Angeles",
+        constraints: {
+          hard: [
+            {
+              type: "max_fixtures_per_day",
+              max: 2,
+              scope: { kind: "entrant", entrantId: "e1" },
+            },
+          ],
+        },
+      },
+    });
+
+    const placed = res.assignments.filter((a) => a.entrants.includes("e1"));
+    expect(placed).toHaveLength(2);
+    expect(res.conflicts.filter((c) => c.reason === "no_slot")).toHaveLength(2);
+  });
+});
+```
+
+Note: the exact nesting of `hard` under `config` must match how `effectiveHard(config)` reads it — confirm against the `effectiveHard` definition and match it. If the shape differs, fix the TEST to the real shape; do not reshape the config to suit the test.
+
+- [ ] **Step 2: Run and verify it fails**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npx vitest run packages/engine/src/scheduling/calendar-day-cap-placement.test.ts --reporter=json --outputFile=/tmp/t3.json > /tmp/t3.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/t3.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests)"
+```
+
+Expected: FAIL — all four placed, zero `no_slot`.
+
+- [ ] **Step 3: Implement**
+
+In the placement loop, before accepting a candidate `start`, reject it when any `max_fixtures_per_day` rule that binds this fixture (via `scopeCoversFixture`) already has `max` placements on `dayKeyInTz(start, tz)`. Maintain counts per (rule, dayKey) and increment in `commit`. When `tz` is absent, SKIP the rule — matching the documented `VerifyConfig.tz` behaviour. Rejection feeds the existing repair loop (push the candidate later on the same court), and an exhausted candidate set reports `no_slot`, which is the existing unplaceable path.
+
+- [ ] **Step 4: Run the test and the full engine suite**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm test --workspace packages/engine -- --reporter=json --outputFile=/tmp/eng3.json > /tmp/eng3.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/eng3.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'empty',r.testResults.filter(s=>!s.assertionResults||!s.assertionResults.length).length)"
+```
+
+Expected: `fail 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && git add packages/engine/src/scheduling/calendar.ts packages/engine/src/scheduling/calendar-day-cap-placement.test.ts && git commit -m "feat(engine): place around max_fixtures_per_day on the org calendar day (#463)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Place around `not_before` / `not_after`
+
+**Files:**
+- Modify: `packages/engine/src/scheduling/calendar.ts` (placement loop)
+- Test: `packages/engine/src/scheduling/calendar-time-bounds-placement.test.ts` (create)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-3. `not_before`/`not_after` carry `time: HHMM` — a WALL-CLOCK time in the org zone, never an instant.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { slotFixtures } from "./calendar.ts";
+
+describe("placer honours not_before / not_after (#463)", () => {
+  it("does not place before the rule's wall-clock bound in the org zone", () => {
+    const res = slotFixtures({
+      fixtures: [{ id: "f1", home: "e1", away: "e2", divisionId: "d1" }],
+      config: {
+        startAt: Date.UTC(2026, 6, 11, 13, 0), // 06:00 local in Los Angeles
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 0,
+        courts: ["C1"],
+        blackouts: [],
+        sessionWindows: [],
+        tz: "America/Los_Angeles",
+        constraints: {
+          hard: [{ type: "not_before", time: "09:00", scope: { kind: "division", divisionId: "d1" } }],
+        },
+      },
+    });
+
+    expect(res.assignments).toHaveLength(1);
+    const hhmm = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "America/Los_Angeles",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(new Date(res.assignments[0].startAt));
+    expect(hhmm >= "09:00").toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run and verify it fails**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npx vitest run packages/engine/src/scheduling/calendar-time-bounds-placement.test.ts --reporter=json --outputFile=/tmp/t4.json > /tmp/t4.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/t4.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests)"
+```
+
+Expected: FAIL — placed at 06:00 local.
+
+- [ ] **Step 3: Implement**
+
+Use the engine's existing `hhmmInTz` from `./tz.ts` to compare a candidate start against each binding rule's `time`. `not_before` raises the candidate's lower bound; `not_after` rejects and lets the repair loop advance, ultimately reporting `no_slot` when no slot on any court satisfies it. Skip when `tz` is absent.
+
+- [ ] **Step 4: Run the test and the full engine suite**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm test --workspace packages/engine -- --reporter=json --outputFile=/tmp/eng4.json > /tmp/eng4.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/eng4.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'empty',r.testResults.filter(s=>!s.assertionResults||!s.assertionResults.length).length)"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && git add packages/engine/src/scheduling/calendar.ts packages/engine/src/scheduling/calendar-time-bounds-placement.test.ts && git commit -m "feat(engine): place around not_before / not_after in the org zone (#463)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Place around `fixture_on_weekday` / `fixture_on_date`
+
+**Files:**
+- Modify: `packages/engine/src/scheduling/calendar.ts` (placement loop)
+- Test: `packages/engine/src/scheduling/calendar-day-targets-placement.test.ts` (create)
+
+**Interfaces:**
+- Consumes: Tasks 1-4. Uses `dayKeyInTz` and the existing `weekdayOfYmd` from `./tz.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { slotFixtures } from "./calendar.ts";
+import { dayKeyInTz } from "./tz.ts";
+
+describe("placer honours fixture_on_date (#463)", () => {
+  it("places the named fixture on the required calendar date", () => {
+    const res = slotFixtures({
+      fixtures: [{ id: "f1", home: "e1", away: "e2", divisionId: "d1" }],
+      config: {
+        startAt: Date.UTC(2026, 6, 11, 17, 0),
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 0,
+        courts: ["C1"],
+        blackouts: [],
+        sessionWindows: [],
+        tz: "America/Los_Angeles",
+        horizonMinutes: 60 * 24 * 14,
+        constraints: {
+          hard: [
+            {
+              type: "fixture_on_date",
+              date: "2026-07-15",
+              scope: { kind: "division", divisionId: "d1" },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(res.assignments).toHaveLength(1);
+    expect(dayKeyInTz(res.assignments[0].startAt, "America/Los_Angeles")).toBe("2026-07-15");
+  });
+});
+```
+
+Confirm the exact field name on `fixture_on_date` (`date`) and on `fixture_on_weekday` against `constraints.ts:74-84` before running; fix the test to the real field name if it differs.
+
+- [ ] **Step 2: Run and verify it fails**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npx vitest run packages/engine/src/scheduling/calendar-day-targets-placement.test.ts --reporter=json --outputFile=/tmp/t5.json > /tmp/t5.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/t5.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests)"
+```
+
+Expected: FAIL — placed on 2026-07-11.
+
+- [ ] **Step 3: Implement**
+
+Reject any candidate whose `dayKeyInTz(start, tz)` does not match a binding `fixture_on_date`, or whose `weekdayOfYmd(dayKeyInTz(start, tz))` does not match a binding `fixture_on_weekday`. Advance the candidate to the next day rather than scanning slot-by-slot across days — the existing 64-iteration repair loop will otherwise exhaust before reaching a date days away, which is exactly why this needs a day-level jump rather than a time-level one.
+
+- [ ] **Step 4: Run the test and the full engine suite**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm test --workspace packages/engine -- --reporter=json --outputFile=/tmp/eng5.json > /tmp/eng5.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/eng5.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'empty',r.testResults.filter(s=>!s.assertionResults||!s.assertionResults.length).length)"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && git add packages/engine/src/scheduling/calendar.ts packages/engine/src/scheduling/calendar-day-targets-placement.test.ts && git commit -m "feat(engine): place around fixture_on_date and fixture_on_weekday (#463)
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: The parity test that makes a future fork fail the suite
+
+This is the deliverable that matters most. A test asserting only the placer's behaviour cannot catch a fork; a test asserting that both sides report the same number cannot miss one.
+
+**Files:**
+- Test: `packages/engine/src/scheduling/calendar-placer-verifier-parity.test.ts` (create)
+
+**Interfaces:**
+- Consumes: `slotFixtures` and `validateAssignments`. Confirm `validateAssignments`' exact signature from `calendar-shared-semantics.test.ts` before writing.
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { describe, expect, it } from "vitest";
+import { slotFixtures, validateAssignments } from "./calendar.ts";
+
+// Feed the placer's OWN OUTPUT back to the verifier. Any family the placer
+// does not honour shows up here as a violation the placer just created.
+const FAMILIES = [
+  { type: "max_fixtures_per_day", max: 2, scope: { kind: "entrant", entrantId: "e1" } },
+  { type: "not_before", time: "09:00", scope: { kind: "division", divisionId: "d1" } },
+  { type: "not_after", time: "20:00", scope: { kind: "division", divisionId: "d1" } },
+  { type: "fixture_on_weekday", weekday: 6, scope: { kind: "division", divisionId: "d1" } },
+] as const;
+
+describe("placer output satisfies the verifier (#463)", () => {
+  for (const rule of FAMILIES) {
+    it(`emits no ${rule.type} violation it could have avoided`, () => {
+      const config = {
+        startAt: Date.UTC(2026, 6, 11, 17, 0),
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 0,
+        courts: ["C1", "C2"],
+        blackouts: [],
+        sessionWindows: [],
+        tz: "America/Los_Angeles",
+        horizonMinutes: 60 * 24 * 21,
+        constraints: { hard: [rule] },
+      };
+      const fixtures = [1, 2, 3, 4, 5, 6].map((n) => ({
+        id: `f${n}`,
+        home: "e1",
+        away: `e${n + 10}`,
+        divisionId: "d1",
+      }));
+
+      const { assignments } = slotFixtures({ fixtures, config });
+      const verdict = validateAssignments(assignments, config);
+
+      // A fixture the placer refused to place is honest; a fixture it placed
+      // into a violation is the fork.
+      expect(verdict.filter((c) => c.rule === rule.type)).toHaveLength(0);
+    });
+  }
+});
+```
+
+Adjust `validateAssignments`' call shape and the violation field name (`rule`) to the real API — read `calendar-shared-semantics.test.ts` first. The ASSERTION is the point: zero self-inflicted violations, per family.
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npx vitest run packages/engine/src/scheduling/calendar-placer-verifier-parity.test.ts --reporter=json --outputFile=/tmp/t6.json > /tmp/t6.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/t6.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests)"
+```
+
+Expected after Tasks 1-5: `total 4`, `fail 0`. Any failure here names a family still forked — fix that family rather than relaxing this test.
+
+- [ ] **Step 3: Full engine suite + engine lint**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm test --workspace packages/engine -- --reporter=json --outputFile=/tmp/eng6.json > /tmp/eng6.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/eng6.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'empty',r.testResults.filter(s=>!s.assertionResults||!s.assertionResults.length).length)"; rtk proxy npx turbo run lint --filter=@seazn/engine 2>&1 | tail -3
+```
+
+The root `npm run lint` does NOT cover `packages/engine` — it has its own task. Run both.
+
+- [ ] **Step 4: apps/web suite (the engine ships as raw TS source, so web compiles it)**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && readlink -f node_modules/@seazn/engine && DATABASE_URL=postgresql://postgres@127.0.0.1:54337/seazn_test_448 DATABASE_SSL=disable npm test --workspace apps/web -- --reporter=json --outputFile=/tmp/web6.json > /tmp/web6.log 2>&1; echo "EXIT=$?"; node -e "const r=require('/tmp/web6.json');console.log('pass',r.numPassedTests,'fail',r.numFailedTests,'total',r.numTotalTests,'pending',r.numPendingTests,'suites',r.testResults.length)"
+```
+
+`readlink` MUST resolve inside this worktree. If it points at the main checkout, you are testing main's engine and every number is meaningless.
+
+- [ ] **Step 5: Drift gates, then commit**
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && npm run openapi:gen && npm run i18n:gen-keys && git status --porcelain
+```
+
+Porcelain must show only your intended files. Then:
+
+```bash
+cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence && git add packages/engine/src/scheduling/calendar-placer-verifier-parity.test.ts && git commit -m "test(engine): assert the placer's own output satisfies the verifier (#463)
+
+A test that asserts only the placer's behaviour cannot catch a fork. This
+feeds the placer's output back to the verifier per rule family, so a future
+divergence fails the suite instead of shipping as 'auto proposes a board the
+gate warns about'.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Not in this plan
+
+- Wave 1b (#458, #462, #461) — `apps/web`, gets its own plan. Until it lands, the capability added here is not reachable from the AI path, which still pins `startWindows: []`.
+- Wave 2 (#467) — independent.
+- `feeder_to_dependent` rest. The spec listed it, but the `HardConstraint` union at `constraints.ts:61-88` has no such member — it is a constraints-v2 config concept, not a hard rule. Confirm where it lives before deciding whether the placer can honour it; do not invent a rule type for it.

--- a/docs/superpowers/plans/2026-08-05-wave-1b-web-inputs.md
+++ b/docs/superpowers/plans/2026-08-05-wave-1b-web-inputs.md
@@ -1,0 +1,132 @@
+# Wave 1b — Web Inputs to the Placer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the engine the inputs it needs, in ONE namespace, so Wave 1a's placement convergence is reachable from the AI path and scoped rules bind on both sides of every seam.
+
+**Architecture:** `apps/web` only. Task 1 extracts the single constraints builder that three call sites currently duplicate — #458 falls out of it. Tasks 2-3 collapse two namespaces down to one each. Tasks 4-5 are independent data/return-shape fixes.
+
+**Tech Stack:** TypeScript, vitest, zod, Playwright.
+
+## Global Constraints
+
+- `apps/web` only. Do NOT modify `packages/engine` — Wave 1a is reviewed and shipped (PR #472). If a fix seems to require an engine change, STOP and report.
+- Never `git stash` in this worktree — the stash stack is shared with the main checkout; a no-op push+pop pops a FOREIGN stash and leaves `package.json` unmerged, blocking every commit. Revert-to-prove with `git show HEAD:<path> > <path>` or a `cp` backup.
+- Prefix `cd /Users/ashokhein/github/seazn.club/.claude/worktrees/sched-convergence &&` in the SAME call as every command you judge; cwd resets to the main checkout between calls.
+- Judge vitest ONLY from `--reporter=json --outputFile`. A drop in `numTotalTests` is a failure, not a pass.
+- Before every commit: `npm run openapi:gen && npm run i18n:gen-keys && git status --porcelain` — porcelain must show only intended files. `openapi:gen` regenerates from the zod schema and will NOT tell you the served JSON changed; if a task touches a boundary payload, assert the payload directly.
+- Do not file GitHub issues. Fix what you find here with a failing-first test, or carry it in one line.
+- DB: `postgresql://postgres@127.0.0.1:54337/seazn_w1a`, `DATABASE_SSL=disable` (fresh, migrated, sports + Stripe seeded). Servers :3100/:3200 are running — do not restart them.
+
+## Verified Starting State
+
+Surveyed 2026-08-05 on `feat/sched-convergence`. Every line below was read.
+
+| Fact | Location |
+| --- | --- |
+| `verifyConfig(pack: SchedulePack): VerifyConfig` | `schedule-ai.ts:1577` |
+| `startWindows: []` pinned, deliberately, comment at `:1458-1465` | `schedule-ai.ts:1606` |
+| `pack.settings.constraints` IS in scope there — access was never the blocker | `schedule-ai.ts:1601-1611` |
+| Sibling A (board): maps every window through, no filter | `schedule.ts:403-406` |
+| Sibling B (joint): `flatMap`, DROPS `target.kind` outside `entrant\|pool\|division` | `competition-schedule-ai.ts:1308-1317` |
+| `PackStartWindow = { target: {kind: string; id: string}; notBefore?; notAfter? }` | `schedule-ai.ts:219-223` |
+| The test PINNING the empty behaviour | `schedule-group-targeting.test.ts:259-263` |
+| `siblingAssignments(...): Promise<Assignment[]>` | `schedule.ts:313-321` |
+| Its four call sites, all `[...others, ...siblings]` into `validateAssignments` | `schedule.ts:618, 753, 978, 1106` |
+| `RuleFixture = { id, extKey, divisionId?, poolId?, winnerTo }` | `calendar.ts:784-790` |
+| `Assignment = { fixtureId, court, startAt, endAt, entrants, people, poolId?, divisionId? }` | `calendar.ts:78-87` |
+| `moveFixture(...): Promise<void>`; conflicts computed then dropped | `schedule.ts:909-916`, `:951`, `:998` |
+| Its only caller discards the value | `fixtures.ts:49` (via route `fixtures/[id]/route.ts:22`) |
+| Placer input pool = **uuid** | `schedule-ai.ts:903` |
+| Pack pool = **`pools.key`** | `schedule-ai.ts:978`, map built `:639` |
+| `toRuleFixture` stamps the KEY onto `RuleFixture.poolId` | `schedule-ai.ts:1558-1564` |
+| Joint twin, same split | `competition-schedule-ai.ts:1146` |
+| `personKeyResolver(): { keyOf, assumptions }` | `schedule-ai.ts:173-176` |
+| Rosters collapsed through it | `schedule-ai.ts:623, 631, 672`; joint `competition-schedule-ai.ts:517,519,580` |
+| `scope.personKey` consumed as bare equality, nothing maps it | `calendar.ts:844` |
+
+**Two received claims are FALSE and must not be acted on:**
+
+1. *"#458 is a copy of either sibling."* The siblings disagree — one filters unrecognised `target.kind`, one does not — and **there is no shared builder**: `verifyConfig`, `schedule.ts`'s `toVerifyConfig`, and the joint builder are three independent literal objects over the same shape. Only `toRuleFixture`, `windowBounds` and `effectiveRestMinutes` are genuinely shared. A fourth copy adds a producer to a bug class defined by having too many.
+2. *"#462: the joint path gets this right, copy it."* **No call site anywhere builds `RuleFixture[]` for siblings** — the joint path builds them only from `pack.fixtures.movable` (`competition-schedule-ai.ts:1383, 1554`). There is nothing to copy; this is new code.
+
+---
+
+### Task 1: One constraints builder, and #458 falls out
+
+**Files:** create `apps/web/src/server/usecases/engine-constraints.ts`; modify `schedule-ai.ts:1601-1611`, `schedule.ts:399-406`, `competition-schedule-ai.ts:1308-1317`; test `apps/web/src/server/usecases/__tests__/engine-constraints.test.ts` (create).
+
+**Interfaces:** Produces `buildEngineConstraints(source, opts?)` returning the `constraints` object `VerifyConfig` expects, including `startWindows`. Consumed by all three sites.
+
+- [ ] **Step 1: Write the failing test.** Assert the builder (a) maps `notBefore`/`notAfter` through `ms()`, (b) DROPS a window whose `target.kind` is unrecognised, and (c) returns a non-empty `startWindows` for a pack that has one. Assert the drop explicitly with a `target.kind: "nonsense"` case — the joint sibling's comment explains why: the pack is a wire shape, `kind` is a bare `string`, and casting an unrecognised kind through lets the engine silently never match it while hiding that a settings row drifted from the enum.
+- [ ] **Step 2: Run it — expect FAIL (module does not exist).**
+- [ ] **Step 3: Implement the builder,** taking the filtering behaviour as canonical. Then route all three call sites through it. Delete the three literal blocks.
+- [ ] **Step 4: Flip the pin test.** `schedule-group-targeting.test.ts:259-263` asserts `verifyConfig(p).constraints?.startWindows` `toEqual([])`. It must now assert the window is carried, with its pool target intact. Rename the test — its title ("the pinned-empty startWindows cannot yet use") is now false.
+- [ ] **Step 5: Full web suite, drift gates, commit** `fix(schedule): build engine constraints in one place, and stop pinning startWindows empty (#458)`.
+
+---
+
+### Task 2: One pool namespace across the engine boundary
+
+`Assignment.poolId` is a **uuid** on the board path and a **pool key** on the AI path. `RuleFixture.poolId` carries the key. `scopeCoversFixture` reads `f?.poolId ?? a.poolId`, so the RuleFixture value MASKS the assignment's — at most one side ever binds. The same split reaches `effectiveRestMinutes`' `restByGroup` lookup (`calendar.ts:107-124`), so a pool-targeted rest rule silently misses on one of the two paths.
+
+**Decision: the uuid is canonical at the engine boundary.** It is what the board path already uses, what the DB stores, and what `restByGroup` keys are authored against. The pool KEY is display metadata (`"A"`, `"B"`) and is not unique across divisions.
+
+**Files:** `schedule-ai.ts:978` (pack build — leave `PackFixture.pool` as the key; it is what the MODEL reads), `schedule-ai.ts:1558-1564` (`toRuleFixture` must stamp the uuid), the `toEngineAssignments` path (comment at `:1450-1456`), `competition-schedule-ai.ts:1146`; test `apps/web/src/server/usecases/__tests__/schedule-pool-namespace.test.ts` (create).
+
+- [ ] **Step 1: Write the failing test.** A pool-scoped rule and a pool-targeted `restByGroup` entry, both authored against the pool **uuid**, must bind on the AI path exactly as they do on the board path. Assert the SAME conflict count from both paths — a test asserting one path cannot catch a namespace split.
+- [ ] **Step 2: Run it — expect FAIL** (AI path reports zero).
+- [ ] **Step 3: Implement.** Keep the model-facing `PackFixture.pool` as the key; carry the uuid alongside it for engine use. Do NOT rename the pack field — it is a wire shape the prompts read.
+- [ ] **Step 4: Full web suite + engine suite** (the engine is a consumer here), drift gates, commit `fix(schedule): one pool namespace at the engine boundary (#449)`.
+
+---
+
+### Task 3: Collapse the person scope the same way rosters are collapsed
+
+Rosters are mapped through `personKeyResolver.keyOf` (`schedule-ai.ts:623-631, 672`), producing `name:<normalised>` where two people share a name. `hard[].scope.personKey` is never mapped, and `calendar.ts:844` compares it raw against `Assignment.people`. So a person-scoped rule stops binding the moment that person collapses.
+
+**Files:** `schedule-ai.ts` where `hard` is assembled for the engine, the joint twin in `competition-schedule-ai.ts`; test `apps/web/src/server/usecases/__tests__/schedule-person-scope.test.ts` (create).
+
+- [ ] **Step 1: Write the failing test.** Two people sharing a display name; a rule scoped to one of their uuids. Assert the rule binds. Add a guard case: with unique names, the rule must bind to that person ONLY — otherwise a collapse that over-matches passes the first assertion.
+- [ ] **Step 2: Run it — expect FAIL.**
+- [ ] **Step 3: Implement** by mapping `scope.personKey` through the SAME `identity.keyOf` instance that collapsed the rosters, at the point the rules are handed to the engine. Do not build a second resolver — one resolver instance, both sides.
+- [ ] **Step 4: Full web suite, drift gates, commit** `fix(schedule): collapse person-scoped rules with the same resolver as the rosters (#450)`.
+
+---
+
+### Task 4: Siblings carry their rule fixtures
+
+`siblingAssignments` returns `Assignment[]`, which structurally cannot carry `extKey` or `winnerTo`. So a competition-scoped rule that names fixtures by selector, or a day cap counting across divisions, sees cross-division fixtures with no rule identity. **Nothing anywhere builds this today** — new code, not a copy.
+
+**Files:** `schedule.ts:313-321` and its four call sites (`:618, 753, 978, 1106`); test `apps/web/src/server/usecases/__tests__/schedule-sibling-rulefixtures.test.ts` (create).
+
+- [ ] **Step 1: Write the failing test.** A competition-scoped `max_fixtures_per_day` over two divisions sharing an entrant. Assert the count includes the sibling division's fixtures. Assert the NUMBER, not merely that a conflict exists.
+- [ ] **Step 2: Run it — expect FAIL (undercount).**
+- [ ] **Step 3: Implement.** Return `{ assignments, ruleFixtures }` (or a second query), and pass `ruleFixtures` into every `validateAssignments` call that receives siblings. All four call sites must be updated — a missed one is a silent undercount, which is exactly the defect.
+- [ ] **Step 4: Full web suite, drift gates, commit** `fix(schedule): sibling fixtures carry their rule identity (#462)`.
+
+---
+
+### Task 5: `moveFixture` returns the conflicts it already computes
+
+`conflicts` is populated at `schedule.ts:998` and discarded because the function is `Promise<void>`. Blocking conflicts throw (409); **warn-level conflicts are silently dropped**, so a drag that creates a warned-about board tells the organiser nothing.
+
+**Files:** `schedule.ts:909-916`, `fixtures.ts:49`, `apps/web/src/app/api/v1/fixtures/[id]/route.ts:22`, plus the UI surface that consumes the PATCH response; test `apps/web/src/server/usecases/__tests__/schedule-move-conflicts.test.ts` (create).
+
+- [ ] **Step 1: Write the failing test.** A move that creates a WARN-level conflict (not blocking, or it throws). Assert the returned conflicts are non-empty and non-blocking.
+- [ ] **Step 2: Run it — expect FAIL (returns undefined).**
+- [ ] **Step 3: Implement.** Change the return type and thread it through `patchFixture` to the route response. **This changes a wire payload** — update the response schema in `apps/web/src/server/api-v1/schemas.ts`, run `openapi:gen`, and commit the regenerated spec. Assert the payload shape in a test; the drift gate alone will not tell you the served JSON changed.
+- [ ] **Step 4: UI.** If the drag surface can render the warning, do it via the `frontend-design` skill and verify at desktop AND 375px with no horizontal page scroll. Any new user-facing string goes in all 4 locale dictionaries, never hardcoded English. If the surface cannot show it without a redesign, say so and stop rather than guessing — a visual restyle needs sign-off.
+- [ ] **Step 5: Full web suite, drift gates, commit** `feat(schedule): a move returns the conflicts it computes (#461)`.
+
+---
+
+## Closing gates for the wave
+
+Unit (engine + web), smoke against a standalone server on a FRESH database, and e2e. Smoke reads `SCHEDULING_AI_BASE_URL` from its OWN env or the v4 AI section skips silently while still reporting success. E2E must use `PLAYWRIGHT_BASE=http://localhost:3100`, not `127.0.0.1` — the stored auth cookie's domain is the hostname, and a mismatch 401s every POST while `apiJson` swallows it into `data: undefined`, which reads convincingly as a broken seed helper.
+
+Rebuild before smoke/e2e, or the servers serve a previous branch and pass.
+
+## Out of scope
+
+Wave 2 (#467). Engine changes of any kind. The remaining untriaged issues: #465, #455, #453, #439, #389, #388.

--- a/docs/superpowers/specs/2026-08-05-scheduling-placer-convergence-design.md
+++ b/docs/superpowers/specs/2026-08-05-scheduling-placer-convergence-design.md
@@ -1,0 +1,188 @@
+# Scheduling placer/verifier convergence — design
+
+Date: 2026-08-05
+Issues: #463, #449, #450, #458, #462, #461, #467
+Branch: `feat/sched-convergence` (this doc), then one branch per wave.
+
+## Why these six are one programme
+
+Every remaining item in the scheduling correctness lane is an instance of one
+defect shape:
+
+> **A value exists on one side of a seam and is absent, or in a different
+> namespace, on the other — and both sides typecheck.**
+
+The tell is always **two producers, one comparison, no normaliser.** `tsc`
+cannot see any of them, so they are found only by reading the *builders*, never
+the types. Eight instances are now on record: #443 (uuid vs ext_key), #446
+(Assignment group ids), #447 (`SlotConfig` assignable to `VerifyConfig` with
+`tz`/`hard`/`ruleFixtures` undefined), #449 (pool key vs uuid), #450 (person
+name vs uuid), #451 (cfg scales vs table scales), #448 (UTC day vs local day),
+and the near-miss caught while fixing #448 (`settings.tz` vs `settings.orgTz`).
+
+The scheduling instance has a name: the **placer/verifier fork**. The placer
+(`slotFixtures`) and the verifier (`validateAssignments`) answer the same
+question from two different code paths, so they can disagree. The user-visible
+symptom is specific and recognisable:
+
+> auto proposes a board that the gate immediately warns about, and re-running
+> auto cannot fix it.
+
+This programme closes the fork rather than patching each divergence.
+
+## Current state, verified against `origin/main` @ `14b8e5f6`
+
+| Site | What is there now |
+| --- | --- |
+| `packages/engine/src/scheduling/calendar.ts:365` | `slotFixtures` — the placer |
+| `calendar.ts:384` | `const lastEnd = new Map<EntrantId, number>()` — rest tracked per **entrant** |
+| `calendar.ts:494`, `:529` | the only writes/reads of `lastEnd` |
+| `calendar.ts:645-656` | `scope.kind` switch: `pool` compares `scope.pool`, `person` compares `scope.personKey` |
+| `calendar.ts:737` | a comment that already documents the `lastEnd` defect |
+| `apps/web/src/server/usecases/schedule-ai.ts:1606` | `startWindows: []`, pinned |
+| `apps/web/src/server/usecases/schedule.ts:313` | `siblingAssignments` returns `Assignment[]` |
+| `apps/web/src/server/usecases/schedule.ts:909` | `moveFixture` returns `Promise<void>` |
+| `packages/engine/src/sports/cricket/cricket.ts` | the only mentions of `revisedTarget` anywhere |
+
+`slotFixtures` folds rest, `startWindows` and `crossPersonClash` and nothing
+else. So `max_fixtures_per_day`, `not_before`/`not_after`,
+`fixture_on_weekday`/`fixture_on_date` and `feeder_to_dependent` rest are
+**reported by the verifier but never placed around**.
+
+## Wave 1a — engine capability
+
+One file: `packages/engine/src/scheduling/calendar.ts`. Closes **#449**,
+**#450**, **#463**.
+
+### Commit 1 — the identity seam
+
+Three of the defects are the same missing normaliser:
+
+```
+lastEnd: Map<EntrantId, …>      compared against  a per_person rule   (#463)
+guardedPeople: identity.keyOf   compared against  a person uuid       (#450)
+scope.pool: "A"                 compared against  a pool uuid         (#449)
+```
+
+Introduce a single key-resolution function, local to the scheduling module.
+Every scope comparison in the `scope.kind` switch and every rest bucket resolves
+its key through it, so both sides of each comparison are produced by the same
+code. `lastEnd` stops being keyed by `EntrantId`.
+
+To be explicit, since this is the sort of thing that gets misread into a much
+larger change: this does **not** alter what `identity.keyOf` means, and does not
+change any persisted key or wire shape. It changes only which function each
+comparison calls to obtain its key. The existing collapse semantics
+(a person uuid resolving to `name:<normalised>`) stay exactly as they are —
+#450 is that both sides must apply that resolution, not that it should stop.
+
+This lands as **its own commit**, before any placement change, so a bisect can
+separate "the normaliser broke something" from "the new placement logic broke
+something". That separation is the whole reason for two commits.
+
+### Commit 2 — placement convergence
+
+Extend `slotFixtures` to place around every family the verifier already checks:
+`max_fixtures_per_day`, `not_before`/`not_after`, `fixture_on_weekday`/
+`fixture_on_date`, `feeder_to_dependent` rest.
+
+Day bucketing uses `dayKeyInTz(instantMs, tz)` from
+`packages/engine/src/scheduling/tz.ts`. Do not write another day helper — that
+helper is the #448 fix and is DST-correct with zero dependencies. The governing
+zone is the **org** zone; a division override must never decide which calendar
+day a fixture falls on.
+
+### The acceptance test that matters
+
+Not "the placer honours rule X". The test is:
+
+> for the same board and the same config, the placer and the verifier report
+> **the same number** of violations of each family.
+
+A test that asserts only the placer's behaviour cannot catch a fork; a test that
+asserts both sides agree cannot miss one. Where practical, extract the shared
+predicate so there is one function rather than two that must be kept in step.
+
+## Wave 1b — the web side supplies what the placer now needs
+
+Without this, Wave 1a is dead capability on the surface users actually touch:
+the engine places around windows that never arrive. Closes **#458**, **#462**,
+**#461**.
+
+- **#458** — `schedule-ai.ts:1606` stops pinning `startWindows: []`. #464 added
+  an assertion pinning the current empty behaviour; that assertion must **flip**
+  in this change.
+
+  **The two siblings are not interchangeable — decide which is right before
+  copying.** `schedule.ts:403-406` maps every window straight through
+  (`target: w.target`). `competition-schedule-ai.ts:1308` instead *drops* any
+  window whose `target.kind` is not `entrant`, `pool` or `division`, with a
+  comment explaining why: the pack is a wire shape, so `target.kind` is a bare
+  `string`, and casting an unrecognised kind through would let the engine
+  silently never match it while hiding that a settings row has drifted from the
+  enum. `schedule-ai.ts` consumes a pack, so the filtering sibling is the
+  correct model for it. Copying the other one would reintroduce the exact
+  silent-never-matches failure that comment was written to prevent.
+
+  Note this divergence is itself an instance of the programme's bug class: two
+  producers of the same engine input, no shared normaliser. Prefer extracting
+  one shared builder over adding a third copy.
+- **#462** — `siblingAssignments` (`schedule.ts:313`) carries `RuleFixture`, so
+  a competition-scoped day cap stops undercounting cross-division fixtures. The
+  joint path already does this correctly; copy it. This is a **prerequisite for
+  correctness**, not a nicety: a day cap that places confidently on undercounted
+  data is worse than today's behaviour, where it does not place at all.
+- **#461** — `moveFixture` (`schedule.ts:909`) returns the conflicts it already
+  computes instead of `Promise<void>`. Same file as #462, and it is the feedback
+  half of the same story.
+
+## Wave 2 — #467
+
+Nothing renders `revisedTarget`. Independent of the waves above; no shared
+files. Worth doing because an invisible output is an unverified output — #451
+survived precisely because nothing displayed this value.
+
+## Testing
+
+Every change ships all four, per the standing rule, and a task is not done until
+all four exist and pass:
+
+1. **unit** — engine and `apps/web`, judged only from
+   `--reporter=json --outputFile`. A drop in `numTotalTests` means DB tests
+   silently skipped and is a failure, not a pass.
+2. **regression** — a test that fails without the change. Prove it red by
+   reverting with `git show <ref>:<path> > <path>` or a `cp` backup. Never
+   `git stash` in a worktree; the stack is shared with the main checkout.
+3. **smoke** — `scripts/smoke.ts` against a real standalone server, with the env
+   from the smoke job in `.github/workflows/ci.yml`. Smoke reads
+   `SCHEDULING_AI_BASE_URL` from its **own** env; without it the v4 AI section
+   skips silently and the run still reports success.
+4. **e2e** — Playwright against a prod build. Never enable
+   `.github/workflows/e2e.yml`.
+
+Before every commit, both CI-only drift gates: `openapi:gen` **and**
+`i18n:gen-keys`, then `git status --porcelain` must be empty.
+
+## Risks
+
+- **Wave 1a is a refactor and new logic in one file.** Mitigated by the
+  two-commit split and by gating the wave on no other worktree holding
+  `calendar.ts` changes. Several sessions run in parallel in this repo; at the
+  time of writing no other worktree has uncommitted `calendar.ts` edits.
+- **The golden corpus cannot catch what no config exercises.** A green
+  conformance run is not coverage. Never run `UPDATE_GOLDEN=1`.
+- **Timing gates lie under load.** `repair-scale` and
+  `calendar-shared-semantics` carry wall-clock assertions and fail on a busy
+  machine. Judge them only from an isolated run.
+- **A spec regenerating cleanly does not mean the served JSON is unchanged.**
+  `openapi:gen` regenerates from the zod schema, which nothing applies at
+  runtime. This gap was demonstrated during #448: a wire-breaking rename passed
+  tsc, vitest, lint and `openapi:gen` in both directions. Where a change touches
+  a boundary payload, assert the payload.
+
+## Out of scope
+
+- Any schema migration. None of the six needs one.
+- The remaining untriaged issues: #465, #455, #453, #439, #389, #388.
+- Re-litigating settled invariants: instruction-rule conflicts are warn-only by
+  design; `blocking` is absolute while the delta lives only in the write gate.

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -15999,6 +15999,11 @@
                                 "minimum": -9007199254740991,
                                 "maximum": 9007199254740991
                               },
+                              "fixture_no": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
                               "home_entrant_id": {
                                 "anyOf": [
                                   {
@@ -16100,6 +16105,7 @@
                               "pool_id",
                               "round_no",
                               "seq_in_round",
+                              "fixture_no",
                               "home_entrant_id",
                               "away_entrant_id",
                               "scheduled_at",
@@ -16142,6 +16148,7 @@
                         "pool_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "round_no": -9007199254740991,
                         "seq_in_round": -9007199254740991,
+                        "fixture_no": -9007199254740991,
                         "home_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "away_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "scheduled_at": "example",
@@ -22917,6 +22924,11 @@
                           "minimum": -9007199254740991,
                           "maximum": 9007199254740991
                         },
+                        "fixture_no": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
                         "home_entrant_id": {
                           "anyOf": [
                             {
@@ -23018,6 +23030,7 @@
                         "pool_id",
                         "round_no",
                         "seq_in_round",
+                        "fixture_no",
                         "home_entrant_id",
                         "away_entrant_id",
                         "scheduled_at",
@@ -23047,6 +23060,7 @@
                     "pool_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "round_no": -9007199254740991,
                     "seq_in_round": -9007199254740991,
+                    "fixture_no": -9007199254740991,
                     "home_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "away_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "scheduled_at": "example",
@@ -23209,7 +23223,7 @@
         ]
       },
       "patch": {
-        "summary": "Schedule move, venue, officials, pin/lock — blocking conflicts → 409",
+        "summary": "Schedule move, venue, officials, pin/lock — blocking conflicts → 409, warn-level ones come back in `conflicts`",
         "tags": [
           "fixtures"
         ],
@@ -23354,6 +23368,11 @@
                           "minimum": -9007199254740991,
                           "maximum": 9007199254740991
                         },
+                        "fixture_no": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
                         "home_entrant_id": {
                           "anyOf": [
                             {
@@ -23446,6 +23465,64 @@
                         },
                         "created_at": {
                           "type": "string"
+                        },
+                        "conflicts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fixture_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "code": {
+                                "type": "string",
+                                "enum": [
+                                  "conflict.court",
+                                  "conflict.start_window",
+                                  "warn.rest",
+                                  "warn.person_overlap",
+                                  "warn.order",
+                                  "warn.blackout",
+                                  "warn.window",
+                                  "warn.instruction",
+                                  "warn.no_slot",
+                                  "warn.official_declined",
+                                  "warn.official_unavailable"
+                                ]
+                              },
+                              "blocking": {
+                                "type": "boolean"
+                              },
+                              "detail": {
+                                "type": "string"
+                              },
+                              "rule": {
+                                "type": "string",
+                                "enum": [
+                                  "H2",
+                                  "H3",
+                                  "H4",
+                                  "H5",
+                                  "H6",
+                                  "H8",
+                                  "CAP"
+                                ]
+                              },
+                              "shortfall_minutes": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": [
+                              "fixture_id",
+                              "code",
+                              "blocking"
+                            ],
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -23455,6 +23532,7 @@
                         "pool_id",
                         "round_no",
                         "seq_in_round",
+                        "fixture_no",
                         "home_entrant_id",
                         "away_entrant_id",
                         "scheduled_at",
@@ -23465,7 +23543,8 @@
                         "outcome",
                         "schedule_source",
                         "schedule_locked",
-                        "created_at"
+                        "created_at",
+                        "conflicts"
                       ],
                       "additionalProperties": false
                     },
@@ -23484,6 +23563,7 @@
                     "pool_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "round_no": -9007199254740991,
                     "seq_in_round": -9007199254740991,
+                    "fixture_no": -9007199254740991,
                     "home_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "away_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "scheduled_at": "example",
@@ -23496,7 +23576,15 @@
                     "outcome": null,
                     "schedule_source": "none",
                     "schedule_locked": true,
-                    "created_at": "example"
+                    "created_at": "example",
+                    "conflicts": [
+                      {
+                        "fixture_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                        "code": "conflict.court",
+                        "blocking": true,
+                        "detail": "example"
+                      }
+                    ]
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
                 }

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -12069,6 +12069,11 @@
                                 "minimum": -9007199254740991,
                                 "maximum": 9007199254740991
                               },
+                              "fixture_no": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              },
                               "home_entrant_id": {
                                 "anyOf": [
                                   {
@@ -12170,6 +12175,7 @@
                               "pool_id",
                               "round_no",
                               "seq_in_round",
+                              "fixture_no",
                               "home_entrant_id",
                               "away_entrant_id",
                               "scheduled_at",
@@ -12212,6 +12218,7 @@
                         "pool_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "round_no": -9007199254740991,
                         "seq_in_round": -9007199254740991,
+                        "fixture_no": -9007199254740991,
                         "home_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "away_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                         "scheduled_at": "example",
@@ -18987,6 +18994,11 @@
                           "minimum": -9007199254740991,
                           "maximum": 9007199254740991
                         },
+                        "fixture_no": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
                         "home_entrant_id": {
                           "anyOf": [
                             {
@@ -19088,6 +19100,7 @@
                         "pool_id",
                         "round_no",
                         "seq_in_round",
+                        "fixture_no",
                         "home_entrant_id",
                         "away_entrant_id",
                         "scheduled_at",
@@ -19117,6 +19130,7 @@
                     "pool_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "round_no": -9007199254740991,
                     "seq_in_round": -9007199254740991,
+                    "fixture_no": -9007199254740991,
                     "home_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "away_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "scheduled_at": "example",
@@ -19279,7 +19293,7 @@
         ]
       },
       "patch": {
-        "summary": "Schedule move, venue, officials, pin/lock — blocking conflicts → 409",
+        "summary": "Schedule move, venue, officials, pin/lock — blocking conflicts → 409, warn-level ones come back in `conflicts`",
         "tags": [
           "fixtures"
         ],
@@ -19424,6 +19438,11 @@
                           "minimum": -9007199254740991,
                           "maximum": 9007199254740991
                         },
+                        "fixture_no": {
+                          "type": "integer",
+                          "minimum": -9007199254740991,
+                          "maximum": 9007199254740991
+                        },
                         "home_entrant_id": {
                           "anyOf": [
                             {
@@ -19516,6 +19535,64 @@
                         },
                         "created_at": {
                           "type": "string"
+                        },
+                        "conflicts": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "fixture_id": {
+                                "type": "string",
+                                "format": "uuid",
+                                "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                              },
+                              "code": {
+                                "type": "string",
+                                "enum": [
+                                  "conflict.court",
+                                  "conflict.start_window",
+                                  "warn.rest",
+                                  "warn.person_overlap",
+                                  "warn.order",
+                                  "warn.blackout",
+                                  "warn.window",
+                                  "warn.instruction",
+                                  "warn.no_slot",
+                                  "warn.official_declined",
+                                  "warn.official_unavailable"
+                                ]
+                              },
+                              "blocking": {
+                                "type": "boolean"
+                              },
+                              "detail": {
+                                "type": "string"
+                              },
+                              "rule": {
+                                "type": "string",
+                                "enum": [
+                                  "H2",
+                                  "H3",
+                                  "H4",
+                                  "H5",
+                                  "H6",
+                                  "H8",
+                                  "CAP"
+                                ]
+                              },
+                              "shortfall_minutes": {
+                                "type": "integer",
+                                "minimum": -9007199254740991,
+                                "maximum": 9007199254740991
+                              }
+                            },
+                            "required": [
+                              "fixture_id",
+                              "code",
+                              "blocking"
+                            ],
+                            "additionalProperties": false
+                          }
                         }
                       },
                       "required": [
@@ -19525,6 +19602,7 @@
                         "pool_id",
                         "round_no",
                         "seq_in_round",
+                        "fixture_no",
                         "home_entrant_id",
                         "away_entrant_id",
                         "scheduled_at",
@@ -19535,7 +19613,8 @@
                         "outcome",
                         "schedule_source",
                         "schedule_locked",
-                        "created_at"
+                        "created_at",
+                        "conflicts"
                       ],
                       "additionalProperties": false
                     },
@@ -19554,6 +19633,7 @@
                     "pool_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "round_no": -9007199254740991,
                     "seq_in_round": -9007199254740991,
+                    "fixture_no": -9007199254740991,
                     "home_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "away_entrant_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
                     "scheduled_at": "example",
@@ -19566,7 +19646,15 @@
                     "outcome": null,
                     "schedule_source": "none",
                     "schedule_locked": true,
-                    "created_at": "example"
+                    "created_at": "example",
+                    "conflicts": [
+                      {
+                        "fixture_id": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b",
+                        "code": "conflict.court",
+                        "blocking": true,
+                        "detail": "example"
+                      }
+                    ]
                   },
                   "requestId": "3f1a2b04-8c1d-4e5f-9a6b-7c8d9e0f1a2b"
                 }

--- a/packages/engine/src/scheduling/calendar-day-cap-placement.test.ts
+++ b/packages/engine/src/scheduling/calendar-day-cap-placement.test.ts
@@ -1,0 +1,107 @@
+// #463 — the placer must honour `max_fixtures_per_day`, and it must count on the
+// ORG calendar day. `validateAssignments` has always reported this rule
+// (`validateInstructionRules`, the `max_fixtures_per_day` branch); the placer
+// packed straight through it, so Auto proposed a board the apply gate warned
+// about and re-running Auto proposed the same board again.
+import { describe, expect, it } from "vitest";
+import { slotFixtures, type SchedulableFixture } from "./calendar.ts";
+import { SchedulingConstraints, type HardConstraint } from "./constraints.ts";
+import { dayKeyInTz } from "./tz.ts";
+
+const TZ = "America/Los_Angeles";
+
+// 2026-07-11 16:00 LOCAL. Deliberately late in the local day: the cards that
+// follow land on 2026-07-12 in UTC while still being Saturday 2026-07-11 in Los
+// Angeles, so a UTC bucket splits the day 2 + 1 and admits a third card onto a
+// day the organiser capped at two. Only the org zone gives the right answer.
+const SAT_1600_LOCAL = Date.UTC(2026, 6, 11, 23, 0);
+
+// All three share `e1`, so with zero rest they serialise in id order on one
+// court — nothing but the cap can move them apart.
+const cards = (n: number): SchedulableFixture[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `f${i + 1}`,
+    home: "e1",
+    away: `e${i + 10}`,
+    divisionId: "d1",
+  }));
+
+// `count`, not `max` — constraints.ts:70. Parsed rather than cast so a wrong
+// field name fails here rather than binding nothing.
+const CAP_2: HardConstraint = {
+  type: "max_fixtures_per_day",
+  count: 2,
+  scope: { kind: "entrant", entrantId: "e1" },
+};
+
+const place = (n: number, hard: HardConstraint[], horizonMinutes: number) =>
+  slotFixtures({
+    fixtures: cards(n),
+    config: {
+      startAt: SAT_1600_LOCAL,
+      matchMinutes: 30,
+      gapMinutes: 0,
+      perEntrantMinRest: 0,
+      courts: ["C1"],
+      blackouts: [],
+      sessionWindows: [],
+      tz: TZ,
+      horizonMinutes,
+      constraints: SchedulingConstraints.parse({ hard }),
+    },
+  });
+
+const localDays = (res: ReturnType<typeof place>): string[] =>
+  [...res.assignments]
+    .sort((a, b) => a.startAt - b.startAt)
+    .map((a) => dayKeyInTz(a.startAt, TZ));
+
+describe("the placer honours max_fixtures_per_day on the ORG day (#463)", () => {
+  it("pushes the capped card to the next LOCAL day, not the next UTC one", () => {
+    const res = place(3, [CAP_2], 60 * 24 * 3);
+    expect(res.assignments).toHaveLength(3);
+    // Cards two and three sit at 23:30Z and 00:00Z — different UTC days, the
+    // same Saturday in Los Angeles.
+    expect(localDays(res)).toEqual(["2026-07-11", "2026-07-11", "2026-07-12"]);
+    expect(res.conflicts).toEqual([]);
+  });
+
+  it("reports no_slot when no later day is reachable inside the horizon", () => {
+    // Two hours of horizon: the next local day starts eight hours out, so the
+    // third card has nowhere legal to go and takes the existing unplaceable path
+    // rather than being packed into a breach.
+    const res = place(3, [CAP_2], 120);
+    expect(res.assignments).toHaveLength(2);
+    expect(res.conflicts.filter((c) => c.reason === "no_slot").map((c) => c.fixtureId)).toEqual(["f3"]);
+  });
+
+  it("packs all three on one local day when no cap is in force", () => {
+    // Guard the guard: without the rule the placer fills the same day, so the
+    // split above is the cap doing the work and not the horizon or the clock.
+    const res = place(3, [], 60 * 24 * 3);
+    expect(localDays(res)).toEqual(["2026-07-11", "2026-07-11", "2026-07-11"]);
+  });
+
+  it("leaves a card the cap does not cover alone", () => {
+    // The cap is scoped to `e1`; `e2`'s card is not its business. Without this a
+    // day-level rejection that ignored scope would still pass every case above.
+    const res = slotFixtures({
+      fixtures: [...cards(2), { id: "f9", home: "e2", away: "e3", divisionId: "d1" }],
+      config: {
+        startAt: SAT_1600_LOCAL,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 0,
+        courts: ["C1", "C2"],
+        blackouts: [],
+        sessionWindows: [],
+        tz: TZ,
+        horizonMinutes: 60 * 24 * 3,
+        constraints: SchedulingConstraints.parse({ hard: [CAP_2] }),
+      },
+    });
+    const f9 = res.assignments.find((a) => a.fixtureId === "f9");
+    expect(f9).toBeDefined();
+    expect(dayKeyInTz(f9!.startAt, TZ)).toBe("2026-07-11");
+  });
+});

--- a/packages/engine/src/scheduling/calendar-day-targets-placement.test.ts
+++ b/packages/engine/src/scheduling/calendar-day-targets-placement.test.ts
@@ -1,0 +1,111 @@
+// #463 — `fixture_on_date` / `fixture_on_weekday` name a CARD, not a scope:
+// constraints.ts:73-84 gives both a required `selector`, a `WeekdayCode` string
+// (never a number), and a YYYY-MM-DD `date`. The verifier resolves that selector
+// through `ruleFixtures` and reports a card on the wrong day; the placer put
+// every card on the first day it could and never moved one for a target date.
+//
+// This is the family that needs a DAY-level jump: the target can be a fortnight
+// out, and a repair loop stepping one 30-minute slot at a time exhausts its 64
+// tries inside the first afternoon.
+import { describe, expect, it } from "vitest";
+import { slotFixtures, type RuleFixture, type SchedulableFixture } from "./calendar.ts";
+import { SchedulingConstraints, type HardConstraint } from "./constraints.ts";
+import { dayKeyInTz, weekdayOfYmd } from "./tz.ts";
+
+const TZ = "America/Los_Angeles";
+// Saturday 2026-07-11, 10:00 local. The first Wednesday after it is 2026-07-15.
+const SAT_1000_LOCAL = Date.UTC(2026, 6, 11, 17, 0);
+
+// Distinct entrants: the two cards are independent, so a card that does NOT
+// move is evidence about the rule and not about rest spacing.
+const FIXTURES: SchedulableFixture[] = [
+  { id: "f1", home: "e1", away: "e2", divisionId: "d1" },
+  { id: "f2", home: "e3", away: "e4", divisionId: "d1" },
+];
+
+const D1 = { kind: "division", divisionId: "d1" } as const;
+const BY_ID = { kind: "id", fixtureId: "f1" } as const;
+
+const place = (hard: HardConstraint[], ruleFixtures?: readonly RuleFixture[]) =>
+  slotFixtures({
+    fixtures: FIXTURES,
+    config: {
+      startAt: SAT_1000_LOCAL,
+      matchMinutes: 30,
+      gapMinutes: 0,
+      perEntrantMinRest: 0,
+      courts: ["C1"],
+      blackouts: [],
+      sessionWindows: [],
+      tz: TZ,
+      horizonMinutes: 60 * 24 * 14,
+      constraints: SchedulingConstraints.parse({ hard }),
+      ...(ruleFixtures !== undefined ? { ruleFixtures } : {}),
+    },
+  });
+
+const dayOf = (res: ReturnType<typeof place>, id: string): string | undefined => {
+  const a = res.assignments.find((x) => x.fixtureId === id);
+  return a === undefined ? undefined : dayKeyInTz(a.startAt, TZ);
+};
+
+describe("the placer honours fixture_on_date / fixture_on_weekday (#463)", () => {
+  it("moves the named card to the required calendar date, days away", () => {
+    const res = place([{ type: "fixture_on_date", selector: BY_ID, date: "2026-07-15", scope: D1 }]);
+    expect(res.conflicts).toEqual([]);
+    expect(dayOf(res, "f1")).toBe("2026-07-15");
+    // The selector names one card. A rule that moved the whole division would
+    // pass the line above and fail this one.
+    expect(dayOf(res, "f2")).toBe("2026-07-11");
+  });
+
+  it("moves the named card to the next matching weekday", () => {
+    const res = place([{ type: "fixture_on_weekday", selector: BY_ID, weekday: "WED", scope: D1 }]);
+    const day = dayOf(res, "f1")!;
+    expect(weekdayOfYmd(day)).toBe("WED");
+    // The NEXT Wednesday, not some later one — the jump is one week at most.
+    expect(day).toBe("2026-07-15");
+    expect(dayOf(res, "f2")).toBe("2026-07-11");
+  });
+
+  it("resolves a terminal selector through ruleFixtures, as the verifier does", () => {
+    // `terminal` is `winnerTo === null` and needs metadata a SchedulableFixture
+    // does not carry. Given `ruleFixtures` the placer resolves it with the same
+    // `resolveSelector` the verifier calls, so both name the same card — here
+    // f2, the one nothing feeds on to.
+    const ruleFixtures: RuleFixture[] = [
+      { id: "f1", extKey: "f1", divisionId: "d1", winnerTo: "f2" },
+      { id: "f2", extKey: "f2", divisionId: "d1", winnerTo: null },
+    ];
+    const res = place(
+      [{ type: "fixture_on_date", selector: { kind: "terminal" }, date: "2026-07-15", scope: D1 }],
+      ruleFixtures,
+    );
+    expect(dayOf(res, "f2")).toBe("2026-07-15");
+    expect(dayOf(res, "f1")).toBe("2026-07-11");
+  });
+
+  it("reports no_slot for a date already behind the first slot", () => {
+    // This pass only ever moves a card LATER, so a target date in the past is
+    // unreachable. Refusing it is the honest answer; placing it on the wrong day
+    // and letting the gate warn is the fork.
+    const res = place([{ type: "fixture_on_date", selector: BY_ID, date: "2026-07-05", scope: D1 }]);
+    expect(res.assignments.map((a) => a.fixtureId)).toEqual(["f2"]);
+    expect(res.conflicts.filter((c) => c.reason === "no_slot").map((c) => c.fixtureId)).toEqual(["f1"]);
+  });
+
+  it("leaves an unresolvable selector alone rather than guessing", () => {
+    // No `ruleFixtures`, so `terminal` cannot be resolved: a SchedulableFixture
+    // carries no `winnerTo`, and assuming every card is terminal would bind a
+    // final's rule to the entire draw.
+    const res = place([
+      { type: "fixture_on_date", selector: { kind: "terminal" }, date: "2026-07-15", scope: D1 },
+    ]);
+    expect(dayOf(res, "f1")).toBe("2026-07-11");
+    expect(dayOf(res, "f2")).toBe("2026-07-11");
+  });
+
+  it("places on the first day when no day target is in force", () => {
+    expect(dayOf(place([]), "f1")).toBe("2026-07-11");
+  });
+});

--- a/packages/engine/src/scheduling/calendar-person-rest.test.ts
+++ b/packages/engine/src/scheduling/calendar-person-rest.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { slotFixtures } from "./calendar.ts";
+
+const T0 = Date.UTC(2026, 6, 4, 9, 0);
+
+describe("placer rests on shared PEOPLE, not only shared entrants (#463)", () => {
+  it("separates two fixtures that share a person but no entrant", () => {
+    const res = slotFixtures({
+      fixtures: [
+        { id: "a", home: "e1", away: "e2", people: ["p-shared"], divisionId: "d1" },
+        { id: "b", home: "e3", away: "e4", people: ["p-shared"], divisionId: "d1" },
+      ],
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 60, // one hour of rest is owed to a shared participant
+        courts: ["C1", "C2"], // two courts, so nothing forces them apart
+        blackouts: [],
+        sessionWindows: [],
+      },
+    });
+
+    expect(res.assignments).toHaveLength(2);
+    const [a, b] = [...res.assignments].sort((x, y) => x.startAt - y.startAt);
+    // Without the fix both are placed at T0 on different courts: they share no
+    // entrant, so `lastEnd` never saw the overlap.
+    expect(b!.startAt - a!.endAt).toBeGreaterThanOrEqual(60 * 60_000);
+  });
+
+  it("still packs fixtures that share nothing", () => {
+    const res = slotFixtures({
+      fixtures: [
+        { id: "a", home: "e1", away: "e2", people: ["p1"], divisionId: "d1" },
+        { id: "b", home: "e3", away: "e4", people: ["p2"], divisionId: "d1" },
+      ],
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 60,
+        courts: ["C1", "C2"],
+        blackouts: [],
+        sessionWindows: [],
+      },
+    });
+    expect(res.assignments.every((a) => a.startAt === T0)).toBe(true);
+  });
+
+  it("does not fuse a person id with an identically-spelled entrant id", () => {
+    // Rest is owed to a PARTICIPANT, but an entrant and a person are different
+    // participants even when their ids collide as strings. One rest map keyed on
+    // the bare id would rest `b` behind `a` for a shared entrant that is really
+    // an unrelated person.
+    const res = slotFixtures({
+      fixtures: [
+        { id: "a", home: "x1", away: "e2", divisionId: "d1" },
+        { id: "b", home: "e3", away: "e4", people: ["x1"], divisionId: "d1" },
+      ],
+      config: {
+        startAt: T0,
+        matchMinutes: 30,
+        gapMinutes: 0,
+        perEntrantMinRest: 60,
+        courts: ["C1", "C2"],
+        blackouts: [],
+        sessionWindows: [],
+      },
+    });
+    expect(res.assignments.every((a) => a.startAt === T0)).toBe(true);
+  });
+});

--- a/packages/engine/src/scheduling/calendar-placer-verifier-parity.test.ts
+++ b/packages/engine/src/scheduling/calendar-placer-verifier-parity.test.ts
@@ -1,0 +1,97 @@
+// #463 — THE test this wave exists for. A test that asserts only the placer's
+// behaviour cannot catch a fork; this one feeds the placer's OWN OUTPUT back to
+// `validateAssignments` per rule family, so any family the placer stops
+// honouring fails here rather than shipping as "Auto proposes a board the apply
+// gate warns about, and re-running Auto proposes the same board again".
+//
+// Every typed-rule breach reports `reason: "instruction"` (rule code H8) — there
+// is no per-family field on `Conflict` — and each case below puts exactly one
+// family in force, so an `instruction` row can only have come from it.
+//
+// Each config is sized so the rule BITES: without the placer honouring it the
+// board really does breach, which is what a parity assertion needs to be worth
+// running. Proven by reverting calendar.ts to the pre-#463 placer, where every
+// case here fails.
+import { describe, expect, it } from "vitest";
+import {
+  slotFixtures,
+  validateAssignments,
+  type RuleFixture,
+  type SchedulableFixture,
+} from "./calendar.ts";
+import { SchedulingConstraints, type HardConstraint } from "./constraints.ts";
+
+const TZ = "America/Los_Angeles";
+const SAT_1000_LOCAL = Date.UTC(2026, 6, 11, 17, 0);
+const SAT_0600_LOCAL = Date.UTC(2026, 6, 11, 13, 0);
+
+const D1 = { kind: "division", divisionId: "d1" } as const;
+const TERMINAL = { kind: "terminal" } as const;
+
+// One shared entrant, so the cards serialise on the board and the rule under
+// test is the only thing that can move them off it.
+const cards = (n: number): SchedulableFixture[] =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `f${i + 1}`,
+    home: "e1",
+    away: `e${i + 10}`,
+    divisionId: "d1",
+  }));
+
+// `winnerTo: null` for all of them: nothing feeds on, so `terminal` names the
+// whole set and a selector-driven rule is exercised rather than skipped.
+const ruleFixturesFor = (n: number): RuleFixture[] =>
+  cards(n).map((f) => ({ id: f.id, extKey: f.id, divisionId: "d1", winnerTo: null }));
+
+const configFor = (rule: HardConstraint, n: number, startAt: number) => ({
+  startAt,
+  matchMinutes: 30,
+  gapMinutes: 0,
+  perEntrantMinRest: 0,
+  courts: ["C1", "C2"],
+  blackouts: [],
+  sessionWindows: [],
+  tz: TZ,
+  horizonMinutes: 60 * 24 * 21,
+  ruleFixtures: ruleFixturesFor(n),
+  constraints: SchedulingConstraints.parse({ hard: [rule] }),
+});
+
+const FAMILIES: ReadonlyArray<readonly [string, HardConstraint, number, number]> = [
+  // Six cards capped at two a day: the placer must spread them over three days.
+  [
+    "max_fixtures_per_day",
+    { type: "max_fixtures_per_day", count: 2, scope: { kind: "entrant", entrantId: "e1" } },
+    6,
+    SAT_1000_LOCAL,
+  ],
+  // First slot is 06:00 local, three hours inside the bound.
+  ["not_before", { type: "not_before", time: "09:00", scope: D1 }, 3, SAT_0600_LOCAL],
+  // Twelve cards from 10:00 local run to 15:30 — seven of them past the bound.
+  ["not_after", { type: "not_after", time: "12:00", scope: D1 }, 12, SAT_1000_LOCAL],
+  // The first slot is a Saturday.
+  ["fixture_on_weekday", { type: "fixture_on_weekday", selector: TERMINAL, weekday: "WED", scope: D1 }, 3, SAT_1000_LOCAL],
+  ["fixture_on_date", { type: "fixture_on_date", selector: TERMINAL, date: "2026-07-15", scope: D1 }, 3, SAT_1000_LOCAL],
+];
+
+describe("the placer's own output satisfies the verifier (#463)", () => {
+  it.each(FAMILIES)("emits no %s violation it could have avoided", (_family, rule, n, startAt) => {
+    const config = configFor(rule, n, startAt);
+    const { assignments, conflicts } = slotFixtures({ fixtures: cards(n), config });
+
+    // A card the placer REFUSED to place is honest; a card it placed into a
+    // violation is the fork. These configs are all satisfiable inside the
+    // horizon, so refusing one would mean the placer over-constrained — and
+    // without this line "place nothing" would satisfy the assertion below.
+    expect(assignments).toHaveLength(n);
+    expect(conflicts.filter((c) => c.reason === "no_slot")).toEqual([]);
+
+    // No cast: the placer's config IS a VerifyConfig now that `SlotConfig`
+    // carries `tz` and `ruleFixtures`, which is the point — one object, one
+    // clock, one rule list, handed to both sides.
+    const verdict = validateAssignments(assignments, config);
+    // Mapped to `detail` so a failure names the day or the time that broke,
+    // rather than printing five identical conflict objects.
+    expect(verdict.filter((c) => c.reason === "instruction").map((c) => c.detail)).toEqual([]);
+  });
+});

--- a/packages/engine/src/scheduling/calendar-time-bounds-placement.test.ts
+++ b/packages/engine/src/scheduling/calendar-time-bounds-placement.test.ts
@@ -1,0 +1,77 @@
+// #463 — `not_before` / `not_after` are WALL-CLOCK bounds in the org zone, never
+// instants (constraints.ts:56-59). The verifier compares `hhmmInTz(start, tz)`
+// against them; the placer ignored them entirely, so "nothing before 9am"
+// displayed as a rule, warned on every board Auto produced, and bound nothing
+// the organiser could act on.
+import { describe, expect, it } from "vitest";
+import { slotFixtures } from "./calendar.ts";
+import { SchedulingConstraints, type HardConstraint } from "./constraints.ts";
+import { dayKeyInTz, hhmmInTz } from "./tz.ts";
+
+const TZ = "America/Los_Angeles";
+const SAT_0600_LOCAL = Date.UTC(2026, 6, 11, 13, 0);
+const SAT_1300_LOCAL = Date.UTC(2026, 6, 11, 20, 0);
+
+const D1 = { kind: "division", divisionId: "d1" } as const;
+const notBefore = (time: string): HardConstraint => ({ type: "not_before", time, scope: D1 });
+const notAfter = (time: string): HardConstraint => ({ type: "not_after", time, scope: D1 });
+
+const place = (startAt: number, hard: HardConstraint[], horizonMinutes = 60 * 24 * 3) =>
+  slotFixtures({
+    fixtures: [{ id: "f1", home: "e1", away: "e2", divisionId: "d1" }],
+    config: {
+      startAt,
+      matchMinutes: 30,
+      gapMinutes: 0,
+      perEntrantMinRest: 0,
+      courts: ["C1"],
+      blackouts: [],
+      sessionWindows: [],
+      tz: TZ,
+      horizonMinutes,
+      constraints: SchedulingConstraints.parse({ hard }),
+    },
+  });
+
+describe("the placer honours not_before / not_after (#463)", () => {
+  it("raises a candidate to the rule's wall-clock time on the same local day", () => {
+    const res = place(SAT_0600_LOCAL, [notBefore("09:00")]);
+    expect(res.assignments).toHaveLength(1);
+    const a = res.assignments[0]!;
+    expect(dayKeyInTz(a.startAt, TZ)).toBe("2026-07-11");
+    expect(hhmmInTz(a.startAt, TZ)).toBe("09:00");
+  });
+
+  it("pushes a candidate past not_after to the next local day", () => {
+    const res = place(SAT_1300_LOCAL, [notAfter("12:00")]);
+    expect(res.assignments).toHaveLength(1);
+    const a = res.assignments[0]!;
+    expect(dayKeyInTz(a.startAt, TZ)).toBe("2026-07-12");
+    expect(hhmmInTz(a.startAt, TZ) <= "12:00").toBe(true);
+  });
+
+  it("resolves both bounds together — next day, then the morning bound", () => {
+    // 13:00 local breaches `not_after`, so the card moves to tomorrow; tomorrow
+    // starts at 00:00, which breaches `not_before`, so it rises again. Two
+    // day-level and time-level jumps inside one repair budget.
+    const res = place(SAT_1300_LOCAL, [notBefore("09:00"), notAfter("12:00")]);
+    expect(res.assignments).toHaveLength(1);
+    const a = res.assignments[0]!;
+    expect(dayKeyInTz(a.startAt, TZ)).toBe("2026-07-12");
+    expect(hhmmInTz(a.startAt, TZ)).toBe("09:00");
+  });
+
+  it("reports no_slot rather than placing inside the bound", () => {
+    // One hour of horizon from 06:00 local: 09:00 is out of reach and the card
+    // takes the existing unplaceable path instead of being packed into a breach.
+    const res = place(SAT_0600_LOCAL, [notBefore("09:00")], 60);
+    expect(res.assignments).toEqual([]);
+    expect(res.conflicts.map((c) => c.reason)).toEqual(["no_slot"]);
+  });
+
+  it("places at the first slot when no bound is in force", () => {
+    // Guard the guard: the movement above is the rule and not the clock.
+    const res = place(SAT_0600_LOCAL, []);
+    expect(res.assignments[0]!.startAt).toBe(SAT_0600_LOCAL);
+  });
+});

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -497,12 +497,26 @@ export function slotFixtures(input: SlotInput): SlotResult {
     const row = scopeRowOf(f);
     const rf = ruleFixtureById.get(f.id);
     const day = dayKeyInTz(start, zone);
+    const time = hhmmInTz(start, zone);
     let bound = start;
     for (let i = 0; i < placementHard.length; i++) {
       const h = placementHard[i]!;
       if (!scopeCoversFixture(h.scope, rf, row)) continue;
       if (h.type === "max_fixtures_per_day") {
         if ((dayCounts[i]!.get(day) ?? 0) >= h.count) bound = Math.max(bound, dayStart(ymdAddDays(day, 1)));
+      }
+      // WALL-CLOCK bounds in the org zone, never instants (constraints.ts:56).
+      // Compared with the same `<` / `>` the verifier uses, so a start landing
+      // exactly ON the bound is legal to both — an off-by-one here would place
+      // boards the gate then refuses.
+      if (h.type === "not_before" && time < h.time) {
+        bound = Math.max(bound, zonedTimeToUtc(day, h.time, zone));
+      }
+      // Too late in the day is not repairable within the day: the only earlier
+      // instants are the ones already rejected, so the next day is the earliest
+      // that can hold it.
+      if (h.type === "not_after" && time > h.time) {
+        bound = Math.max(bound, dayStart(ymdAddDays(day, 1)));
       }
     }
     return bound > start ? bound : null;

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -6,7 +6,13 @@
 // occupancy and warns on per-person overlaps. No wall-clock reads — all times
 // are injected (the same unit throughout, e.g. epoch ms); durations are minutes.
 import type { EntrantId } from "../core/types.ts";
-import type { ConstraintScope, FixtureSelector, HardConstraint, SchedulingConstraints } from "./constraints.ts";
+import type {
+  ConstraintScope,
+  FixtureSelector,
+  HardConstraint,
+  SchedulingConstraints,
+  WeekdayCode,
+} from "./constraints.ts";
 import { dayKeyInTz, hhmmInTz, weekdayOfYmd, ymdAddDays, zonedTimeToUtc } from "./tz.ts";
 
 const MS_PER_MIN = 60_000;
@@ -469,6 +475,35 @@ export function slotFixtures(input: SlotInput): SlotResult {
     }
     return out;
   };
+  /** Which of THIS run's cards each day-target rule names, index-aligned with
+   *  `placementHard`; `null` means the placer cannot resolve the selector and
+   *  the rule is skipped.
+   *
+   *  With `ruleFixtures` it is `resolveSelector`, the verifier's own function,
+   *  so both sides name the same cards. Without them only an `id` selector can
+   *  be resolved — `terminal` and `ext_key` need metadata a
+   *  `SchedulableFixture` does not carry, and inventing it (treating every card
+   *  as terminal, say) would bind a final's rule to the whole draw. Which is
+   *  also what the verifier does with no `ruleFixtures`: `resolveSelector` over
+   *  an empty list names nothing. */
+  const selectorNames = placementHard.map((h) => {
+    if (h.type !== "fixture_on_weekday" && h.type !== "fixture_on_date") return null;
+    if (config.ruleFixtures !== undefined) {
+      return new Set(resolveSelector(h.selector, h.scope, config.ruleFixtures).map((x) => x.id));
+    }
+    return h.selector.kind === "id" ? new Set([h.selector.fixtureId]) : null;
+  });
+  /** The next day strictly after `from` falling on `want`. At most one week,
+   *  and one JUMP either way — the repair budget is spent on courts, not on
+   *  stepping through the days in between. */
+  const nextYmdWithWeekday = (from: string, want: WeekdayCode): string => {
+    let y = from;
+    for (let d = 0; d < 7; d++) {
+      y = ymdAddDays(y, 1);
+      if (weekdayOfYmd(y) === want) break;
+    }
+    return y;
+  };
   const countDay = (row: ScopeRow, rf: RuleFixture | undefined, startAt: number): void => {
     if (tz === undefined) return;
     const day = dayKeyInTz(startAt, tz);
@@ -517,6 +552,21 @@ export function slotFixtures(input: SlotInput): SlotResult {
       // that can hold it.
       if (h.type === "not_after" && time > h.time) {
         bound = Math.max(bound, dayStart(ymdAddDays(day, 1)));
+      }
+      // Day targets name a CARD, so the selector decides — a rule about the
+      // final may not move the group stage that shares its division.
+      if (h.type === "fixture_on_date" || h.type === "fixture_on_weekday") {
+        const names = selectorNames[i]!;
+        if (names === null || !names.has(f.id)) continue;
+        if (h.type === "fixture_on_weekday") {
+          if (weekdayOfYmd(day) !== h.weekday) bound = Math.max(bound, dayStart(nextYmdWithWeekday(day, h.weekday)));
+          continue;
+        }
+        // This pass only ever moves a card LATER, so a target date already
+        // behind the candidate is unreachable: say so instead of spending the
+        // repair budget proving it, and let the caller report `no_slot`.
+        if (day > h.date) return Infinity;
+        if (day < h.date) bound = Math.max(bound, dayStart(h.date));
       }
     }
     return bound > start ? bound : null;
@@ -670,8 +720,11 @@ export function slotFixtures(input: SlotInput): SlotResult {
         // strictly greater than `start`, so the loop always makes progress.
         const bound = nextAcceptableStart(f, start);
         if (bound === null) break;
-        lb = bound;
         start = null;
+        // `Infinity` — no later instant can ever satisfy the rule. Abandon this
+        // court now; the unplaceable path reports it.
+        if (!Number.isFinite(bound)) break;
+        lb = bound;
       }
       if (start === null) continue;
       if (start > window.notAfter) {

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -7,7 +7,7 @@
 // are injected (the same unit throughout, e.g. epoch ms); durations are minutes.
 import type { EntrantId } from "../core/types.ts";
 import type { ConstraintScope, FixtureSelector, HardConstraint, SchedulingConstraints } from "./constraints.ts";
-import { dayKeyInTz, hhmmInTz, weekdayOfYmd } from "./tz.ts";
+import { dayKeyInTz, hhmmInTz, weekdayOfYmd, ymdAddDays, zonedTimeToUtc } from "./tz.ts";
 
 const MS_PER_MIN = 60_000;
 
@@ -42,6 +42,20 @@ export interface SlotConfig {
   horizonMinutes?: number; // how far past startAt to search before reporting no_slot
   /** Constraints v2 (Jul3/04 §3) — extends, never replaces, the base pass. */
   constraints?: SchedulingConstraints;
+  /** The ORG zone (#397), spelled exactly as `VerifyConfig` spells it so ONE
+   *  config object can drive the placer and the verifier and neither can be
+   *  handed a different clock. A typed rule that needs a calendar day or a
+   *  wall-clock time is SKIPPED when this is absent rather than bucketed in UTC
+   *  — placing around a rule the organiser never expressed is worse than not
+   *  placing around it, and it is the #448 defect in the other direction. */
+  tz?: string;
+  /** Fixture metadata for the typed rules, exactly as `VerifyConfig` takes it:
+   *  a `fixture_on_date`/`fixture_on_weekday` selector resolves through it, and
+   *  a `max_fixtures_per_day` tally seeds from the `existing` cards it names.
+   *  Absent for every pre-#463 caller, and then the placer counts only what it
+   *  places and resolves only `id` selectors — which is exactly what the
+   *  verifier does with no `ruleFixtures` either. */
+  ruleFixtures?: readonly RuleFixture[];
 }
 
 export interface SchedulableFixture {
@@ -419,6 +433,81 @@ export function slotFixtures(input: SlotInput): SlotResult {
     ...(f.poolId !== undefined ? { poolId: f.poolId } : {}),
     ...(f.divisionId !== undefined ? { divisionId: f.divisionId } : {}),
   });
+  // --- typed rules the PLACER refuses a slot over (#463) --------------------
+  //
+  // `validateAssignments` has always reported these families; `slotFixtures`
+  // packed straight through them. That is the placer/verifier fork in its
+  // costliest form: Auto proposes a board the apply gate warns about, and
+  // re-running Auto proposes the same board again because the placer does not
+  // know the rule exists.
+  //
+  // Every family here needs a calendar day or a wall-clock time, so every one
+  // of them needs the ORG zone. Without one the whole block is INERT — the same
+  // ruling `VerifyConfig.tz` documents, and the reason every pre-#463 caller
+  // (none of which can set `tz`, because `SlotConfig` had no such field) keeps
+  // its exact previous behaviour.
+  const tz = config.tz;
+  const placementHard: readonly HardConstraint[] =
+    tz === undefined ? [] : hard.filter((h) => h.type !== "min_rest_minutes");
+  const ruleFixtureById = ruleFixtureIndex(config);
+  /** Per-RULE day tallies for `max_fixtures_per_day`, index-aligned with
+   *  `placementHard`. Per rule and not per day because two rules can cap the
+   *  same day at different numbers for different scopes. */
+  const dayCounts = placementHard.map(() => new Map<string, number>());
+  /** The instant a calendar day begins in the org zone. Never `+ 86_400_000`:
+   *  a DST day is 23 or 25 hours long. */
+  const dayStart = (ymd: string): number => zonedTimeToUtc(ymd, "00:00", tz as string);
+  /** Which `max_fixtures_per_day` rules bind a row, as indices. One resolution
+   *  for the tally READ at placement time and the tally WRITE at commit time —
+   *  two scope walks is how a placer and a verifier fork in the first place. */
+  const dayCapRulesFor = (row: ScopeRow, rf: RuleFixture | undefined): number[] => {
+    const out: number[] = [];
+    for (let i = 0; i < placementHard.length; i++) {
+      const h = placementHard[i]!;
+      if (h.type !== "max_fixtures_per_day" || !scopeCoversFixture(h.scope, rf, row)) continue;
+      out.push(i);
+    }
+    return out;
+  };
+  const countDay = (row: ScopeRow, rf: RuleFixture | undefined, startAt: number): void => {
+    if (tz === undefined) return;
+    const day = dayKeyInTz(startAt, tz);
+    for (const i of dayCapRulesFor(row, rf)) dayCounts[i]!.set(day, (dayCounts[i]!.get(day) ?? 0) + 1);
+  };
+  // Seed from the rest of the board. A cap is a statement about how busy a day
+  // is, and a day is exactly as busy as everything already on it — the same
+  // count `validateInstructionRules` takes, including its filter: only entries
+  // that are KNOWN FIXTURES count, because an outside booking or a closed court
+  // is not a fixture and counting one would invent a cap breach.
+  for (const a of input.existing ?? []) {
+    const rf = ruleFixtureById.get(a.fixtureId);
+    if (rf !== undefined) countDay(a, rf, a.startAt);
+  }
+
+  /** The earliest start ≥ `start` that every typed rule binding this fixture
+   *  would accept, or `null` when `start` itself is already acceptable.
+   *
+   *  Returns a bound rather than a boolean because the rejections are
+   *  DAY-LEVEL: the repair loop below gets 64 tries, and stepping a half-hour
+   *  at a time would exhaust well inside the very day the rule is telling it to
+   *  leave. */
+  const nextAcceptableStart = (f: SchedulableFixture, start: number): number | null => {
+    if (placementHard.length === 0) return null;
+    const zone = tz as string;
+    const row = scopeRowOf(f);
+    const rf = ruleFixtureById.get(f.id);
+    const day = dayKeyInTz(start, zone);
+    let bound = start;
+    for (let i = 0; i < placementHard.length; i++) {
+      const h = placementHard[i]!;
+      if (!scopeCoversFixture(h.scope, rf, row)) continue;
+      if (h.type === "max_fixtures_per_day") {
+        if ((dayCounts[i]!.get(day) ?? 0) >= h.count) bound = Math.max(bound, dayStart(ymdAddDays(day, 1)));
+      }
+    }
+    return bound > start ? bound : null;
+  };
+
   const restForMs = (f: SchedulableFixture): number =>
     (hard.length === 0
       ? effectiveRestMinutes(config, f)
@@ -506,6 +595,10 @@ export function slotFixtures(input: SlotInput): SlotResult {
     };
     bookings.push(assignment);
     placed.push(assignment);
+    // Locked fixtures come through here too, and they fill the day just as much
+    // as a placed one — a pinned card the organiser cannot move is precisely
+    // what makes the next one breach the cap.
+    countDay(assignment, ruleFixtureById.get(f.id), start);
     for (const k of restKeysOf(f)) lastEnd.set(k, Math.max(lastEnd.get(k) ?? -Infinity, assignment.endAt));
     // Per-person overlap against everything already on the board (warn only).
     for (const person of assignment.people) {
@@ -554,8 +647,16 @@ export function slotFixtures(input: SlotInput): SlotResult {
         start = earliestOnCourt(court, lb, durMs, gapMs, horizon, bookings, blackouts);
         if (start === null) break;
         const clash = personBlocked(f, start) ?? blockModeBlocked(start);
-        if (clash === null) break;
-        lb = Math.max(clash.endAt, start + 1);
+        if (clash !== null) {
+          lb = Math.max(clash.endAt, start + 1);
+          start = null;
+          continue;
+        }
+        // Typed-rule rejection (#463), on the same repair budget. The bound is
+        // strictly greater than `start`, so the loop always makes progress.
+        const bound = nextAcceptableStart(f, start);
+        if (bound === null) break;
+        lb = bound;
         start = null;
       }
       if (start === null) continue;

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -483,9 +483,15 @@ export function slotFixtures(input: SlotInput): SlotResult {
    *  so both sides name the same cards. Without them only an `id` selector can
    *  be resolved — `terminal` and `ext_key` need metadata a
    *  `SchedulableFixture` does not carry, and inventing it (treating every card
-   *  as terminal, say) would bind a final's rule to the whole draw. Which is
-   *  also what the verifier does with no `ruleFixtures`: `resolveSelector` over
-   *  an empty list names nothing. */
+   *  as terminal, say) would bind a final's rule to the whole draw.
+   *
+   *  The `id` branch is deliberately NOT symmetric with the verifier, and the
+   *  asymmetry is one-directional on purpose. `resolveSelector`'s `case "id"`
+   *  filters `ruleFixtures`, so with none it names nothing; here an `id`
+   *  selector still names its own card. The placer therefore AVOIDS a slot the
+   *  verifier would not have complained about — over-cautious, never
+   *  under-cautious, so it cannot produce a board the gate then warns about,
+   *  which is the only direction that matters. */
   const selectorNames = placementHard.map((h) => {
     if (h.type !== "fixture_on_weekday" && h.type !== "fixture_on_date") return null;
     if (config.ruleFixtures !== undefined) {

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -381,9 +381,24 @@ export function slotFixtures(input: SlotInput): SlotResult {
   const siblings = input.existing ?? []; // other divisions' fixed board (parallelism=block)
   const placed: Assignment[] = [];
   const conflicts: Conflict[] = [];
-  const lastEnd = new Map<EntrantId, number>(); // this division's per-entrant rest tracking
+  // Rest is owed to a PARTICIPANT, and a participant is an entrant OR a person
+  // (#463). Keyed by `EntrantId` alone, this map made a per-person rest rule
+  // invisible to the placer while `validateAssignments` still reported it
+  // (:1150) — two fixtures sharing a person but no entrant were packed adjacent
+  // and then flagged, which is the placer/verifier fork this module exists to
+  // prevent. `SchedulableFixture.people` (:52) already carried the participants;
+  // the placer simply never read them.
+  const lastEnd = new Map<string, number>(); // this division's per-participant rest tracking
   const courtUse = new Map<EntrantId, Map<string, number>>(); // fieldFairness=balance
   const lastCourt = new Map<EntrantId, string>(); // fieldFairness=rotate
+  // Namespaced, not concatenated: an entrant and a person are different
+  // participants even if their ids collide as strings, and fusing them would
+  // rest a fixture behind one it shares nothing with. `courtUse`/`lastCourt`
+  // stay entrant-keyed — field fairness is an entrant-level concept.
+  const restKeysOf = (f: SchedulableFixture): string[] => [
+    ...entrantsOf(f).map((e) => `entrant:${e}`),
+    ...(f.people ?? []).map((p) => `person:${p}`),
+  ];
   const c = config.constraints;
 
   // Jul3/04 §3 — shared with validateAssignments so the placer and the verifier
@@ -491,7 +506,7 @@ export function slotFixtures(input: SlotInput): SlotResult {
     };
     bookings.push(assignment);
     placed.push(assignment);
-    for (const e of ent) lastEnd.set(e, Math.max(lastEnd.get(e) ?? -Infinity, assignment.endAt));
+    for (const k of restKeysOf(f)) lastEnd.set(k, Math.max(lastEnd.get(k) ?? -Infinity, assignment.endAt));
     // Per-person overlap against everything already on the board (warn only).
     for (const person of assignment.people) {
       for (const other of bookings) {
@@ -526,7 +541,7 @@ export function slotFixtures(input: SlotInput): SlotResult {
     const restF = Math.max(restMs, restForMs(f));
     const window = windowFor(f);
     let ready = Math.max(config.startAt, window.notBefore);
-    for (const e of ent) ready = Math.max(ready, (lastEnd.get(e) ?? -Infinity) + restF);
+    for (const k of restKeysOf(f)) ready = Math.max(ready, (lastEnd.get(k) ?? -Infinity) + restF);
 
     let best: { court: string; start: number } | null = null;
     let windowBound = false;


### PR DESCRIPTION
Closes #467
Closes #463
Closes #458
Closes #449
Closes #450
Closes #462
Closes #461

Six of the seven items in the scheduling-correctness lane, as one programme. They
are not six bugs — they are one defect shape in six places:

> **A value present on one side of a seam and absent, or in a different
> namespace, on the other — where both sides typecheck.**
> The tell is always: two producers, one comparison, no normaliser.

Design: `docs/superpowers/specs/2026-08-05-scheduling-placer-convergence-design.md`.
Plans: `docs/superpowers/plans/2026-08-05-wave-1a-placer-convergence.md`,
`…-wave-1b-web-inputs.md`.

## Wave 1a — the engine places around what the gate checks

`slotFixtures` folded rest, `startWindows` and `crossPersonClash` and nothing
else, so `max_fixtures_per_day`, `not_before`, `not_after`, `fixture_on_weekday`
and `fixture_on_date` were **reported but never placed around**. `lastEnd` was
keyed by `EntrantId`, so rest owed to a shared *person* was invisible.

The symptom had a test pinning it: auto proposes a board, the gate immediately
warns about it, and re-running auto cannot fix it.

| commit | change |
| --- | --- |
| `cbacce65` | rest covers shared people, not only entrants |
| `a4572b2a` | place around `max_fixtures_per_day` on the ORG calendar day |
| `0a62c2df` | place around `not_before`/`not_after` as wall-clock in the org zone |
| `0e3af9eb` | place around `fixture_on_date`/`fixture_on_weekday` |
| `85520fc7` | parity test: the placer's output fed back to the verifier |
| `899a1c7c` | rebuild the two tests that pinned the old behaviour |
| `dd81fdd2` | correct a comment that overclaimed placer/verifier symmetry |

Day buckets use the existing DST-correct `dayKeyInTz`; no new helper, no
`toISOString().slice(0, 10)` — that pattern was #448. An absent `tz` SKIPS the
rule rather than bucketing in UTC.

**The parity test is the deliverable that stops this recurring.** It feeds the
placer's own output back into `validateAssignments` and asserts zero
self-inflicted violations per family. Mutation-proved: restoring the pre-fix
`calendar.ts` makes it **0 passed / 5 failed**, with 6, 3, 7, 3 and 3 violations.

## Wave 1b — the web hands the engine one namespace

| commit | change |
| --- | --- |
| `3e377453` | ONE engine-constraints builder; `startWindows` unpinned (#458) |
| `27b26d36` | one pool namespace at the engine boundary (#449) |
| `de6978e0` | person-scoped rules collapse with the roster resolver (#450) |
| `067b342d` | sibling fixtures carry their rule identity (#462) |
| `df5848d8` | `moveFixture` returns the conflicts it computes (#461) |

Two received descriptions of this work were **false**, and the survey proved it
before any code was written:

- *"#458 is a copy of either sibling."* The siblings disagreed — one dropped
  unrecognised `target.kind`, one passed everything through — and there was **no
  shared builder**: `verifyConfig`, `toSlotConfig` and the joint builder were
  three independent literals over one shape, with a fourth in `jointSlotConfig`.
  A copy would have added a fifth producer to a bug class defined by having too
  many. It is now an extraction, with the filtering behaviour canonical.
- *"#462: the joint path gets this right, copy it."* **Nothing anywhere built
  `RuleFixture[]` for siblings.** There was no correct path to copy.

`buildEngineConstraints` takes its policy **required**, not optional: a default
would either drop the organiser's `fieldFairness` or carry `hard` onto the AI
paths, where `effectiveHard` merges it with the top-level field and every
durable rule counts twice.

## Wire changes

PATCH `/fixtures/{id}` now returns `conflicts[]`. Warn-level conflicts were
computed and silently discarded, so a drag that produced a warned-about board
told the organiser nothing.

`Fixture` gained `fixture_no`. It is NOT NULL (`V263__routing_slugs.sql:37`,
plus an always-firing trigger), rides `FIXTURE_COLS`, and is served by every
fixture route — but was declared in no schema and no spec. It surfaced because
the new test runs the response schema over a real payload, and it was added
rather than weakening the assertion to accommodate a known lie. Additive; it
documents what was already served.

Both specs regenerated. The payload is asserted directly —
`PatchedFixture.parse(wire)).toEqual(wire)` against a live DB-backed response —
because `openapi:gen` regenerates from the zod schema, which nothing applies at
runtime, and so cannot tell you the served JSON changed.

## Behaviour changes to expect

- **Auto-schedule now returns compliant boards.** `schedule-durable-hard-surfaces.test.ts`
  went from asserting 6 `warn.instruction` conflicts to zero. Surfaces 2-4 were
  rebuilt on an explicitly violating board the test constructs, so the pinned
  product decision — an instruction conflict is warn-only, and an organiser is
  never locked out of the board they need in order to fix it — is still covered.
- **The AI pack drafts 22 of 28 fixtures where it drafted 26.** Two entrants
  share a player and were placed 30 minutes apart with **zero** person rest;
  honouring rest stretches the makespan past the session window. Those four were
  previously drafted *in violation*. The snapshot was proven before re-recording
  (`{...pack, draft: 0}` byte-identical, all 40 ids present, order stable) and a
  direct person-rest assertion now guards the recorded times.

No i18n keys were added and none are owed: the drag surface already repaints
conflict badges via `queueValidate()` after every drop, so #461's gap was the
API contract, not the console.

## Verification

| gate | result |
| --- | --- |
| engine unit | **2320 total / 0 failed** / 97 suites / 0 empty |
| apps/web unit | **5351 passed / 5403 total** / 606 suites / 0 empty |
| smoke | **751 passed / 0 failed**, standalone server, fresh DB |
| e2e | **18/18** — `schedule-panels` + full `ai-architect`, incl. 390px mobile |
| lint / tsc | clean both workspaces |
| drift | `openapi:gen` + `i18n:gen-keys` → porcelain empty |
| review | Wave 1a 6/6 checks, Wave 1b 7/7 checks, **no findings** |

The 2 remaining unit failures are `credits-bootstrap-grant` / `credits-monthly-cron`,
which pass **165/0 in isolation** — machine-load timeouts, reproduced and
confirmed rather than assumed.

## Known and deliberately not fixed here

`crossPersonClash` is pinned to `"warn"` on both AI paths while the board path
honours the organiser's stored value — the same shape as #458. Honouring a hard
value would make the solver refuse boards it currently only warns about, which
is a product decision rather than a mechanical fix. Now visible in one place
(`AI_VERIFY_POLICY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)