### PR TITLE
The monthly credit sweep skips granted wallets and stops resolving plans per row (#390)

### DIFF
--- a/apps/web/src/lib/__tests__/credits-bootstrap-grant.test.ts
+++ b/apps/web/src/lib/__tests__/credits-bootstrap-grant.test.ts
@@ -67,8 +67,14 @@ describe.skipIf(!HAS_DB)("createOrgForUser — AI credit wallet bootstrap grant"
     await grantMonthlyForAllWallets();
 
     // Same idempotency key (`monthly:${walletId}:${period}`) as the bootstrap
-    // call — the cron sees it already granted this period and skips, so the
-    // balance stays 10, not 20.
+    // call, so the balance stays 10, not 20.
+    //
+    // Since #390 it stays 10 for a BETTER reason than it used to. The cron no
+    // longer opens this wallet at all: the sweep's `not exists` anti-join sees
+    // the bootstrap grant's key for this period and never selects the row, so
+    // there is no per-wallet resolve, no advisory lock and no transaction to
+    // discover the no-op inside. The outcome asserted here is unchanged —
+    // that is the point — but the work behind it is gone.
     expect(await balance(walletId)).toBe(10);
   });
 });

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -17,7 +17,7 @@
 // Real Postgres required; skipped without DATABASE_URL.
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
-import { sql } from "@/lib/db";
+import { sql, statementCount } from "@/lib/db";
 import { balance, grantBalance, grantMonthlyForAllWallets } from "@/lib/credits";
 import { setOrgPlan } from "./_billing-group";
 
@@ -356,5 +356,59 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     expect(second.wallets).toBe(first.wallets); // still considered — no key was ever written
     expect(second.granted).toBe(0);
     expect(await balance(subId)).toBe(0);
+  });
+
+  it("#390: grants three different plans their own rate in ONE sweep", async () => {
+    // The observable guard on resolving the grant amount in the sweep rather
+    // than per row: a single hoisted `ai.credits.monthly` read invites exactly
+    // one failure mode — smearing the first plan's rate across every wallet.
+    // Three plans that disagree is the only shape that can catch it; a sweep
+    // of same-plan wallets is satisfied by the bug.
+    const [proOrg, plusOrg, commOrg] = await Promise.all([seedOrg(), seedOrg(), seedOrg()]);
+    const pro = await setOrgPlan(proOrg, "pro");
+    const plus = await setOrgPlan(plusOrg, "pro_plus");
+    const comm = await setOrgPlan(commOrg, "community");
+
+    const res = await grantMonthlyForAllWallets({ walletIds: [pro, plus, comm] });
+
+    expect(res.wallets).toBe(3);
+    expect(res.failed).toBe(0);
+    expect(await balance(pro)).toBe(60);
+    expect(await balance(plus)).toBe(200);
+    expect(await balance(comm)).toBe(10);
+    expect(res.granted).toBe(60 + 200 + 10);
+  });
+
+  it("#390: a re-qualifying zero-grant wallet costs one statement per wallet, not two", async () => {
+    const orgs = await Promise.all([seedOrg(), seedOrg(), seedOrg(), seedOrg()]);
+    const subs = await Promise.all(orgs.map((o) => setOrgPlan(o, "event_pass")));
+
+    const before = statementCount();
+    const res = await grantMonthlyForAllWallets({ walletIds: subs });
+    const used = statementCount() - before;
+
+    expect(res.wallets).toBe(subs.length);
+    expect(res.granted).toBe(0);
+
+    // Budget, DERIVED not fitted: the sweep itself (1) + one `orgPlanKey`
+    // resolve per wallet (N) + ONE batched `ai.credits.monthly` read covering
+    // every distinct plan key (1) = N + 2.
+    //
+    // Event Pass carries no `ai.credits.monthly` row, so `delta <= 0` returns
+    // before any transaction is opened — this measures the PURE per-row
+    // overhead with no grant work mixed in. It is also the population that
+    // pays it every single day: a zero-grant wallet never writes an
+    // idempotency key, so the #390 anti-join can never filter it out. If the
+    // sweep's per-row cost is going to matter anywhere, it is here.
+    //
+    // Before this change it was 1 + 2N — `grantMonthly` did its own
+    // `plan_entitlements` read per wallet on top of `orgPlanKey`'s.
+    //
+    // `orgPlanKey` stays one query per row on purpose: it is a seven-arm
+    // resolver (comp expiry, past_due grace, trial backstop, incomplete,
+    // canceled, org suspension) and the app has already paid for three
+    // divergent copies of it once. A cron with its own subtly different plan
+    // resolution would grant the WRONG AMOUNT — far worse than an N+1.
+    expect(used).toBeLessThanOrEqual(subs.length + 2);
   });
 });

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -289,4 +289,72 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
 
     expect(await balance(subId)).toBe(60 * 3);
   });
