### PR TITLE
The placer avoids a person double-booking whatever crossPersonClash says

### DIFF
--- a/apps/web/src/server/usecases/__tests__/schedule-pool-namespace.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-pool-namespace.test.ts
@@ -115,7 +115,7 @@ function settings(constraints: Record<string, unknown>): ScheduleSettingsOut {
       perEntrantMinRest: 30,
       constraints,
     }),
-    tz: "UTC",
+    displayTz: "UTC",
     orgTz: "UTC",
     updated_at: iso(T0),
   };

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -474,11 +474,13 @@ export async function buildCompetitionPack(
     // Two consumers, one map, loaded once here because both need it before the
     // per-division build loop starts:
     //
-    //  * `fixedOccupancy` below. Under `crossPersonClash: "hard"` slotFixtures
-    //    rejects any placement overlapping someone already committed in
-    //    `existing` (calendar.ts:275-283), so an empty people list silently
-    //    disables that block and lets a draft double-book a person against a
-    //    fixture nobody can move.
+    //  * `fixedOccupancy` below. `slotFixtures` rejects any placement
+    //    overlapping someone already committed in `existing` — unconditionally
+    //    now, not only under `crossPersonClash: "hard"`, because the write gate
+    //    refuses an introduced person overlap whatever that setting says. So an
+    //    empty people list silently disables that block and lets a draft
+    //    double-book a person against a fixture nobody can move, which the
+    //    organiser then cannot apply.
     //  * the #396 identity guard and participant recursion. Deliberately the
     //    FULL entrant→persons map and not the pack's `people` display list: that
     //    one keeps only persons rostered into 2+ entrants, which is exactly the
@@ -588,8 +590,9 @@ export async function buildCompetitionPack(
         entrants: [r.home_entrant_id, r.away_entrant_id].filter((e): e is string => e !== null),
         // Unlike the drafts below, these rows come from this module's own SQL,
         // so the person data IS available — and it is load-bearing: it is what
-        // makes `crossPersonClash: "hard"` reject a draft that would commit
-        // someone already playing in another division's fixed fixture.
+        // makes `slotFixtures` reject a draft that would commit someone already
+        // playing in another division's fixed fixture. No longer conditional on
+        // `crossPersonClash`: the placer avoids what the write gate blocks.
         //
         // BOTH the raw id and its guarded key, deliberately. This list is handed
         // to a per-division greedy pass whose own fixtures carry that division's
@@ -1291,18 +1294,16 @@ export function jointFeedDependencies(pack: CompetitionPack): OrderDependency[] 
  *                        avoids the divisions drafted BEFORE it and never those
  *                        after), so honouring it in the verifier would turn a
  *                        build-order artefact into a verdict.
- *    crossPersonClash: warn   matches the single-division AI PLAN path
- *                        (`verifyConfig`, schedule-ai.ts:914) — this function's
- *                        actual twin. It does NOT match the single-division
- *                        APPLY path, and that asymmetry is deliberate on both
- *                        sides: `applySchedule` hands the division's real
- *                        setting to `mapConflicts` (schedule.ts:553) and refuses
- *                        a hand-placed person double-booking, while the plan
- *                        path warns and never asks the model to repair it.
- *                        An earlier version of this comment claimed the two
- *                        matched "exactly". They never did. The joint APPLY
- *                        re-applies the setting itself rather than changing this
- *                        line — see `applyCompetitionSchedule`. */
+ *    crossPersonClash: warn   INERT, and left here only so this literal keeps
+ *                        parsing. Nothing reads the field any more: #399 made
+ *                        the write gate refuse an INTRODUCED person overlap
+ *                        absolutely (`isBlockingConflict` lists
+ *                        `person_overlap` unconditionally), and the placer now
+ *                        avoids one for that same reason rather than consulting
+ *                        the setting. The asymmetry earlier revisions of this
+ *                        comment documented — plan warns, apply refuses — is
+ *                        therefore gone: both sides refuse. Do not restore a
+ *                        branch on this value without first changing the gate. */
 export function verifyConfigFor(
   division: CompetitionPackDivision,
   /** The RUN's resolved calendar window, epoch ms (#397). Optional, but the

--- a/packages/engine/src/scheduling/calendar-person-clash-placement.test.ts
+++ b/packages/engine/src/scheduling/calendar-person-clash-placement.test.ts
@@ -1,0 +1,213 @@
+// The placer must avoid a person double-booking whatever `crossPersonClash`
+// says, because the WRITE GATE already refuses one whatever it says.
+//
+// `assertNoNewBlocking` (apps/web schedule.ts) filters the delta through
+// `isBlockingConflict`, which lists `person_overlap` unconditionally — #399
+// retired the setting as the switch, and `competition-schedule-apply.test.ts`
+// pins that with a clean A/B ("refuses an INTRODUCED person double-booking
+// whatever crossPersonClash says").
+//
+// The gap is narrower than it first looks, and the two cases are worth keeping
+// straight:
+//
+//   draft vs draft      already safe. #463 widened `lastEnd` to namespaced
+//                       `person:` keys, so two movable cards sharing a person
+//                       serialise through the REST path even at `restF = 0`.
+//                       Guarded below so a narrowing of `restKeysOf` is caught.
+//   draft vs `existing`  NOT safe. `input.existing` seeds `bookings` and
+//                       `dayCounts` and never `lastEnd`, so the rest path is
+//                       blind to a person already committed on a sibling
+//                       division's fixed board. `personBlocked` was the only
+//                       guard, and it was gated on `crossPersonClash === "hard"`.
+//
+// That second case is exactly what both AI plan paths hit: they load the
+// entrant→people map specifically so the block can bite
+// (`competition-schedule-ai.ts:442`) and then pin the setting to "warn". Auto
+// proposes a board double-booking someone against a fixed card nobody can move,
+// Apply 409s, and re-running Auto proposes the same board again — the
+// placer/verifier fork, in the one family where the gate is absolute.
+import { describe, expect, it } from "vitest";
+import {
+  slotFixtures,
+  validateAssignments,
+  type Assignment,
+  type SchedulableFixture,
+  type SlotConfig,
+} from "./calendar.ts";
+import { SchedulingConstraints } from "./constraints.ts";
+
+const TZ = "America/Los_Angeles";
+const SAT_1000_LOCAL = Date.UTC(2026, 6, 11, 17, 0);
+const MIN = 60_000;
+
+const configFor = (clash: "warn" | "hard"): SlotConfig => ({
+  startAt: SAT_1000_LOCAL,
+  matchMinutes: 30,
+  gapMinutes: 0,
+  perEntrantMinRest: 0,
+  courts: ["C1", "C2"],
+  blackouts: [],
+  sessionWindows: [],
+  tz: TZ,
+  horizonMinutes: 60 * 24 * 7,
+  constraints: SchedulingConstraints.parse({ crossPersonClash: clash }),
+});
+
+// A sibling division's card, already committed: it occupies C1 for the first
+// half hour and carries person p1. Deliberately on a DIFFERENT court set entry
+// than the one the draft will prefer second, so court occupancy alone can never
+// be what moves the draft — only the person can.
+const committed = (): Assignment[] => [
+  {
+    fixtureId: "sib1",
+    court: "C1",
+    startAt: SAT_1000_LOCAL,
+    endAt: SAT_1000_LOCAL + 30 * MIN,
+    entrants: ["e7", "e8"],
+    people: ["p1"],
+    divisionId: "d2",
+  },
+];
+
+// One movable card sharing p1 with the committed one. Its own entrants are
+// disjoint from the sibling's, so no rest or entrant rule can serialise it.
+const draft = (): SchedulableFixture[] => [
+  { id: "f1", home: "e1", away: "e2", divisionId: "d1", people: ["p1"] },
+];
+
+describe("the placer never introduces a person double-booking", () => {
+  it.each(["warn", "hard"] as const)(
+    "avoids a person already committed on a sibling division's board (crossPersonClash=%s)",
+    (clash) => {
+      const config = configFor(clash);
+      const existing = committed();
+      const { assignments, conflicts } = slotFixtures({
+        fixtures: draft(),
+        config,
+        existing,
+      });
+
+      // Placed, not refused. C2 is free from the first instant and the horizon
+      // is a week, so an unplaced card here would mean the placer
+      // over-constrained — and without this line "place nothing" would satisfy
+      // every assertion below.
+      expect(assignments).toHaveLength(1);
+      expect(conflicts.filter((c) => c.reason === "no_slot")).toEqual([]);
+
+      // The placer's own report AND the verifier's, because the fork is exactly
+      // a disagreement between the two. Feeding the placer's output back through
+      // `validateAssignments` — with the same `existing` the placer saw — is
+      // what makes this a parity assertion rather than a restatement of the
+      // placer's opinion of itself.
+      expect(conflicts.filter((c) => c.reason === "person_overlap")).toEqual([]);
+      expect(
+        validateAssignments(assignments, config, existing).filter(
+          (c) => c.reason === "person_overlap",
+        ),
+      ).toEqual([]);
+
+      // Named: it moved in TIME, past the committed card, rather than taking the
+      // free court alongside it. C2 was available at the first instant, so this
+      // is the assertion that would fail if the placer merely dodged the COURT.
+      expect(assignments[0]!.startAt).toBeGreaterThanOrEqual(SAT_1000_LOCAL + 30 * MIN);
+    },
+  );
+
+  it("still packs cards in parallel when they share nobody", () => {
+    // The guard that makes the cases above meaningful. Serialising EVERY card
+    // would satisfy "no person overlap" trivially and would be a real
+    // regression — boards would run days longer for no reason. Same shape, same
+    // config, only the shared person removed.
+    const config = configFor("warn");
+    const existing: Assignment[] = [{ ...committed()[0]!, people: ["p9"] }];
+    const { assignments } = slotFixtures({ fixtures: draft(), config, existing });
+
+    expect(assignments).toHaveLength(1);
+    expect(assignments[0]!.startAt).toBe(SAT_1000_LOCAL);
+    expect(assignments[0]!.court).toBe("C2");
+  });
+
+  it("serialises two MOVABLE cards sharing a person, through the rest path (#463)", () => {
+    // Already true before this change — `lastEnd` carries `person:` keys — and
+    // asserted here so a narrowing of `restKeysOf` cannot quietly re-open the
+    // draft-vs-draft half of the same hole.
+    const config = configFor("warn");
+    const both: SchedulableFixture[] = [
+      { id: "f1", home: "e1", away: "e2", divisionId: "d1", people: ["p1"] },
+      { id: "f2", home: "e3", away: "e4", divisionId: "d1", people: ["p1"] },
+    ];
+    const { assignments, conflicts } = slotFixtures({ fixtures: both, config });
+
+    expect(assignments).toHaveLength(2);
+    expect(conflicts.filter((c) => c.reason === "person_overlap")).toEqual([]);
+    expect(Math.abs(assignments[0]!.startAt - assignments[1]!.startAt)).toBeGreaterThanOrEqual(
+      30 * MIN,
+    );
+  });
+
+  it("names the person when one is why the card could not be placed at all", () => {
+    // The cost of avoidance: where a `warn` board used to place the card and
+    // report `person_overlap` — which names the human — an unavoidable clash now
+    // ends as an unplaced card, and a bare "no court/time within horizon" would
+    // lose the one fact the organiser needs to act on.
+    //
+    // Still `no_slot` and not `person_overlap`: nothing was placed, so no
+    // overlap exists on the board, and `person_overlap` is BLOCKING — reporting
+    // one for a card the placer declined to place would refuse the organiser's
+    // apply over a fixture that is not even on the board.
+    // p1 is committed for ten hours while the horizon is one, so EVERY candidate
+    // start inside the horizon collides with them. Sized this way on purpose: a
+    // sibling that merely ends early is escapable, and the placer escapes it by
+    // starting afterwards — which is the behaviour the cases above assert.
+    const config: SlotConfig = { ...configFor("warn"), courts: ["C1"], horizonMinutes: 60 };
+    const existing: Assignment[] = [
+      {
+        fixtureId: "sib",
+        court: "C9",
+        startAt: SAT_1000_LOCAL,
+        endAt: SAT_1000_LOCAL + 600 * MIN,
+        entrants: ["e7", "e8"],
+        people: ["p1"],
+        divisionId: "d2",
+      },
+    ];
+    const { assignments, conflicts } = slotFixtures({ fixtures: draft(), config, existing });
+
+    expect(assignments).toEqual([]);
+    const unplaceable = conflicts.filter((c) => c.reason === "no_slot");
+    expect(unplaceable).toHaveLength(1);
+    expect(unplaceable[0]!.detail).toContain("p1");
+    expect(unplaceable[0]!.detail).toContain("sib");
+    expect(conflicts.some((c) => c.reason === "person_overlap")).toBe(false);
+  });
+
+  it("reports — and does not silently drop — an overlap the organiser PINNED", () => {
+    // Avoidance is a placement rule, so it can only bind cards the placer is
+    // free to move. A locked pair is honoured as pinned and the overlap comes
+    // back as a warning, which is the behaviour the write gate's DELTA basis
+    // depends on: a board that already carries an overlap must stay applyable.
+    const config = configFor("warn");
+    const pinned: SchedulableFixture[] = [
+      {
+        id: "f1",
+        home: "e1",
+        away: "e2",
+        divisionId: "d1",
+        people: ["p1"],
+        locked: { court: "C1", startAt: SAT_1000_LOCAL },
+      },
+      {
+        id: "f2",
+        home: "e3",
+        away: "e4",
+        divisionId: "d1",
+        people: ["p1"],
+        locked: { court: "C2", startAt: SAT_1000_LOCAL },
+      },
+    ];
+    const { assignments, conflicts } = slotFixtures({ fixtures: pinned, config });
+
+    expect(assignments).toHaveLength(2);
+    expect(conflicts.filter((c) => c.reason === "person_overlap")).not.toEqual([]);
+  });
+});

--- a/packages/engine/src/scheduling/calendar.test.ts
+++ b/packages/engine/src/scheduling/calendar.test.ts
@@ -77,7 +77,13 @@ describe("slotFixtures — greedy placement (spec 05 §2.6)", () => {
     expect((assignments[0] as Assignment).startAt).toBe(35 * MIN);
   });
 
-  it("warns (does not block) on a per-person overlap across divisions", () => {
+  it("moves a per-person overlap across divisions off the clash, rather than warning", () => {
+    // Was "warns (does not block)" until #399 made the write gate absolute for
+    // an INTRODUCED person overlap whatever `crossPersonClash` says. A placer
+    // that took the free court here proposed a board the gate then refused, and
+    // re-running Auto proposed it again. It now steps past the sibling card.
+    // The warning still exists for an overlap the placer did not introduce —
+    // see the locked case in calendar-person-clash-placement.test.ts.
     const existing: Assignment[] = [
       { fixtureId: "sib", court: "C9", startAt: 0, endAt: 30 * MIN, entrants: ["X"], people: ["kid1"] },
     ];
@@ -89,9 +95,11 @@ describe("slotFixtures — greedy placement (spec 05 §2.6)", () => {
       config: baseConfig({ courts: ["C1"] }),
       existing,
     });
-    // Placed at 0 on a free court, but kid1 also plays sib at 0 → warn.
+    // C1 is free the whole time — only kid1 can move this card, so the start
+    // time is the assertion that a court-only dodge would fail.
     expect(assignments).toHaveLength(1);
-    expect(conflicts.some((c) => c.reason === "person_overlap")).toBe(true);
+    expect((assignments[0] as Assignment).startAt).toBeGreaterThanOrEqual(30 * MIN);
+    expect(conflicts.some((c) => c.reason === "person_overlap")).toBe(false);
   });
 
   it("honours a locked slot and reports a court clash rather than moving it", () => {

--- a/packages/engine/src/scheduling/calendar.ts
+++ b/packages/engine/src/scheduling/calendar.ts
@@ -605,10 +605,26 @@ export function slotFixtures(input: SlotInput): SlotResult {
     return { notBefore, notAfter };
   };
 
-  // crossPersonClash=hard (Jul3/04 §2): a person double-booking rejects the
-  // placement like a court clash instead of warning after the fact.
+  // A person double-booking rejects the placement like a court clash, for every
+  // `crossPersonClash` setting.
+  //
+  // NOT gated on `crossPersonClash === "hard"` any more (Jul3/04 §2 as amended
+  // by #399). The write gate refuses an INTRODUCED person overlap whatever the
+  // setting says — `isBlockingConflict` lists `person_overlap` unconditionally,
+  // and `assertNoNewBlocking` takes the delta — so a placer that honoured the
+  // setting here proposed boards the gate then refused, with re-running Auto
+  // proposing the same board again. Avoiding what the gate blocks is not an
+  // opt-in.
+  //
+  // The setting still means something at the REPORT boundary, which is why it
+  // survives: `warn` boards published before #399 keep their overlaps, keep
+  // being reported, and stay applyable on the delta basis. What it no longer
+  // does is tell the placer to walk into one.
+  //
+  // Draft-vs-draft was already covered by the `person:` rest keys (#463); this
+  // is what guards draft-vs-`existing`, which seeds `bookings` but never
+  // `lastEnd`. Both halves are pinned in calendar-person-clash-placement.test.ts.
   const personBlocked = (f: SchedulableFixture, start: number): Assignment | null => {
-    if (c?.crossPersonClash !== "hard") return null;
     const people = f.people ?? [];
     if (people.length === 0) return null;
     const end = start + durMs;
@@ -708,6 +724,13 @@ export function slotFixtures(input: SlotInput): SlotResult {
 
     let best: { court: string; start: number } | null = null;
     let windowBound = false;
+    // The last person this fixture was pushed off, if any. Kept so an
+    // UNPLACEABLE card can still name the human who made it unplaceable: before
+    // person avoidance became unconditional, a `warn` board always placed and
+    // reported `person_overlap`, which names the person in its detail. Without
+    // this the same situation degrades to a bare "no court/time within horizon"
+    // and the organiser loses the one fact that tells them what to change.
+    let personBound: { person: string; other: string } | null = null;
     for (const court of config.courts) {
       // repair loop: person-clash / block-parallelism rejections push the
       // candidate later on the same court instead of silently placing
@@ -716,8 +739,13 @@ export function slotFixtures(input: SlotInput): SlotResult {
       for (let i = 0; i < 64; i++) {
         start = earliestOnCourt(court, lb, durMs, gapMs, horizon, bookings, blackouts);
         if (start === null) break;
-        const clash = personBlocked(f, start) ?? blockModeBlocked(start);
+        const person = personBlocked(f, start);
+        const clash = person ?? blockModeBlocked(start);
         if (clash !== null) {
+          if (person !== null) {
+            const shared = (f.people ?? []).find((p) => person.people.includes(p));
+            if (shared !== undefined) personBound = { person: shared, other: person.fixtureId };
+          }
           lb = Math.max(clash.endAt, start + 1);
           start = null;
           continue;
@@ -756,12 +784,21 @@ export function slotFixtures(input: SlotInput): SlotResult {
 
     if (best === null) {
       // over-constrained: best-effort + a named binding constraint (Jul3/04 §7)
+      //
+      // Still `no_slot` when a person was the binding constraint, deliberately
+      // NOT `person_overlap`. Nothing was placed, so there is no overlap on the
+      // board to report — and `person_overlap` is BLOCKING, so claiming one here
+      // would make a card the placer declined to place refuse the organiser's
+      // apply. The person travels in `detail`, which is part of `conflictKey`
+      // and so already distinguishes this from an ordinary exhausted horizon.
       conflicts.push({
         fixtureId: f.id,
         reason: windowBound ? "start_window" : "no_slot",
         detail: windowBound
           ? "no feasible slot before the start window's notAfter bound"
-          : "no court/time within horizon",
+          : personBound !== null
+            ? `no court/time within horizon free of person ${personBound.person} (also in ${personBound.other})`
+            : "no court/time within horizon",
       });
       continue;
     }

--- a/packages/engine/src/scheduling/constraints.ts
+++ b/packages/engine/src/scheduling/constraints.ts
@@ -110,7 +110,14 @@ export const SchedulingConstraints = z.object({
   startWindows: z.array(StartWindow).default([]),
   fieldFairness: z.enum(["off", "balance", "rotate"]).default("off"), // 14 Apr
   parallelism: z.enum(["block", "mixed"]).default("mixed"), // 29 May
-  crossPersonClash: z.enum(["warn", "hard"]).default("warn"), // Jul3/04 §2
+  /** @deprecated Accepted and stored, read by nothing. Jul3/04 §2 made this the
+   *  switch for whether a person double-booking blocked; #399 then made the
+   *  write gate refuse an INTRODUCED one absolutely (`isBlockingConflict` lists
+   *  `person_overlap` unconditionally), and the placer now avoids one for the
+   *  same reason — so neither side consults it. Kept so stored settings and the
+   *  wire schema keep parsing; the organiser-facing control it backs should be
+   *  retired in its own change, with the UI and dictionaries. */
+  crossPersonClash: z.enum(["warn", "hard"]).default("warn"),
   /** Durable division rules, in the SAME vocabulary a compiled instruction
    *  produces (#398), so hard rules have exactly one home and the referee reads
    *  one list. Defaults to [] so every pre-W3 persisted


### PR DESCRIPTION
## The fork

The write gate has refused an INTRODUCED `person_overlap` unconditionally since #399 — `isBlockingConflict` lists it with no reference to the setting, and `assertNoNewBlocking` takes the delta. The placer still consulted `crossPersonClash` before avoiding one, and the default is `warn`, with both AI plan paths pinning `warn` outright.

Every fixture on an AI-planned board is newly placed, so every overlap on it is *introduced* — exactly what the gate refuses. Auto proposed a board, Apply returned 409 `SCHEDULE_CONFLICT`, and re-running Auto proposed the same board again. The placer/verifier fork, in the one family where the gate is absolute.

Setting the placer to avoid produces **fewer** refusals, not more. There was no product trade-off to weigh.

## The hole was narrower than it looks

| | |
|---|---|
| draft vs draft | already safe — #463 widened `lastEnd` to namespaced `person:` keys, so two movable cards sharing a person serialise through the rest path even at `restF = 0` |
| draft vs `existing` | **not** safe — `input.existing` seeds `bookings` and `dayCounts` and never `lastEnd`, so the rest path was blind to a person already committed on a sibling division's fixed board. `personBlocked` was the only guard, and it was the one gated on the setting |

My first regression test passed *without* the fix, which is what exposed the real boundary.

## Where a card genuinely cannot be placed

The candidate loop already handled the ordinary case: a person rejection pushes the start past the clashing booking and retries, per court, so a shared person lands later or on another court. Boards spread out; they don't lose fixtures.

Where the clash is unavoidable the card does go unplaced, and that path now names the person in `detail`. It stays `no_slot` and **not** `person_overlap` deliberately: nothing was placed, so no overlap exists on the board, and `person_overlap` is blocking — reporting one for a card the placer declined to place would refuse the organiser's apply over a fixture that isn't on the board at all.

## Also here

`crossPersonClash` is now read by no engine code and by neither side of the gate. Marked `@deprecated` where it is declared. **Carried forward, not done here:** retiring the organiser-facing control it backs (UI + 4 dictionaries) belongs in its own change.

Second commit repairs a break already on `main`: `ScheduleSettingsOut.tz` became `displayTz` in a2821af7 (#472) but a test helper still built the literal with `tz`, so `tsc -p apps/web` fails on `main` today. vitest doesn't typecheck, so 5364 green tests never saw it, and the typecheck gate is PR-only and peaks ~2.8 GB against CI's ~2 GB heap.

## Gates

| gate | result |
|---|---|
| engine unit | 2326 passed / 0 failed / 2327 total, 615 suites |
| apps/web unit | 5364 passed / 0 failed / 5414 total, 1758 suites |
| regression | proven red first, twice — placer fix (`warn` arm only; `hard` passed) and the diagnostic (`expected 'no court/time within horizon' to contain 'p1'`) |
| smoke | 715 passed / 0 failed, against a standalone prod server on a pristine DB |
| lint | 0 errors / 78 warnings; engine lint exit 0 |
| typecheck | engine 0, apps/web 0 |
| drift | `openapi:gen` + `i18n:gen-keys` both exit 0, `git status --porcelain` clean after |
| e2e | running locally; there is no CI path (e2e.yml is deliberately disabled). Result reported when it lands — flagged rather than claimed |

`repair-scale`'s wall-clock budget case failed in full runs (10275ms, 8182ms vs 7000) and passes 4/4 isolated. It never calls `slotFixtures`, so this change is unreachable from it, and the suite's own parallelism drove load 2.44 → 8.70 mid-run.

One honest note on cost: `personBlocked` is now O(bookings) per candidate in the **default** mode, where it previously early-returned. Fixtures with no people still short-circuit and no timing gate moved, but it is a real complexity increase on large boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)