### PR TITLE
Quote/charge integrity across the three AI run paths (#385, #387, #383, #384)

### DIFF
--- a/apps/web/e2e/ai-architect.spec.ts
+++ b/apps/web/e2e/ai-architect.spec.ts
@@ -226,8 +226,11 @@ test("pro: brief → run → CLEAN → officials → apply → undo", async ({ p
   expect(scheduleCall).toBeTruthy();
   expect(scheduleCall!.assignments).toBe(6);
 
-  // Officials step: the zero-token solver auto-draft renders its grid (no model call).
+  // Officials step: #383 — arriving no longer spends anything. The organiser
+  // presses the button, and only then does the zero-token solver draft run.
   await page.getByRole("button", { name: "Assign officials" }).click();
+  await expect(page.getByLabel("Officials by fixture")).toHaveCount(0);
+  await page.getByRole("button", { name: /Draft the duty spread.*1 credit\b/ }).click();
   await expect(page.getByLabel("Officials by fixture")).toBeVisible({ timeout: 20_000 });
   await expect(
     page.getByText("Draft duty spread from the solver — no AI tokens used."),
@@ -520,14 +523,22 @@ test("the officials step prices itself: free draft with no picker, priced once a
   await compileAndConfirm(page);
   await expect(page.getByText(/CLEAN · 0 blocking/)).toBeVisible({ timeout: 20_000 });
   await page.getByRole("button", { name: "Assign officials" }).click();
-  await expect(page.getByLabel("Officials by fixture")).toBeVisible({ timeout: 20_000 });
 
+  // #383: the card is on screen BEFORE anything has run, which is the whole
+  // point — this used to be reachable only after the auto-run had already
+  // charged for it.
   const card = page.getByRole("region", { name: "What this run costs" });
   await expect(card).toBeVisible();
   await expect(card.getByRole("radiogroup")).toHaveCount(0);
   await expect(
     card.getByText("The first pass runs on the solver, without the AI model — a flat 1 credit."),
   ).toBeVisible();
+
+  // The draft happens when it is asked for. This test's own subject — a free
+  // draft shows no rung picker — is unchanged either side of the press.
+  await page.getByRole("button", { name: /Draft the duty spread.*1 credit\b/ }).click();
+  await expect(page.getByLabel("Officials by fixture")).toBeVisible({ timeout: 20_000 });
+  await expect(card.getByRole("radiogroup")).toHaveCount(0);
 
   // A typed brief is a model call, so the card becomes a priced one.
   await page.locator("#ai-officials-instruction").fill("keep one referee per team's group games");
@@ -542,6 +553,54 @@ test("the officials step prices itself: free draft with no picker, priced once a
   await expect(chips.nth(1)).toBeFocused();
   await expect(chips.nth(1)).toHaveAttribute("aria-checked", "true");
   await expect(page.getByRole("button", { name: /Re-plan officials.*2 credits/ })).toBeVisible();
+});
+
+/**
+ * #383 — the officials step does not spend before the organiser presses.
+ *
+ * THE assertion that would have caught the bug, and it is a claim about MONEY,
+ * so it is read from the credit ledger by SQL rather than from the screen. The
+ * screen is rendered by the same component tree that was wrong; the wallet is
+ * not. Arriving at the step is free, and the press costs exactly the 1 credit
+ * the card promised — no more (a double-fire) and no less (a button that only
+ * looks like it ran).
+ */
+test("pro: the officials draft spends nothing until the organiser presses", async ({
+  page,
+  request,
+}) => {
+  fixture.reset();
+  const orgId = await activateFreshProPlusOrg(page, request);
+  const { divisionId } = await seedAiDivision(request, { officials: true });
+
+  await page.goto(`/divisions/${divisionId}/schedule?tab=board`);
+  await openConsole(page);
+  await page.locator("#ai-instruction").fill("Spread the matches across the day.");
+  await compileAndConfirm(page);
+  await expect(page.getByText(/CLEAN · 0 blocking/)).toBeVisible({ timeout: 20_000 });
+
+  // Phase A has been paid for; measure from HERE, so what follows is attributed
+  // to the officials step alone.
+  await page.getByRole("button", { name: "Assign officials" }).click();
+  const card = page.getByRole("region", { name: "What this run costs" });
+  await expect(card).toBeVisible();
+  const before = await aiCreditBalance(orgId);
+
+  // Arriving is free. The grid is absent because nothing has run — that absence
+  // is the feature, not a loading state.
+  await expect(page.getByLabel("Officials by fixture")).toHaveCount(0);
+  await expect(card).toHaveAttribute("data-ai-credits", "1");
+  expect(await aiCreditBalance(orgId)).toBe(before);
+
+  // The press, and exactly one credit.
+  await page.getByRole("button", { name: /Draft the duty spread.*1 credit\b/ }).click();
+  await expect(page.getByLabel("Officials by fixture")).toBeVisible({ timeout: 20_000 });
+  await expect(
+    page.getByText("Draft duty spread from the solver — no AI tokens used."),
+  ).toBeVisible();
+  expect(await aiCreditBalance(orgId)).toBe(before - 1);
+  // Zero-token by construction: the empty-instruction path calls no model.
+  expect(fixture.calls.some((c) => c.phase === "officials")).toBe(false);
 });
 
 /**

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/schedule/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/schedule/page.tsx
@@ -15,6 +15,8 @@ import { hasFeature } from "@/lib/entitlements";
 import { preferredCurrency } from "@/lib/currency-server";
 import { withTenant } from "@/lib/db";
 import { ScheduleBoard } from "@/components/v2/schedule-board";
+import { RungConfigProvider } from "@/components/v2/board/rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import { StandaloneScheduleSettings } from "@/components/v2/board/settings-panel";
 import { OfficialsPanel } from "@/components/v2/officials-panel";
 import { HistoryPanel } from "@/components/v2/history-panel";
@@ -194,6 +196,13 @@ export default async function DivisionSchedulePage({
                 <UpgradeGate feature="scheduling.board" compact />
               </div>
             )}
+            {/* #385: the AI rung weights and token budgets, resolved HERE —
+                this is a server component, and `resolveRungConfig` reads
+                AI_RUNG_* through a computed `process.env` key that Next never
+                substitutes into a client bundle. Without this the confirm card
+                prices on the built-in defaults while the server charges on the
+                overrides. */}
+            <RungConfigProvider value={resolveRungConfig()}>
             <ScheduleBoard
               divisions={[{ id: division.id, name: division.name, slug: division.slug, status: division.status, seq: Number(division.seq), schedule_locked: division.schedule_locked }]}
               stages={stages.map((s) => ({ id: s.id, division_id: id, seq: s.seq, kind: s.kind, name: s.name, status: s.status }))}
@@ -219,6 +228,7 @@ export default async function DivisionSchedulePage({
               showSettings={false}
               officialsWithBlackout={new Set(blackouts.map((b) => b.official_id)).size}
             />
+            </RungConfigProvider>
           </>
         )}
 

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/schedule/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/schedule/page.tsx
@@ -15,6 +15,8 @@ import { hasFeature } from "@/lib/entitlements";
 import { preferredCurrency } from "@/lib/currency-server";
 import { withTenant } from "@/lib/db";
 import { ScheduleBoard } from "@/components/v2/schedule-board";
+import { RungConfigProvider } from "@/components/v2/board/rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import { feedLabels, type FeedRow } from "@/lib/schedule-board";
 import { UpgradeGate } from "@/components/upgrade-gate";
 import { resolveLocale } from "@/lib/resolve-locale";
@@ -130,6 +132,12 @@ export default async function CompetitionSchedulePage({
           </h1>
         </div>
 
+        {/* #385: the AI rung weights and token budgets, resolved HERE — this is
+            a server component, and `resolveRungConfig` reads AI_RUNG_* through a
+            computed `process.env` key that Next never substitutes into a client
+            bundle. Without this the confirm card prices on the built-in
+            defaults while the server charges on the overrides. */}
+        <RungConfigProvider value={resolveRungConfig()}>
         <ScheduleBoard
           divisions={perDivision.map(({ division }) => ({
             id: division.id,
@@ -182,6 +190,7 @@ export default async function CompetitionSchedulePage({
           // all three joint endpoints.
           competition={{ id, divisionSettings }}
         />
+        </RungConfigProvider>
       </main>
     </>
   );

--- a/apps/web/src/components/v2/board/__tests__/ai-competition-console.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-competition-console.test.tsx
@@ -17,6 +17,13 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Dict } from "@/lib/i18n-constants";
 import { DictProvider } from "@/components/i18n/dict-provider";
+// #385: every surface that prices a run now reads its rung weights and token
+// budgets from the provider the board's RSC seeds — a client module cannot
+// resolve AI_RUNG_* for itself. Server-resolved DEFAULTS here: these suites are
+// about copy and wiring, and rung-config-provider.test.tsx owns the assertion
+// that an override actually reaches the card.
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import en from "@/dictionaries/en/ui.json";
 import { quoteRun, schedulingRungWeights } from "@/lib/ai-rung";
 import type { AiCompetitionPlanResponse, AiParsePreviewResponse } from "@/server/api-v1/schemas";
@@ -104,6 +111,7 @@ const DIVISIONS: JointDivision[] = [
 
 function render(divisions = DIVISIONS): string {
   return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict} locale="en">
       <AiCompetitionConsole
         competitionId="c1"
@@ -113,7 +121,8 @@ function render(divisions = DIVISIONS): string {
         fixtures={[]}
         onClose={() => {}}
       />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 }
 
@@ -454,6 +463,7 @@ function review(
   over: Partial<Parameters<typeof JointReviewStep>[0]> = {},
 ): string {
   return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict} locale="en">
       <JointReviewStep
         plan={plan()}
@@ -478,7 +488,8 @@ function review(
         msg={(k, v) => tEn(k as string, v)}
         {...over}
       />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 }
 

--- a/apps/web/src/components/v2/board/__tests__/ai-console-frozen.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-console-frozen.test.tsx
@@ -5,6 +5,13 @@
 import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import { DictProvider } from "@/components/i18n/dict-provider";
+// #385: every surface that prices a run now reads its rung weights and token
+// budgets from the provider the board's RSC seeds — a client module cannot
+// resolve AI_RUNG_* for itself. Server-resolved DEFAULTS here: these suites are
+// about copy and wiring, and rung-config-provider.test.tsx owns the assertion
+// that an override actually reaches the card.
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import { AiConsole } from "../ai-console";
 
 const stub = {
@@ -42,9 +49,11 @@ const props: Parameters<typeof AiConsole>[0] = {
 
 const render = (scheduleFrozen: boolean) =>
   renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={stub} locale="en">
       <AiConsole {...props} scheduleFrozen={scheduleFrozen} />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 
 describe("AiConsole — frozen schedule", () => {

--- a/apps/web/src/components/v2/board/__tests__/ai-console-gate-wiring.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-console-gate-wiring.test.tsx
@@ -49,6 +49,19 @@ vi.mock("@/lib/client-v1", async (importOriginal) => {
 // `usePlural` THROWS outside a DictProvider and the harness has no provider
 // tree. The real runtime over the real English catalog is the same fallback
 // `useMsg` already takes there, so the copy stays the shipped copy.
+// #385: the console prices on the rung config the board's RSC resolved, read
+// through `useRungConfig`. The hookless harness has no provider tree — its
+// `useContext` returns the context DEFAULT, and this context has none on
+// purpose — so the hook is replaced with the server-resolved defaults. The
+// production guarantee (a missing provider throws) is pinned by
+// rung-config-provider.test.tsx, not weakened here.
+vi.mock("../rung-config-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../rung-config-provider")>();
+  const { resolveRungConfig } = await import("@/lib/ai-rung");
+  const config = resolveRungConfig();
+  return { ...actual, useRungConfig: () => config };
+});
+
 vi.mock("@/components/i18n/dict-provider", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/i18n/dict-provider")>();
   const { plural } = await import("@/lib/i18n-runtime");

--- a/apps/web/src/components/v2/board/__tests__/ai-console-officials-autorun.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-console-officials-autorun.test.tsx
@@ -1,0 +1,353 @@
+// #383 — the officials step must not spend a credit before the organiser has
+// seen a price.
+//
+// The console used to auto-fire the solver draft the moment the officials step
+// mounted. That run charges 1 credit (`freeDraftQuote` is a price CAP, not
+// zero: "free" means free of MODEL cost), so the organiser was billed before
+// any confirm surface rendered — the one credit-spending path in the product
+// with no pre-spend surface, and the one they could not decline.
+//
+// TWO HALVES, and both are needed. The CALLBACK half is driven through the
+// shared hook harness: arriving at the step must make no POST, and the run must
+// happen when — and only when — the organiser asks for it. The JSX half is a
+// static render: the pre-run card has to carry the flat 1-credit price and an
+// enabled button, or "they can press it" is a claim about a button nobody can
+// reach.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { propsOf, renderIsland } from "@/components/__tests__/_hook-harness";
+import type { AiOfficialsPlanResponse, AiPlanResponse } from "@/server/api-v1/schemas";
+
+const net = vi.hoisted(() => ({
+  calls: [] as { url: string; method?: string; json?: unknown }[],
+  handler: null as
+    | null
+    | ((url: string, options?: { method?: string; json?: unknown }) => Promise<unknown>),
+}));
+
+vi.mock("@/lib/client-v1", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/client-v1")>();
+  return {
+    ...actual,
+    apiV1: (url: string, options?: { method?: string; json?: unknown }) => {
+      net.calls.push({ url, method: options?.method, json: options?.json });
+      if (!net.handler) return Promise.reject(new Error(`no handler for ${url}`));
+      return net.handler(url, options);
+    },
+  };
+});
+
+// #385: the console prices on the config the board's RSC resolved. The harness
+// has no provider tree and this context has no default on purpose, so the hook
+// is replaced with the server-resolved defaults here.
+vi.mock("../rung-config-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../rung-config-provider")>();
+  const { resolveRungConfig } = await import("@/lib/ai-rung");
+  const config = resolveRungConfig();
+  return { ...actual, useRungConfig: () => config };
+});
+
+vi.mock("@/components/i18n/dict-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/i18n/dict-provider")>();
+  const { plural } = await import("@/lib/i18n-runtime");
+  const { messages } = await import("@/lib/messages");
+  return {
+    ...actual,
+    usePlural:
+      () => (key: string, count: number, vars?: Record<string, string | number>) =>
+        plural(messages, key, count, "en", vars),
+  };
+});
+
+vi.mock("next/navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next/navigation")>()),
+  usePathname: () => "/o/riverside/divisions/d1",
+}));
+
+import type { Dict } from "@/lib/i18n-constants";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
+import en from "@/dictionaries/en/ui.json";
+import { AiConsole, OfficialsStep } from "../ai-console";
+import { initialAiConsoleState, type AiConsoleState } from "../ai-console-state";
+
+const DIVISION = "00000000-0000-4000-8000-000000000001";
+const OFFICIALS_URL = `/api/v1/divisions/${DIVISION}/officials/ai-plan`;
+
+const dict = en as unknown as Dict;
+const enText = en as unknown as Record<string, string>;
+
+const SCHEDULE_PLAN = {
+  proposal: [
+    { fixture_id: "f0", scheduled_at: "2026-08-01T10:00:00.000Z", court_label: "Court 1" },
+  ],
+  unschedulable: [],
+  warnings: [],
+  blocking: [],
+  diff: { moved: [], placed: [], unscheduled: [], unchanged: [] },
+  explanations: [],
+  summary: "ok",
+  assumptions: [],
+  usage: { input_tokens: 0, output_tokens: 0, repair_rounds: 0 },
+  repair: { engine: "none", solver_ran: false },
+  officials_coverage: null,
+} as unknown as AiPlanResponse;
+
+const OFFICIALS_PLAN = {
+  assignments: [{ fixtureId: "f0", officialId: "o1", roleKey: "referee" }],
+  conflicts: [],
+  diff: { changed: [], unchanged: ["f0"], unfilled: [] },
+  lazy_unfilled: [],
+  explanations: [],
+  summary: "drafted",
+  usage: { input_tokens: 0, output_tokens: 0, repair_rounds: 0 },
+  credits: 1,
+} as unknown as AiOfficialsPlanResponse;
+
+const props: Parameters<typeof AiConsole>[0] = {
+  divisionId: DIVISION,
+  expectedSeq: 1,
+  aiAllowed: true,
+  currency: "usd",
+  brief: {
+    courts: ["Court 1", "Court 2"],
+    windows: 1,
+    blackouts: 0,
+    constraintsSet: false,
+    movableFixtures: [{ id: "f0", scheduled_at: "2026-08-01T10:00:00.000Z", court_label: "Court 1" }],
+    pinned: 0,
+    entrants: [
+      { id: "e1", name: "Team A" },
+      { id: "e2", name: "Team B" },
+    ],
+    activeEntrants: 2,
+    officialsWithBlackout: 0,
+  },
+  fixtures: [],
+  scheduleFrozen: false,
+  onClose: () => {},
+};
+
+const mountAnswers: Record<string, unknown> = { "/api/v1/officials": [] };
+
+function serve(post: (url: string, body: unknown) => Promise<unknown>) {
+  net.handler = (url, options) => {
+    if (options?.method === "POST") return post(url, options.json);
+    if (url in mountAnswers) return Promise.resolve(mountAnswers[url]);
+    return Promise.reject(new Error(`unanswered GET ${url}`));
+  };
+}
+
+const officialsPosts = () => net.calls.filter((c) => c.method === "POST" && c.url === OFFICIALS_URL);
+
+type Dispatch = (action: Record<string, unknown>) => void;
+
+/** The step element carrying `onReplan` — the officials step and nothing else.
+ *  The harness renders one level deep, so this IS the console's own wiring. */
+function officialsStep(tree: ReactElement[]): ReactElement {
+  const el = tree.find((e) => typeof propsOf(e).onReplan === "function");
+  if (!el) throw new Error("officials step not rendered");
+  return el;
+}
+
+/** Any element with a `dispatch` — every step is handed the console's. */
+function anyDispatch(tree: ReactElement[]): Dispatch {
+  const el = tree.find((e) => typeof propsOf(e).dispatch === "function");
+  if (!el) throw new Error("nothing rendered with a dispatch");
+  return propsOf(el).dispatch as Dispatch;
+}
+
+/** Walk the console to the officials step WITHOUT running anything: a schedule
+ *  plan is dispatched straight in, exactly as a completed Phase A would. */
+function atOfficialsStep() {
+  const island = renderIsland(AiConsole, props);
+  const dispatch = anyDispatch(island.tree());
+  dispatch({ type: "RUN_DONE", plan: SCHEDULE_PLAN });
+  dispatch({ type: "GOTO_STEP", step: "officials" });
+  return island;
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("AiConsole — the officials draft asks before it spends (#383)", () => {
+  beforeEach(() => {
+    net.calls = [];
+    net.handler = null;
+  });
+
+  it("does not spend a credit before the organiser has seen a price", async () => {
+    serve(async (url) => {
+      throw new Error(`the console POSTed ${url} on arriving at the officials step`);
+    });
+    const island = atOfficialsStep();
+    await flush();
+
+    expect(officialsPosts()).toHaveLength(0);
+    // And the step really is mounted — otherwise "no POST" is satisfied by a
+    // console that never got there.
+    expect(() => officialsStep(island.tree())).not.toThrow();
+  });
+
+  it("runs the draft when the organiser asks for it", async () => {
+    // The positive discriminator: a console that can never draft at all would
+    // pass the test above and be a worse bug than the one being fixed.
+    serve(async () => OFFICIALS_PLAN);
+    const island = atOfficialsStep();
+    await flush();
+
+    await (propsOf(officialsStep(island.tree())).onReplan as () => Promise<void>)();
+    expect(officialsPosts()).toHaveLength(1);
+    // The free draft: an empty instruction is the server's OWN predicate for
+    // the zero-token solver pass and its flat 1-credit price.
+    expect((officialsPosts()[0]!.json as { instruction: string }).instruction).toBe("");
+  });
+
+  it("a second press while the first run is in flight spends nothing extra", async () => {
+    // The double-submit class. `busy` guards `runOfficials` at the request site,
+    // not only on the button's `disabled` attribute — a disabled prop is a hint
+    // to a pointer and the money is spent by the fetch.
+    let release: (v: unknown) => void = () => {};
+    serve(
+      () =>
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+    );
+    const island = atOfficialsStep();
+    await flush();
+
+    const first = (propsOf(officialsStep(island.tree())).onReplan as () => Promise<void>)();
+    await flush();
+    expect(officialsPosts()).toHaveLength(1);
+
+    await (propsOf(officialsStep(island.tree())).onReplan as () => Promise<void>)();
+    expect(officialsPosts()).toHaveLength(1);
+
+    release(OFFICIALS_PLAN);
+    await first;
+    await flush();
+    expect(officialsPosts()).toHaveLength(1);
+  });
+
+  it("leaving and re-entering the step does not re-draft, and does not re-charge", async () => {
+    serve(async () => OFFICIALS_PLAN);
+    const island = atOfficialsStep();
+    await flush();
+    await (propsOf(officialsStep(island.tree())).onReplan as () => Promise<void>)();
+    expect(officialsPosts()).toHaveLength(1);
+
+    const dispatch = anyDispatch(island.tree());
+    dispatch({ type: "GOTO_STEP", step: "schedule" });
+    await flush();
+    dispatch({ type: "GOTO_STEP", step: "officials" });
+    await flush();
+
+    expect(officialsPosts()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The JSX half. `renderToStaticMarkup`, the repo's client-component convention.
+// ---------------------------------------------------------------------------
+
+function tEn(key: string, vars?: Record<string, string | number>): string {
+  const raw = enText[key] ?? key;
+  return vars ? raw.replace(/\{(\w+)\}/g, (m, n) => (n in vars ? String(vars[n]) : m)) : raw;
+}
+
+function renderStep(over: Partial<AiConsoleState> = {}, busy = false): string {
+  return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
+      <DictProvider dict={dict} locale="en">
+        {OfficialsStep({
+          state: {
+            ...initialAiConsoleState,
+            step: "officials",
+            schedulePlan: SCHEDULE_PLAN,
+            ...over,
+          } as AiConsoleState,
+          dispatch: () => {},
+          currency: "usd",
+          fixtures: [],
+          roster: [],
+          policyRoles: ["referee"],
+          hadPrior: false,
+          busy,
+          traceNonce: 0,
+          wishes: [],
+          onWishes: () => {},
+          onReplan: () => {},
+          onAdopt: () => {},
+          onPulse: () => {},
+        })}
+      </DictProvider>
+    </RungConfigProvider>,
+  );
+}
+
+/**
+ * The run button's own markup — it carries the `.ai-run` class.
+ *
+ * Cut at its OWN closing tag, not a fixed window: the step-navigation
+ * "Continue to apply" button a few hundred characters later is legitimately
+ * `disabled` with no plan, and a wider slice makes every disabled-state
+ * assertion here pass for the wrong element.
+ */
+function runButton(html: string): string {
+  const marker = html.indexOf("ai-run");
+  expect(marker, "the officials step rendered no run button").toBeGreaterThan(-1);
+  // From the OPENING TAG: React emits attributes in JSX order, so `disabled`
+  // sits before `className` and a slice anchored on the class name cannot see
+  // it at all.
+  const start = html.lastIndexOf("<button", marker);
+  const end = html.indexOf("</button>", marker);
+  expect(start, "no opening tag before the run button's class").toBeGreaterThan(-1);
+  expect(end, "the run button never closed").toBeGreaterThan(marker);
+  return html.slice(start, end);
+}
+
+describe("the officials pre-run surface (#383)", () => {
+  it("shows the flat 1-credit price before anything has run", () => {
+    const html = renderStep();
+    // `freeDraftQuote`'s price, unchanged: this task moved the surface, not the
+    // arithmetic.
+    expect(html).toContain('data-ai-credits="1"');
+    expect(html).toContain(tEn("board.ai.quote.freeDraft"));
+  });
+
+  it("offers a button the organiser can actually press", () => {
+    const btn = runButton(renderStep());
+    expect(btn).toContain(tEn("board.ai.officials.run"));
+    // The whole point: before #383 this button was `disabled` until a plan
+    // existed, and the only thing that produced one was the auto-run.
+    //
+    // Anchored on the ATTRIBUTE, not the word: the button's class list carries
+    // `disabled:cursor-not-allowed disabled:opacity-50`, so a bare substring
+    // check passes in both states and pins nothing.
+    expect(btn).not.toContain('disabled=""');
+  });
+
+  it("disables the button while a run is in flight", () => {
+    expect(runButton(renderStep({}, true))).toContain('disabled=""');
+  });
+
+  it("goes back to naming the re-plan once a draft exists", () => {
+    // The pre-run label belongs to the pre-run state only — an organiser
+    // looking at a drafted grid is refining it, not drafting it.
+    const btn = runButton(renderStep({ officialsPlan: OFFICIALS_PLAN }));
+    expect(btn).not.toContain(tEn("board.ai.officials.run"));
+    expect(btn).toContain(tEn("board.ai.officials.replan"));
+  });
+
+  it("carries the button label in all four locales", async () => {
+    for (const locale of ["en", "es", "fr", "nl"] as const) {
+      const d = (await import(`@/dictionaries/${locale}/ui.json`)).default as Record<string, string>;
+      expect(d["board.ai.officials.run"], locale).toBeTruthy();
+      if (locale !== "en") {
+        expect(d["board.ai.officials.run"], locale).not.toBe(enText["board.ai.officials.run"]);
+      }
+    }
+  });
+});

--- a/apps/web/src/components/v2/board/__tests__/ai-joint-console-wiring.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-joint-console-wiring.test.tsx
@@ -56,6 +56,19 @@ vi.mock("@/lib/client-v1", async (importOriginal) => {
 // component with no provider tree. This is the same fallback `useMsg` already
 // takes there — the real runtime over the real English catalog — so the copy
 // the console builds is still the shipped copy.
+// #385: the console prices on the rung config the board's RSC resolved, read
+// through `useRungConfig`. The hookless harness has no provider tree — its
+// `useContext` returns the context DEFAULT, and this context has none on
+// purpose — so the hook is replaced with the server-resolved defaults. The
+// production guarantee (a missing provider throws) is pinned by
+// rung-config-provider.test.tsx, not weakened here.
+vi.mock("../rung-config-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../rung-config-provider")>();
+  const { resolveRungConfig } = await import("@/lib/ai-rung");
+  const config = resolveRungConfig();
+  return { ...actual, useRungConfig: () => config };
+});
+
 vi.mock("@/components/i18n/dict-provider", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/components/i18n/dict-provider")>();
   const { plural } = await import("@/lib/i18n-runtime");

--- a/apps/web/src/components/v2/board/__tests__/ai-joint-console-wiring.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-joint-console-wiring.test.tsx
@@ -287,7 +287,8 @@ describe("what the CTA sends is what the receipt priced", () => {
     pickRung("d2", 3);
     // The pick reached the PRICE first — otherwise the body below could match
     // a receipt that never moved, and the two would agree about nothing.
-    expect(creditsOnCta()).not.toBe(quoted);
+    const repriced = creditsOnCta();
+    expect(repriced).not.toBe(quoted);
 
     await confirm();
 
@@ -303,6 +304,10 @@ describe("what the CTA sends is what the receipt priced", () => {
         instruction: BRIEF,
         rungs: { d2: 3 },
         previewId: PREVIEW_ID,
+        // #387: the number the CTA is showing, read off the CTA itself rather
+        // than restated — the whole point of the field is that the server can
+        // compare the charge against what this organiser was actually shown.
+        quotedCredits: repriced as number,
       }),
     );
     // Spelled out, so a change to jointRunBody cannot make both sides agree on
@@ -313,6 +318,7 @@ describe("what the CTA sends is what the receipt priced", () => {
       mode: "generate",
       rung_overrides: { d2: 3 },
       preview_id: PREVIEW_ID,
+      quoted_credits: repriced,
     });
   });
 

--- a/apps/web/src/components/v2/board/__tests__/ai-officials-quote.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-officials-quote.test.tsx
@@ -7,6 +7,13 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Dict } from "@/lib/i18n-constants";
 import { DictProvider } from "@/components/i18n/dict-provider";
+// #385: every surface that prices a run now reads its rung weights and token
+// budgets from the provider the board's RSC seeds — a client module cannot
+// resolve AI_RUNG_* for itself. Server-resolved DEFAULTS here: these suites are
+// about copy and wiring, and rung-config-provider.test.tsx owns the assertion
+// that an override actually reaches the card.
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import {
   officialsRungWeights,
   quoteRun,
@@ -58,6 +65,7 @@ function render(
   } = {},
 ): string {
   return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict} locale="en">
       <AiOfficialsReview
         plan={over.plan ?? null}
@@ -84,7 +92,8 @@ function render(
         onContinue={() => {}}
         onPulse={() => {}}
       />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 }
 
@@ -94,6 +103,7 @@ function render(
  *  never that the step feeds it the string the adopt path actually sends. */
 function stepHtml(state: Partial<AiConsoleState>): string {
   return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict} locale="en">
       {OfficialsStep({
         state: {
@@ -116,7 +126,8 @@ function stepHtml(state: Partial<AiConsoleState>): string {
         onAdopt: () => {},
         onPulse: () => {},
       })}
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 }
 
@@ -257,7 +268,8 @@ describe("officials confirm card", () => {
     // Nothing below rung 1, so drive it from a pack the officials weights put
     // on rung 2: 300 + 0.25*40 + 1*10 = 320 -> rung 2.
     const html = renderToStaticMarkup(
-      <DictProvider dict={dict} locale="en">
+      <RungConfigProvider value={resolveRungConfig()}>
+    <DictProvider dict={dict} locale="en">
         <AiOfficialsReview
           plan={null}
           placements={[]}
@@ -283,7 +295,8 @@ describe("officials confirm card", () => {
           onContinue={() => {}}
           onPulse={() => {}}
         />
-      </DictProvider>,
+      </DictProvider>
+    </RungConfigProvider>,
     );
     expect(creditsShown(html)).toBe(1);
     expect(html).toContain(enText["board.ai.quote.underfunded"]);

--- a/apps/web/src/components/v2/board/__tests__/ai-officials-quote.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-officials-quote.test.tsx
@@ -152,11 +152,19 @@ describe("officials confirm card", () => {
     expect(creditsShown(render())).toBe(officials);
   });
 
-  it("names the credit count on the Re-plan button", () => {
-    const html = render();
-    const btn = html.slice(html.lastIndexOf("ai-run"));
-    expect(btn).toContain("1 credit");
-    expect(btn).toContain(enText["board.ai.officials.replan"]);
+  it("names the credit count on the run button", () => {
+    // #383: with no plan yet this button DRAFTS — the step no longer auto-fires
+    // one, so "re-plan" would name work that has not happened. The subject of
+    // this test is unchanged: the CTA names what the run costs.
+    const btn = (html: string) => html.slice(html.lastIndexOf("ai-run"));
+    const drafting = btn(render());
+    expect(drafting).toContain("1 credit");
+    expect(drafting).toContain(enText["board.ai.officials.run"]);
+
+    // Once a draft exists the same button refines it, and says so.
+    const refining = btn(render({ plan: planWith(0) }));
+    expect(refining).toContain("1 credit");
+    expect(refining).toContain(enText["board.ai.officials.replan"]);
   });
 
   it("quotes the empty-instruction draft at a flat 1 credit, with no rung control", () => {

--- a/apps/web/src/components/v2/board/__tests__/ai-preview-error-copy.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-preview-error-copy.test.tsx
@@ -17,6 +17,13 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Dict, Locale } from "@/lib/i18n-constants";
 import { DictProvider } from "@/components/i18n/dict-provider";
+// #385: every surface that prices a run now reads its rung weights and token
+// budgets from the provider the board's RSC seeds — a client module cannot
+// resolve AI_RUNG_* for itself. Server-resolved DEFAULTS here: these suites are
+// about copy and wiring, and rung-config-provider.test.tsx owns the assertion
+// that an override actually reaches the card.
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import { BriefStep } from "../ai-console";
 import { initialAiConsoleState, type AiConsoleState } from "../ai-console-state";
 import en from "@/dictionaries/en/ui.json";
@@ -113,6 +120,7 @@ function render(state: AiConsoleState, locale: Locale = "en"): string {
   const dict = DICTS[locale];
   const msg = formatter(dict);
   return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict as unknown as Dict} locale={locale}>
       <BriefStep
         state={state}
@@ -130,7 +138,8 @@ function render(state: AiConsoleState, locale: Locale = "en"): string {
         lastRun={null}
         scheduleFrozen={false}
       />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 }
 

--- a/apps/web/src/components/v2/board/__tests__/ai-quote-card.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-quote-card.test.tsx
@@ -16,6 +16,13 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Dict } from "@/lib/i18n-constants";
 import { DictProvider } from "@/components/i18n/dict-provider";
+// #385: every surface that prices a run now reads its rung weights and token
+// budgets from the provider the board's RSC seeds — a client module cannot
+// resolve AI_RUNG_* for itself. Server-resolved DEFAULTS here: these suites are
+// about copy and wiring, and rung-config-provider.test.tsx owns the assertion
+// that an override actually reaches the card.
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import { quoteRun, schedulingRungWeights, type RungInput } from "@/lib/ai-rung";
 import en from "@/dictionaries/en/ui.json";
 import type { AiConsoleFixture } from "../ai-diff";
@@ -76,9 +83,11 @@ function line(key: string, input: RungInput, chosen: number | null = null, label
 
 function render(lines: QuoteCardLine[], busy = false): string {
   return renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict} locale="en">
       <AiQuoteCard lines={lines} onChange={() => {}} msg={(k, v) => tEn(k as string, v)} busy={busy} />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 }
 
@@ -433,9 +442,11 @@ const consoleProps: Parameters<typeof AiConsole>[0] = {
 
 const renderConsole = (props: Partial<Parameters<typeof AiConsole>[0]> = {}): string =>
   renderToStaticMarkup(
+    <RungConfigProvider value={resolveRungConfig()}>
     <DictProvider dict={dict} locale="en">
       <AiConsole {...consoleProps} {...props} />
-    </DictProvider>,
+    </DictProvider>
+    </RungConfigProvider>,
   );
 
 const runButton = (html: string): string =>

--- a/apps/web/src/components/v2/board/__tests__/ai-quote-mismatch-note.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-quote-mismatch-note.test.tsx
@@ -1,0 +1,126 @@
+// #387 — the receipt correction line, and the field that makes it possible.
+//
+// Two halves, and both have to hold or the feature measures nothing:
+//   1. the RUN BODY carries the number the confirm card showed, so the server
+//      has something to compare its charge against;
+//   2. the RESULT SURFACE says so when they disagreed — in BOTH directions,
+//      because an over-charge and an under-charge are different news.
+//
+// The comparison itself is server-side and is proved in
+// server/usecases/__tests__/ai-quote-mismatch.test.ts. Nothing here recomputes
+// it: a client that decided for itself whether the numbers matched could agree
+// with itself while disagreeing with the invoice.
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Dict } from "@/lib/i18n-constants";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import en from "@/dictionaries/en/ui.json";
+import es from "@/dictionaries/es/ui.json";
+import fr from "@/dictionaries/fr/ui.json";
+import nl from "@/dictionaries/nl/ui.json";
+import { AiQuoteMismatchNote } from "../ai-quote-card";
+import { officialsPlanBody, schedulePlanBody } from "../ai-console";
+import { initialAiConsoleState } from "../ai-console-state";
+
+const dict = en as unknown as Dict;
+const enText = en as unknown as Record<string, string>;
+
+function tEn(key: string, vars?: Record<string, string | number>): string {
+  const raw = enText[key] ?? key;
+  return vars ? raw.replace(/\{(\w+)\}/g, (m, n) => (n in vars ? String(vars[n]) : m)) : raw;
+}
+
+function render(mismatch: { quoted: number; charged: number } | undefined): string {
+  return renderToStaticMarkup(
+    <DictProvider dict={dict} locale="en">
+      <AiQuoteMismatchNote mismatch={mismatch} msg={(k, v) => tEn(k as string, v)} />
+    </DictProvider>,
+  );
+}
+
+describe("the receipt correction line (#387)", () => {
+  it("says so when the organiser was charged MORE than the card quoted", () => {
+    const html = render({ quoted: 1, charged: 3 });
+    // Direction is on the element, so a tone change cannot silently swap which
+    // case gets the amber treatment.
+    expect(html).toContain('data-ai-quote-mismatch="over"');
+    expect(html).toContain("Quoted 1, charged 3");
+    expect(html).toContain("more than the estimate");
+    // The card's existing caution vocabulary — this is the complaint-shaped
+    // direction, and it reads as part of the receipt rather than a new alert.
+    expect(html).toContain("amber");
+    expect(html).toContain('role="status"');
+  });
+
+  it("says so when they were charged LESS, quietly", () => {
+    const html = render({ quoted: 3, charged: 1 });
+    expect(html).toContain('data-ai-quote-mismatch="under"');
+    expect(html).toContain("Quoted 3, charged 1");
+    expect(html).toContain("less than the estimate");
+    // Not amber: alarming someone about money they did not spend trains them to
+    // stop reading the amber one.
+    expect(html).not.toContain("amber");
+  });
+
+  it("renders nothing at all when the card and the charge agreed", () => {
+    expect(render(undefined)).toBe("");
+  });
+
+  it("carries both copy keys in all four locales", () => {
+    for (const [locale, d] of [
+      ["en", en],
+      ["es", es],
+      ["fr", fr],
+      ["nl", nl],
+    ] as const) {
+      const flat = d as unknown as Record<string, string>;
+      for (const key of ["board.ai.quote.mismatchOver", "board.ai.quote.mismatchUnder"]) {
+        expect(flat[key], `${locale} ${key}`).toBeTruthy();
+        // Both figures interpolate, or the line names one number and leaves the
+        // reader to guess the other.
+        expect(flat[key], `${locale} ${key}`).toContain("{quoted}");
+        expect(flat[key], `${locale} ${key}`).toContain("{charged}");
+      }
+      if (locale !== "en") {
+        // Never leave English sitting in the other three files.
+        expect(flat["board.ai.quote.mismatchOver"]).not.toBe(enText["board.ai.quote.mismatchOver"]);
+        expect(flat["board.ai.quote.mismatchUnder"]).not.toBe(enText["board.ai.quote.mismatchUnder"]);
+      }
+    }
+  });
+});
+
+describe("the run bodies carry the quote (#387)", () => {
+  const state = initialAiConsoleState;
+
+  it("sends quoted_credits on the schedule path when the card showed one", () => {
+    const body = schedulePlanBody(state, { instruction: "plan it", mode: "generate", quotedCredits: 2 });
+    expect(body.quoted_credits).toBe(2);
+  });
+
+  it("sends quoted_credits on the officials path when the card showed one", () => {
+    const body = officialsPlanBody(state, {
+      instruction: "",
+      schedule: [],
+      policy: { roles: ["referee"] } as never,
+      quotedCredits: 1,
+    });
+    expect(body.quoted_credits).toBe(1);
+  });
+
+  it("OMITS the key entirely when no card was on screen", () => {
+    // Absence is silence, not "quoted zero" — the server must not file a
+    // mismatch against a caller that never quoted anything. A `quoted_credits:
+    // undefined` on the wire would serialise away, but the key must not be
+    // there at all for the same reason `rung` is not: what is sent is what is
+    // asserted on.
+    const schedule = schedulePlanBody(state, { instruction: "plan it", mode: "generate" });
+    expect("quoted_credits" in schedule).toBe(false);
+    const officials = officialsPlanBody(state, {
+      instruction: "",
+      schedule: [],
+      policy: { roles: ["referee"] } as never,
+    });
+    expect("quoted_credits" in officials).toBe(false);
+  });
+});

--- a/apps/web/src/components/v2/board/__tests__/ai-request-rung.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/ai-request-rung.test.tsx
@@ -10,6 +10,13 @@ import { describe, expect, it } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { Dict } from "@/lib/i18n-constants";
 import { DictProvider } from "@/components/i18n/dict-provider";
+// #385: every surface that prices a run now reads its rung weights and token
+// budgets from the provider the board's RSC seeds — a client module cannot
+// resolve AI_RUNG_* for itself. Server-resolved DEFAULTS here: these suites are
+// about copy and wiring, and rung-config-provider.test.tsx owns the assertion
+// that an override actually reaches the card.
+import { RungConfigProvider } from "../rung-config-provider";
+import { resolveRungConfig } from "@/lib/ai-rung";
 import en from "@/dictionaries/en/ui.json";
 import type { AiOfficialsPlanResponse } from "@/server/api-v1/schemas";
 import {
@@ -234,7 +241,8 @@ describe("the two phases keep their rungs apart", () => {
     // different control than one reading `state.officialsRung`. Phase A is 3,
     // Phase B is 1 — the card must show 1 checked.
     const html = renderToStaticMarkup(
-      <DictProvider dict={dict} locale="en">
+      <RungConfigProvider value={resolveRungConfig()}>
+    <DictProvider dict={dict} locale="en">
         {OfficialsStep(
           officialsStepProps({
             // Non-empty, or the card renders its free-draft state and offers no
@@ -244,7 +252,8 @@ describe("the two phases keep their rungs apart", () => {
             officialsRung: 1,
           }),
         )}
-      </DictProvider>,
+      </DictProvider>
+    </RungConfigProvider>,
     );
     const checked = [...html.matchAll(/<button[^>]*role="radio"[^>]*>/g)]
       .filter((m) => /aria-checked="true"/.test(m[0]))

--- a/apps/web/src/components/v2/board/__tests__/rung-config-provider.test.tsx
+++ b/apps/web/src/components/v2/board/__tests__/rung-config-provider.test.tsx
@@ -1,0 +1,172 @@
+// #385 — the client must price on the rung config the SERVER resolved.
+//
+// `envNumber` (lib/ai-rung.ts) reads `process.env[name]` with a COMPUTED key.
+// Next replaces `process.env.FOO` by static substitution, and only for
+// NEXT_PUBLIC_-prefixed names, so a computed lookup is never replaced at all:
+// in a `"use client"` module every AI_RUNG_* override falls through to its
+// fallback. The card therefore priced on defaults while the server priced on
+// the overrides, and when an override RAISES a price that is a silent
+// under-quote — the organiser charged more than the confirm card promised.
+//
+// THIS CLASS OF BUG IS INVISIBLE TO A SERVER-SIDE SUITE. Every vitest run has a
+// working `process.env`, so calling `schedulingRungWeights()` in a test proves
+// nothing about what a browser bundle would have read. The assertion therefore
+// has to be on the value REACHING the card through the provider, never on the
+// pure function's return.
+//
+// Rendering is `renderToStaticMarkup` — the repo's client-component convention;
+// there is no jsdom or @testing-library in this workspace.
+import { describe, expect, it } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Dict } from "@/lib/i18n-constants";
+import { DictProvider } from "@/components/i18n/dict-provider";
+import { officialsRungWeights, resolveRungConfig, type RungConfig } from "@/lib/ai-rung";
+import en from "@/dictionaries/en/ui.json";
+import { AiQuoteCard, type QuoteCardLine } from "../ai-quote-card";
+import { RungConfigProvider, useRungConfig } from "../rung-config-provider";
+
+const dict = en as unknown as Dict;
+const enText = en as unknown as Record<string, string>;
+
+function tEn(key: string, vars?: Record<string, string | number>): string {
+  const raw = enText[key] ?? key;
+  return vars ? raw.replace(/\{(\w+)\}/g, (m, n) => (n in vars ? String(vars[n]) : m)) : raw;
+}
+
+/** The card stamps its total on `data-ai-credits` — the number the organiser is
+ *  told they will be charged. */
+function creditsShown(html: string): number | null {
+  const m = /data-ai-credits="(\d+)"/.exec(html);
+  return m ? Number(m[1]) : null;
+}
+
+const LINE: QuoteCardLine = {
+  key: "d1",
+  label: null,
+  input: { movableFixtures: 4, entrants: 8, courts: 2 },
+  chosen: null,
+};
+
+function renderCard(config: RungConfig): string {
+  return renderToStaticMarkup(
+    <DictProvider dict={dict} locale="en">
+      <RungConfigProvider value={config}>
+        <AiQuoteCard lines={[LINE]} onChange={() => {}} msg={(k, v) => tEn(k as string, v)} busy={false} />
+      </RungConfigProvider>
+    </DictProvider>,
+  );
+}
+
+describe("RungConfigProvider (#385)", () => {
+  it("prices from the server-provided config, not from process.env", () => {
+    // Weights a `"use client"` module could never have read for itself. A
+    // four-fixture division is rung 1 under the defaults (score 12 <= 60) and
+    // rung 3 under these (score 994 > s2 = 2), so the rendered total tells the
+    // two sources apart with no ambiguity.
+    const config: RungConfig = {
+      scheduling: { entrantWeight: 99, courtWeight: 99, s1: 1, s2: 2, estTokensAtS1: 1, estTokensAtS2: 2 },
+      officials: officialsRungWeights(),
+      budgets: [32_000, 64_000, 128_000, 160_000, 192_000, 224_000],
+    };
+    expect(creditsShown(renderCard(config))).toBe(3);
+  });
+
+  it("keeps pricing on the defaults when the server resolved the defaults", () => {
+    // The other half of the claim: the card is not simply always saying 3. Same
+    // component, same line, the config a server with no overrides set produces.
+    expect(creditsShown(renderCard(resolveRungConfig()))).toBe(1);
+  });
+
+  it("reads the token budget the server resolved, not its own table", () => {
+    const config: RungConfig = {
+      ...resolveRungConfig(),
+      // A budget no default table produces, at the index a 1-credit run reads.
+      budgets: [777_000, 64_000, 128_000, 160_000, 192_000, 224_000],
+    };
+    expect(renderCard(config)).toContain('data-ai-budget="777000"');
+  });
+
+  it("falls back past the end of the resolved table rather than rendering nothing", () => {
+    // `budgets` holds 1..6 credits. #350's joint solve can price above that
+    // (three rung-3 divisions total 9), and `cfg.budgets[n - 1]` is then
+    // `undefined` — which `formatTokens` would render as "NaN" and the data
+    // attribute would drop entirely. The tail fallback covers it.
+    const config = resolveRungConfig();
+    const three: QuoteCardLine[] = ["d1", "d2", "d3"].map((key) => ({
+      key,
+      label: key,
+      input: { movableFixtures: 4, entrants: 8, courts: 2 },
+      chosen: 3,
+    }));
+    const html = renderToStaticMarkup(
+      <DictProvider dict={dict} locale="en">
+        <RungConfigProvider value={config}>
+          <AiQuoteCard lines={three} onChange={() => {}} msg={(k, v) => tEn(k as string, v)} busy={false} />
+        </RungConfigProvider>
+      </DictProvider>,
+    );
+    // rungTotal 9 → the budget the ladder's own table gives, not `undefined`.
+    expect(html).toContain('data-ai-budget="320000"');
+    expect(html).not.toContain("NaN");
+    // And the run is still priced with the batch discount: max(1, 9 - 1).
+    expect(creditsShown(html)).toBe(8);
+  });
+
+  it("throws rather than silently defaulting when no provider is mounted", () => {
+    // This matters more than it looks. A `useContext` default value would
+    // reintroduce exactly the silent-fallback failure this task exists to
+    // remove: the card would price on defaults and say nothing about it.
+    function Bare() {
+      useRungConfig();
+      return null;
+    }
+    expect(() => renderToStaticMarkup(<Bare />)).toThrow(/RungConfigProvider/);
+  });
+});
+
+describe("every route that mounts the board seeds the config (#385)", () => {
+  // A grep-and-wrap invites exactly one kind of miss: a second route that
+  // mounts `ScheduleBoard` and is never wrapped. That is not a wrong price —
+  // `useRungConfig` throws, so it is a blank page on a route nobody ran a unit
+  // test against. Scanning the app directory means a route added later is
+  // caught by this test rather than by an organiser.
+  const APP = fileURLToPath(new URL("../../../../app", import.meta.url));
+
+  function tsxFiles(dir: string, out: string[] = []): string[] {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, e.name);
+      if (e.isDirectory()) tsxFiles(full, out);
+      else if (e.name.endsWith(".tsx")) out.push(full);
+    }
+    return out;
+  }
+
+  const mounts = tsxFiles(APP).filter((f) => readFileSync(f, "utf8").includes("<ScheduleBoard"));
+
+  it("finds the routes at all", () => {
+    // Guards the scan itself: a renamed component or a moved app directory
+    // would otherwise make every assertion below vacuously true.
+    expect(mounts.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(mounts)("%s wraps the board in a RungConfigProvider", (file) => {
+    const src = readFileSync(file, "utf8");
+    expect(src).toContain("<RungConfigProvider value={resolveRungConfig()}>");
+    // The board must be INSIDE it, not a sibling.
+    expect(src.indexOf("<RungConfigProvider")).toBeLessThan(src.indexOf("<ScheduleBoard"));
+    expect(src.indexOf("<ScheduleBoard")).toBeLessThan(src.indexOf("</RungConfigProvider>"));
+  });
+});
+
+describe("resolveRungConfig (#385)", () => {
+  it("carries both weight sets and a budget per credit 1..6", () => {
+    const cfg = resolveRungConfig();
+    expect(cfg.scheduling.s1).toBe(60);
+    expect(cfg.officials.s1).toBe(120);
+    // Index 0 is 1 credit — the off-by-one the card's `budgets[n - 1]` depends on.
+    expect(cfg.budgets).toEqual([32_000, 64_000, 128_000, 160_000, 192_000, 224_000]);
+  });
+});

--- a/apps/web/src/components/v2/board/ai-competition-console.tsx
+++ b/apps/web/src/components/v2/board/ai-competition-console.tsx
@@ -42,6 +42,7 @@ import {
   type PickerDivision,
 } from "./ai-division-picker";
 import { AiQuoteCard, quoteFor, type QuoteCardLine } from "./ai-quote-card";
+import { useRungConfig } from "./rung-config-provider";
 import {
   aiErrorKey,
   applyErrorKey,
@@ -877,7 +878,11 @@ export function AiCompetitionConsole({
   const lines = jointQuoteLines(divisions, selected, rungs);
   // ONE quote. The CTA and the receipt read the same object, because pricing the
   // same run twice is exactly how a button and the card above it disagree.
-  const quote = quoteFor(lines);
+  // #385: on the SERVER-resolved weights — a client module never sees an
+  // AI_RUNG_* override, so the built-in fallback would price this run on the
+  // defaults while the invoice used the overrides.
+  const cfg = useRungConfig();
+  const quote = quoteFor(lines, { weights: cfg.scheduling });
   const divergent = divergentCourts(divisions, selected);
   const zones = timezoneSpread(divisions, selected);
   // The gate, and the click that feeds it. Both derived during render, so a

--- a/apps/web/src/components/v2/board/ai-competition-console.tsx
+++ b/apps/web/src/components/v2/board/ai-competition-console.tsx
@@ -41,7 +41,7 @@ import {
   selectableDivisions,
   type PickerDivision,
 } from "./ai-division-picker";
-import { AiQuoteCard, quoteFor, type QuoteCardLine } from "./ai-quote-card";
+import { AiQuoteCard, AiQuoteMismatchNote, quoteFor, type QuoteCardLine } from "./ai-quote-card";
 import { useRungConfig } from "./rung-config-provider";
 import {
   aiErrorKey,
@@ -624,6 +624,11 @@ export function JointReviewStep({
         {plan.summary}
       </p>
 
+      {/* #387 — the receipt correction, directly above the division ledger:
+          the ledger is what the run priced, and this is the line that says the
+          price it charged is not the one the confirm card promised. */}
+      <AiQuoteMismatchNote mismatch={plan.quote_mismatch} msg={msg} />
+
       {/* The ledger: one row per division, in the order it was picked and
           priced. This is what "the run covered all of them" looks like. */}
       <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
@@ -968,7 +973,17 @@ export function AiCompetitionConsole({
       // redeemed. Null when the organiser took the preference fallback — the
       // one path where nothing was confirmed.
       const result = await runJointPlan(
-        { competitionId, selected, instruction, rungs, prior, previewId: preview.slice.id },
+        {
+          competitionId,
+          selected,
+          instruction,
+          rungs,
+          prior,
+          previewId: preview.slice.id,
+          // #387: the number the receipt above this button is showing — the
+          // SAME `quote` object the card and the CTA read, not a recomputation.
+          quotedCredits: quote.credits,
+        },
         {
           inFlight,
           // Fires only after the guard passes, so a refused second click cannot
@@ -996,7 +1011,7 @@ export function AiCompetitionConsole({
       const key = aiErrorKey(result.httpStatus, result.code);
       setError({ message: msg(key), key });
     },
-    [competitionId, instruction, msg, onProposalChange, preview, running, rungs, selected],
+    [competitionId, instruction, msg, onProposalChange, preview, quote.credits, running, rungs, selected],
   );
 
   const doApply = useCallback(async () => {

--- a/apps/web/src/components/v2/board/ai-console.tsx
+++ b/apps/web/src/components/v2/board/ai-console.tsx
@@ -164,6 +164,11 @@ export function schedulePlanBody(
     mode: AiMode;
     officialsPolicy?: AiPlanRequest["officials_policy"] | null;
     prior?: AiPlanRequest["prior"] | null;
+    /** #387: the credits the confirm card SHOWED. The server compares it to
+     *  what it charges and records the divergence. Absent when no card was on
+     *  screen (the seq-conflict re-run), because silence must never be read as
+     *  "quoted zero". */
+    quotedCredits?: number;
   },
 ): AiPlanRequest {
   return {
@@ -187,6 +192,7 @@ export function schedulePlanBody(
     ...(state.preview.id ? { preview_id: state.preview.id } : {}),
     ...(args.officialsPolicy ? { officials_policy: args.officialsPolicy } : {}),
     ...(args.prior ? { prior: args.prior } : {}),
+    ...(args.quotedCredits !== undefined ? { quoted_credits: args.quotedCredits } : {}),
   };
 }
 
@@ -201,6 +207,8 @@ export function officialsPlanBody(
     /** Round-tripped assignments; the brief they were produced under comes from
      *  state, so the two halves of `prior` cannot describe different runs. */
     priorAssignments?: AiOfficialsPlanResponse["assignments"] | null;
+    /** #387 — see `schedulePlanBody`. */
+    quotedCredits?: number;
   },
 ): AiOfficialsPlanRequest {
   return {
@@ -216,6 +224,7 @@ export function officialsPlanBody(
           },
         }
       : {}),
+    ...(args.quotedCredits !== undefined ? { quoted_credits: args.quotedCredits } : {}),
   };
 }
 
@@ -519,6 +528,10 @@ export function AiConsole({
   // the write already forces a render on every path that sets it, so this is
   // a same-render swap, not a new one.
   const [officialsHadPrior, setOfficialsHadPrior] = useState(false);
+  // #385/#387: the SERVER's rung config, and the quotes the two confirm
+  // surfaces are showing. The run bodies send those numbers so the server can
+  // say whether what it charged is what the organiser was promised.
+  const rungConfig = useRungConfig();
   const officialsAutoStarted = useRef(false);
   // Cancel any in-flight run on close/unmount (the board conditionally renders
   // the dock, so unmount cleanup covers close too) — its rejection is ignored.
@@ -606,6 +619,13 @@ export function AiConsole({
     const body = schedulePlanBody(state, {
       instruction,
       mode,
+      // #387: the price the brief step is showing. Built from the SAME pure
+      // `scheduleQuoteLines` + `quoteFor` pair the card renders — the whole
+      // point of this field is that it is the card's number, so recomputing it
+      // a second way here would make it measure nothing.
+      quotedCredits: quoteFor(scheduleQuoteLines(divisionId, brief, mode, state.scope, state.rung), {
+        weights: rungConfig.scheduling,
+      }).credits,
       // A dry officials-coverage preview rides along only when the division has a
       // saved policy (none is persisted today, so this is omitted — see the prop).
       officialsPolicy,
@@ -645,7 +665,7 @@ export function AiConsole({
     // `state` whole, not a field list: the body builder reads the state object
     // itself (so a call site cannot hand it the wrong phase's rung), which means
     // a field list would go stale the moment the builder reads a new one.
-  }, [busy, divisionId, msg, officialsPolicy, state]);
+  }, [brief, busy, divisionId, msg, officialsPolicy, rungConfig, state]);
 
   // Phase B run. Empty instruction + no prior = the zero-token solver draft (the
   // auto-run on first entry); a non-empty instruction plans with the LLM; a
@@ -670,8 +690,25 @@ export function AiConsole({
       }));
       // Phase B's rung is read by the builder from `officialsRung` — never
       // passed in, so this call site cannot hand it Phase A's.
+      // #387: the officials card's own price. `freeDraft` is the SERVER's own
+      // predicate — `officials-ai.ts` takes `freeDraftQuote` iff the sent
+      // instruction is empty — and both spend paths (re-plan, adopt) supply
+      // that string themselves, so asking it of `opts.instruction` asks the
+      // question the server will ask of this very request.
+      const quotedCredits = quoteFor(
+        [
+          {
+            key: "officials",
+            label: null,
+            input: officialsQuoteInput(fixtures, schedule),
+            chosen: state.officialsRung,
+          },
+        ],
+        { weights: rungConfig.officials, freeDraft: opts.instruction.trim() === "" },
+      ).credits;
       const officialsBody = officialsPlanBody(state, {
         instruction: opts.instruction,
+        quotedCredits,
         schedule,
         policy: officialsPolicy ?? DEFAULT_OFFICIALS_POLICY,
         priorAssignments: opts.priorAssignments,
@@ -694,7 +731,7 @@ export function AiConsole({
       }
     },
     // See the note on `run`'s deps — the body builder reads `state` itself.
-    [busy, divisionId, msg, officialsPolicy, state],
+    [busy, divisionId, fixtures, msg, officialsPolicy, rungConfig, state],
   );
 
   // Auto-run the free solver draft the first time the organiser reaches the

--- a/apps/web/src/components/v2/board/ai-console.tsx
+++ b/apps/web/src/components/v2/board/ai-console.tsx
@@ -41,6 +41,7 @@ import {
 import { AiWishChips } from "./ai-wish-chips";
 import { AiPreflight, AiLastRun, type PreflightInput } from "./ai-preflight";
 import { AiQuoteCard, quoteFor, type QuoteCardLine } from "./ai-quote-card";
+import { useRungConfig } from "./rung-config-provider";
 import { compileWishes, deriveFreeText, joinNonEmpty, type Wish } from "./wish-compile";
 import { compileOfficialsWishes, type OfficialsWish } from "./officials-wish-compile";
 import { AiTrace, type TraceEvent } from "./ai-trace";
@@ -1087,6 +1088,11 @@ export function BriefStep({
   lastRun: AiLastResult | null;
 }) {
   const plural = usePlural();
+  // #385: the CTA and the confirm card price through the SAME server-resolved
+  // weights the card renders with. Letting `quoteFor` fall back to
+  // `schedulingRungWeights()` here would put a defaults-priced number on the
+  // button above a card priced on the overrides.
+  const cfg = useRungConfig();
   const tooShort = state.instruction.trim().length < 3;
   const presetNums = [1, 2, 3] as const;
   // ONE line — the division being planned. The joint competition console
@@ -1129,7 +1135,7 @@ export function BriefStep({
     ? runAction
     : msg("board.ai.quote.cta", {
         action: runAction,
-        credits: plural("board.ai.quote.credits", quoteFor(quoteLines).credits),
+        credits: plural("board.ai.quote.credits", quoteFor(quoteLines, { weights: cfg.scheduling }).credits),
       });
   return (
     <div className="space-y-3">
@@ -1291,7 +1297,7 @@ export function BriefStep({
       {cardVisible && state.preview.data && (
         <AiInstructionPreview
           preview={state.preview.data}
-          credits={quoteFor(quoteLines).credits}
+          credits={quoteFor(quoteLines, { weights: cfg.scheduling }).credits}
           onConfirm={run}
           onDismiss={() => dispatch({ type: "PREVIEW_DISMISS" })}
           onAsPreference={() => dispatch({ type: "PREVIEW_AS_PREFERENCE" })}

--- a/apps/web/src/components/v2/board/ai-console.tsx
+++ b/apps/web/src/components/v2/board/ai-console.tsx
@@ -532,7 +532,6 @@ export function AiConsole({
   // surfaces are showing. The run bodies send those numbers so the server can
   // say whether what it charged is what the organiser was promised.
   const rungConfig = useRungConfig();
-  const officialsAutoStarted = useRef(false);
   // Cancel any in-flight run on close/unmount (the board conditionally renders
   // the dock, so unmount cleanup covers close too) — its rejection is ignored.
   const abortRef = useRef<AbortController | null>(null);
@@ -647,10 +646,9 @@ export function AiConsole({
         { method: "POST", json: body, signal: ac.signal },
       );
       priorInstruction.current = instruction;
-      // A new schedule invalidates the officials draft (reducer clears the plan);
-      // reset the auto-run latch so the officials step re-solves over the new
-      // times on next entry rather than showing stale assignments.
-      officialsAutoStarted.current = false;
+      // A new schedule invalidates the officials draft — the reducer clears the
+      // plan, so the officials step returns to its pre-run card and the
+      // organiser drafts again over the new times when they choose to (#383).
       dispatch({ type: "RUN_DONE", plan });
     } catch (err) {
       // A cancelled run is not an error — the console is closing or superseded.
@@ -734,22 +732,13 @@ export function AiConsole({
     [busy, divisionId, fixtures, msg, officialsPolicy, rungConfig, state],
   );
 
-  // Auto-run the free solver draft the first time the organiser reaches the
-  // officials step so it is never blank (design/v4/03 §3). Fires once per open;
-  // refines are manual. On error the plan stays null and the ref stays set, so
-  // it never retries in a loop — the inline error offers Re-plan.
-  useEffect(() => {
-    if (
-      state.step === "officials" &&
-      state.officialsPlan === null &&
-      state.schedulePlan !== null &&
-      !officialsAutoStarted.current &&
-      !busy
-    ) {
-      officialsAutoStarted.current = true;
-      void runOfficials({ instruction: "" });
-    }
-  }, [state.step, state.officialsPlan, state.schedulePlan, busy, runOfficials]);
+  // #383: the officials step used to auto-fire the solver draft here. That run
+  // spends 1 credit (`freeDraftQuote` is a price CAP, not zero — "free" means
+  // free of MODEL cost), so the organiser was charged before a confirm card
+  // could render: the one credit-spending path in the product with no pre-spend
+  // surface, and the one they could not decline. The card in the officials step
+  // now carries the flat 1-credit price and a button, exactly as this step's
+  // siblings do.
 
   // ---------------------------------------------------- apply orchestration (T15)
   // Chain the existing apply rails: a before-ai checkpoint, the schedule apply(s)

--- a/apps/web/src/components/v2/board/ai-diff-panel.tsx
+++ b/apps/web/src/components/v2/board/ai-diff-panel.tsx
@@ -18,6 +18,7 @@ import {
   type AiConsoleFixture,
   type AiDiffSlot,
 } from "./ai-diff";
+import { AiQuoteMismatchNote } from "./ai-quote-card";
 import { Marker } from "./ai-marker";
 import { CONFLICT_LABEL } from "./types";
 
@@ -95,6 +96,11 @@ export function AiDiffPanel({
           ))}
         </div>
       </div>
+
+      {/* #387 — the receipt correction. Directly under the usage row because
+          that is where the run reports what it cost, and this is the line that
+          says that number is not the one the confirm card promised. */}
+      <AiQuoteMismatchNote mismatch={plan.quote_mismatch} msg={msg} />
 
       {/* Officials coverage preview — only when a policy was sent (§2). */}
       {cov && <CoverageStrip fillable={cov.fillable} total={cov.total} unfilled={cov.unfilled.length} />}

--- a/apps/web/src/components/v2/board/ai-joint-run.ts
+++ b/apps/web/src/components/v2/board/ai-joint-run.ts
@@ -41,6 +41,13 @@ export interface JointRunInput {
    *  fallback after a failed compile, which is the one path where nothing was
    *  confirmed and the server compiles inline exactly as it did before. */
   previewId?: string | null;
+  /** #387: the credits the confirm card SHOWED. The server compares it against
+   *  what it charges and records a divergence — so this must be the number the
+   *  receipt rendered, read from the same `quoteFor` call, never a second
+   *  computation that could quietly agree with itself while disagreeing with
+   *  the card. Optional: a re-run started with no card on screen quotes
+   *  nothing, and silence must not read as "quoted zero". */
+  quotedCredits?: number;
 }
 
 /** What a joint compile is asked about. Deliberately the run's own inputs minus
@@ -100,6 +107,7 @@ export function jointRunBody(input: JointRunInput): AiCompetitionPlanRequest {
     instruction: text,
     mode: input.prior ? "refine" : "generate",
     ...rungOverrides(input.rungs, input.selected),
+    ...(input.quotedCredits !== undefined ? { quoted_credits: input.quotedCredits } : {}),
     ...(input.previewId ? { preview_id: input.previewId } : {}),
     ...(input.prior
       ? {

--- a/apps/web/src/components/v2/board/ai-officials-review.tsx
+++ b/apps/web/src/components/v2/board/ai-officials-review.tsx
@@ -231,8 +231,14 @@ export function AiOfficialsReview({
     weights: officialsWeights,
     freeDraft,
   }).credits;
+  // #383: before anything has run there is no plan to re-plan — the button is
+  // the DRAFT, and it is the organiser's first chance to decline the spend.
+  // Naming it "Re-plan officials" while the grid is empty would describe work
+  // that has not happened; naming the price is what makes the button a
+  // decision rather than a surprise on the invoice.
+  const drafting = plan === null;
   const replanLabel = msg("board.ai.quote.cta", {
-    action: msg("board.ai.officials.replan"),
+    action: msg(drafting ? "board.ai.officials.run" : "board.ai.officials.replan"),
     credits: plural("board.ai.quote.credits", replanCredits),
   });
   const model = useMemo(
@@ -384,7 +390,11 @@ export function AiOfficialsReview({
         <button
           type="button"
           onClick={onReplan}
-          disabled={busy || plan === null}
+          // #383: NOT gated on a plan existing any more. That gate was written
+          // when the only thing that produced the first draft was the auto-run
+          // this task removed — leaving it would mean the organiser arrives at
+          // an empty step whose one button is permanently disabled.
+          disabled={busy}
           className="ai-run inline-flex w-full items-center justify-center gap-2 rounded-lg bg-gradient-to-br from-violet-600 to-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {busy ? (

--- a/apps/web/src/components/v2/board/ai-officials-review.tsx
+++ b/apps/web/src/components/v2/board/ai-officials-review.tsx
@@ -15,8 +15,9 @@
 import { useMemo, useState } from "react";
 import { timeLabel } from "@/lib/day-label";
 import { useMsg, usePlural } from "@/components/i18n/dict-provider";
-import { officialsRungWeights, type RungInput } from "@/lib/ai-rung";
+import { type RungInput } from "@/lib/ai-rung";
 import { AiQuoteCard, quoteFor, type QuoteCardLine } from "./ai-quote-card";
+import { useRungConfig } from "./rung-config-provider";
 import type { MessageKey } from "@/lib/messages";
 import type { AiOfficialsPlanResponse } from "@/server/api-v1/schemas";
 import { OfficialAvatar } from "@/components/v2/officials-shared";
@@ -211,7 +212,11 @@ export function AiOfficialsReview({
   // adopt brief and an empty box, Re-plan alone would in fact be free, so the
   // card OVER-quotes it. Over-quoting is the safe error; under-quoting bills
   // someone more than the surface they confirmed.
-  const officialsWeights = useMemo(() => officialsRungWeights(), []);
+  // #385: resolved on the SERVER. `officialsRungWeights()` called here read
+  // `process.env` through a computed key, which a `"use client"` bundle never
+  // gets substituted — so every AI_RUNG_OFFICIALS_* override the server priced
+  // with was invisible to this card.
+  const officialsWeights = useRungConfig().officials;
   const freeDraft = instruction.trim() === "" && adoptInstruction.trim() === "";
   // DISPLAY ONLY — never a price input (see above). A plan that reports no
   // tokens is *usually* the solver pass, which is good enough to pick the

--- a/apps/web/src/components/v2/board/ai-officials-review.tsx
+++ b/apps/web/src/components/v2/board/ai-officials-review.tsx
@@ -16,7 +16,7 @@ import { useMemo, useState } from "react";
 import { timeLabel } from "@/lib/day-label";
 import { useMsg, usePlural } from "@/components/i18n/dict-provider";
 import { type RungInput } from "@/lib/ai-rung";
-import { AiQuoteCard, quoteFor, type QuoteCardLine } from "./ai-quote-card";
+import { AiQuoteCard, AiQuoteMismatchNote, quoteFor, type QuoteCardLine } from "./ai-quote-card";
 import { useRungConfig } from "./rung-config-provider";
 import type { MessageKey } from "@/lib/messages";
 import type { AiOfficialsPlanResponse } from "@/server/api-v1/schemas";
@@ -294,6 +294,9 @@ export function AiOfficialsReview({
               ))}
             </div>
           </div>
+
+          {/* #387 — the receipt correction, beside the run's own usage row. */}
+          <AiQuoteMismatchNote mismatch={plan.quote_mismatch} msg={msg} />
 
           <CoverageLine filled={model.filled} total={model.total} />
         </div>

--- a/apps/web/src/components/v2/board/ai-quote-card.tsx
+++ b/apps/web/src/components/v2/board/ai-quote-card.tsx
@@ -318,6 +318,64 @@ export function AiQuoteCard({
   );
 }
 
+/**
+ * The receipt correction line (#387) — what the card quoted against what the
+ * run actually charged.
+ *
+ * Server-detected: the client sends the number its card showed and the server
+ * compares it against the charge, so this renders what the response reports and
+ * computes nothing itself. A client that recomputed the comparison could agree
+ * with itself while disagreeing with the invoice, which is the failure being
+ * measured.
+ *
+ * TWO TONES, because the two directions are not the same news. Charged MORE
+ * than quoted is the complaint-shaped one and takes the card's existing amber
+ * caution treatment — the same vocabulary the oversize and underfunded warnings
+ * already use, so it reads as part of the receipt rather than as a new kind of
+ * alert. Charged LESS is a correction in the organiser's favour and stays
+ * muted: alarming someone about money they did not spend trains them to ignore
+ * the amber one.
+ *
+ * The figures live in the sentence and nowhere else. An earlier pass paired
+ * them as a struck-through before/after; it printed both numbers twice, which
+ * is decoration, so it went.
+ */
+export function AiQuoteMismatchNote({
+  mismatch,
+  msg,
+}: {
+  mismatch: { quoted: number; charged: number } | undefined;
+  msg: ReturnType<typeof useMsg>;
+}) {
+  if (!mismatch) return null;
+  const over = mismatch.charged > mismatch.quoted;
+  const text = msg(over ? "board.ai.quote.mismatchOver" : "board.ai.quote.mismatchUnder", {
+    quoted: mismatch.quoted,
+    charged: mismatch.charged,
+  });
+  // `tabular-nums` on the whole line: the digits sit inside the sentence here,
+  // and the card's other amounts are lined up, so these should not be the one
+  // place the figures wobble.
+  return over ? (
+    <p
+      role="status"
+      data-ai-quote-mismatch="over"
+      className="flex items-start gap-1.5 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-[11px] leading-snug tabular-nums text-amber-900"
+    >
+      <span aria-hidden>⚠</span>
+      <span>{text}</span>
+    </p>
+  ) : (
+    <p
+      role="status"
+      data-ai-quote-mismatch="under"
+      className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-[11px] leading-snug tabular-nums text-slate-600"
+    >
+      {text}
+    </p>
+  );
+}
+
 function Caution({ children }: { children: ReactNode }) {
   return (
     <p

--- a/apps/web/src/components/v2/board/ai-quote-card.tsx
+++ b/apps/web/src/components/v2/board/ai-quote-card.tsx
@@ -37,6 +37,7 @@ import {
   type RungInput,
   type RungWeights,
 } from "@/lib/ai-rung";
+import { useRungConfig } from "./rung-config-provider";
 
 export const RUNGS: Rung[] = [1, 2, 3];
 
@@ -150,8 +151,20 @@ export function AiQuoteCard({
   busy: boolean;
 } & QuoteCardOptions) {
   const plural = usePlural();
-  const quote = quoteFor(lines, { weights, freeDraft });
+  // #385: the weights and budgets the SERVER resolved. `quoteFor` keeps its
+  // optional `weights` because the server calls it directly, but the COMPONENT
+  // never falls back to `schedulingRungWeights()` — a client module reads
+  // `process.env` through a computed key and always gets the defaults, so that
+  // fallback is precisely how the card came to quote a different number than
+  // the invoice charged.
+  const cfg = useRungConfig();
+  const quote = quoteFor(lines, { weights: weights ?? cfg.scheduling, freeDraft });
   const joint = quote.lines.length > 1;
+  // Same reasoning for the token budget. The tail fallback covers credit totals
+  // past the resolved table (a joint run of many rung-3 divisions); the ladder
+  // does not currently produce one, and a budget of `undefined` on screen would
+  // be worse than a defaults-derived number.
+  const budgetFor = (n: number): number => cfg.budgets[n - 1] ?? tokenBudgetForCredits(n);
 
   // "Very large" means the work outgrows what the TOP rung can buy — #348 §8's
   // "predicted > rung-3 capacity → still allow it, warn". It is measured
@@ -167,7 +180,7 @@ export function AiQuoteCard({
   // (run fewer divisions together), so it gets its own line.
   const oversized = freeDraft
     ? []
-    : quote.lines.filter((l) => l.estTokens > tokenBudgetForCredits(l.predictedRung));
+    : quote.lines.filter((l) => l.estTokens > budgetFor(l.predictedRung));
   // EVERY oversized line gets a name. Dropping the unnamed ones instead
   // (`.filter(Boolean)`) means a joint run whose oversized lines are all
   // unlabelled yields an empty list and falls through to the singular
@@ -176,9 +189,11 @@ export function AiQuoteCard({
   const oversizedNames = oversized.map(
     (l) => lines.find((x) => x.key === l.key)?.label ?? msg("board.ai.quote.thisDivision"),
   );
-  const predictedBudget = tokenBudgetForCredits(
-    quote.lines.reduce((n, l) => n + l.predictedRung, 0),
-  );
+  const predictedBudget = budgetFor(quote.lines.reduce((n, l) => n + l.predictedRung, 0));
+  // `quoteRun` sized this from its OWN `tokenBudgetForCredits`, which on the
+  // client is the defaults table. The number the organiser reads is the
+  // server's.
+  const budget = budgetFor(quote.rungTotal);
   const jointTooBig = !freeDraft && oversized.length === 0 && quote.estTokens > predictedBudget;
 
   return (
@@ -283,8 +298,8 @@ export function AiQuoteCard({
             for the free draft — it makes no model call, so promising it a
             thinking budget would describe a run that does not happen. */}
         {!freeDraft && (
-          <p className="text-[11px] text-slate-500" data-ai-budget={quote.budget}>
-            {msg("board.ai.quote.budget", { tokens: formatTokens(quote.budget) })}
+          <p className="text-[11px] text-slate-500" data-ai-budget={budget}>
+            {msg("board.ai.quote.budget", { tokens: formatTokens(budget) })}
           </p>
         )}
         {quote.underfunded && <Caution>{msg("board.ai.quote.underfunded")}</Caution>}

--- a/apps/web/src/components/v2/board/rung-config-provider.tsx
+++ b/apps/web/src/components/v2/board/rung-config-provider.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+// #385 — the rung weights and token budgets the SERVER resolved, carried to the
+// client surfaces that price a run.
+//
+// Why a provider rather than a prop: `schedule-board.tsx` is itself a client
+// module, so there is no server component in the console's own tree to hand the
+// value down from. The RSC that renders the board calls `resolveRungConfig()`
+// and wraps the board; everything below reads it from context.
+import { createContext, useContext, type ReactNode } from "react";
+import type { RungConfig } from "@/lib/ai-rung";
+
+const Ctx = createContext<RungConfig | null>(null);
+
+/** Seeded by the RSC that renders the board — see `resolveRungConfig` (#385). */
+export function RungConfigProvider({ value, children }: { value: RungConfig; children: ReactNode }) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+/**
+ * No default value, deliberately.
+ *
+ * A fallback here would reintroduce the exact silent divergence #385 is about:
+ * the card would quietly price on the built-in defaults while the server priced
+ * on its overrides, and nothing on screen or in a test would say so. A missing
+ * provider is a bug in the tree, so it throws where it happens rather than
+ * surfacing later as a support ticket about being overcharged.
+ */
+export function useRungConfig(): RungConfig {
+  const v = useContext(Ctx);
+  if (v === null) throw new Error("useRungConfig requires a RungConfigProvider");
+  return v;
+}

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -2809,6 +2809,8 @@
   "board.ai.quote.total": "Total",
   "board.ai.quote.budget": "Credits buy a thinking budget — up to {tokens} tokens for this run.",
   "board.ai.quote.underfunded": "Below the recommended credits. This run may stop before a full schedule.",
+  "board.ai.quote.mismatchOver": "Quoted {quoted}, charged {charged}. You were charged more than the estimate — please tell us.",
+  "board.ai.quote.mismatchUnder": "Quoted {quoted}, charged {charged}. You were charged less than the estimate.",
   "board.ai.quote.veryLarge": "This run is very large. Split the division and schedule it in parts for a better result.",
   "board.ai.quote.sizePlain": "{fixtures} fixtures · {courts} courts",
   "board.ai.quote.veryLargeDivisions.one": "{divisions} is very large. Schedule it in parts, or run fewer divisions together.",

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -2774,6 +2774,7 @@
   "board.ai.officials.instructionPlaceholder": "e.g. Put senior referees on the finals and spread duties evenly.",
   "board.ai.officials.instructionHint": "Plain language works best — describe duties, times and rest gaps, or add a wish below.",
   "board.ai.officials.replan": "Re-plan officials",
+  "board.ai.officials.run": "Draft the duty spread",
   "board.ai.officials.toApply": "Review & apply",
   "board.ai.officials.conflict.official_overlap": "Double-booked",
   "board.ai.officials.conflict.team_ref_self": "Officiating own match",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -2809,6 +2809,8 @@
   "board.ai.quote.total": "Total",
   "board.ai.quote.budget": "Los créditos compran un presupuesto de razonamiento — hasta {tokens} tokens en esta ejecución.",
   "board.ai.quote.underfunded": "Por debajo de los créditos recomendados. Esta ejecución puede detenerse antes de completar el calendario.",
+  "board.ai.quote.mismatchOver": "Presupuesto {quoted}, cobro {charged}. Se te cobró más que la estimación: cuéntanoslo.",
+  "board.ai.quote.mismatchUnder": "Presupuesto {quoted}, cobro {charged}. Se te cobró menos que la estimación.",
   "board.ai.quote.veryLarge": "Esta ejecución es muy grande. Divide la división y prográmala por partes para obtener un mejor resultado.",
   "board.ai.quote.sizePlain": "{fixtures} partidos · {courts} pistas",
   "board.ai.quote.veryLargeDivisions.one": "{divisions} es muy grande. Prográmala por partes o ejecuta menos divisiones juntas.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -2774,6 +2774,7 @@
   "board.ai.officials.instructionPlaceholder": "p. ej. Pon árbitros veteranos en las finales y reparte las tareas de forma equitativa.",
   "board.ai.officials.instructionHint": "El lenguaje natural funciona mejor: describe funciones, horarios y descansos, o añade un deseo abajo.",
   "board.ai.officials.replan": "Replanificar árbitros",
+  "board.ai.officials.run": "Redactar el reparto de tareas",
   "board.ai.officials.toApply": "Revisar y aplicar",
   "board.ai.officials.conflict.official_overlap": "Doble asignación",
   "board.ai.officials.conflict.team_ref_self": "Arbitra su propio partido",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -2774,6 +2774,7 @@
   "board.ai.officials.instructionPlaceholder": "p. ex. Placer les arbitres expérimentés sur les finales et répartir les tâches équitablement.",
   "board.ai.officials.instructionHint": "Le langage courant fonctionne le mieux — décrivez les fonctions, les horaires et les temps de repos, ou ajoutez un souhait ci-dessous.",
   "board.ai.officials.replan": "Replanifier les officiels",
+  "board.ai.officials.run": "Établir la répartition des tâches",
   "board.ai.officials.toApply": "Vérifier et appliquer",
   "board.ai.officials.conflict.official_overlap": "Double réservation",
   "board.ai.officials.conflict.team_ref_self": "Arbitre son propre match",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -2809,6 +2809,8 @@
   "board.ai.quote.total": "Total",
   "board.ai.quote.budget": "Les crédits achètent un budget de réflexion — jusqu’à {tokens} tokens pour cette exécution.",
   "board.ai.quote.underfunded": "En dessous des crédits recommandés. Cette exécution peut s’arrêter avant d’avoir terminé le calendrier.",
+  "board.ai.quote.mismatchOver": "Devis {quoted}, facturé {charged}. Vous avez été facturé plus que l’estimation — dites-le-nous.",
+  "board.ai.quote.mismatchUnder": "Devis {quoted}, facturé {charged}. Vous avez été facturé moins que l’estimation.",
   "board.ai.quote.veryLarge": "Cette exécution est très volumineuse. Divisez la division et planifiez-la en plusieurs fois pour un meilleur résultat.",
   "board.ai.quote.sizePlain": "{fixtures} matchs · {courts} terrains",
   "board.ai.quote.veryLargeDivisions.one": "{divisions} est très volumineuse. Planifiez-la en plusieurs fois, ou lancez moins de divisions ensemble.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -2774,6 +2774,7 @@
   "board.ai.officials.instructionPlaceholder": "bijv. Zet ervaren scheidsrechters op de finales en verdeel de taken gelijkmatig.",
   "board.ai.officials.instructionHint": "Gewone taal werkt het best — beschrijf taken, tijden en rustpauzes, of voeg hieronder een wens toe.",
   "board.ai.officials.replan": "Officials opnieuw plannen",
+  "board.ai.officials.run": "Stel de taakverdeling op",
   "board.ai.officials.toApply": "Controleren en toepassen",
   "board.ai.officials.conflict.official_overlap": "Dubbel geboekt",
   "board.ai.officials.conflict.team_ref_self": "Leidt eigen wedstrijd",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -2809,6 +2809,8 @@
   "board.ai.quote.total": "Totaal",
   "board.ai.quote.budget": "Credits kopen een denkbudget — tot {tokens} tokens voor deze run.",
   "board.ai.quote.underfunded": "Onder het aanbevolen aantal credits. Deze run stopt mogelijk voordat het schema af is.",
+  "board.ai.quote.mismatchOver": "Offerte {quoted}, in rekening gebracht {charged}. Je hebt meer betaald dan de schatting — laat het ons weten.",
+  "board.ai.quote.mismatchUnder": "Offerte {quoted}, in rekening gebracht {charged}. Je hebt minder betaald dan de schatting.",
   "board.ai.quote.veryLarge": "Deze run is erg groot. Splits de divisie en plan die in delen voor een beter resultaat.",
   "board.ai.quote.sizePlain": "{fixtures} wedstrijden · {courts} velden",
   "board.ai.quote.veryLargeDivisions.one": "{divisions} is erg groot. Plan die in delen, of plan minder divisies samen.",

--- a/apps/web/src/lib/ai-rung.ts
+++ b/apps/web/src/lib/ai-rung.ts
@@ -79,6 +79,46 @@ export function officialsRungWeights(): RungWeights {
   };
 }
 
+/**
+ * Every AI_RUNG_* override, resolved in ONE place, for handing to the client
+ * (#385).
+ *
+ * `envNumber` above reads `process.env[name]` with a COMPUTED key. Next
+ * replaces `process.env.FOO` by static substitution, and only for
+ * NEXT_PUBLIC_-prefixed names, so a computed lookup is never replaced at all:
+ * in a `"use client"` module every one of these calls falls through to its
+ * fallback. The confirm card therefore priced on defaults while the server
+ * priced on the overrides — and when an override RAISES a price that is a
+ * silent under-quote, the organiser charged more than the card promised.
+ *
+ * Nothing sets these variables today, which is exactly why this is worth fixing
+ * now: the mechanism exists to be used in production WITHOUT a deploy (see
+ * `tokenBudgetForCredits`' own note), so the first calibration change would
+ * introduce the divergence.
+ */
+export interface RungConfig {
+  scheduling: RungWeights;
+  officials: RungWeights;
+  /** Budget for 1..6 credits, resolved server-side. Index 0 is 1 credit. Six
+   *  because #350's joint solve tops out well inside that; the card falls back
+   *  to `tokenBudgetForCredits` for anything past the end rather than showing a
+   *  budget of `undefined`. */
+  budgets: number[];
+}
+
+/**
+ * SERVER-ONLY. Call it in an RSC and pass the result through
+ * `RungConfigProvider` — see the note on {@link RungConfig} for why a client
+ * module cannot resolve these for itself.
+ */
+export function resolveRungConfig(): RungConfig {
+  return {
+    scheduling: schedulingRungWeights(),
+    officials: officialsRungWeights(),
+    budgets: [1, 2, 3, 4, 5, 6].map((n) => tokenBudgetForCredits(n)),
+  };
+}
+
 export interface RungInput {
   movableFixtures: number;
   entrants: number;

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -626,6 +626,8 @@ export type DictionaryKey =
   | "board.ai.quote.discount"
   | "board.ai.quote.discountAmount"
   | "board.ai.quote.freeDraft"
+  | "board.ai.quote.mismatchOver"
+  | "board.ai.quote.mismatchUnder"
   | "board.ai.quote.predicted"
   | "board.ai.quote.rungAria"
   | "board.ai.quote.rungAriaDivision"

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -519,6 +519,7 @@ export type DictionaryKey =
   | "board.ai.officials.lockedTitle"
   | "board.ai.officials.noEligible"
   | "board.ai.officials.replan"
+  | "board.ai.officials.run"
   | "board.ai.officials.running"
   | "board.ai.officials.solverSuggests"
   | "board.ai.officials.toApply"

--- a/apps/web/src/server/api-v1/schemas.ts
+++ b/apps/web/src/server/api-v1/schemas.ts
@@ -1695,6 +1695,22 @@ const AiRunPriceFields = {
   /** Single-division form. */
   rung: RungLiteral.optional(),
   predicted_rung: RungLiteral.optional(),
+  /**
+   * Set ONLY when the client's confirm card quoted a different number than the
+   * server charged (#387).
+   *
+   * The card computes its quote by calling the same pure function the server
+   * calls — deliberately, so there is one arithmetic implementation and no
+   * per-keystroke fetch. That rests on one premise: same function, same inputs,
+   * same environment. PR #359 found three ways it breaks and #385 closed the
+   * largest; this field makes any residual divergence VISIBLE instead of
+   * silent.
+   *
+   * Both directions are reported. An over-quote is a bad surprise on screen; an
+   * under-quote is a billing complaint. Absent means they agreed — or that the
+   * caller sent no quote at all, which is not the same as quoting zero.
+   */
+  quote_mismatch: z.object({ quoted: z.number().int(), charged: z.number().int() }).optional(),
   /** Joint (multi-division) form — issue #350. */
   discount: z.number().int().optional(),
   divisions: z
@@ -1751,6 +1767,18 @@ export const AiPlanRequest = z.object({
    * they always have.
    */
   preview_id: Uuid.optional(),
+  /**
+   * What the confirm card showed (#387). The server compares it against what it
+   * actually charged, reports the divergence on `quote_mismatch` and records a
+   * `schedule.ai_quote_mismatch` competition_event.
+   *
+   * OPTIONAL, and it must stay that way: server-side callers, smoke and every
+   * external consumer send none. `.positive()` rather than `.nonnegative()`
+   * because there is no such thing as a zero-credit quote — an absent value must
+   * never be read as "quoted nothing", and a client that means "I showed no
+   * price" says so by omitting the field.
+   */
+  quoted_credits: z.number().int().positive().optional(),
 });
 export type AiPlanRequest = z.infer<typeof AiPlanRequest>;
 
@@ -1934,6 +1962,18 @@ export const AiOfficialsPlanRequest = z.object({
   // Ignored on the empty-instruction path, which makes no model call and is
   // always priced at 1 credit.
   rung: RungLiteral.optional(),
+  /**
+   * What the confirm card showed (#387). The server compares it against what it
+   * actually charged, reports the divergence on `quote_mismatch` and records a
+   * `schedule.ai_quote_mismatch` competition_event.
+   *
+   * OPTIONAL, and it must stay that way: server-side callers, smoke and every
+   * external consumer send none. `.positive()` rather than `.nonnegative()`
+   * because there is no such thing as a zero-credit quote — an absent value must
+   * never be read as "quoted nothing", and a client that means "I showed no
+   * price" says so by omitting the field.
+   */
+  quoted_credits: z.number().int().positive().optional(),
 });
 export type AiOfficialsPlanRequest = z.infer<typeof AiOfficialsPlanRequest>;
 
@@ -2034,6 +2074,18 @@ export const AiCompetitionPlanRequest = z.object({
    *  a preview taken against ONE division is refused here, because its window
    *  was resolved from a different fixture count than this run's. */
   preview_id: Uuid.optional(),
+  /**
+   * What the confirm card showed (#387). The server compares it against what it
+   * actually charged, reports the divergence on `quote_mismatch` and records a
+   * `schedule.ai_quote_mismatch` competition_event.
+   *
+   * OPTIONAL, and it must stay that way: server-side callers, smoke and every
+   * external consumer send none. `.positive()` rather than `.nonnegative()`
+   * because there is no such thing as a zero-credit quote — an absent value must
+   * never be read as "quoted nothing", and a client that means "I showed no
+   * price" says so by omitting the field.
+   */
+  quoted_credits: z.number().int().positive().optional(),
 });
 export type AiCompetitionPlanRequest = z.infer<typeof AiCompetitionPlanRequest>;
 

--- a/apps/web/src/server/usecases/__tests__/ai-quote-mismatch-resilience.test.ts
+++ b/apps/web/src/server/usecases/__tests__/ai-quote-mismatch-resilience.test.ts
@@ -1,0 +1,99 @@
+// #387 — what happens when the TELEMETRY write itself fails.
+//
+// Separate from `ai-quote-mismatch.test.ts` on purpose: that suite drives the
+// three real run paths against real Postgres, where the insert succeeds. The
+// failure this file is about cannot be produced there — it needs the write to
+// throw, which means mocking `withTenant`, which is incompatible with a suite
+// whose other assertions read the rows back.
+//
+// Why it matters: all three call sites `await recordQuoteMismatch(...)` bare,
+// and they sit inside functions whose outer wrapper re-throws once the credit
+// is consumed. Before the catch inside the helper, a constraint or
+// serialization error on this insert turned a PAID, SUCCESSFUL run into a 500 —
+// the organiser lost the response to a plan they had already been charged for,
+// caused by the very telemetry that exists to detect them being overcharged.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { withTenantMock } = vi.hoisted(() => ({ withTenantMock: vi.fn() }));
+vi.mock("@/lib/db", () => ({ withTenant: withTenantMock }));
+
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { recordQuoteMismatch } from "../ai-quote-mismatch";
+
+const auth = { orgId: "org-1", userId: "user-1" } as unknown as AuthCtx;
+const ctx = { competitionId: "comp-1", divisionIds: ["div-1", "div-2"] };
+
+describe("recordQuoteMismatch — the write failing must not fail the run", () => {
+  beforeEach(() => {
+    withTenantMock.mockReset();
+    // Default: the write succeeds. Individual tests override.
+    withTenantMock.mockResolvedValue(undefined);
+  });
+
+  it("still resolves with the mismatch when the insert throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    withTenantMock.mockRejectedValue(new Error("duplicate key value violates unique constraint"));
+
+    // The assertion that carries the regression: without the catch this
+    // REJECTS, and the three call sites propagate that to a 500.
+    await expect(recordQuoteMismatch(auth, ctx, 7, 9)).resolves.toEqual({
+      quoted: 7,
+      charged: 9,
+    });
+
+    // The failure is not silent — a swallowed telemetry error that leaves no
+    // trace is how a permanently broken insert goes unnoticed for a month.
+    expect(warn).toHaveBeenCalledWith("[quote-mismatch] record failed:", expect.any(Error));
+    warn.mockRestore();
+  });
+
+  it("reports the mismatch to the caller even though nothing was recorded", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    withTenantMock.mockRejectedValue(new Error("could not serialize access"));
+
+    // A lost row is not a reason to tell the caller their quote matched. The
+    // comparison is pure and was already true before the write was attempted,
+    // so the response field stays truthful independently of the database.
+    const out = await recordQuoteMismatch(auth, ctx, 12, 4);
+    expect(out).toEqual({ quoted: 12, charged: 4 });
+    vi.restoreAllMocks();
+  });
+
+  it("returns the mismatch when the insert succeeds, and writes exactly once", async () => {
+    // Guards the other direction: a catch-all that swallowed everything would
+    // pass the two tests above while never writing at all.
+    const out = await recordQuoteMismatch(auth, ctx, 3, 5);
+    expect(out).toEqual({ quoted: 3, charged: 5 });
+    expect(withTenantMock).toHaveBeenCalledTimes(1);
+    expect(withTenantMock).toHaveBeenCalledWith("org-1", expect.any(Function));
+  });
+
+  it("does not touch the database when the quote matched the charge", async () => {
+    await expect(recordQuoteMismatch(auth, ctx, 6, 6)).resolves.toBeUndefined();
+    expect(withTenantMock).not.toHaveBeenCalled();
+  });
+
+  it("does not touch the database when no quote was sent", async () => {
+    // `undefined` is silence, not zero — server-side callers, smoke and every
+    // external consumer send nothing.
+    await expect(recordQuoteMismatch(auth, ctx, undefined, 5)).resolves.toBeUndefined();
+    expect(withTenantMock).not.toHaveBeenCalled();
+  });
+
+  it("does not treat a zero charge against a zero quote as a mismatch", async () => {
+    // 0 is falsy; a `!quoted` guard instead of `=== undefined` would file a
+    // mismatch here and miss the real one below.
+    await expect(recordQuoteMismatch(auth, ctx, 0, 0)).resolves.toBeUndefined();
+    expect(withTenantMock).not.toHaveBeenCalled();
+  });
+
+  it("records a free run that was quoted as costing something", async () => {
+    // The other half of the 0 pair: quoted 2, charged 0 IS a mismatch, and the
+    // direction is `under`.
+    await expect(recordQuoteMismatch(auth, ctx, 2, 0)).resolves.toEqual({
+      quoted: 2,
+      charged: 0,
+    });
+    expect(withTenantMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/ai-quote-mismatch.test.ts
+++ b/apps/web/src/server/usecases/__tests__/ai-quote-mismatch.test.ts
@@ -1,0 +1,425 @@
+// #387 — the server compares what it CHARGED to what the confirm card QUOTED,
+// reports the divergence on the response and records it as a competition_event.
+//
+// What makes this worth a suite of its own: the comparison lives on three
+// separate run paths (`aiPlanForDivision`, `aiPlanForCompetition`,
+// `officialsAiPlanForDivision`) behind ONE helper. A helper with a missing call
+// site is completely silent — the run succeeds, the response simply omits the
+// field, and every other suite stays green. So each path is driven here, not
+// just the division one.
+//
+// Model boundary is mocked at @/server/ai/select-provider (not just the
+// Anthropic SDK): the shipped ladder's first rung is OpenRouter and a developer
+// .env.local carries a real key, so mocking the SDK alone still leaves a live
+// network path. Entitlements, credits and the pack builder hit real Postgres.
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import type { AiChatResponse } from "@/server/ai/provider";
+
+const { chat } = vi.hoisted(() => ({ chat: vi.fn() }));
+
+// The stage-1 instruction compiler (#398) makes its own LLM call BEFORE the
+// architect's. This suite's fake provider queue is 1:1 with architect calls, so
+// an un-neutralised pre-flight eats the first queued response and every
+// assertion shifts by one. It has its own suites; here it must not exist.
+const { parseInstructionMock } = vi.hoisted(() => ({
+  parseInstructionMock: vi.fn(async () => ({
+    raw: null,
+    failed: false,
+    tokens: 0,
+    servedModel: null,
+  })),
+}));
+vi.mock("../schedule-ai-parse", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../schedule-ai-parse")>();
+  return { ...actual, parseInstruction: parseInstructionMock };
+});
+
+vi.mock("@/server/ai/select-provider", () => {
+  const provider = { id: "anthropic" as const, isConfigured: () => true, chat };
+  return { selectProvider: () => provider, resolveProvider: () => provider };
+});
+
+import { sql } from "@/lib/db";
+import { invalidateOrgEntitlements } from "@/lib/entitlements";
+import type { AuthCtx } from "@/server/api-v1/auth";
+import { AiCompetitionPlanRequest, AiOfficialsPlanRequest, AiPlanRequest } from "@/server/api-v1/schemas";
+import { createCompetition } from "../competitions";
+import { createDivision } from "../divisions";
+import { createEntrants } from "../entrants";
+import { createStages, generateStageFixtures } from "../stages";
+import { aiPlanForDivision } from "../schedule-ai";
+import { aiPlanForCompetition } from "../competition-schedule-ai";
+import { officialsAiPlanForDivision } from "../officials-ai";
+import { GENERIC_CONFIG, seedOrg } from "./_seed";
+import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+import { recordPackPurchase, walletIdFor } from "@/lib/credits";
+import { QUOTE_MISMATCH_EVENT } from "../ai-quote-mismatch";
+
+/** The officials-auto policy body, in full — `AssignPolicyBody` has no
+ *  defaults, so a partial literal does not typecheck. */
+const REFEREE_POLICY = {
+  roles: ["referee"],
+  poolLock: false,
+  blockStay: true,
+  fairness: "tournament" as const,
+  teamRefKeepDivision: false,
+  restMinMinutes: 0,
+  blockGapMinutes: 30,
+};
+
+const HAS_DB = !!process.env.DATABASE_URL;
+const TZ = "Europe/London";
+const MIN = 60_000;
+const T0 = Date.parse("2026-08-01T09:00:00.000Z");
+
+function settingsConfig(courts: string[]) {
+  return {
+    startAt: "2026-08-01T09:00:00.000Z",
+    matchMinutes: 30,
+    gapMinutes: 0,
+    courts,
+    perEntrantMinRest: 0,
+    blackouts: [],
+    sessionWindows: [{ from: "2026-08-01T09:00:00.000Z", to: "2026-08-01T21:00:00.000Z" }],
+    constraints: {
+      restMin: 0,
+      noBackToBack: false,
+      startWindows: [],
+      fieldFairness: "balance",
+      parallelism: "mixed",
+      crossPersonClash: "hard",
+    },
+  };
+}
+
+interface SeededDivision {
+  id: string;
+  courts: string[];
+  fixtureIds: string[];
+}
+
+async function seedDivision(
+  auth: AuthCtx,
+  competitionId: string,
+  opts: { courts?: string[]; officials?: number } = {},
+): Promise<SeededDivision> {
+  const courts = opts.courts ?? ["Court 1", "Court 2"];
+  const slug = `d-${randomUUID().slice(0, 8)}`;
+  const division = await createDivision(auth, competitionId, {
+    name: slug,
+    slug,
+    sport_key: "generic",
+    variant_key: "score",
+    config: GENERIC_CONFIG,
+    eligibility: [],
+  });
+  await createEntrants(
+    auth,
+    division.id,
+    Array.from({ length: 4 }, (_, i) => ({
+      kind: "individual" as const,
+      display_name: `${slug}-E${i + 1}`,
+      seed: i + 1,
+      members: [],
+    })),
+  );
+  await sql`
+    insert into schedule_settings (division_id, config, tz, updated_at)
+    values (${division.id}, ${sql.json(settingsConfig(courts) as never)}, ${TZ}, now())
+    on conflict (division_id) do update set config = excluded.config, tz = excluded.tz`;
+  const [stage] = await createStages(auth, division.id, { seq: 1, kind: "league", name: "League", config: {} });
+  const { fixtures } = await generateStageFixtures(auth, stage!.id);
+  for (let i = 0; i < (opts.officials ?? 0); i++) {
+    await sql`
+      insert into officials (org_id, display_name, role_keys)
+      values (${auth.orgId}, ${"Ref " + i}, ${sql.json(["referee"])})`;
+  }
+  return {
+    id: division.id,
+    courts,
+    fixtureIds: [...fixtures]
+      .sort((a, b) => a.round_no - b.round_no || a.seq_in_round - b.seq_in_round)
+      .map((f) => f.id),
+  };
+}
+
+/** pro_plus (scheduling.ai + scheduling.multi_division) with a funded wallet. */
+async function seedPlusOrg(): Promise<AuthCtx> {
+  const { auth } = await seedOrg("community");
+  await setOrgPlan(auth.orgId, "pro_plus");
+  await invalidateOrgEntitlements(auth.orgId);
+  await recordPackPurchase(await walletIdFor(auth.orgId), 100, `seed-${randomUUID()}`);
+  return auth;
+}
+
+function legalPlan(divisions: SeededDivision[]): unknown {
+  return {
+    assignments: divisions.flatMap((d) =>
+      d.fixtureIds.map((id, i) => ({
+        fixture_id: id,
+        scheduled_at: new Date(T0 + Math.floor(i / d.courts.length) * 30 * MIN).toISOString(),
+        court_label: d.courts[i % d.courts.length]!,
+      })),
+    ),
+    unschedulable: [],
+    explanations: [],
+    summary: "ok",
+  };
+}
+
+function chatResponse(parsed: unknown): AiChatResponse<unknown> {
+  return {
+    parsed,
+    assistantTurn: { role: "assistant", content: [] },
+    usage: { inputTokens: 1000, outputTokens: 500, costUsd: 0.01 },
+    servedModel: "claude-sonnet-5",
+    refused: false,
+  };
+}
+
+interface MismatchEvent {
+  payload: { quoted: number; charged: number; division_ids: string[]; direction: string };
+  competition_id: string;
+  org_id: string;
+}
+
+async function mismatchEvents(competitionId: string): Promise<MismatchEvent[]> {
+  return sql<MismatchEvent[]>`
+    select payload, competition_id, org_id from competition_events
+     where competition_id = ${competitionId} and type = ${QUOTE_MISMATCH_EVENT}
+     order by created_at`;
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const g = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = g._sql;
+  g._sql = undefined;
+  await client?.end();
+});
+
+beforeEach(() => {
+  chat.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// The wire contract. These run without a DB — an absent quote and a zero quote
+// must not be the same thing, and the boundary is where that is enforced
+// (usecases never re-parse their input).
+// ---------------------------------------------------------------------------
+describe("quoted_credits on the wire (#387)", () => {
+  const base = { instruction: "plan it", mode: "generate" as const };
+
+  it("is carried through when a client sends one", () => {
+    expect(AiPlanRequest.parse({ ...base, quoted_credits: 2 }).quoted_credits).toBe(2);
+    expect(
+      AiOfficialsPlanRequest.parse({ instruction: "", policy: REFEREE_POLICY, quoted_credits: 3 })
+        .quoted_credits,
+    ).toBe(3);
+    expect(
+      AiCompetitionPlanRequest.parse({
+        division_ids: [randomUUID(), randomUUID()],
+        instruction: "plan it",
+        quoted_credits: 5,
+      }).quoted_credits,
+    ).toBe(5);
+  });
+
+  it("is absent, not zero, when a caller sends none", () => {
+    // Server-side callers and every external consumer send nothing. Silence
+    // must never read as "quoted zero" — that would file a mismatch against
+    // every one of them.
+    expect(AiPlanRequest.parse(base).quoted_credits).toBeUndefined();
+    expect("quoted_credits" in AiPlanRequest.parse(base)).toBe(false);
+  });
+
+  it("refuses 0 and negatives at the boundary", () => {
+    // There is no such thing as a zero-credit quote: `quoteRun` floors every
+    // line at rung 1. Accepting 0 here would let a client claim it showed a
+    // free run and have the server agree it was a mismatch rather than nonsense.
+    for (const bad of [0, -1, -3]) {
+      expect(AiPlanRequest.safeParse({ ...base, quoted_credits: bad }).success).toBe(false);
+      expect(
+        AiOfficialsPlanRequest.safeParse({ instruction: "", policy: REFEREE_POLICY, quoted_credits: bad })
+          .success,
+      ).toBe(false);
+      expect(
+        AiCompetitionPlanRequest.safeParse({
+          division_ids: [randomUUID(), randomUUID()],
+          instruction: "plan it",
+          quoted_credits: bad,
+        }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("refuses a fractional quote", () => {
+    expect(AiPlanRequest.safeParse({ ...base, quoted_credits: 1.5 }).success).toBe(false);
+  });
+});
+
+describe.skipIf(!HAS_DB)("quote/charge mismatch — schedule-ai (#387)", () => {
+  it("records a competition_event when the charge differs from the quote", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM", visibility: "public", branding: {} });
+    const division = await seedDivision(auth, comp.id);
+    chat.mockResolvedValueOnce(chatResponse(legalPlan([division])));
+
+    // The card said 2; this division prices at 1.
+    const plan = await aiPlanForDivision(auth, division.id, {
+      instruction: "plan it",
+      mode: "generate",
+      quoted_credits: 2,
+    });
+
+    expect(plan.credits).toBe(1);
+    expect(plan.quote_mismatch).toEqual({ quoted: 2, charged: 1 });
+
+    const events = await mismatchEvents(comp.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload.quoted).toBe(2);
+    expect(events[0]!.payload.charged).toBe(1);
+    // Traceable back to the pack that was priced, and scoped to the tenant.
+    expect(events[0]!.payload.division_ids).toEqual([division.id]);
+    expect(events[0]!.org_id).toBe(auth.orgId);
+    expect(events[0]!.competition_id).toBe(comp.id);
+    // The organiser still gets their plan. This is telemetry, not a gate: they
+    // have already been charged, so refusing here would take the credit and
+    // hand back nothing.
+    expect(plan.proposal).toHaveLength(division.fixtureIds.length);
+  });
+
+  it("reports an UNDER-quote too — the billing-complaint direction", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM under", visibility: "public", branding: {} });
+    // Forcing rung 3 makes the server charge 3 against a card that said 1.
+    const division = await seedDivision(auth, comp.id);
+    chat.mockResolvedValueOnce(chatResponse(legalPlan([division])));
+
+    const plan = await aiPlanForDivision(auth, division.id, {
+      instruction: "plan it",
+      mode: "generate",
+      rung: 3,
+      quoted_credits: 1,
+    });
+
+    expect(plan.credits).toBe(3);
+    expect(plan.quote_mismatch).toEqual({ quoted: 1, charged: 3 });
+    const events = await mismatchEvents(comp.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload.direction).toBe("over"); // charged > quoted
+  });
+
+  it("records nothing and reports nothing when they agree", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM agree", visibility: "public", branding: {} });
+    const division = await seedDivision(auth, comp.id);
+    chat.mockResolvedValueOnce(chatResponse(legalPlan([division])));
+
+    const plan = await aiPlanForDivision(auth, division.id, {
+      instruction: "plan it",
+      mode: "generate",
+      quoted_credits: 1,
+    });
+
+    expect(plan.credits).toBe(1);
+    expect(plan.quote_mismatch).toBeUndefined();
+    expect(await mismatchEvents(comp.id)).toHaveLength(0);
+  });
+
+  it("an omitted quoted_credits is not a mismatch", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM silent", visibility: "public", branding: {} });
+    const division = await seedDivision(auth, comp.id);
+    chat.mockResolvedValueOnce(chatResponse(legalPlan([division])));
+
+    const plan = await aiPlanForDivision(auth, division.id, { instruction: "plan it", mode: "generate" });
+
+    expect(plan.quote_mismatch).toBeUndefined();
+    expect(await mismatchEvents(comp.id)).toHaveLength(0);
+  });
+});
+
+describe.skipIf(!HAS_DB)("quote/charge mismatch — the joint solve (#387)", () => {
+  it("records it on the competition path too", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM joint", visibility: "public", branding: {} });
+    const a = await seedDivision(auth, comp.id, { courts: ["Court 1", "Court 2"] });
+    const b = await seedDivision(auth, comp.id, { courts: ["Court 3", "Court 4"] });
+    chat.mockResolvedValueOnce(chatResponse(legalPlan([a, b])));
+
+    // Two rung-1 divisions price at max(1, 2 - 1) = 1; the card said 4.
+    const plan = await aiPlanForCompetition(auth, comp.id, {
+      division_ids: [a.id, b.id],
+      instruction: "plan the whole competition",
+      mode: "generate",
+      quoted_credits: 4,
+    });
+
+    expect(plan.credits).toBe(1);
+    expect(plan.quote_mismatch).toEqual({ quoted: 4, charged: 1 });
+    const events = await mismatchEvents(comp.id);
+    expect(events).toHaveLength(1);
+    // BOTH divisions, so the event names the run that was priced rather than an
+    // arbitrary one of them.
+    expect([...events[0]!.payload.division_ids].sort()).toEqual([a.id, b.id].sort());
+    expect(events[0]!.payload.direction).toBe("under");
+  });
+
+  it("records nothing when the joint quote agrees", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM joint ok", visibility: "public", branding: {} });
+    const a = await seedDivision(auth, comp.id, { courts: ["Court 1", "Court 2"] });
+    const b = await seedDivision(auth, comp.id, { courts: ["Court 3", "Court 4"] });
+    chat.mockResolvedValueOnce(chatResponse(legalPlan([a, b])));
+
+    const plan = await aiPlanForCompetition(auth, comp.id, {
+      division_ids: [a.id, b.id],
+      instruction: "plan the whole competition",
+      mode: "generate",
+      quoted_credits: 1,
+    });
+
+    expect(plan.quote_mismatch).toBeUndefined();
+    expect(await mismatchEvents(comp.id)).toHaveLength(0);
+  });
+});
+
+describe.skipIf(!HAS_DB)("quote/charge mismatch — officials (#387)", () => {
+  it("records it on the officials path too", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM officials", visibility: "public", branding: {} });
+    const division = await seedDivision(auth, comp.id, { officials: 2 });
+
+    // The empty-instruction path is the deterministic solver draft: no model
+    // call, flat 1 credit. The card claimed 3.
+    const plan = await officialsAiPlanForDivision(auth, division.id, {
+      instruction: "",
+      policy: REFEREE_POLICY,
+      quoted_credits: 3,
+    });
+
+    expect(chat).not.toHaveBeenCalled();
+    expect(plan.credits).toBe(1);
+    expect(plan.quote_mismatch).toEqual({ quoted: 3, charged: 1 });
+    const events = await mismatchEvents(comp.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.payload.division_ids).toEqual([division.id]);
+  });
+
+  it("records nothing when the officials quote agrees", async () => {
+    const auth = await seedPlusOrg();
+    const comp = await createCompetition(auth, { name: "QM officials ok", visibility: "public", branding: {} });
+    const division = await seedDivision(auth, comp.id, { officials: 2 });
+
+    const plan = await officialsAiPlanForDivision(auth, division.id, {
+      instruction: "",
+      policy: REFEREE_POLICY,
+      quoted_credits: 1,
+    });
+
+    expect(plan.quote_mismatch).toBeUndefined();
+    expect(await mismatchEvents(comp.id)).toHaveLength(0);
+  });
+});

--- a/apps/web/src/server/usecases/__tests__/officials-ai-adopt.test.ts
+++ b/apps/web/src/server/usecases/__tests__/officials-ai-adopt.test.ts
@@ -1,0 +1,209 @@
+// #384 — an adopted candidate must reach the solve.
+//
+// Adopting a candidate while the instruction box is empty silently discarded
+// the adoption. Three symptoms, one root: `pack.prior` was carried into the
+// pack and consumed ONLY as a diff baseline (`officialsDiff`), never as a solve
+// input — so `draftAsPlan` re-derived everything from the deterministic solver
+// and threw the organiser's click away, while the diff then reported their own
+// adoption as something the AI had changed away.
+//
+// `prior` carries two fields doing unrelated jobs. `prior.instruction` is the
+// previous run's sentence. `prior.assignments` is the grid on screen with the
+// adoption patched in — data produced by the click that just happened, not a
+// stale instruction replayed. THIS PATH READS `prior.assignments` ONLY: on the
+// empty-instruction branch there is no instruction to execute, which is the
+// premise of the branch (zero LLM calls, deterministic solver, flat 1 credit).
+//
+// PURE — every pack is hand-built, no DB and no provider.
+import { describe, expect, it } from "vitest";
+import { runOfficialsAiPlan, type OfficialsPack } from "../officials-ai";
+
+const POLICY = {
+  roles: ["referee"],
+  poolLock: false,
+  blockStay: false,
+  fairness: "tournament" as const,
+  teamRefKeepDivision: false,
+  restMinMinutes: 0,
+  blockGapMinutes: 30,
+};
+
+function fixture(id: string, start_at: string): OfficialsPack["fixtures"][number] {
+  return { id, start_at, court: "Court 1", pool: null, entrants: [] };
+}
+
+function official(id: string): OfficialsPack["officials"][number] {
+  return {
+    id,
+    name: id,
+    role_keys: ["referee"],
+    home_pool_id: null,
+    max_per_day: null,
+    blackout_dates: [],
+    busy_elsewhere: [],
+    entrant_ids: [],
+  };
+}
+
+const F1 = fixture("f1", "2026-08-01T09:00:00+00:00");
+const F2 = fixture("f2", "2026-08-01T11:00:00+00:00");
+
+/** A two-fixture pack whose solver draft puts `solver-official` everywhere, so
+ *  an adoption is always visibly different from what the draft would produce. */
+function packWithPrior(over: {
+  instruction?: string;
+  priorInstruction?: string;
+  priorAssignments: OfficialsPack["prior"] extends null ? never : { fixtureId: string; roleKey: string; officialId: string; locked?: boolean }[] | null;
+  fixtures?: OfficialsPack["fixtures"];
+}): OfficialsPack {
+  const fixtures = over.fixtures ?? [F1, F2];
+  return {
+    division: { id: "div", name: "Open", sport: "generic", tz: "UTC", org_tz: "UTC" },
+    match_minutes: 30,
+    policy: POLICY,
+    fixtures,
+    officials: [official("solver-official"), official("adopted-official")],
+    locked: [],
+    draft: fixtures.map((f) => ({
+      fixtureId: f.id,
+      officialId: "solver-official",
+      roleKey: "referee",
+      locked: false,
+    })),
+    instruction: over.instruction ?? "",
+    prior:
+      over.priorAssignments === null
+        ? null
+        : { instruction: over.priorInstruction ?? "", assignments: over.priorAssignments },
+  };
+}
+
+const ADOPTED = [
+  { fixtureId: "f1", roleKey: "referee", officialId: "adopted-official", locked: false },
+  { fixtureId: "f2", roleKey: "referee", officialId: "solver-official", locked: false },
+];
+
+const officialFor = (
+  result: Awaited<ReturnType<typeof runOfficialsAiPlan>>,
+  fixtureId: string,
+): string | undefined => result.assignments.find((a) => a.fixtureId === fixtureId)?.officialId;
+
+describe("the empty-instruction path solves from the adopted grid (#384)", () => {
+  it("keeps the adopted official rather than re-deriving from the solver", async () => {
+    const out = await runOfficialsAiPlan(packWithPrior({ priorAssignments: ADOPTED }));
+    expect(officialFor(out, "f1")).toBe("adopted-official");
+    // The discriminator: the SOLVER would have said `solver-official` here, so
+    // this is not simply "whatever the draft produced".
+    expect(officialFor(out, "f2")).toBe("solver-official");
+  });
+
+  it("does not report the organiser's own adoption as changed", async () => {
+    // Symptom 3: the grid diffed a locked-derived draft against the prior the
+    // organiser adopted FROM, and highlighted their own adoption as
+    // AI-overwritten. `officialsDiff` is untouched — after this fix the solve
+    // and the diff simply agree.
+    const out = await runOfficialsAiPlan(packWithPrior({ priorAssignments: ADOPTED }));
+    expect(out.diff.changed).not.toContain("f1");
+    expect(out.diff.unchanged).toContain("f1");
+  });
+
+  it("still solves from the deterministic draft when there is no prior", async () => {
+    const pack = packWithPrior({ priorAssignments: null });
+    const out = await runOfficialsAiPlan(pack);
+    expect(out.assignments.map((a) => a.officialId)).toEqual(pack.draft.map((d) => d.officialId));
+  });
+
+  it("never re-executes prior.instruction on the empty path", async () => {
+    // The guard that keeps this a DATA change rather than a re-run. A model
+    // call here would both spend tokens the flat 1-credit price does not cover
+    // and re-apply a sentence the organiser has since cleared.
+    const provider = {
+      id: "anthropic" as const,
+      isConfigured: () => true,
+      chat: async () => {
+        throw new Error("the empty-instruction path made a model call");
+      },
+    };
+    const out = await runOfficialsAiPlan(
+      packWithPrior({ priorInstruction: "put Sam on every court", priorAssignments: ADOPTED }),
+      undefined,
+      // A provider name would resolve a REAL provider; passing none keeps the
+      // path provider-free, which is the assertion. The usage totals prove it.
+      undefined,
+    );
+    expect(out.usage).toMatchObject({ input_tokens: 0, output_tokens: 0, repair_rounds: 0 });
+    expect(provider.isConfigured()).toBe(true); // the stub is unused, deliberately
+  });
+});
+
+describe("partial and malformed priors (#384)", () => {
+  it("fills the slots a partial prior does not cover from the solver draft", async () => {
+    // The realistic shape: one cell adopted, the rest of the grid untouched. If
+    // the prior REPLACED the draft outright, every fixture it does not mention
+    // would come back unassigned — an adopt that blanks the rest of the board.
+    const out = await runOfficialsAiPlan(
+      packWithPrior({
+        priorAssignments: [
+          { fixtureId: "f1", roleKey: "referee", officialId: "adopted-official", locked: false },
+        ],
+      }),
+    );
+    expect(officialFor(out, "f1")).toBe("adopted-official");
+    expect(officialFor(out, "f2")).toBe("solver-official");
+    expect(out.diff.unfilled).toEqual([]);
+  });
+
+  it("reports a slot NEITHER the prior nor the draft can fill", async () => {
+    const pack = packWithPrior({
+      priorAssignments: [
+        { fixtureId: "f1", roleKey: "referee", officialId: "adopted-official", locked: false },
+      ],
+    });
+    // The solver could not place f2 either — so coverage has to say so rather
+    // than quietly returning a short grid.
+    pack.draft = pack.draft.filter((d) => d.fixtureId !== "f2");
+    const out = await runOfficialsAiPlan(pack);
+    expect(officialFor(out, "f1")).toBe("adopted-official");
+    expect(out.diff.unfilled).toEqual([
+      { fixture_id: "f2", role_key: "referee", reason: "no eligible official available" },
+    ]);
+  });
+
+  it("an EMPTY prior.assignments behaves like no prior, not like 'adopt nothing'", async () => {
+    // `prior: { instruction, assignments: [] }` is a present object with nothing
+    // in it. Reading the array as the whole answer would blank every slot and
+    // return a grid with no officials at all.
+    const pack = packWithPrior({ priorAssignments: [] });
+    const out = await runOfficialsAiPlan(pack);
+    expect(out.assignments.map((a) => a.officialId)).toEqual(pack.draft.map((d) => d.officialId));
+    expect(out.diff.unfilled).toEqual([]);
+  });
+
+  it("ignores a prior row naming a fixture that no longer exists", async () => {
+    // A fixture deleted mid-session. The row must not reach the referee — the
+    // engine is handed assignments keyed by fixture id and a dangling one is
+    // not a conflict, it is a lie about the board.
+    const out = await runOfficialsAiPlan(
+      packWithPrior({
+        priorAssignments: [
+          ...ADOPTED,
+          { fixtureId: "deleted-fixture", roleKey: "referee", officialId: "adopted-official", locked: false },
+        ],
+      }),
+    );
+    expect(out.assignments.map((a) => a.fixtureId).sort()).toEqual(["f1", "f2"]);
+    expect(officialFor(out, "f1")).toBe("adopted-official");
+  });
+
+  it("ignores a prior row naming a role the policy does not require", async () => {
+    const out = await runOfficialsAiPlan(
+      packWithPrior({
+        priorAssignments: [
+          ...ADOPTED,
+          { fixtureId: "f1", roleKey: "scorer", officialId: "adopted-official", locked: false },
+        ],
+      }),
+    );
+    expect(out.assignments.map((a) => a.roleKey)).toEqual(["referee", "referee"]);
+  });
+});

--- a/apps/web/src/server/usecases/ai-quote-mismatch.ts
+++ b/apps/web/src/server/usecases/ai-quote-mismatch.ts
@@ -37,8 +37,18 @@ export const QUOTE_MISMATCH_EVENT = "schedule.ai_quote_mismatch" as const;
  * external consumer send nothing, and reading that as "quoted 0" would file a
  * mismatch against every one of them.
  *
- * Best-effort by construction: it is called AFTER the run's own ledger row, so
- * a failure here cannot cost the organiser their plan.
+ * Best-effort BY CONSTRUCTION AND BY CATCH, and it needs both. It is called
+ * AFTER the run's own ledger row, so the credit is already spent and the plan
+ * already generated — but the three call sites await it bare, inside functions
+ * whose outer wrapper re-throws once `claim.creditConsumed` is true. An
+ * uncaught insert failure there would turn a paid, successful run into a 500,
+ * which is the exact outcome this telemetry exists to avoid causing. So the
+ * write is caught here, once, rather than at each call site where a fourth
+ * path would forget it.
+ *
+ * The catch does NOT suppress the return value. The comparison is pure and
+ * already known to be true by this point; a lost telemetry row is no reason to
+ * tell the caller their quote matched when it did not.
  */
 export async function recordQuoteMismatch(
   auth: AuthCtx,
@@ -47,22 +57,26 @@ export async function recordQuoteMismatch(
   charged: number,
 ): Promise<QuoteMismatch | undefined> {
   if (quoted === undefined || quoted === charged) return undefined;
-  await withTenant(auth.orgId, async (tx) => {
-    await tx`
-      insert into competition_events (competition_id, org_id, type, payload, actor_id)
-      values (${ctx.competitionId}, ${auth.orgId}, ${QUOTE_MISMATCH_EVENT},
-              ${tx.json({
-                quoted,
-                charged,
-                // Which run this was about. A competition-scoped event with no
-                // division ids cannot be traced back to the pack that was
-                // priced, which is the whole point of recording it.
-                division_ids: ctx.divisionIds,
-                // Direction, denormalised so an analytics query does not have to
-                // recompute it: `over` means the organiser paid more than the
-                // card promised, which is the complaint-shaped one.
-                direction: charged > quoted ? "over" : "under",
-              } as never)}, ${auth.userId})`;
-  });
+  try {
+    await withTenant(auth.orgId, async (tx) => {
+      await tx`
+        insert into competition_events (competition_id, org_id, type, payload, actor_id)
+        values (${ctx.competitionId}, ${auth.orgId}, ${QUOTE_MISMATCH_EVENT},
+                ${tx.json({
+                  quoted,
+                  charged,
+                  // Which run this was about. A competition-scoped event with no
+                  // division ids cannot be traced back to the pack that was
+                  // priced, which is the whole point of recording it.
+                  division_ids: ctx.divisionIds,
+                  // Direction, denormalised so an analytics query does not have
+                  // to recompute it: `over` means the organiser paid more than
+                  // the card promised, which is the complaint-shaped one.
+                  direction: charged > quoted ? "over" : "under",
+                } as never)}, ${auth.userId})`;
+    });
+  } catch (err) {
+    console.warn("[quote-mismatch] record failed:", err);
+  }
   return { quoted, charged };
 }

--- a/apps/web/src/server/usecases/ai-quote-mismatch.ts
+++ b/apps/web/src/server/usecases/ai-quote-mismatch.ts
@@ -1,0 +1,68 @@
+// #387 — did the organiser get charged what the confirm card promised?
+//
+// The card computes its quote by calling the same pure function the server
+// calls (`quoteRun` in lib/ai-rung.ts). That design is deliberate and good: no
+// per-keystroke fetch, one arithmetic implementation. It rests on one premise —
+// same function, same inputs, same environment — and PR #359 found three ways
+// that premise breaks. #385 closed the largest of them.
+//
+// DETECTION IS SERVER-SIDE. The client sends the number its card showed; the
+// server compares it against what it actually charged. The telemetry then fires
+// even when nobody is looking at the screen, and the event is written by the
+// side that knows the truth about the charge.
+//
+// This is TELEMETRY, NOT A GATE. A mismatch never refuses a run and never
+// alters a plan: the organiser already paid, and refusing here would take their
+// credit and give them nothing. It is recorded and reported.
+import { withTenant } from "@/lib/db";
+import type { AuthCtx } from "@/server/api-v1/auth";
+
+/** What the response carries when the two disagree — see `AiRunPriceFields`. */
+export interface QuoteMismatch {
+  quoted: number;
+  charged: number;
+}
+
+export const QUOTE_MISMATCH_EVENT = "schedule.ai_quote_mismatch" as const;
+
+/**
+ * Compare the card's quote to the charge, record the divergence, return it.
+ *
+ * Called by all three run paths (`schedule-ai.ts`, `competition-schedule-ai.ts`,
+ * `officials-ai.ts`) so they cannot come to different conclusions about what
+ * counts as a mismatch — a fork between those three is what produced the
+ * divergence #387 is about in the first place.
+ *
+ * `undefined` quoted is SILENCE, not zero: server-side callers, smoke and every
+ * external consumer send nothing, and reading that as "quoted 0" would file a
+ * mismatch against every one of them.
+ *
+ * Best-effort by construction: it is called AFTER the run's own ledger row, so
+ * a failure here cannot cost the organiser their plan.
+ */
+export async function recordQuoteMismatch(
+  auth: AuthCtx,
+  ctx: { competitionId: string; divisionIds: string[] },
+  quoted: number | undefined,
+  charged: number,
+): Promise<QuoteMismatch | undefined> {
+  if (quoted === undefined || quoted === charged) return undefined;
+  await withTenant(auth.orgId, async (tx) => {
+    await tx`
+      insert into competition_events (competition_id, org_id, type, payload, actor_id)
+      values (${ctx.competitionId}, ${auth.orgId}, ${QUOTE_MISMATCH_EVENT},
+              ${tx.json({
+                quoted,
+                charged,
+                // Which run this was about. A competition-scoped event with no
+                // division ids cannot be traced back to the pack that was
+                // priced, which is the whole point of recording it.
+                division_ids: ctx.divisionIds,
+                // Direction, denormalised so an analytics query does not have to
+                // recompute it: `over` means the organiser paid more than the
+                // card promised, which is the complaint-shaped one.
+                direction: charged > quoted ? "over" : "under",
+              } as never)}, ${auth.userId})`;
+  });
+  return { quoted, charged };
+}

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -123,6 +123,7 @@ import {
 } from "@/lib/ai-rung";
 import { balance, spendCredit, walletIdFor } from "@/lib/credits";
 import { deferred } from "@/lib/deferred";
+import { recordQuoteMismatch, type QuoteMismatch } from "./ai-quote-mismatch";
 import { requireFeature } from "@/lib/entitlements";
 import { captureServer, isServerFeatureEnabled } from "@/lib/posthog-server";
 import { rateLimit } from "@/lib/rate-limit";
@@ -2134,6 +2135,9 @@ export interface AiCompetitionPlanRequest {
    *  a run without one compiles inline exactly as before, which is what smoke,
    *  e2e and every external consumer do. */
   preview_id?: string;
+  /** #387: the credits the joint confirm card SHOWED. Optional, and an absent
+   *  value is silence rather than zero — server-side callers send none. */
+  quoted_credits?: number;
 }
 
 /**
@@ -2181,6 +2185,14 @@ export interface AiCompetitionPlanResponse
   skipped_divisions: { id: string; name: string; reason: "no_movable_fixtures" }[];
   /** Public shape only — `cost_usd` stays on the ledger event. */
   usage: { input_tokens: number; output_tokens: number; repair_rounds: number };
+  /**
+   * #387: present ONLY when the confirm card's quote and the charge disagreed.
+   *
+   * Declared here rather than on `RunMeterStamp`, which every ledger event
+   * spreads: `meterStamp` never produces this field, and putting it on that
+   * shape would advertise a key those rows can never carry.
+   */
+  quote_mismatch?: QuoteMismatch;
 }
 
 /** The competition-level ledger event a successful joint RUN writes. Named once
@@ -2748,6 +2760,17 @@ async function planForCompetition(
     }),
   );
 
+  // #387: the card's quote against the charge. The joint path is where a
+  // divergence is most likely — the batch discount is arithmetic the client
+  // reimplements nowhere but still has to arrive at — and the event names every
+  // division in the run.
+  const quote_mismatch = await recordQuoteMismatch(
+    auth,
+    { competitionId, divisionIds: pack.divisions.map((d) => d.id) },
+    input.quoted_credits,
+    quote.credits,
+  );
+
   await captureServer({
     event: "ai_plan_run",
     distinctId,
@@ -2798,6 +2821,8 @@ async function planForCompetition(
       repair_rounds: result.usage.repair_rounds,
     },
     ...meterStamp(quote, meter, parseStamp),
+    // #387 — present only when the card and the charge disagreed.
+    ...(quote_mismatch ? { quote_mismatch } : {}),
     // AFTER the stamp, deliberately: the stamp carries its own narrow
     // `divisions` breakdown and this merged one replaces it (see the field's
     // doc comment). Every solved division has a quote line — they are built

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -727,24 +727,76 @@ function officialsStructuralCheck(plan: AiOfficialsPlan, pack: OfficialsPack): s
   return null;
 }
 
-/** The deterministic solver draft, expressed as an AiOfficialsPlan — the proposal
- *  returned for an empty instruction (no LLM call). Slots the draft could not fill
- *  are declared unfilled so coverage still surfaces. */
+/**
+ * The empty-instruction proposal: the ADOPTED grid where there is one, the
+ * deterministic solver draft everywhere else. No LLM call. Slots neither can
+ * fill are declared unfilled so coverage still surfaces.
+ *
+ * #384: `pack.prior.assignments` is a SOLVE INPUT here, not only a diff
+ * baseline. Before this, an adopt with an empty instruction re-derived
+ * everything from the solver and threw the organiser's click away — while
+ * `officialsDiff` DID read `pack.prior.assignments` as its baseline, which made
+ * the grid report the organiser's own adoption as something the AI changed. The
+ * diff is untouched; after this the solve and the diff simply agree.
+ *
+ * MERGED, not replaced. A prior is usually the whole grid with one cell patched
+ * (ai-console.tsx round-trips the full assignment set), but it need not be:
+ * treating a partial one as the whole answer would blank every slot it does not
+ * mention, which is a worse version of the bug being fixed. An EMPTY
+ * `assignments` array therefore behaves exactly like no prior at all.
+ *
+ * `pack.prior.instruction` is deliberately NOT read. On this path there is no
+ * instruction to execute — that is the premise of the branch (zero LLM calls,
+ * deterministic solver, flat 1 credit) — so the previous run's sentence is not
+ * re-run.
+ *
+ * Rows are filtered to slots this pack actually has. A prior naming a fixture
+ * deleted mid-session, or a role the policy no longer requires, is stale client
+ * state; forwarding it would hand the referee an assignment for a board that
+ * does not exist.
+ */
 function draftAsPlan(pack: OfficialsPack): AiOfficialsPlan {
-  const covered = new Set(pack.draft.map((a) => slotKey(a.fixtureId, a.roleKey)));
+  const fixtureIds = new Set(pack.fixtures.map((f) => f.id));
+  const roles = new Set(pack.policy.roles);
+  const inScope = (a: FixtureOfficial): boolean =>
+    fixtureIds.has(a.fixtureId) && roles.has(a.roleKey);
+
+  // Slot -> row. The prior claims its slots first; the draft fills the rest.
+  const bySlot = new Map<string, FixtureOfficial>();
+  for (const a of pack.prior?.assignments ?? []) {
+    if (inScope(a)) bySlot.set(slotKey(a.fixtureId, a.roleKey), a);
+  }
+  const adopted = bySlot.size;
+  for (const a of pack.draft) {
+    if (inScope(a) && !bySlot.has(slotKey(a.fixtureId, a.roleKey))) {
+      bySlot.set(slotKey(a.fixtureId, a.roleKey), a);
+    }
+  }
+
   const unfilled: AiOfficialsPlan["unfilled"] = [];
   for (const f of pack.fixtures) {
     for (const r of pack.policy.roles) {
-      if (!covered.has(slotKey(f.id, r))) {
+      if (!bySlot.has(slotKey(f.id, r))) {
         unfilled.push({ fixture_id: f.id, role_key: r, reason: "no eligible official available" });
       }
     }
   }
   return {
-    assignments: pack.draft.map((a) => ({ fixture_id: a.fixtureId, official_id: a.officialId, role_key: a.roleKey })),
+    assignments: [...bySlot.values()].map((a) => ({
+      fixture_id: a.fixtureId,
+      official_id: a.officialId,
+      role_key: a.roleKey,
+    })),
     unfilled,
     explanations: [],
-    summary: "Default duty spread from the deterministic solver (no instruction given).",
+    // SERVER-GENERATED PROSE, not a dictionary key — and it does not reach the
+    // screen on this path: a zero-token plan renders the localized
+    // `board.ai.officials.draftNote` instead (ai-officials-review.tsx). It is
+    // here for the run ledger and for any API consumer reading the response.
+    summary:
+      adopted > 0
+        ? "Adopted assignments kept; remaining slots from the deterministic solver."
+        : "Default duty spread from the deterministic solver (no instruction given).",
   };
 }
 

--- a/apps/web/src/server/usecases/officials-ai.ts
+++ b/apps/web/src/server/usecases/officials-ai.ts
@@ -38,6 +38,7 @@ import { withTenant } from "@/lib/db";
 import { HttpError } from "@/lib/errors";
 import { requireFeature } from "@/lib/entitlements";
 import { spendCredit, walletIdFor } from "@/lib/credits";
+import { recordQuoteMismatch } from "./ai-quote-mismatch";
 import { rateLimit } from "@/lib/rate-limit";
 import { captureServer, isServerFeatureEnabled } from "@/lib/posthog-server";
 import type { AuthCtx } from "@/server/api-v1/auth";
@@ -1289,6 +1290,18 @@ export async function officialsAiPlanForDivision(
     );
   }
 
+  // #387: what the confirm card said, against what was actually charged.
+  // Skipped only when the division vanished mid-run — `recordOfficialsRun`
+  // recorded nothing either, so there is no competition to file it against.
+  const quote_mismatch = competitionId
+    ? await recordQuoteMismatch(
+        auth,
+        { competitionId, divisionIds: [divisionId] },
+        input.quoted_credits,
+        quote.credits,
+      )
+    : undefined;
+
   await captureServer({
     event: "ai_plan_run",
     distinctId,
@@ -1326,6 +1339,8 @@ export async function officialsAiPlanForDivision(
     // the predictor said, whether the confirm card's warning applies, and
     // whether the budget cut the run short.
     ...meterStamp(quote, meter),
+    // #387 — present only when the card and the charge disagreed.
+    ...(quote_mismatch ? { quote_mismatch } : {}),
   };
 }
 

--- a/apps/web/src/server/usecases/schedule-ai.ts
+++ b/apps/web/src/server/usecases/schedule-ai.ts
@@ -35,6 +35,7 @@ import {
   type TokenMeter,
 } from "@/lib/ai-rung";
 import { deferred } from "@/lib/deferred";
+import { recordQuoteMismatch } from "./ai-quote-mismatch";
 import { maybeAlertExpensiveRun } from "@/server/usecases/ai-runs-admin";
 import {
   computeParticipants,
@@ -2893,6 +2894,16 @@ async function planForDivision(
     }),
   );
 
+  // #387: what the confirm card said, against what was actually charged.
+  // AFTER the ledger row above and outside every gate — the credit is already
+  // spent, so this reports and records; it never refuses.
+  const quote_mismatch = await recordQuoteMismatch(
+    auth,
+    { competitionId: gate.competitionId, divisionIds: [divisionId] },
+    input.quoted_credits,
+    quote.credits,
+  );
+
   const officials_coverage = input.officials_policy
     ? coveragePreview(pack, result.proposal, input.officials_policy)
     : null;
@@ -2949,5 +2960,7 @@ async function planForDivision(
     // whether the budget cut the run short, so the client can reconcile against
     // its own (advisory) prediction.
     ...meterStamp(quote, meter, parseStamp),
+    // #387 — present only when the card and the charge disagreed.
+    ...(quote_mismatch ? { quote_mismatch } : {}),
   };
 }

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -53117,6 +53117,11 @@
                         "const": 3
                       }
                     ]
+                  },
+                  "quoted_credits": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [
@@ -53414,6 +53419,26 @@
                               "const": 3
                             }
                           ]
+                        },
+                        "quote_mismatch": {
+                          "type": "object",
+                          "properties": {
+                            "quoted": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "charged": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "quoted",
+                            "charged"
+                          ],
+                          "additionalProperties": false
                         },
                         "discount": {
                           "type": "integer",
@@ -58117,6 +58142,11 @@
                     "type": "string",
                     "format": "uuid",
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "quoted_credits": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [
@@ -58703,6 +58733,26 @@
                               "const": 3
                             }
                           ]
+                        },
+                        "quote_mismatch": {
+                          "type": "object",
+                          "properties": {
+                            "quoted": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "charged": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "quoted",
+                            "charged"
+                          ],
+                          "additionalProperties": false
                         },
                         "discount": {
                           "type": "integer",
@@ -62430,6 +62480,11 @@
                     "type": "string",
                     "format": "uuid",
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "quoted_credits": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [
@@ -62893,6 +62948,26 @@
                               "const": 3
                             }
                           ]
+                        },
+                        "quote_mismatch": {
+                          "type": "object",
+                          "properties": {
+                            "quoted": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "charged": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "quoted",
+                            "charged"
+                          ],
+                          "additionalProperties": false
                         },
                         "discount": {
                           "type": "integer",

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -37346,6 +37346,11 @@
                         "const": 3
                       }
                     ]
+                  },
+                  "quoted_credits": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [
@@ -37643,6 +37648,26 @@
                               "const": 3
                             }
                           ]
+                        },
+                        "quote_mismatch": {
+                          "type": "object",
+                          "properties": {
+                            "quoted": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "charged": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "quoted",
+                            "charged"
+                          ],
+                          "additionalProperties": false
                         },
                         "discount": {
                           "type": "integer",
@@ -42346,6 +42371,11 @@
                     "type": "string",
                     "format": "uuid",
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "quoted_credits": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [
@@ -42932,6 +42962,26 @@
                               "const": 3
                             }
                           ]
+                        },
+                        "quote_mismatch": {
+                          "type": "object",
+                          "properties": {
+                            "quoted": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "charged": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "quoted",
+                            "charged"
+                          ],
+                          "additionalProperties": false
                         },
                         "discount": {
                           "type": "integer",
@@ -46659,6 +46709,11 @@
                     "type": "string",
                     "format": "uuid",
                     "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|ffffffff-ffff-ffff-ffff-ffffffffffff)$"
+                  },
+                  "quoted_credits": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "maximum": 9007199254740991
                   }
                 },
                 "required": [
@@ -47122,6 +47177,26 @@
                               "const": 3
                             }
                           ]
+                        },
+                        "quote_mismatch": {
+                          "type": "object",
+                          "properties": {
+                            "quoted": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            },
+                            "charged": {
+                              "type": "integer",
+                              "minimum": -9007199254740991,
+                              "maximum": 9007199254740991
+                            }
+                          },
+                          "required": [
+                            "quoted",
+                            "charged"
+                          ],
+                          "additionalProperties": false
                         },
                         "discount": {
                           "type": "integer",

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -6644,6 +6644,10 @@ async function latestCompetitionEvent(
   parse_failed?: boolean;
   spent_tokens?: number;
   budget?: number;
+  /** #387: the `schedule.ai_quote_mismatch` payload — what the confirm card
+   *  quoted against what the run actually charged. */
+  quoted?: number;
+  charged?: number;
 } | null> {
   const sql = smokeDb();
   try {
@@ -7638,6 +7642,11 @@ async function v4AiSuite(admin: Session, proOrgId: string, proOrgSlug: string): 
       const offRes = await v1(plus, `/api/v1/divisions/${divId}/officials/ai-plan`, "POST", {
         instruction: "",
         policy: { roles: ["referee"] },
+        // #387: what a confirm card would have shown. The empty-instruction
+        // path is priced at a flat 1 credit, so 3 is a deliberate divergence —
+        // the server must REPORT it and RECORD it, and must still return the
+        // plan (this is telemetry, not a gate).
+        quoted_credits: 3,
         schedule: plan.proposal.map((a) => ({
           fixture_id: a.fixture_id,
           scheduled_at: a.scheduled_at,
@@ -7651,6 +7660,8 @@ async function v4AiSuite(admin: Session, proOrgId: string, proOrgSlug: string): 
           repair_rounds: number;
         };
         assignments: unknown[];
+        credits?: number;
+        quote_mismatch?: { quoted: number; charged: number };
       }>(offRes);
       check(
         "v4 AI/plus: officials ai-plan (empty instruction) returns a zero-token solver draft",
@@ -7667,6 +7678,21 @@ async function v4AiSuite(admin: Session, proOrgId: string, proOrgSlug: string): 
       check(
         'v4 AI/plus: schedule.ai_officials_generated ledger row stamps model "solver-draft"',
         !!offEvent && offEvent.model === "solver-draft",
+      );
+
+      // #387 — quote/charge reconciliation.
+      check(
+        "#387: the officials run reports the card's quote against what it charged",
+        off.quote_mismatch?.quoted === 3 && off.quote_mismatch?.charged === off.credits,
+      );
+      check(
+        "#387: a mismatch does not withhold the plan — it is telemetry, not a gate",
+        offRes.status === 200 && off.assignments.length > 0,
+      );
+      const mismatchEvent = await latestCompetitionEvent(compId, "schedule.ai_quote_mismatch");
+      check(
+        "#387: the divergence is recorded on the competition ledger",
+        !!mismatchEvent && mismatchEvent.quoted === 3 && mismatchEvent.charged === 1,
       );
 
       // ---- #396: a to-be-decided bracket slot is checked against everyone who

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -7440,10 +7440,12 @@ async function v4AiSuite(admin: Session, proOrgId: string, proOrgSlug: string): 
       const plusOrg = (await signIn(plus, `smoke-ai-plus-${tag}@example.com`)).org_id;
       await setPlan(plusOrg, "pro_plus", plus);
       const { compId, divId, stageId } = await seedPlannableAiDivision(plus, "AI Plus");
-      await v1(plus, "/api/v1/officials", "POST", {
-        display_name: `AI Ref ${tag}`,
-        role_keys: ["referee"],
-      });
+      const firstRefId = v1data<{ id: string }>(
+        await v1(plus, "/api/v1/officials", "POST", {
+          display_name: `AI Ref ${tag}`,
+          role_keys: ["referee"],
+        }),
+      ).id;
 
       // #398: carries a phrase the stage-1 compiler can turn into a typed rule
       // ("two matches per day"), so the pre-flight compile actually runs on this
@@ -7693,6 +7695,73 @@ async function v4AiSuite(admin: Session, proOrgId: string, proOrgSlug: string): 
       check(
         "#387: the divergence is recorded on the competition ledger",
         !!mismatchEvent && mismatchEvent.quoted === 3 && mismatchEvent.charged === 1,
+      );
+
+      // ---- #384: an adopted candidate reaches the SOLVE, not just the diff ----
+      //
+      // Adopting a candidate with an empty instruction used to be discarded:
+      // `prior.assignments` was consumed only as a diff baseline, so the plan
+      // was re-derived from the solver and the organiser's click vanished —
+      // while the diff, which DID read the prior, then reported their own
+      // adoption as something the AI had changed.
+      //
+      // NOT VACUOUS BY CONSTRUCTION: a second referee is added and the run
+      // above is used as the control, so the adopted official is deliberately
+      // the one the solver did NOT choose for that slot. If the adoption were
+      // dropped, the response would come back naming the control's pick.
+      const secondRefId = v1data<{ id: string }>(
+        await v1(plus, "/api/v1/officials", "POST", {
+          display_name: `AI Ref B ${tag}`,
+          role_keys: ["referee"],
+        }),
+      ).id;
+      const officialsSchedule = plan.proposal.map((a) => ({
+        fixture_id: a.fixture_id,
+        scheduled_at: a.scheduled_at,
+        court_label: a.court_label,
+      }));
+      const control = v1data<{
+        assignments: { fixtureId: string; officialId: string; roleKey: string }[];
+      }>(
+        await v1(plus, `/api/v1/divisions/${divId}/officials/ai-plan`, "POST", {
+          instruction: "",
+          policy: { roles: ["referee"] },
+          schedule: officialsSchedule,
+        }),
+      );
+      const target = control.assignments[0];
+      const adoptedId = target?.officialId === secondRefId ? firstRefId : secondRefId;
+      const adoptRes = await v1(plus, `/api/v1/divisions/${divId}/officials/ai-plan`, "POST", {
+        instruction: "",
+        policy: { roles: ["referee"] },
+        schedule: officialsSchedule,
+        prior: {
+          instruction: "",
+          assignments: control.assignments.map((a) =>
+            a.fixtureId === target?.fixtureId && a.roleKey === target?.roleKey
+              ? { ...a, officialId: adoptedId }
+              : a,
+          ),
+        },
+      });
+      const adopt = v1data<{
+        assignments: { fixtureId: string; officialId: string; roleKey: string }[];
+        diff: { changed: string[]; unchanged: string[] };
+      }>(adoptRes);
+      const adoptedSlot = adopt.assignments.find(
+        (a) => a.fixtureId === target?.fixtureId && a.roleKey === target?.roleKey,
+      );
+      check(
+        "#384: an adopted official survives the empty-instruction solve",
+        adoptRes.status === 200 && !!target && adoptedSlot?.officialId === adoptedId,
+      );
+      check(
+        "#384: the organiser's own adoption is not reported as AI-changed",
+        !!target && !adopt.diff.changed.includes(target.fixtureId),
+      );
+      check(
+        "#384: every other slot still comes back filled (an adopt does not blank the grid)",
+        adopt.assignments.length === control.assignments.length,
       );
 
       // ---- #396: a to-be-decided bracket slot is checked against everyone who


### PR DESCRIPTION
Closes #385, #387, #383, #384.

Four issues that share one theme: what the confirm card promises and what the server charges must not diverge, and nothing may spend a credit the organiser did not ask to spend.

## What ships

**#385 — client quote cards price on the server's rung config.** `resolveRungConfig()` plus a `RungConfigProvider` with **no default value**, so a missing provider throws rather than silently falling back to a stale local guess. Both board RSCs wrap. The issue named `ai-joint-run.ts` as affected; it never calls the rung weight functions, and `schedule-board.tsx` is itself `"use client"` — so the fix is a provider seeded by the RSC above it, not a prop threaded from the server.

**#387 — report and record a quote/charge mismatch.** `quoted_credits` in, `quote_mismatch` out, through **one helper** called by all three run paths, so they cannot come to different conclusions about what counts as a mismatch. Telemetry, never a gate: the organiser has already paid, and refusing here would take the credit and give nothing back. `undefined` is silence, not zero — server-side callers, smoke and every external consumer send nothing.

**#383 — the officials free draft asks before it spends.** The auto-run effect and its `officialsAutoStarted` ref are gone; a pre-run card and an explicit button replace them. Pricing is untouched.

**#384 — an adopted candidate reaches the solve.**

## Two things found that the issues did not name

**Two unlisted call sites** carried the same silent rung fallback #385 is about (`ai-console` CTA, `ai-competition-console` quote). Both fixed.

**A defect in the implementation plan itself.** Its literal `draftAsPlan` used `pack.prior.assignments` as the base, which blanks every slot a partial or empty prior omits — and contradicted the plan's own summary string. Shipped instead as a merge of prior over the solver draft, filtered to fixtures and roles the pack actually has.

## Review found one real defect, fixed here

`recordQuoteMismatch` writes after the run's ledger row and was awaited bare at all three call sites, inside functions whose wrapper re-throws once the credit is consumed. A constraint or serialization error on the **telemetry insert** therefore turned a paid, successful run into a 500 — the organiser losing a plan they had been charged for, caused by the very telemetry meant to detect overcharging. Caught inside the helper rather than per call site, so a fourth run path cannot forget it. The catch does not suppress the return value: the comparison is pure and already true, and a lost row is no reason to tell the caller their quote matched.

## Verification

Full `apps/web` gate green, 0 failed suites, 0 foreign. Every change carries a test that fails without it — the new resilience suite is 7/7, and mutating its catch to rethrow reds exactly the two failure-path tests. `tsc` 0, `eslint` 0, both drift gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)