+
+  // #390 — the sweep runs DAILY but grants MONTHLY, so on 30 of 31 days every
+  // wallet it opened was already granted. The anti-join moves that skip from
+  // "one round trip per wallet discovers a no-op" into the sweep's own WHERE.
+  // `wallets` therefore means "wallets this run CONSIDERED", not "every
+  // subscription in the schema" — the assertions below pin that new meaning.
+  it("does not re-consider a wallet already granted this period (#390)", async () => {
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro_plus");
+
+    const first = await grantMonthlyForAllWallets({ walletIds: [subId] });
+    expect(first.wallets).toBe(1);
+    expect(first.granted).toBe(200);
+
+    // Second run the same month: the wallet is filtered out by the sweep
+    // itself, so it is never opened, locked, or re-read.
+    const second = await grantMonthlyForAllWallets({ walletIds: [subId] });
+    expect(second.wallets).toBe(0);
+    expect(second.granted).toBe(0);
+    expect(await balance(subId)).toBe(200);
+  });
+
+  it("still grants a wallet that has no key for this period (#390)", async () => {
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro");
+    const res = await grantMonthlyForAllWallets({ walletIds: [subId] });
+    expect(res.wallets).toBe(1);
+    expect(res.granted).toBeGreaterThan(0);
+  });
+
+  it("#390: the anti-join is a pre-filter, not the guard — a concurrent double-run still grants once", async () => {
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro_plus");
+    // Both calls pass the anti-join (neither sees a key yet); the advisory
+    // lock and the in-transaction key check must still make exactly one of
+    // them win. If the anti-join were ever mistaken for the guard, this is
+    // the test that catches it.
+    const [a, b] = await Promise.all([
+      grantMonthlyForAllWallets({ walletIds: [subId] }),
+      grantMonthlyForAllWallets({ walletIds: [subId] }),
+    ]);
+    expect(a.failed + b.failed).toBe(0);
+    expect(a.granted + b.granted).toBe(200);
+    expect(await balance(subId)).toBe(200);
+  });
+
+  it("#390: a zero-grant plan keeps re-qualifying, and that is harmless", async () => {
+    // `delta <= 0` returns BEFORE the idempotency key is written, so a wallet
+    // whose plan grants nothing never writes one and comes back every day.
+    // Documented, not fixed by the anti-join alone — and the reason Task 11
+    // resolves the grant amount in the sweep rather than per row.
+    //
+    // The zero-grant plan here is `event_pass`, NOT `community`: community
+    // carries `ai.credits.monthly = 10` (V320), so it grants, writes a key,
+    // and IS filtered out on the second run. Event Pass deliberately carries
+    // no `ai.credits.monthly` row at all — it is the only plan in the matrix
+    // whose monthly grant is genuinely zero (scripts/smoke.ts says so too).
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "event_pass");
+
+    const first = await grantMonthlyForAllWallets({ walletIds: [subId] });
+    expect(first.granted).toBe(0);
+
+    const second = await grantMonthlyForAllWallets({ walletIds: [subId] });
+    expect(second.wallets).toBe(first.wallets); // still considered — no key was ever written
+    expect(second.granted).toBe(0);
+    expect(await balance(subId)).toBe(0);
+  });
 });

--- a/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
+++ b/apps/web/src/lib/__tests__/credits-monthly-cron.test.ts
@@ -18,7 +18,7 @@
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 import { sql, statementCount } from "@/lib/db";
-import { balance, grantBalance, grantMonthlyForAllWallets } from "@/lib/credits";
+import { balance, grantBalance, grantMonthlyForAllWallets, utcMonthStart } from "@/lib/credits";
 import { setOrgPlan } from "./_billing-group";
 
 const HAS_DB = !!process.env.DATABASE_URL;
@@ -410,5 +410,156 @@ describe.skipIf(!HAS_DB)("grantMonthlyForAllWallets (billing-grant cron)", () =>
     // divergent copies of it once. A cron with its own subtly different plan
     // resolution would grant the WRONG AMOUNT — far worse than an N+1.
     expect(used).toBeLessThanOrEqual(subs.length + 2);
+  });
+
+  // #390 edges. The six above pin the anti-join's happy path; these pin the
+  // ways it could quietly stop being a PRE-FILTER and start being a bug —
+  // wrong period scope, wrong empty-scope branch, wrong population.
+  //
+  // (A plan carrying no `ai.credits.monthly` row at all is NOT re-pinned here:
+  // "#390: a zero-grant plan keeps re-qualifying, and that is harmless" above
+  // already seeds `event_pass` — the matrix's only genuinely zero-grant plan —
+  // and asserts a 0 grant and a 0 balance with nothing thrown.)
+
+  it("#390: a wallet granted in the PREVIOUS month still qualifies this month — the anti-join is period-scoped, not 'ever granted'", async () => {
+    // The single highest-consequence way to get the anti-join wrong: match on
+    // any `monthly:<wallet>:%` key rather than THIS period's. Nothing else in
+    // this file would notice — every other test grants inside one period — and
+    // the production symptom is that monthly grants stop, permanently and
+    // silently, for every wallet that has ever been granted once.
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro");
+
+    const now = new Date();
+    const priorPeriod = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 1))
+      .toISOString()
+      .slice(0, 7);
+    await sql`
+      insert into ai_credit_ledger (wallet_id, delta, source, bucket, balance_after, idempotency_key)
+      values (${subId}, 60, 'monthly_grant', 'grant', 60, ${`monthly:${subId}:${priorPeriod}`})`;
+
+    const res = await grantMonthlyForAllWallets({ walletIds: [subId] });
+
+    expect(res.wallets).toBe(1); // considered, despite last month's key
+    expect(res.granted).toBe(60);
+    expect(res.failed).toBe(0);
+    // Last month's 60 was expired (D1 use-or-lose) and this month's granted —
+    // exactly one month's allowance in the bucket, not a banked 120.
+    expect(await grantBalance(subId)).toBe(60);
+    expect(await balance(subId)).toBe(60);
+  });
+
+  it("#390: a MIXED sweep considers only the wallets still missing this period's key", async () => {
+    // Every #390 test above sweeps one wallet at a time, so a `wallets` count
+    // of 1 vs 0 is all they can distinguish. This is the shape the daily cron
+    // actually meets: most of the batch already granted, a few not.
+    const orgs = await Promise.all([seedOrg(), seedOrg(), seedOrg(), seedOrg()]);
+    const [a, b, c, d] = await Promise.all(orgs.map((o) => setOrgPlan(o, "pro")));
+
+    await grantMonthlyForAllWallets({ walletIds: [a!, b!] });
+
+    const res = await grantMonthlyForAllWallets({ walletIds: [a!, b!, c!, d!] });
+
+    expect(res.wallets).toBe(2); // c and d only — a and b never opened
+    expect(res.granted).toBe(60 * 2);
+    expect(res.failed).toBe(0);
+    for (const sub of [a!, b!, c!, d!]) expect(await balance(sub)).toBe(60);
+    // ...and the already-granted pair got exactly one grant row each, not two.
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from ai_credit_ledger
+       where wallet_id in ${sql([a!, b!])} and source = 'monthly_grant'`;
+    expect(n).toBe(2);
+  });
+
+  it("#390: the UNSCOPED sweep — the shape the cron itself runs — honours the anti-join too", async () => {
+    // `walletIds` is a test affordance; the anti-join has to hold on the call
+    // shape production uses, where the scope clause is absent entirely.
+    const [orgA, orgB] = await Promise.all([seedOrg(), seedOrg()]);
+    const [subA, subB] = await Promise.all([
+      setOrgPlan(orgA!, "pro"),
+      setOrgPlan(orgB!, "pro"),
+    ]);
+    await grantMonthlyForAllWallets({ walletIds: [subA, subB] });
+
+    // Wallets already carrying this period's key, counted BEFORE the sweep —
+    // subA and subB at minimum, which is what keeps the bound below
+    // non-vacuous.
+    const period = utcMonthStart().toISOString().slice(0, 7);
+    const [{ keyed }] = await sql<{ keyed: number }[]>`
+      select count(*)::int as keyed from subscriptions s
+       where exists (select 1 from organizations o
+                      where o.subscription_id = s.id and o.deleted_at is null)
+         and exists (select 1 from ai_credit_ledger l
+                      where l.idempotency_key = 'monthly:' || s.id::text || ':' || ${period})`;
+    expect(keyed).toBeGreaterThanOrEqual(2);
+
+    const swept = await grantMonthlyForAllWallets();
+
+    expect(await balance(subA)).toBe(60); // one grant each, not two
+    expect(await balance(subB)).toBe(60);
+
+    // ...and neither was even CONSIDERED. `total` is the population the sweep
+    // would have opened WITHOUT the anti-join (every subscription with a live
+    // org), read AFTER the run: pairing an after-total with a before-keyed
+    // means a sibling suite's concurrent insert can only LOOSEN this bound,
+    // never tighten it into a flake (#351). Drop the anti-join and
+    // `swept.wallets` becomes the whole population, overshooting by `keyed`.
+    const [{ total }] = await sql<{ total: number }[]>`
+      select count(*)::int as total from subscriptions s
+       where exists (select 1 from organizations o
+                      where o.subscription_id = s.id and o.deleted_at is null)`;
+    expect(swept.wallets).toBeLessThanOrEqual(total - keyed);
+  });
+
+  it("#390: an explicitly EMPTY scope grants nothing — it must not fall through to the every-wallet branch", async () => {
+    // `opts.walletIds ?? null` only nulls out undefined, and `[]` is truthy in
+    // JS — so an empty array is a real, if unusual, caller intent ("sweep these
+    // zero wallets"), not an absent scope. It must mean nothing, not everything.
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro");
+
+    const res = await grantMonthlyForAllWallets({ walletIds: [] });
+
+    expect(res.wallets).toBe(0);
+    expect(res.granted).toBe(0);
+    expect(res.failed).toBe(0);
+    expect(await balance(subId)).toBe(0); // untouched — an unscoped fall-through would have granted it
+  });
+
+  it("skips a wallet whose only org is soft-deleted — the live-org lateral is a CROSS join", async () => {
+    // Both laterals filter `deleted_at is null`, and they are CROSS joins: a
+    // group whose every org is soft-deleted produces no `rep` row, so the
+    // subscription drops out of the sweep entirely. Turning either into a LEFT
+    // join would surface a null `rep_org_id` and hand it to `orgPlanKey`.
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro");
+    await sql`update organizations set deleted_at = now() where id = ${orgId}`;
+
+    const res = await grantMonthlyForAllWallets({ walletIds: [subId] });
+
+    expect(res.wallets).toBe(0);
+    expect(res.granted).toBe(0);
+    expect(res.failed).toBe(0); // not considered at all — never a resolve failure
+    expect(await balance(subId)).toBe(0);
+  });
+
+  it("a paid wallet with quantity_paid = 0 grants nothing and writes NO ledger row (never a negative one)", async () => {
+    // The seat count, not the plan, is what zeroes this one: `perSeat * qty`
+    // hits `delta <= 0` and returns before the transaction opens (credits.ts).
+    // The row worth guarding against is a NEGATIVE grant — `balance_after >= 0`
+    // would reject it, so the sweep would report `failed`, not a bad balance.
+    const orgId = await seedOrg();
+    const subId = await setOrgPlan(orgId, "pro");
+    await sql`update subscriptions set quantity_paid = 0 where id = ${subId}`;
+
+    const res = await grantMonthlyForAllWallets({ walletIds: [subId] });
+
+    expect(res.wallets).toBe(1); // considered — no key was ever written for it
+    expect(res.granted).toBe(0);
+    expect(res.failed).toBe(0);
+    const [{ n }] = await sql<{ n: number }[]>`
+      select count(*)::int as n from ai_credit_ledger where wallet_id = ${subId}`;
+    expect(n).toBe(0); // no grant row, no expiry row, no key
+    expect(await balance(subId)).toBe(0);
   });
 });

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -281,11 +281,42 @@ export async function grantMonthly(
   planKey: string,
   quantityPaid: number,
 ): Promise<number> {
-  const [entitlement] = await sql<{ int_value: number | null }[]>`
-    select int_value from plan_entitlements
-     where plan_key = ${planKey} and feature_key = 'ai.credits.monthly'`;
-  const perSeat = entitlement?.int_value ?? 0;
-  const delta = perSeat * quantityPaid;
+  const perSeat = (await monthlyPerSeatByPlan([planKey])).get(planKey) ?? 0;
+  return grantMonthlyDelta(walletId, perSeat * quantityPaid);
+}
+
+/**
+ * `ai.credits.monthly` per seat, for a set of plan keys, in ONE read (#390).
+ *
+ * The sweep resolves a plan per wallet and would otherwise re-read this row
+ * per wallet too — but there are only ever a handful of DISTINCT plan keys in
+ * the whole matrix, so the per-row read was pure waste. A plan with no row
+ * (Event Pass carries none, deliberately) is absent from the map and reads as
+ * 0 via the callers' `?? 0`, which is the same answer the per-row read gave.
+ *
+ * This is the ONLY place the monthly entitlement is read, so the single-wallet
+ * path and the sweep can never disagree about a rate.
+ */
+async function monthlyPerSeatByPlan(
+  planKeys: readonly string[],
+): Promise<Map<string, number>> {
+  const distinct = [...new Set(planKeys)];
+  if (distinct.length === 0) return new Map();
+  const rows = await sql<{ plan_key: string; int_value: number | null }[]>`
+    select plan_key, int_value from plan_entitlements
+     where feature_key = 'ai.credits.monthly' and plan_key in ${sql(distinct)}`;
+  return new Map(rows.map((r) => [r.plan_key, r.int_value ?? 0]));
+}
+
+/**
+ * The expire-then-grant transaction, given an ALREADY-RESOLVED delta.
+ *
+ * Split out of `grantMonthly` (#390) so the sweep can resolve every wallet's
+ * rate in one batched read and still run the identical, single-copy
+ * transaction body — the advisory lock and the in-transaction idempotency
+ * check are not duplicated anywhere.
+ */
+async function grantMonthlyDelta(walletId: string, delta: number): Promise<number> {
   if (delta <= 0) return 0;
 
   const period = monthlyPeriod();
@@ -472,6 +503,19 @@ export async function grantMonthlyForAllWallets(
      ${ids ? sql`and s.id in ${sql(ids as string[])}` : sql``}`;
   let granted = 0;
   let failed = 0;
+
+  // Pass 1 — resolve each wallet's plan and seat count.
+  //
+  // `orgPlanKey` stays ONE QUERY PER ROW, deliberately (#390). It is a
+  // seven-arm read-time resolver (lapsed comp, past_due grace anchored on the
+  // status transition, trial-end backstop, incomplete, canceled, per-org
+  // moderation suspension), and the app has already paid once for three
+  // divergent copies of it — see `__tests__/entitlements-duplicate-resolvers`.
+  // Inlining a fourth copy into the cron to save a round trip would risk the
+  // sweep granting a DIFFERENT amount than every other entitlement read of the
+  // same org resolves, which is a far worse bug than an N+1. It stays the
+  // single source of truth; only the entitlement read below is batched.
+  const resolved: { walletId: string; planKey: string; qty: number }[] = [];
   for (const row of rows) {
     try {
       const planKey = await orgPlanKey(row.rep_org_id);
@@ -481,10 +525,27 @@ export async function grantMonthlyForAllWallets(
           : row.status === "trialing"
             ? Math.max(row.quantity_paid, row.live_org_count)
             : row.quantity_paid;
-      granted += await grantMonthly(row.id, planKey, qty);
+      resolved.push({ walletId: row.id, planKey, qty });
     } catch (err) {
       failed++;
-      console.error(`[credits] monthly grant failed for wallet ${row.id}`, err);
+      console.error(`[credits] monthly plan resolve failed for wallet ${row.id}`, err);
+    }
+  }
+
+  // Pass 2 — ONE entitlement read for every distinct plan key in the batch,
+  // instead of one per wallet inside `grantMonthly`. This is what makes a
+  // zero-grant wallet (Event Pass, which never writes a key and so re-qualifies
+  // every single day past the anti-join) cost one statement rather than two.
+  const perSeatByPlan = await monthlyPerSeatByPlan(resolved.map((r) => r.planKey));
+
+  // Pass 3 — grant. Still strictly sequential and still per-wallet isolated: one
+  // wallet's failure is logged and skipped rather than aborting the sweep.
+  for (const r of resolved) {
+    try {
+      granted += await grantMonthlyDelta(r.walletId, (perSeatByPlan.get(r.planKey) ?? 0) * r.qty);
+    } catch (err) {
+      failed++;
+      console.error(`[credits] monthly grant failed for wallet ${r.walletId}`, err);
     }
   }
   return { wallets: rows.length, granted, failed };

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -427,7 +427,29 @@ export async function grantMonthlyForAllWallets(
   // takes the sweep's cost from "every row the whole session accumulated" down
   // to the rows the test made, which is what pushed these cases past their
   // 20s timeout in full runs.
+  //
+  // #390 — the anti-join below is a PRE-FILTER, not a replacement for the
+  // guard. Two overlapping runs can both pass it (neither sees a key yet), so
+  // the `pg_advisory_xact_lock` and the in-transaction `idempotency_key` check
+  // in `grantMonthly` (:296-299) stay exactly as written. This filter may only
+  // ever REDUCE the candidate set — never decide whether a grant is safe.
+  //
+  // It does not reach zero rows on its own: `delta <= 0` returns before the
+  // key is written (:289), so a wallet whose plan grants nothing (Event Pass
+  // carries no `ai.credits.monthly` row) never writes one and re-qualifies
+  // every day. Harmless, and the reason the grant amount is resolved in the
+  // sweep rather than per row (see `monthlyPerSeatByPlan` below).
+  //
+  // `wallets` consequently means "wallets this run CONSIDERED", not "every
+  // subscription in the schema". That is the number worth alerting on: it is
+  // the work the run actually had to do.
+  //
+  // The DAILY cadence stays. It is deliberate — retry after a failed run, no
+  // 28/29/30/31 or timezone edges, and it carries `checkEarnGrantVolumeAlert`,
+  // which needs a genuinely daily poll. This makes the daily run cheap; it
+  // does not make it rarer.
   const ids = opts.walletIds ?? null;
+  const period = monthlyPeriod();
   const rows = await sql<
     { id: string; status: string; quantity_paid: number; rep_org_id: string; live_org_count: number }[]
   >`
@@ -443,7 +465,11 @@ export async function grantMonthlyForAllWallets(
         select count(*)::int as n from organizations o
          where o.subscription_id = s.id and o.deleted_at is null
       ) live
-     ${ids ? sql`where s.id in ${sql(ids as string[])}` : sql``}`;
+     where not exists (
+       select 1 from ai_credit_ledger l
+        where l.idempotency_key = 'monthly:' || s.id::text || ':' || ${period}
+     )
+     ${ids ? sql`and s.id in ${sql(ids as string[])}` : sql``}`;
   let granted = 0;
   let failed = 0;
   for (const row of rows) {

--- a/apps/web/src/lib/credits.ts
+++ b/apps/web/src/lib/credits.ts
@@ -462,11 +462,11 @@ export async function grantMonthlyForAllWallets(
   // #390 — the anti-join below is a PRE-FILTER, not a replacement for the
   // guard. Two overlapping runs can both pass it (neither sees a key yet), so
   // the `pg_advisory_xact_lock` and the in-transaction `idempotency_key` check
-  // in `grantMonthly` (:296-299) stay exactly as written. This filter may only
-  // ever REDUCE the candidate set — never decide whether a grant is safe.
+  // in `grantMonthlyDelta` (:326-330) stay exactly as written. This filter may
+  // only ever REDUCE the candidate set — never decide whether a grant is safe.
   //
   // It does not reach zero rows on its own: `delta <= 0` returns before the
-  // key is written (:289), so a wallet whose plan grants nothing (Event Pass
+  // key is written (:320), so a wallet whose plan grants nothing (Event Pass
   // carries no `ai.credits.monthly` row) never writes one and re-qualifies
   // every day. Harmless, and the reason the grant amount is resolved in the
   // sweep rather than per row (see `monthlyPerSeatByPlan` below).


### PR DESCRIPTION
Closes #390.

Two performance defects in the monthly AI-credit grant sweep. Both premises verified real against the code before any change.

## What ships

**Skip already-granted wallets.** An anti-join replaces the walk-everything-then-check pattern, so a wallet already granted for the period is never loaded.

**Resolve wallet plans in the sweep, not per row.** `1 + 2N` queries become `N + 2`. The batched read is `plan_entitlements`, lifted out of `grantMonthly` into `monthlyPerSeatByPlan()`, with a shared `grantMonthlyDelta()` holding the advisory lock and the idempotency-key check once.

## One deliberate deviation

`orgPlanKey` was **left** as one query per row. It is a seven-arm read-time resolver — lapsed competition, `past_due` grace, trial backstop, incomplete, canceled, org suspension — whose own docstring already records three divergent copies of that logic elsewhere. Batching it would have made a fourth. The N+1 that actually mattered was the entitlements read, and that is the one that moved.

## No production defect found in the edge pass

`credits.ts` is unchanged by the edge work — confirmed by diff. Six edge cases were added (period boundary, mixed sweep, unscoped anti-join, `walletIds: []`, soft-deleted org, `quantity_paid` 0), and each was **mutation-proved individually**. The one worth naming: a period-blind anti-join (`like 'monthly:%'`) reds **only** the period-boundary test, so that gap was real and nothing else in the suite covered it. A bug there would silently stop every monthly grant forever.

`walletIds: []` was the suspect going in and is already correct — postgres.js renders `sql([])` as `(null)`, so `s.id in (null)` matches zero rows rather than raising `42601`.

## Scope

No e2e and no smoke extension: the sweep is cron-internal with no UI, and `scripts/smoke.ts` never calls it.

## Verification

`src/lib/__tests__` 1629/1654, 0 failed, 0 failed suites, 0 foreign; the cron suite grew 18 → 24 tests. `tsc` 0, `eslint` 0, both drift gates clean. Reviewed clean apart from one stale comment citation, fixed in-branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)