### PR TITLE
Open the schedule board to every plan, and roll save points instead of refusing (#382)

### DIFF
--- a/apps/web/content/help/scheduling/ai-scheduling.md
+++ b/apps/web/content/help/scheduling/ai-scheduling.md
@@ -174,7 +174,7 @@ Separately, every plan has a burst brake of **5 AI runs an hour per division** f
 
 ## Scheduling several divisions together
 
-The competition's own schedule board (**Competition → Schedule**) can plan **several divisions at once**, so divisions sharing a venue are fitted around each other in a single pass instead of being scheduled one at a time and patched up afterwards. The multi-division board is a **Pro** feature.
+The competition's own schedule board (**Competition → Schedule**) can plan **several divisions at once**, so divisions sharing a venue are fitted around each other in a single pass instead of being scheduled one at a time and patched up afterwards. Planning several divisions together needs **Pro**, or this competition's **Event Pass**, which lifts it for that one competition. The board itself, and the scheduling constraints behind it, are open on every plan.
 
 Pick the divisions in the console, write one instruction covering all of them, and review the proposal division by division. Applying writes every division together — **all of them or none**.
 

--- a/apps/web/content/help/scheduling/ai-scheduling.md
+++ b/apps/web/content/help/scheduling/ai-scheduling.md
@@ -178,7 +178,7 @@ The competition's own schedule board (**Competition → Schedule**) can plan **s
 
 Pick the divisions in the console, write one instruction covering all of them, and review the proposal division by division. Applying writes every division together — **all of them or none**.
 
-Undo works the other way round. Each division gets its own **before-AI** save point, and undo restores them one at a time rather than in a single step, so a restore that fails doesn't stop the rest going back. If any division is left on the AI schedule, the console names it and offers to try just those again — and the save points stay valid, so you can also restore any of them from its own schedule page later.
+Undo works the other way round. Each division gets its own **before-AI** save point, and undo restores them one at a time rather than in a single step, so a restore that fails doesn't stop the rest going back. If any division is left on the AI schedule, the console names it and offers to try just those again — and the save points stay valid, so you can also restore any of them from its own schedule page later. Only the newest three before-AI points are kept, so you can still step back past the most recent one.
 
 **Shared courts are matched by name, and by nothing else.** There is no venue-wide court list behind the scenes: a court is the label you typed into each division's schedule settings. So "Court 1" in one division and "Court A" in another are **two different courts** as far as the run is concerned, and it will happily put a match on each at the same time. If the divisions you picked don't use the same names, the console warns you before the run — the fix is to make the names match in each division's schedule settings.
 

--- a/apps/web/content/help/scheduling/undo.md
+++ b/apps/web/content/help/scheduling/undo.md
@@ -10,12 +10,16 @@ Schedule edits are a **history**, like a document: undo steps back one change, r
 
 A **save point** bookmarks the timetable exactly as it is now — every kick-off time and court. Made a mess experimenting? **Restore** rewinds the schedule to the bookmark by undoing each change since, one by one.
 
-Match results are never touched by either: if rewinding would erase a played result, the restore stops right there and tells you. **Community keeps 1 save point per division, Pro keeps 5, and Pro Plus is unlimited.**
+Match results are never touched by either: if rewinding would erase a played result, the restore stops right there and tells you. **Community keeps 2 save points per division, Pro keeps 5, and Pro Plus is unlimited.**
+
+When you're already at your plan's number, saving a new one **replaces the oldest** rather than refusing. The panel names the one that went, so you're never left hunting for a bookmark that quietly disappeared — and because a save point is only a bookmark, undo still rewinds past it.
+
+AI restore points are separate: they don't use up your save points, and the newest three per division are kept.
 
 ## Common questions
 
 **Does undo affect scores?** Never — schedule history and the score ledger are separate. Fixing a wrong score happens on the fixture itself.
 
-**How far back can I undo?** To the last save point or the start of the division's schedule history, whichever you hit first.
+**How far back can I undo?** To the start of the division's schedule history. Save points are bookmarks, not boundaries — undo walks straight past them, including past one that has been replaced.
 
 **Can two admins undo each other?** History is shared, so undo reverses the last change whoever made it — coordinate before big rewinds, or freeze the board first.

--- a/apps/web/e2e/event-pass.spec.ts
+++ b/apps/web/e2e/event-pass.spec.ts
@@ -583,10 +583,14 @@ for (const vp of VIEWPORTS) {
       await page.getByPlaceholder("U16 Boys T20").fill("Eleventh");
       await page.getByRole("button", { name: "Scheduling" }).click();
       await page.getByRole("button", { name: "Create division" }).click();
-      // Scoped to the feature that actually bit. The scheduling tab carries its
-      // own COMPACT gate (`scheduling.constraints`, a Pro key the pass never
-      // covered) which also marks itself `data-pass-owned` once a pass is held,
-      // so `.first()` reads the wrong card and asserts nothing about divisions.
+      // Scoped to the feature that actually bit, never `.first()`. The
+      // scheduling tab used to carry its own COMPACT gate
+      // (`scheduling.constraints`) which also marked itself `data-pass-owned`
+      // once a pass was held, so `.first()` read the wrong card and asserted
+      // nothing about divisions. V353 (#382) opened `scheduling.constraints` to
+      // every plan, so that gate no longer renders — the scoping stays anyway:
+      // it is what makes this an assertion about DIVISIONS rather than about
+      // whichever gate happens to come first on the page.
       const owned = page.locator(
         '[data-pass-owned][data-feature="divisions.per_competition.max"]',
       );

--- a/apps/web/e2e/open-scheduling.spec.ts
+++ b/apps/web/e2e/open-scheduling.spec.ts
@@ -207,10 +207,25 @@ test.describe("Community reaches the board and the constraints (#382)", () => {
     await loginAsOwner(page, org.ownerEmail);
     const rig = await seedRig(page.request);
 
-    await page.goto(`/o/${org.orgSlug}/c/${rig.compSlug}/d/${rig.divSlug}/schedule`);
-    await expect(page.getByRole("heading", { name: "History" })).toBeVisible({ timeout: 30_000 });
+    const schedule = `/o/${org.orgSlug}/c/${rig.compSlug}/d/${rig.divSlug}/schedule`;
+    await page.goto(schedule);
+    // Anchor on the tab strip, not on a panel heading: the panels are separate
+    // ?tab= views, so "History" is a LINK here and its heading only exists once
+    // that tab is open. Anchoring on the heading made this wait 30s and fail on
+    // a page that had rendered the whole board correctly.
+    await expect(page.getByRole("link", { name: "history" })).toBeVisible({ timeout: 30_000 });
     // The UpgradeGate carries data-feature; neither scheduling key may appear.
     await expect(page.locator('[data-feature="scheduling.board"]')).toHaveCount(0);
+    await expect(page.locator('[data-feature="scheduling.constraints"]')).toHaveCount(0);
+
+    // The constraints editor is the other half of what V353 opened, and it is a
+    // tab of its own — a board-only check would pass even if it were still
+    // walled. Assert the panel actually rendered, so an empty tab cannot pass
+    // as an ungated one.
+    await page.goto(`${schedule}?tab=constraints`);
+    await expect(
+      page.getByRole("heading", { name: "Constraints & planning", exact: true }),
+    ).toBeVisible({ timeout: 30_000 });
     await expect(page.locator('[data-feature="scheduling.constraints"]')).toHaveCount(0);
   });
 
@@ -234,10 +249,16 @@ test.describe("At the save-point cap the window rolls, and the panel says so (#3
     await loginAsOwner(page, org.ownerEmail);
     const rig = await seedRig(page.request);
 
-    await page.goto(`/o/${org.orgSlug}/c/${rig.compSlug}/d/${rig.divSlug}/schedule`);
+    // ?tab=history — the save-point control lives in the HistoryPanel, which the
+    // page only mounts for that tab. Landing on the default board tab left this
+    // waiting 30s for an input that was never going to be there.
+    await page.goto(`/o/${org.orgSlug}/c/${rig.compSlug}/d/${rig.divSlug}/schedule?tab=history`);
     const input = page.getByLabel("Save point label");
     await expect(input).toBeVisible({ timeout: 30_000 });
-    const save = page.getByRole("button", { name: "Save point" });
+    // exact: true — the panel also carries two info buttons labelled "About:
+    // Undo and save points" and "About: Save points", and getByRole matches a
+    // name by substring, so the loose form resolves to three elements.
+    const save = page.getByRole("button", { name: "Save point", exact: true });
 
     const first = `before rain ${hex()}`;
     for (const label of [first, `after rain ${hex()}`]) {
@@ -254,7 +275,14 @@ test.describe("At the save-point cap the window rolls, and the panel says so (#3
     await save.click();
 
     // The save SUCCEEDED (no paywall), and the notice names the label that went.
-    await expect(page.getByText(first, { exact: false })).toHaveCount(0, { timeout: 20_000 });
+    //
+    // Scoped to the LIST, not the page. The eviction notice itself quotes the
+    // evicted label — that is the point of it — so a page-wide `getByText(first)`
+    // is self-contradictory with the `toContainText(first)` assertion three lines
+    // below: it matches the very notice it then requires to name `first`.
+    await expect(page.getByRole("listitem").filter({ hasText: first })).toHaveCount(0, {
+      timeout: 20_000,
+    });
     const notice = page.getByText("was replaced", { exact: false });
     await expect(notice).toBeVisible({ timeout: 20_000 });
     await expect(notice).toContainText(first);
@@ -262,5 +290,16 @@ test.describe("At the save-point cap the window rolls, and the panel says so (#3
     // A notice, not a paywall: nothing was refused.
     await expect(page.locator('[data-feature="schedule.checkpoints.max"]')).toHaveCount(0);
     await expect(page.getByText("Undo still rewinds past it", { exact: false })).toBeVisible();
+
+    // 375px — the notice is new copy on a panel that was already dense, and it
+    // is the longest single sentence in it. Asserted rather than screenshotted
+    // so a future edit that makes it overflow fails here instead of shipping.
+    await page.setViewportSize({ width: 375, height: 667 });
+    await expect(notice).toBeVisible();
+    const overflows = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+    );
+    expect(overflows, "the history panel scrolls horizontally at 375px").toBe(false);
+    await page.screenshot({ path: "test-results/eviction-notice-375.png", fullPage: true });
   });
 });

--- a/apps/web/e2e/open-scheduling.spec.ts
+++ b/apps/web/e2e/open-scheduling.spec.ts
@@ -1,0 +1,266 @@
+import { test, expect, type Page } from "@playwright/test";
+import { randomBytes } from "node:crypto";
+import { TAG, apiJson, loginUi, addEntrantsViaApi, createStageAndGenerate } from "./helpers";
+
+/**
+ * Division scheduling is open to every plan (#382, V353) — proven in the
+ * browser, on a real COMMUNITY org.
+ *
+ * Why this file exists. V353 is a data change: three rows flipped, five
+ * inserted. Nothing in TypeScript moved, so every unit suite could stay green
+ * with the migration unapplied — and `entitlements-scheduling.test.ts` proves
+ * only that `hasFeature` answers true, never that the organiser reaches the
+ * board. The three `requireFeature` calls it unblocks
+ * (`putScheduleSettings`, `applySchedule`, `moveFixture`) are only exercised
+ * end-to-end from here.
+ *
+ * EVERY TEST IS TWO-SIDED where a paywall still exists. Asserting only "the
+ * community org got a 200" is satisfied by an entitlement table with no gates
+ * left at all, which is precisely the over-shoot to guard against:
+ * `scheduling.multi_division` must STILL refuse community, or #382 quietly gave
+ * away the one scheduling feature that was meant to stay paid.
+ *
+ * Own org, own owner, own competition — nothing here touches the shared Pro
+ * user's org budget, so it belongs in the parallel project.
+ */
+
+const GENERIC_CONFIG = {
+  resultMode: "score",
+  allowDraws: true,
+  points: { w: 3, d: 1, l: 0 },
+  progressScore: false,
+};
+
+const hex = () => randomBytes(4).toString("hex");
+
+async function withDb<T>(fn: (sql: import("postgres").Sql) => Promise<T>): Promise<T> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error("DATABASE_URL required for direct DB setup in e2e");
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl, {
+    connection: { search_path: process.env.DB_SCHEMA ?? "seazn_club" },
+    ssl:
+      process.env.DATABASE_SSL === "disable"
+        ? false
+        : /@(localhost|127\.0\.0\.1)[:/]/.test(dbUrl)
+          ? false
+          : "require",
+    prepare: !dbUrl.includes(":6543"),
+    max: 1,
+  });
+  try {
+    return await fn(sql);
+  } finally {
+    await sql.end();
+  }
+}
+
+interface SeededOrg {
+  orgId: string;
+  orgSlug: string;
+  ownerEmail: string;
+}
+
+/** A COMMUNITY org with its own fresh owner — explicitly on the free plan, so
+ *  nothing here can accidentally read as a Pro result. */
+async function seedCommunityOrg(): Promise<SeededOrg> {
+  const tag = hex();
+  const ownerEmail = `os-owner-${TAG}-${tag}@example.com`;
+  return withDb(async (sql) => {
+    const [owner] = await sql<{ id: string }[]>`
+      insert into users (email, display_name, email_verified)
+      values (${ownerEmail}, ${"OS Owner " + tag}, true)
+      returning id`;
+    const orgSlug = `os-org-${TAG}-${tag}`;
+    const [org] = await sql<{ id: string }[]>`
+      insert into organizations (name, slug, status, created_by)
+      values (${"OS Org " + tag}, ${orgSlug}, 'active', ${owner!.id})
+      returning id`;
+    await sql`
+      insert into org_members (org_id, user_id, role)
+      values (${org!.id}, ${owner!.id}, 'owner')`;
+    const [group] = await sql<{ id: string }[]>`
+      insert into subscriptions (owner_user_id, plan_key, status)
+      values (${owner!.id}, 'community', 'active')
+      returning id`;
+    await sql`update organizations set subscription_id = ${group!.id} where id = ${org!.id}`;
+    return { orgId: org!.id, orgSlug, ownerEmail };
+  });
+}
+
+async function loginAsOwner(page: Page, email: string): Promise<void> {
+  await loginUi(page, email);
+  await page.request.post("/api/onboarding/complete", { data: {} }).catch(() => undefined);
+}
+
+interface Rig {
+  compId: string;
+  compSlug: string;
+  divisionId: string;
+  divSlug: string;
+  stageId: string;
+  fixtureIds: string[];
+}
+
+/** A private competition, a generic division with four entrants, and one
+ *  stage's fixtures — created through the API as the signed-in owner. Slugs are
+ *  read back, because the console pages are slug-routed. */
+async function seedRig(request: import("@playwright/test").APIRequestContext): Promise<Rig> {
+  const comp = await apiJson<{ id: string; slug: string }>(request, "/api/v1/competitions", "POST", {
+    name: `Open Sched ${TAG} ${hex()}`,
+    visibility: "private",
+  });
+  const div = await apiJson<{ id: string; slug: string }>(
+    request,
+    `/api/v1/competitions/${comp.data!.id}/divisions`,
+    "POST",
+    {
+      name: `Open ${hex()}`,
+      sport_key: "generic",
+      variant_key: "score",
+      config: GENERIC_CONFIG,
+      eligibility: [],
+    },
+  );
+  await addEntrantsViaApi(request, div.data!.id, ["Bolt", "Wire", "Coil", "Fuse"]);
+  const { stageId, fixtureIds } = await createStageAndGenerate(request, div.data!.id);
+  return {
+    compId: comp.data!.id,
+    compSlug: comp.data!.slug,
+    divisionId: div.data!.id,
+    divSlug: div.data!.slug,
+    stageId,
+    fixtureIds,
+  };
+}
+
+test.describe("Community reaches the board and the constraints (#382)", () => {
+  test("a Community org stores a constraint-bearing schedule setting", async ({ page }) => {
+    const org = await seedCommunityOrg();
+    await loginAsOwner(page, org.ownerEmail);
+    const rig = await seedRig(page.request);
+
+    // Every one of these trips `usesConstraints` on its own: a rest floor, a
+    // blackout AND a second court. Before V353 this was a flat 402 on community.
+    const res = await page.request.put(`/api/v1/divisions/${rig.divisionId}/schedule-settings`, {
+      headers: { "content-type": "application/json" },
+      data: JSON.stringify({
+        tz: "UTC",
+        config: {
+          startAt: new Date(Date.UTC(2026, 9, 12, 9, 0)).toISOString(),
+          matchMinutes: 45,
+          gapMinutes: 5,
+          courts: ["Court A", "Court B"],
+          perEntrantMinRest: 30,
+        },
+      }),
+    });
+    expect(res.status(), await res.text()).toBe(200);
+
+    // …and it STUCK. A 200 that stored nothing would pass a status-only check.
+    const read = await apiJson<{ config: { courts: string[]; perEntrantMinRest: number } }>(
+      page.request,
+      `/api/v1/divisions/${rig.divisionId}/schedule-settings`,
+    );
+    expect(read.data!.config.courts).toEqual(["Court A", "Court B"]);
+    expect(read.data!.config.perEntrantMinRest).toBe(30);
+  });
+
+  test("a Community org edits the board: a manual apply and a pin", async ({ page }) => {
+    const org = await seedCommunityOrg();
+    await loginAsOwner(page, org.ownerEmail);
+    const rig = await seedRig(page.request);
+
+    // `source: "manual"` is the branch gated on `scheduling.board`.
+    const applied = await page.request.post(`/api/v1/stages/${rig.stageId}/schedule/apply`, {
+      headers: { "content-type": "application/json" },
+      data: JSON.stringify({
+        source: "manual",
+        assignments: [
+          {
+            fixture_id: rig.fixtureIds[0],
+            scheduled_at: new Date(Date.UTC(2026, 9, 12, 9, 0)).toISOString(),
+            court_label: "Court A",
+          },
+        ],
+      }),
+    });
+    expect(applied.status(), await applied.text()).toBe(200);
+
+    // `schedule_locked` on a move is the other `scheduling.board` branch.
+    const pinned = await page.request.patch(`/api/v1/fixtures/${rig.fixtureIds[0]}`, {
+      headers: { "content-type": "application/json" },
+      data: JSON.stringify({ schedule_locked: true }),
+    });
+    expect(pinned.status(), await pinned.text()).toBe(200);
+
+    const fixture = await apiJson<{ schedule_locked: boolean; court_label: string | null }>(
+      page.request,
+      `/api/v1/fixtures/${rig.fixtureIds[0]}`,
+    );
+    expect(fixture.data!.schedule_locked).toBe(true);
+    expect(fixture.data!.court_label).toBe("Court A");
+  });
+
+  test("the division board page renders no scheduling paywall for Community", async ({ page }) => {
+    const org = await seedCommunityOrg();
+    await loginAsOwner(page, org.ownerEmail);
+    const rig = await seedRig(page.request);
+
+    await page.goto(`/o/${org.orgSlug}/c/${rig.compSlug}/d/${rig.divSlug}/schedule`);
+    await expect(page.getByRole("heading", { name: "History" })).toBeVisible({ timeout: 30_000 });
+    // The UpgradeGate carries data-feature; neither scheduling key may appear.
+    await expect(page.locator('[data-feature="scheduling.board"]')).toHaveCount(0);
+    await expect(page.locator('[data-feature="scheduling.constraints"]')).toHaveCount(0);
+  });
+
+  test("multi-division stays the ONE scheduling paywall on Community", async ({ page }) => {
+    // The two-sided half of this file. If this ever goes green-by-absence, #382
+    // gave away the feature it was explicitly meant to keep behind the wall.
+    const org = await seedCommunityOrg();
+    await loginAsOwner(page, org.ownerEmail);
+    const rig = await seedRig(page.request);
+
+    await page.goto(`/o/${org.orgSlug}/c/${rig.compSlug}/schedule`);
+    await expect(page.locator('[data-feature="scheduling.multi_division"]')).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});
+
+test.describe("At the save-point cap the window rolls, and the panel says so (#382)", () => {
+  test("the third save point names the one it replaced", async ({ page }) => {
+    const org = await seedCommunityOrg();
+    await loginAsOwner(page, org.ownerEmail);
+    const rig = await seedRig(page.request);
+
+    await page.goto(`/o/${org.orgSlug}/c/${rig.compSlug}/d/${rig.divSlug}/schedule`);
+    const input = page.getByLabel("Save point label");
+    await expect(input).toBeVisible({ timeout: 30_000 });
+    const save = page.getByRole("button", { name: "Save point" });
+
+    const first = `before rain ${hex()}`;
+    for (const label of [first, `after rain ${hex()}`]) {
+      await input.fill(label);
+      await save.click();
+      await expect(page.getByText(label, { exact: false })).toBeVisible({ timeout: 20_000 });
+    }
+    // Two saves, still under the community cap of 2 — no notice yet. Asserting
+    // its ABSENCE first is what stops a notice that always renders from passing
+    // the assertion below.
+    await expect(page.getByText("was replaced", { exact: false })).toHaveCount(0);
+
+    await input.fill(`third ${hex()}`);
+    await save.click();
+
+    // The save SUCCEEDED (no paywall), and the notice names the label that went.
+    await expect(page.getByText(first, { exact: false })).toHaveCount(0, { timeout: 20_000 });
+    const notice = page.getByText("was replaced", { exact: false });
+    await expect(notice).toBeVisible({ timeout: 20_000 });
+    await expect(notice).toContainText(first);
+    await expect(notice).toContainText("2 save points");
+    // A notice, not a paywall: nothing was refused.
+    await expect(page.locator('[data-feature="schedule.checkpoints.max"]')).toHaveCount(0);
+    await expect(page.getByText("Undo still rewinds past it", { exact: false })).toBeVisible();
+  });
+});

--- a/apps/web/e2e/pro-plus-tier.spec.ts
+++ b/apps/web/e2e/pro-plus-tier.spec.ts
@@ -189,18 +189,40 @@ async function setFixtureOfficials(
   return { status: res.status(), featureKey: body.error?.feature_key };
 }
 
-/** POST a named checkpoint and return {status, feature_key}. */
+/** POST a named checkpoint. Returns the status, the 402 feature key if there
+ *  ever is one again, and — since #382 — the save point this one rolled out of
+ *  the plan's window. */
 async function createCheckpoint(
   request: import("@playwright/test").APIRequestContext,
   divisionId: string,
   label: string,
-): Promise<{ status: number; featureKey?: string }> {
+): Promise<{ status: number; featureKey?: string; evicted?: string }> {
   const res = await request.post(`/api/v1/divisions/${divisionId}/checkpoints`, {
     headers: { "content-type": "application/json" },
     data: JSON.stringify({ label }),
   });
-  const body = (await res.json().catch(() => ({}))) as { error?: { feature_key?: string } };
-  return { status: res.status(), featureKey: body.error?.feature_key };
+  const body = (await res.json().catch(() => ({}))) as {
+    error?: { feature_key?: string };
+    data?: { evicted?: { label?: string } };
+    evicted?: { label?: string };
+  };
+  return {
+    status: res.status(),
+    featureKey: body.error?.feature_key,
+    evicted: (body.data?.evicted ?? body.evicted)?.label,
+  };
+}
+
+/** Manual save points on a division, newest first. */
+async function listManualCheckpoints(
+  request: import("@playwright/test").APIRequestContext,
+  divisionId: string,
+): Promise<string[]> {
+  const res = await request.get(`/api/v1/divisions/${divisionId}/checkpoints`);
+  const body = (await res.json().catch(() => ({}))) as {
+    data?: { label: string; kind?: string }[];
+  };
+  return (body.data ?? []).filter((r) => (r.kind ?? "manual") === "manual").map((r) => r.label);
 }
 
 // ===========================================================================
@@ -278,27 +300,49 @@ test.describe("Pro Plus · officials-per-fixture quota", () => {
 });
 
 test.describe("Pro Plus · schedule save-point quota", () => {
-  test("Community: the 3rd save point 402s (limit 2)", async ({ page }) => {
+  // #382 turned the refusal into a rolling window. The quota is still real —
+  // it is the WIDTH of the window — but the save always succeeds, because a
+  // checkpoint is a named bookmark and the ledger keeps every event regardless.
+  test("Community: the 3rd save point rolls the window rather than 402ing (limit 2)", async ({
+    page,
+  }) => {
     const org = await seedOrg({ plan: "community" });
     await loginAsOwner(page, org.ownerEmail);
     const { divisionId } = await seedDivision(page.request);
 
-    expect((await createCheckpoint(page.request, divisionId, `cp1 ${hex()}`)).status).toBe(201);
-    expect((await createCheckpoint(page.request, divisionId, `cp2 ${hex()}`)).status).toBe(201);
-    const third = await createCheckpoint(page.request, divisionId, `cp3 ${hex()}`);
-    expect(third.status).toBe(402);
-    expect(third.featureKey).toBe("schedule.checkpoints.max");
+    const one = `cp1 ${hex()}`;
+    const two = `cp2 ${hex()}`;
+    const three = `cp3 ${hex()}`;
+    expect((await createCheckpoint(page.request, divisionId, one)).status).toBe(201);
+    expect((await createCheckpoint(page.request, divisionId, two)).status).toBe(201);
+
+    const third = await createCheckpoint(page.request, divisionId, three);
+    expect(third.status).toBe(201);
+    expect(third.featureKey).toBeUndefined();
+    // The response NAMES what it replaced — the organiser is told which label
+    // they lost rather than finding a hole later.
+    expect(third.evicted).toBe(one);
+    // Two-sided: the window is still exactly the plan's width, and it is the
+    // OLDEST that went.
+    expect(await listManualCheckpoints(page.request, divisionId)).toEqual([three, two]);
   });
 
-  test("Pro: 5 save points are allowed, the 6th 402s (limit 5)", async ({ page }) => {
+  test("Pro: 5 save points are silent, the 6th rolls (limit 5)", async ({ page }) => {
     // Shared Pro org (schedule.checkpoints.max = 5).
     const { divisionId } = await seedDivision(page.request);
+    const labels: string[] = [];
     for (let i = 1; i <= 5; i++) {
-      expect((await createCheckpoint(page.request, divisionId, `cp${i} ${hex()}`)).status).toBe(201);
+      const label = `cp${i} ${hex()}`;
+      labels.push(label);
+      const res = await createCheckpoint(page.request, divisionId, label);
+      expect(res.status).toBe(201);
+      expect(res.evicted, `cp${i} evicted something below the cap`).toBeUndefined();
     }
-    const sixth = await createCheckpoint(page.request, divisionId, `cp6 ${hex()}`);
-    expect(sixth.status).toBe(402);
-    expect(sixth.featureKey).toBe("schedule.checkpoints.max");
+    const sixthLabel = `cp6 ${hex()}`;
+    const sixth = await createCheckpoint(page.request, divisionId, sixthLabel);
+    expect(sixth.status).toBe(201);
+    expect(sixth.evicted).toBe(labels[0]);
+    expect(await listManualCheckpoints(page.request, divisionId)).toHaveLength(5);
   });
 
   test("Pro Plus: save points are unlimited (6+ all succeed)", async ({ page }) => {

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/schedule/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/d/[divSlug]/schedule/page.tsx
@@ -1,6 +1,8 @@
 export const dynamic = "force-dynamic";
 // Drag-and-drop schedule board for one division (doc 12 §2, PROMPT-17).
-// Community renders it view-only (doc 12 §5 — scheduling.board).
+// Community used to render it view-only; V353 (#382) opened `scheduling.board`
+// and `scheduling.constraints` to every plan, so the gates below no longer fire
+// on any tier. They stay: an override or a future tier still moves through them.
 import Link from "@/components/ui/console-link";
 import { venueLabel } from "@/lib/venue";
 import { requireDivisionPage } from "@/server/page-auth";

--- a/apps/web/src/app/o/[orgSlug]/c/[compSlug]/schedule/page.tsx
+++ b/apps/web/src/app/o/[orgSlug]/c/[compSlug]/schedule/page.tsx
@@ -35,7 +35,11 @@ export default async function CompetitionSchedulePage({
   const locale = await resolveLocale();
   const dict = await getDictionary(locale, "ui");
 
-  const multiAllowed = await hasFeature(auth.orgId, "scheduling.multi_division");
+  // Competition-scoped since V353 (#382): `scheduling.multi_division` is now
+  // lifted by an Event Pass, and a pass covers ONE competition. Asking org-wide
+  // would deny the competition-wide board to the very organiser who paid to
+  // unlock this competition — the fault `pass-scoping-guard` exists to catch.
+  const multiAllowed = await hasFeature(auth.orgId, "scheduling.multi_division", id);
   if (!multiAllowed) {
     return (
       <>

--- a/apps/web/src/components/__tests__/upgrade-gate.test.tsx
+++ b/apps/web/src/components/__tests__/upgrade-gate.test.tsx
@@ -50,9 +50,16 @@ const PASS_PRICE = formatMinor(passPrice("usd", "event_pass"), "usd"); // "$29"
 const FLOOR_USD = formatMinor(lowestPassRung("usd").amountMinor, "usd"); // "$29"
 const FLOOR_GBP = formatMinor(lowestPassRung("gbp").amountMinor, "gbp"); // "£25"
 
-/** A key the pass lifts, and one it can never lift. */
+/** A key the pass lifts, and one it can never lift.
+ *
+ *  `NOT_LIFTABLE` was `scheduling.multi_division` until V353 (#382) put that
+ *  key on the Event Pass column — which turned every "the pass never covered
+ *  this" assertion below into a claim about a key the pass now DOES cover.
+ *  `officials.auto` is an above-Pro (Pro Plus) key with no `event_pass` row at
+ *  all, so no pass can ever lift it. `upgrade-gate-pass-features.test.ts`
+ *  derives the real lifted set from the live matrix and reds if this drifts. */
 const LIFTABLE = "divisions.per_competition.max";
-const NOT_LIFTABLE = "scheduling.multi_division";
+const NOT_LIFTABLE = "officials.auto";
 
 // The CTA carries `?feature=<key>`: the upgrade page keys its ceiling state off
 // that param, the gate is the only place that knows which key was refused, and

--- a/apps/web/src/components/v2/__tests__/history-panel-eviction-notice.test.tsx
+++ b/apps/web/src/components/v2/__tests__/history-panel-eviction-notice.test.tsx
@@ -11,7 +11,7 @@
 // catalog, the output tree — through the shared hook harness.
 import { describe, expect, it, vi } from "vitest";
 import { renderIsland, propsOf, textOf } from "@/components/__tests__/_hook-harness";
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 // `useConfirm` throws outside its provider by design; the harness's useContext
 // hands back the context default, which is that null. Everything else in the
@@ -52,11 +52,15 @@ function stubApi(createReturns: unknown, after: ReturnType<typeof cp>[]) {
   });
 }
 
+interface PanelProps {
+  divisionId: string;
+  scheduleLocked: boolean;
+  canEdit: boolean;
+}
+type Island = ReturnType<typeof renderIsland<PanelProps>>;
+
 /** Type a label and submit the create form, then let the panel's reload settle. */
-async function saveNamed(
-  island: ReturnType<typeof renderIsland<Record<string, unknown>>>,
-  label: string,
-) {
+async function saveNamed(island: Island, label: string) {
   const input = island
     .tree()
     .find((el: ReactElement) => propsOf(el)["aria-label"] === "Save point label");
@@ -69,12 +73,12 @@ async function saveNamed(
   await new Promise((r) => setTimeout(r, 0));
 }
 
-const render = () =>
-  renderIsland(
-    (props: Record<string, unknown>) =>
-      HistoryPanel(props as { divisionId: string; scheduleLocked: boolean; canEdit: boolean }),
-    { divisionId: "d1", scheduleLocked: false, canEdit: true },
-  );
+const render = (): Island =>
+  renderIsland<PanelProps>((props: PanelProps) => HistoryPanel(props), {
+    divisionId: "d1",
+    scheduleLocked: false,
+    canEdit: true,
+  });
 
 describe("HistoryPanel — the save-point eviction notice (#382)", () => {
   it("names the save point that was replaced, and how many the plan keeps", async () => {
@@ -137,7 +141,8 @@ describe("HistoryPanel — the save-point eviction notice (#382)", () => {
     const undo = island
       .tree()
       .find(
-        (el: ReactElement) => el.type === "button" && textOf(propsOf(el).children).includes("Undo"),
+        (el: ReactElement) =>
+          el.type === "button" && textOf(propsOf(el).children as ReactNode).includes("Undo"),
       );
     (propsOf(undo!).onClick as () => void)();
     await new Promise((r) => setTimeout(r, 0));

--- a/apps/web/src/components/v2/__tests__/history-panel-eviction-notice.test.tsx
+++ b/apps/web/src/components/v2/__tests__/history-panel-eviction-notice.test.tsx
@@ -1,0 +1,147 @@
+// #382 — the eviction notice, read off the rendered panel.
+//
+// `usecases/__tests__/history.test.ts` pins that `createCheckpoint` RETURNS an
+// `evicted` field. Nothing there says the organiser is ever told. A save that
+// silently drops a bookmark is the whole failure mode this change is supposed
+// to avoid, so the join between the API's answer and the sentence on screen
+// needs its own witness.
+//
+// A static `renderToStaticMarkup` cannot reach it: the notice only exists AFTER
+// a submit, so this drives the real island — state, effects, the English
+// catalog, the output tree — through the shared hook harness.
+import { describe, expect, it, vi } from "vitest";
+import { renderIsland, propsOf, textOf } from "@/components/__tests__/_hook-harness";
+import type { ReactElement } from "react";
+
+// `useConfirm` throws outside its provider by design; the harness's useContext
+// hands back the context default, which is that null. Everything else in the
+// panel runs for real — `useMsg` falls back to the English catalog outside a
+// DictProvider, which IS the production path, so the sentences below are the
+// shipped ones rather than dictionary keys.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn(), push: vi.fn() }),
+}));
+vi.mock("@/components/ui/confirm-provider", () => ({
+  useConfirm: () => vi.fn(async () => false),
+}));
+
+const apiV1 = vi.fn();
+vi.mock("@/lib/client-v1", () => ({
+  apiV1: (...args: unknown[]) => apiV1(...args),
+  ApiV1Error: class extends Error {},
+}));
+
+const { HistoryPanel } = await import("../history-panel");
+
+const cp = (id: string, label: string) => ({
+  id,
+  seq: 1,
+  label,
+  kind: "manual" as const,
+  created_at: "2026-08-05T10:00:00.000Z",
+});
+
+/** The panel's two mount reads, plus the POST the submit makes.
+ *  `createReturns` is what `POST /checkpoints` answers with. */
+function stubApi(createReturns: unknown, after: ReturnType<typeof cp>[]) {
+  apiV1.mockReset();
+  apiV1.mockImplementation(async (path: string, init?: { method?: string }) => {
+    if (init?.method === "POST") return createReturns;
+    if (path.endsWith("/history")) return { watermark: 1, seq: 1, events: [] };
+    return after;
+  });
+}
+
+/** Type a label and submit the create form, then let the panel's reload settle. */
+async function saveNamed(
+  island: ReturnType<typeof renderIsland<Record<string, unknown>>>,
+  label: string,
+) {
+  const input = island
+    .tree()
+    .find((el: ReactElement) => propsOf(el)["aria-label"] === "Save point label");
+  (propsOf(input!).onChange as (e: unknown) => void)({ target: { value: label } });
+  const form = island.tree().find((el: ReactElement) => el.type === "form");
+  (propsOf(form!).onSubmit as (e: unknown) => void)({ preventDefault: () => {} });
+  // The submit handler is fire-and-forget (`void run(...)`); let its awaits and
+  // the reload that follows drain before reading the tree.
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+const render = () =>
+  renderIsland(
+    (props: Record<string, unknown>) =>
+      HistoryPanel(props as { divisionId: string; scheduleLocked: boolean; canEdit: boolean }),
+    { divisionId: "d1", scheduleLocked: false, canEdit: true },
+  );
+
+describe("HistoryPanel — the save-point eviction notice (#382)", () => {
+  it("names the save point that was replaced, and how many the plan keeps", async () => {
+    stubApi(
+      { ...cp("c3", "three"), evicted: { id: "c1", label: "before rain reshuffle" } },
+      [cp("c3", "three"), cp("c2", "two")],
+    );
+    const island = render();
+    await saveNamed(island, "three");
+
+    const text = textOf(island.tree());
+    // The interpolated NAME, not just the key: a sentence that renders
+    // "“{name}” was replaced" satisfies a key-level assertion and tells the
+    // organiser nothing.
+    expect(text).toContain("“before rain reshuffle” was replaced");
+    // The count is the manual group's own length — two survivors on community.
+    expect(text).toContain("your plan keeps 2 save points");
+    // And the reassurance, or the notice reads as data loss.
+    expect(text).toContain("Undo still rewinds past it");
+  });
+
+  it("says nothing when the save evicted nothing", async () => {
+    stubApi(cp("c1", "one"), [cp("c1", "one")]);
+    const island = render();
+    await saveNamed(island, "one");
+
+    const text = textOf(island.tree());
+    expect(text).not.toContain("was replaced");
+    expect(text).not.toContain("Undo still rewinds past it");
+  });
+
+  it("is a notice, not a paywall — no UpgradeGate is rendered", async () => {
+    stubApi(
+      { ...cp("c3", "three"), evicted: { id: "c1", label: "one" } },
+      [cp("c3", "three"), cp("c2", "two")],
+    );
+    const island = render();
+    await saveNamed(island, "three");
+
+    // The 402 path renders <UpgradeGate>. Nothing was refused here, so the
+    // organiser must not be shown one.
+    const gates = island
+      .tree()
+      .filter((el: ReactElement) => typeof el.type === "function" && el.type.name === "UpgradeGate");
+    expect(gates).toHaveLength(0);
+    expect(textOf(island.tree())).toContain("was replaced");
+  });
+
+  it("clears the notice when the next action is not a save", async () => {
+    stubApi(
+      { ...cp("c3", "three"), evicted: { id: "c1", label: "one" } },
+      [cp("c3", "three"), cp("c2", "two")],
+    );
+    const island = render();
+    await saveNamed(island, "three");
+    expect(textOf(island.tree())).toContain("was replaced");
+
+    // Undo. A notice left standing beside an unrelated action would claim that
+    // action dropped a save point.
+    const undo = island
+      .tree()
+      .find(
+        (el: ReactElement) => el.type === "button" && textOf(propsOf(el).children).includes("Undo"),
+      );
+    (propsOf(undo!).onClick as () => void)();
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(textOf(island.tree())).not.toContain("was replaced");
+  });
+});

--- a/apps/web/src/components/v2/board/ai-console-state.ts
+++ b/apps/web/src/components/v2/board/ai-console-state.ts
@@ -467,6 +467,11 @@ export function applyErrorKey(
   // not the AI grade — AI is already granted on this tier, so route it to the
   // save-point line ("delete a save point or upgrade") instead of the generic
   // "upgrade to use AI" the plain 402 → error.upgrade mapping would give.
+  //
+  // #382 made this branch UNREACHABLE from the manual save path: at the cap the
+  // save now rolls the window rather than 402ing. It stays deliberately — it
+  // still guards any future caller that reintroduces a hard cap, and deleting a
+  // defensive branch to chase coverage is how the next regression gets in.
   if (outcome.errorStatus === 402 && outcome.errorCode === "schedule.checkpoints.max") {
     return "board.ai.apply.checkpointQuota";
   }

--- a/apps/web/src/components/v2/history-panel.tsx
+++ b/apps/web/src/components/v2/history-panel.tsx
@@ -34,6 +34,9 @@ interface Checkpoint {
   /** Every AI anchor except the newest. Struck through, still restorable. */
   superseded?: boolean;
   created_at: string;
+  /** #382 — only ever on the row a CREATE returns: the save point this one
+   *  pushed out of the plan's rolling window. */
+  evicted?: { id: string; label: string };
 }
 
 /** Render order is deliberate: the organiser's own save points first, since
@@ -75,6 +78,11 @@ export function HistoryPanel({
   const [label, setLabel] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [paywallFeature, setPaywallFeature] = useState<string | null>(null);
+  /** #382 — the label the last save rolled out of the window. A NOTICE, not a
+   *  paywall: the save SUCCEEDED, and undo still rewinds past the dropped
+   *  bookmark. Naming it is the whole point — an organiser who is not told
+   *  which label went looks for it later and finds a hole. */
+  const [evicted, setEvicted] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   const load = useCallback(async () => {
@@ -99,6 +107,9 @@ export function HistoryPanel({
   async function run(fn: () => Promise<unknown>) {
     setError(null);
     setPaywallFeature(null);
+    // Cleared per action, not per save: the notice belongs to the action the
+    // organiser just took, and a stale one beside an undo would be a lie.
+    setEvicted(null);
     setBusy(true);
     try {
       await fn();
@@ -203,11 +214,14 @@ export function HistoryPanel({
                 e.preventDefault();
                 if (!label.trim()) return;
                 void run(async () => {
-                  await apiV1(`/api/v1/divisions/${divisionId}/checkpoints`, {
-                    method: "POST",
-                    json: { label: label.trim() },
-                  });
+                  const created = await apiV1<Checkpoint>(
+                    `/api/v1/divisions/${divisionId}/checkpoints`,
+                    { method: "POST", json: { label: label.trim() } },
+                  );
                   setLabel("");
+                  // #382 — the save succeeded either way; `evicted` only says
+                  // whether it cost the oldest bookmark its label.
+                  if (created?.evicted) setEvicted(created.evicted.label);
                 });
               }}
             >
@@ -232,6 +246,19 @@ export function HistoryPanel({
                 Save point
               </button>
             </form>
+          )}
+          {/* #382 — non-blocking, and deliberately NOT an UpgradeGate: nothing
+              was refused. The count is the manual group's own length, which
+              after an eviction IS the plan's window width — no second read,
+              and it cannot disagree with the list right below it. */}
+          {evicted && (
+            <p className="rounded-md bg-amber-50 px-2.5 py-1.5 text-[11px] leading-snug text-amber-800 dark:bg-amber-950/60 dark:text-amber-200">
+              {msg("history.checkpoint.evicted", {
+                name: evicted,
+                count: String(checkpoints.filter((c) => (c.kind ?? "manual") === "manual").length),
+              })}{" "}
+              <span className="opacity-80">{msg("history.checkpoint.evictedHint")}</span>
+            </p>
           )}
           {/* Grouped by kind, because the two obey different rules: a manual
               save point spends the organiser's quota, an AI anchor does not.

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -99,6 +99,8 @@
   "history.checkpoint.notCounted": "not counted",
   "history.checkpoint.groupAi": "AI restore points",
   "history.checkpoint.groupYours": "Yours",
+  "history.checkpoint.evicted": "“{name}” was replaced — your plan keeps {count} save points.",
+  "history.checkpoint.evictedHint": "Undo still rewinds past it.",
   "board.ai.errorLabel": "Couldn't finish.",
   "board.ai.errorGeneric": "Something went wrong. Try again.",
   "board.ai.error.upgrade": "AI scheduling needs a Pro plan.",

--- a/apps/web/src/dictionaries/en/ui.json
+++ b/apps/web/src/dictionaries/en/ui.json
@@ -882,7 +882,7 @@
   "upgrade.ownerOnly": "Only the organization owner can purchase upgrades.",
   "upgrade.proCard.title": "Running events all year?",
   "upgrade.perMonth": "/month",
-  "upgrade.proCard.body": "Pro raises every competition in {org}, not just this one — and adds the schedule board, player stats, officials and API access the pass never covers.",
+  "upgrade.proCard.body": "Pro raises every competition in {org}, not just this one — and adds player stats and API access the pass never covers.",
   "upgrade.proCard.cta": "Go Pro — 14-day free trial",
   "upgrade.proCard.ctaNoTrial": "Go Pro",
   "upgrade.titleOwned": "Event Pass — “{name}”",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -99,6 +99,8 @@
   "history.checkpoint.notCounted": "no se cuentan",
   "history.checkpoint.groupAi": "Puntos de restauración de IA",
   "history.checkpoint.groupYours": "Tuyos",
+  "history.checkpoint.evicted": "«{name}» se reemplazó: tu plan conserva {count} puntos de guardado.",
+  "history.checkpoint.evictedHint": "Deshacer sigue retrocediendo más allá de él.",
   "board.ai.errorLabel": "No se pudo completar.",
   "board.ai.errorGeneric": "Algo salió mal. Inténtalo de nuevo.",
   "board.ai.error.upgrade": "La programación con IA necesita un plan Pro.",

--- a/apps/web/src/dictionaries/es/ui.json
+++ b/apps/web/src/dictionaries/es/ui.json
@@ -882,7 +882,7 @@
   "upgrade.ownerOnly": "Solo el propietario de la organización puede comprar mejoras.",
   "upgrade.proCard.title": "¿Organizas eventos todo el año?",
   "upgrade.perMonth": "/mes",
-  "upgrade.proCard.body": "Pro mejora todas las competiciones de {org}, no solo esta — y añade el tablero de planificación, las estadísticas de jugadores, los oficiales y el acceso a la API que el pase nunca cubre.",
+  "upgrade.proCard.body": "Pro mejora todas las competiciones de {org}, no solo esta — y añade las estadísticas de jugadores y el acceso a la API que el pase nunca cubre.",
   "upgrade.proCard.cta": "Pasar a Pro — prueba gratuita de 14 días",
   "upgrade.proCard.ctaNoTrial": "Hazte Pro",
   "upgrade.titleOwned": "Event Pass — «{name}»",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -882,7 +882,7 @@
   "upgrade.ownerOnly": "Seul le propriétaire de l’organisation peut acheter des améliorations.",
   "upgrade.proCard.title": "Vous organisez des événements toute l’année ?",
   "upgrade.perMonth": "/mois",
-  "upgrade.proCard.body": "Pro améliore toutes les compétitions de {org}, pas seulement celle-ci — et ajoute le tableau de planification, les statistiques des joueurs, les officiels et l’accès API que le pass ne couvre jamais.",
+  "upgrade.proCard.body": "Pro améliore toutes les compétitions de {org}, pas seulement celle-ci — et ajoute les statistiques des joueurs et l’accès API que le pass ne couvre jamais.",
   "upgrade.proCard.cta": "Passer à Pro — essai gratuit de 14 jours",
   "upgrade.proCard.ctaNoTrial": "Passer à Pro",
   "upgrade.titleOwned": "Event Pass — « {name} »",

--- a/apps/web/src/dictionaries/fr/ui.json
+++ b/apps/web/src/dictionaries/fr/ui.json
@@ -99,6 +99,8 @@
   "history.checkpoint.notCounted": "non comptés",
   "history.checkpoint.groupAi": "Points de restauration IA",
   "history.checkpoint.groupYours": "Les vôtres",
+  "history.checkpoint.evicted": "« {name} » a été remplacé — votre offre conserve {count} points de sauvegarde.",
+  "history.checkpoint.evictedHint": "Annuler revient toujours au-delà.",
   "board.ai.errorLabel": "Impossible de terminer.",
   "board.ai.errorGeneric": "Une erreur s'est produite. Réessayez.",
   "board.ai.error.upgrade": "La planification IA nécessite un forfait Pro.",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -882,7 +882,7 @@
   "upgrade.ownerOnly": "Alleen de eigenaar van de organisatie kan upgrades kopen.",
   "upgrade.proCard.title": "Het hele jaar door evenementen organiseren?",
   "upgrade.perMonth": "/maand",
-  "upgrade.proCard.body": "Pro upgradet elke competitie in {org}, niet alleen deze — en voegt het planningsbord, spelersstatistieken, officials en API-toegang toe die de pass nooit dekt.",
+  "upgrade.proCard.body": "Pro upgradet elke competitie in {org}, niet alleen deze — en voegt spelersstatistieken en API-toegang toe die de pass nooit dekt.",
   "upgrade.proCard.cta": "Neem Pro — 14 dagen gratis proberen",
   "upgrade.proCard.ctaNoTrial": "Word Pro",
   "upgrade.titleOwned": "Event Pass — “{name}”",

--- a/apps/web/src/dictionaries/nl/ui.json
+++ b/apps/web/src/dictionaries/nl/ui.json
@@ -99,6 +99,8 @@
   "history.checkpoint.notCounted": "tellen niet mee",
   "history.checkpoint.groupAi": "AI-herstelpunten",
   "history.checkpoint.groupYours": "Van jou",
+  "history.checkpoint.evicted": "“{name}” is vervangen — je abonnement bewaart {count} bewaarpunten.",
+  "history.checkpoint.evictedHint": "Ongedaan maken gaat er nog steeds voorbij.",
   "board.ai.errorLabel": "Kon niet voltooien.",
   "board.ai.errorGeneric": "Er ging iets mis. Probeer opnieuw.",
   "board.ai.error.upgrade": "AI-planning vereist een Pro-abonnement.",

--- a/apps/web/src/lib/__tests__/dictionary-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/dictionary-copy-truth.test.ts
@@ -57,6 +57,7 @@ import {
   localeCreditLeadershipFaults,
   localeHalfClaimFaults,
   localePassBoundFaults,
+  localePassUncoveredFaults,
   localePlusDifferentiatorFaults,
   retiredClaimFaults,
   valueClauses,
@@ -181,6 +182,14 @@ const PASS_CREDIT_VALUES = across("marketing", "pricing.faq.eventPass.a");
  *  red on honest copy. (Measured: it carries no permanence hit in any locale
  *  today, in any of the four vocabularies.) */
 const PLUS_VALUES = across("marketing", "pricing.faq.proPlus.a");
+
+/** #382 review, finding 1 — the Pro card on the per-competition upgrade page
+ *  (`app/o/[orgSlug]/c/[compSlug]/upgrade/page.tsx`). A FOURTH key axis, and
+ *  the reason it now exists: this card sits on the same screen as the Event
+ *  Pass it was describing, and V353 moved what the pass covers without moving
+ *  the card. Its own file, `ui.json`, not the marketing dictionary — this is
+ *  console copy, shown after a gate has already stopped somebody. */
+const PRO_CARD_BODY = across("ui", "upgrade.proCard.body");
 
 /**
  * THE PRO PLUS CARD — a THIRD key axis, and the reason it now exists.
@@ -2235,6 +2244,98 @@ describe.skipIf(!HAS_DB)("the four-locale dictionaries match plan_entitlements",
     expect(
       localeCreditLeadershipFaults(PLUS_CARD_VALUES, { ...credits, pro: 500 }).join(" "),
     ).toContain("but pro_plus grants 200");
+  });
+
+  // ── #382 review, finding 1: the Pro card on the UPGRADE page ──────────────
+  //
+  // `upgrade.proCard.body` is rendered to a community org with NO pass — the
+  // organiser who has just hit the `scheduling.multi_division` gate and landed
+  // on `?feature=scheduling.multi_division`, with the $29 Event Pass on the
+  // same screen. Its "the pass never covers …" list named the schedule board
+  // and officials, both of which V353 put on the pass. The card argued against
+  // the purchase directly above it.
+  //
+  // Judged against the matrix, not against a banned phrase: if a migration ever
+  // took `scheduling.board` off the pass, the old sentence would become true and
+  // this must fall silent.
+  it("the Pro card never sells the pass short, in all four locales (#382)", async () => {
+    const grants = await grantsFor([
+      "scheduling.board",
+      "scheduling.multi_division",
+      "officials.marks",
+      "stats.player",
+      "api.access",
+    ]);
+    // The premise, read from the seed rather than asserted from memory.
+    expect(grants["scheduling.board"]!.event_pass, "V353 put the board on the pass").toBe(true);
+    expect(grants["scheduling.multi_division"]!.event_pass).toBe(true);
+    expect(grants["officials.marks"]!.event_pass).toBe(true);
+    expect(grants["stats.player"]?.event_pass ?? false, "no event_pass row").toBe(false);
+    expect(grants["api.access"]?.event_pass ?? false, "no event_pass row").toBe(false);
+
+    expect(localePassUncoveredFaults(PRO_CARD_BODY, grants)).toEqual([]);
+  });
+
+  it("…and the pre-V353 card reds in every locale, so that is not silence (#382)", async () => {
+    const grants = await grantsFor([
+      "scheduling.board",
+      "officials.marks",
+      "stats.player",
+      "api.access",
+    ]);
+    // The shipped strings, verbatim, before this fix. Given per locale so a
+    // guard that only speaks English cannot pass this.
+    const preFix: LocalisedValue[] = (
+      [
+        [
+          "en",
+          "Pro raises every competition in Riverside, not just this one — and adds the schedule board, player stats, officials and API access the pass never covers.",
+        ],
+        [
+          "es",
+          "Pro mejora todas las competiciones de Riverside, no solo esta — y añade el tablero de planificación, las estadísticas de jugadores, los oficiales y el acceso a la API que el pase nunca cubre.",
+        ],
+        [
+          "fr",
+          "Pro améliore toutes les compétitions de Riverside, pas seulement celle-ci — et ajoute le tableau de planification, les statistiques des joueurs, les officiels et l’accès API que le pass ne couvre jamais.",
+        ],
+        [
+          "nl",
+          "Pro upgradet elke competitie in Riverside, niet alleen deze — en voegt het planningsbord, spelersstatistieken, officials en API-toegang toe die de pass nooit dekt.",
+        ],
+      ] as Array<[DictionaryLocale, string]>
+    ).map(([locale, value]) => ({ locale, key: "pre-fix", value }));
+
+    const faults = localePassUncoveredFaults(preFix, grants).join(" | ");
+    for (const locale of DICTIONARY_LOCALES) {
+      expect(faults, `${locale}: the board claim must red`).toContain(
+        `${locale} pre-fix: sells scheduling.board as something the Event Pass never covers`,
+      );
+      expect(faults, `${locale}: the officials claim must red`).toContain(
+        `${locale} pre-fix: sells officials.marks as something the Event Pass never covers`,
+      );
+    }
+
+    // ANTI-VACUITY: a card that names nothing at all is a fault of its own, so
+    // "fixing" this by deleting the list cannot pass.
+    for (const locale of DICTIONARY_LOCALES) {
+      expect(
+        localePassUncoveredFaults([{ locale, key: "empty", value: "Pro is better." }], grants),
+        locale,
+      ).toEqual([
+        `${locale} empty: names no recognised capability — the ${locale} vocabulary has gone stale and this guard examined nothing`,
+      ]);
+    }
+
+    // …and it must fall silent the day the matrix moves the other way: with the
+    // board off the pass, the pre-fix sentence is TRUE about the board again.
+    const lifted = {
+      ...grants,
+      "scheduling.board": { ...grants["scheduling.board"]!, event_pass: false },
+    };
+    expect(localePassUncoveredFaults(preFix, lifted).join(" | ")).not.toContain(
+      "sells scheduling.board",
+    );
   });
 });
 

--- a/apps/web/src/lib/__tests__/entitlements-scheduling.test.ts
+++ b/apps/web/src/lib/__tests__/entitlements-scheduling.test.ts
@@ -1,0 +1,128 @@
+// #382 — division scheduling is open to every plan; multi-division stays paid.
+//
+// `hasFeature` returns `row?.bool_value === true` (entitlements.ts), so a
+// MISSING row is false. Event Pass carried no row at all for board, constraints
+// or multi_division, which is why V353 INSERTS for it rather than flipping.
+//
+// Both resolution paths are exercised, because they are genuinely different
+// reads and a matrix row can serve one and not the other:
+//   - the org's own plan (`subscriptions.plan_key`), and
+//   - a competition pass overlaid on a community org (`competition_passes`),
+//     which is how an Event Pass is actually held in production.
+//
+// LOCATION IS LOAD-BEARING: `src/lib/__tests__/` — CI's Postgres job selects
+// `src/server src/lib` and `src/app`; from elsewhere the whole
+// `describe.skipIf(!HAS_DB)` body would run in no job at all and report green.
+import { afterAll, describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { sql } from "@/lib/db";
+import { hasFeature, invalidateOrgEntitlements } from "@/lib/entitlements";
+import { setOrgPlan } from "@/lib/__tests__/_billing-group";
+
+const HAS_DB = !!process.env.DATABASE_URL;
+
+/** Every plan key the matrix carries. */
+const PLANS = ["community", "pro", "pro_plus", "event_pass", "event_pass_l"] as const;
+
+async function seedOrg(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [org] = await sql<{ id: string }[]>`
+    insert into organizations (name, slug)
+    values (${"Sched " + suffix}, ${"sched-" + suffix})
+    returning id`;
+  return org!.id;
+}
+
+/** An org whose own subscription sits on `plan`. */
+async function seedOrgOnPlan(plan: string): Promise<string> {
+  const orgId = await seedOrg();
+  if (plan !== "community") await setOrgPlan(orgId, plan);
+  await invalidateOrgEntitlements(orgId);
+  return orgId;
+}
+
+/** A COMMUNITY org holding `passKey` on one competition — the production shape
+ *  of an Event Pass. Returns the competition the pass lifts. */
+async function seedOrgWithPass(passKey: string): Promise<{ orgId: string; competitionId: string }> {
+  const orgId = await seedOrg();
+  const [comp] = await sql<{ id: string }[]>`
+    insert into competitions (org_id, name, slug)
+    values (${orgId}, 'Passed Cup', ${"passed-" + randomUUID().slice(0, 8)})
+    returning id`;
+  await sql`
+    insert into competition_passes (competition_id, org_id, pass_key)
+    values (${comp!.id}, ${orgId}, ${passKey})`;
+  await invalidateOrgEntitlements(orgId);
+  return { orgId, competitionId: comp!.id };
+}
+
+afterAll(async () => {
+  if (!HAS_DB) return;
+  const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
+  const client = globalForDb._sql;
+  globalForDb._sql = undefined;
+  await client?.end();
+});
+
+describe.skipIf(!HAS_DB)("scheduling entitlements after V353 (#382)", () => {
+  it("opens board and constraints to every plan (#382)", async () => {
+    for (const plan of PLANS) {
+      const orgId = await seedOrgOnPlan(plan);
+      expect(await hasFeature(orgId, "scheduling.board"), `${plan} board`).toBe(true);
+      expect(await hasFeature(orgId, "scheduling.constraints"), `${plan} constraints`).toBe(true);
+    }
+  });
+
+  it("opens board and constraints on a competition an Event Pass lifts", async () => {
+    // The pass path is a different read: `resolve` joins `competition_passes`
+    // and overlays the PASS row on the plan row. A community org that bought a
+    // pass must reach the board on that competition too — and, since V353 opens
+    // the base plan, everywhere else as well.
+    for (const passKey of ["event_pass", "event_pass_l"]) {
+      const { orgId, competitionId } = await seedOrgWithPass(passKey);
+      expect(await hasFeature(orgId, "scheduling.board", competitionId), passKey).toBe(true);
+      expect(await hasFeature(orgId, "scheduling.constraints", competitionId), passKey).toBe(true);
+    }
+  });
+
+  it("keeps multi-division as the only scheduling paywall", async () => {
+    expect(await hasFeature(await seedOrgOnPlan("community"), "scheduling.multi_division")).toBe(
+      false,
+    );
+    for (const plan of ["pro", "pro_plus", "event_pass", "event_pass_l"]) {
+      expect(
+        await hasFeature(await seedOrgOnPlan(plan), "scheduling.multi_division"),
+        plan,
+      ).toBe(true);
+    }
+  });
+
+  it("an Event Pass lifts multi-division on the competition it covers", async () => {
+    for (const passKey of ["event_pass", "event_pass_l"]) {
+      const { orgId, competitionId } = await seedOrgWithPass(passKey);
+      expect(
+        await hasFeature(orgId, "scheduling.multi_division", competitionId),
+        passKey,
+      ).toBe(true);
+      // …and NOT org-wide: the community base still denies it off the pass.
+      expect(await hasFeature(orgId, "scheduling.multi_division"), `${passKey} org-wide`).toBe(
+        false,
+      );
+    }
+  });
+
+  it("every plan carries an explicit row, so no grant rests on a missing row", async () => {
+    // A missing row reads as false. The matrix must state board/constraints for
+    // every plan key rather than leaning on a default that does not exist.
+    const rows = await sql<{ plan_key: string; feature_key: string; bool_value: boolean }[]>`
+      select plan_key, feature_key, bool_value from plan_entitlements
+       where feature_key in ('scheduling.board', 'scheduling.constraints')`;
+    for (const plan of PLANS) {
+      for (const key of ["scheduling.board", "scheduling.constraints"]) {
+        const row = rows.find((r) => r.plan_key === plan && r.feature_key === key);
+        expect(row, `${plan} ${key} row`).toBeDefined();
+        expect(row!.bool_value, `${plan} ${key} value`).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/__tests__/help-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/help-copy-truth.test.ts
@@ -2504,3 +2504,45 @@ describe("the add-ons gate catches what the vocabulary cannot", () => {
     expect(inventoryFaults("x", swapped, APPROVED_ADD_ONS_INVENTORY)).not.toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// The OpenAPI summaries are PUBLISHED SURFACE, and one of them was quoting a
+// retired price. `/divisions/{id}/checkpoints` (POST) advertised the save-point
+// quota as "1 free / 5 Pro / unlimited Pro Plus". Community has been 2 since
+// V319 — so the spec every integrator reads, and every generated client's
+// docstring, carried a false claim about what a plan includes.
+//
+// Found during #382 triage, in no issue. Exactly the class this file exists for:
+// a number in prose that no longer matches the number the resolver enforces.
+//
+// Reading the SEEDED value rather than hardcoding 2 is the point — the next
+// entitlement change fails this test instead of quietly re-staling the copy.
+// ---------------------------------------------------------------------------
+describe.skipIf(!HAS_DB)("the OpenAPI checkpoint summary quotes the seeded quota (#382)", () => {
+  it("the checkpoint quota summary matches the seeded entitlement (#382)", async () => {
+    const { ROUTES } = await import("@/server/api-v1/openapi");
+    const [row] = await sql<{ int_value: number }[]>`
+      select int_value from plan_entitlements
+       where plan_key = 'community' and feature_key = 'schedule.checkpoints.max'`;
+    expect(row, "no seeded community checkpoint quota to compare against").toBeDefined();
+
+    const route = ROUTES.find(
+      (r) => r.path === "/divisions/{id}/checkpoints" && r.method === "post",
+    );
+    expect(route, "the checkpoints POST route").toBeDefined();
+    const summary = route!.summary ?? "";
+
+    expect(summary).toContain(String(row!.int_value));
+    expect(summary, "the retired '1 free' claim").not.toMatch(/\b1\s+free\b/);
+  });
+
+  it("also states what now happens AT the cap, since it no longer refuses", async () => {
+    // #382 turned the refusal into a rolling window. A summary that names the
+    // number but still implies a hard stop is the same class of stale claim.
+    const { ROUTES } = await import("@/server/api-v1/openapi");
+    const summary =
+      ROUTES.find((r) => r.path === "/divisions/{id}/checkpoints" && r.method === "post")
+        ?.summary ?? "";
+    expect(summary.toLowerCase()).toContain("replaced");
+  });
+});

--- a/apps/web/src/lib/__tests__/help-copy-truth.test.ts
+++ b/apps/web/src/lib/__tests__/help-copy-truth.test.ts
@@ -41,6 +41,7 @@ import {
   unapprovedClaimFaults,
   lockedRateConstantFaults,
   markdownSection,
+  multiDivisionBoardPlanGateFaults,
   plainProse,
   passBoundProseFaults,
   passCreditProseFaults,
@@ -411,6 +412,100 @@ Unlike schedule generations, **officials AI runs are not metered** — restaff a
     );
     expect(reverted, "the replacement never matched — the article moved").not.toBe(aiOfficials);
     expect(unmeteredAiRunProseFaults("x", reverted)).not.toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #382 review, finding 4 — scheduling/ai-scheduling.md and what V353 opened.
+//
+// "The multi-division board is a **Pro** feature." was true when it was
+// written. V353 granted `scheduling.multi_division` to `event_pass` and
+// `event_pass_l`, and turned `scheduling.board`/`scheduling.constraints` on for
+// every plan key. So the sentence named the one door that costs $29/month while
+// the $29 ONE-TIME door — the pass, which lifts it for this competition — went
+// unmentioned, and it implied the board itself was paid when it is not.
+//
+// The same lost-sale shape as the upgrade card in `dictionary-copy-truth`: the
+// reader of this paragraph is an organiser who has just been stopped.
+// ─────────────────────────────────────────────────────────────────────────────
+describe("scheduling/ai-scheduling.md states both doors to the joint board (#382)", () => {
+  const aiScheduling = helpArticleBySlug("scheduling/ai-scheduling");
+
+  it("never names Pro as the only way to plan several divisions together", () => {
+    expect(multiDivisionBoardPlanGateFaults("ai-scheduling.md", aiScheduling)).toEqual([]);
+  });
+
+  // MUTATION PROOF: the exact sentence #382's review found, restored. Without
+  // this the guard above could be inert and read as clean.
+  it("reds on the exact Pro-only sentence #382 found", () => {
+    const reverted = aiScheduling.replace(
+      /Planning several divisions together needs[^\n]*/,
+      "The multi-division board is a **Pro** feature.",
+    );
+    expect(reverted, "the replacement never matched — the article moved").not.toBe(aiScheduling);
+    expect(multiDivisionBoardPlanGateFaults("x", reverted).join(" | ")).toContain(
+      "names Pro as the only way to plan several divisions together",
+    );
+  });
+
+  // …and the SECOND falsehood V353 created, which the first rule cannot see:
+  // the board itself sold as paid. Its own patterns, no pass exemption, because
+  // naming the pass would not make it true.
+  it("reds on a sentence gating the board itself on a plan", () => {
+    for (const sentence of [
+      "The schedule board is a **Pro** feature.",
+      "The drag-and-drop board is a paid feature.",
+      "The scheduling board requires **Pro**.",
+      "You need to upgrade to Pro to use the schedule board.",
+    ]) {
+      expect(
+        multiDivisionBoardPlanGateFaults("x", `# T\n\n${sentence}\n`).join(" | "),
+        sentence,
+      ).toContain("gates the schedule board on a plan");
+    }
+  });
+
+  // ANTI-VACUITY, the other direction: naming the pass is what clears the
+  // multi-division rule, so a sentence that gates on Pro ALONE must still red
+  // while the same sentence with the pass must not. A guard that never fires,
+  // and a guard that always fires, both read as green somewhere.
+  it("the pass clause is what clears the guard, not the phrasing", () => {
+    const withoutPass = "# T\n\nPlanning several divisions together needs **Pro**.\n";
+    const withPass =
+      "# T\n\nPlanning several divisions together needs **Pro**, or this competition's **Event Pass**.\n";
+    expect(multiDivisionBoardPlanGateFaults("x", withoutPass)).not.toEqual([]);
+    expect(multiDivisionBoardPlanGateFaults("x", withPass)).toEqual([]);
+  });
+});
+
+/**
+ * The matrix half of #382's finding 4, the same pairing `ai-officials.md` gets
+ * above: the vocabulary scan forbids the false sentence coming back, but only a
+ * row read can notice the article going stale again because the DATA moved. It
+ * became wrong that way once already — V353 changed no TypeScript at all.
+ */
+describe.skipIf(!HAS_DB)("ai-scheduling.md's joint-board claim is the matrix's (#382)", () => {
+  it("the pass lifts scheduling.multi_division, and the board is open to all", async () => {
+    const rows = await sql<{ feature_key: string; plan_key: string; bool_value: boolean | null }[]>`
+      select feature_key, plan_key, bool_value from plan_entitlements
+      where feature_key in ('scheduling.multi_division', 'scheduling.board')
+      order by feature_key, plan_key`;
+    // Canary: a typo'd key would return nothing and every assertion below would
+    // pass vacuously.
+    expect(rows.length, "no scheduling rows — the keys moved").toBeGreaterThan(6);
+    const grant = (feature: string, plan: string) =>
+      rows.find((r) => r.feature_key === feature && r.plan_key === plan)?.bool_value === true;
+
+    // Why the article must name the pass at all.
+    expect(grant("scheduling.multi_division", "event_pass")).toBe(true);
+    expect(grant("scheduling.multi_division", "event_pass_l")).toBe(true);
+    expect(grant("scheduling.multi_division", "pro")).toBe(true);
+    // …and why "needs Pro" is still worth saying: community does NOT have it.
+    expect(grant("scheduling.multi_division", "community")).toBe(false);
+    // Why the board itself may not be described as paid.
+    for (const plan of ["community", "event_pass", "event_pass_l", "pro", "pro_plus"]) {
+      expect(grant("scheduling.board", plan), `scheduling.board on ${plan}`).toBe(true);
+    }
   });
 });
 

--- a/apps/web/src/lib/copy-truth.ts
+++ b/apps/web/src/lib/copy-truth.ts
@@ -1357,6 +1357,75 @@ export function aiOfficialsPlanGateFaults(label: string, markdown: string): stri
   return faults;
 }
 
+/**
+ * #382 review, finding 4: `content/help/scheduling/ai-scheduling.md` said "The
+ * multi-division board is a **Pro** feature." Two things about that are now
+ * wrong, and V353 (`db/migration/deltas/V353__open_scheduling_entitlements.sql`)
+ * made both wrong at once, as a DATA change no compiler could see:
+ *
+ *   1. `scheduling.multi_division` is granted to `event_pass` and
+ *      `event_pass_l`. A $29 pass lifts it for ONE competition, so naming Pro
+ *      as the only door costs the sale the reader is closest to making —
+ *      exactly the shape of the upgrade card in `localePassUncoveredFaults`.
+ *   2. `scheduling.board` and `scheduling.constraints` are now true on EVERY
+ *      plan key, so the board itself is not a paid feature at all. A sentence
+ *      gating "the schedule board" on a plan is false however it is worded.
+ *
+ * TWO RULE SHAPES, because the two falsehoods differ. Gating the MULTI-DIVISION
+ * board on Pro is INCOMPLETE rather than false — Pro really does lift it — so
+ * it is a fault only when the sentence does not also name the pass; that keeps
+ * the guard silent on the corrected copy, which states both doors. Gating the
+ * BOARD ITSELF on any plan is false outright and needs no positive half.
+ *
+ * SCOPED TO ONE ARTICLE at its call site, like `aiOfficialsPlanGateFaults`
+ * above and for the same reason: `board.md` and the plan pages legitimately
+ * discuss what Pro adds, and a vocabulary broad enough to catch this claim
+ * anywhere would catch true sentences elsewhere.
+ */
+export function multiDivisionBoardPlanGateFaults(label: string, markdown: string): string[] {
+  const subject = String.raw`(?:multi[-\s]division|several\s+divisions|divisions?\s+at\s+once|competition[-\s]wide)`;
+  const gate = String.raw`(?:is|are)\s+a\s+(?:\w+\s+){0,2}?pro\b|(?:requires?|needs?|takes)\s+(?:\w+\s+){0,2}?pro\b|pro[-\s]only|only\s+on\s+pro\b|available\s+on\s+pro\b`;
+  // Pro as the ONLY door to planning several divisions together.
+  const proOnlyDoor = [
+    new RegExp(String.raw`\b${subject}\b[^.;]{0,60}\b(?:${gate})`, "i"),
+    new RegExp(String.raw`\b(?:${gate})[^.;]{0,60}\b${subject}\b`, "i"),
+  ];
+  // …unless the sentence also names the other door. Deliberately requires
+  // "Event Pass" in full: this article calls each AI phase a "pass" ("the
+  // schedule pass", "the officials pass", "a single pass"), so a bare \bpass\b
+  // would exempt almost every sentence in it — the guard would read clean
+  // because it was looking at the wrong noun.
+  const namesThePass = /\bevent\s+pass(es)?\b/i;
+  // The board ITSELF sold as a paid feature — false on its own, no exemption.
+  const boardIsPaid = [
+    /\b(?:schedule|scheduling|drag[-\s]and[-\s]drop)\s+board\b[^.;]{0,40}\b(?:is|are)\s+a\s+(?:\w+\s+){0,2}?(?:pro|paid|premium)\b/i,
+    /\b(?:schedule|scheduling)\s+board\b[^.;]{0,40}\b(?:requires?|needs?)\s+(?:\w+\s+){0,2}?(?:pro|a\s+paid\s+plan|an\s+upgrade)\b/i,
+    /\b(?:upgrade|pro|a\s+paid\s+plan)\b[^.;]{0,40}\bto\s+(?:use|open|reach)\s+the\s+(?:schedule|scheduling)\s+board\b/i,
+  ];
+
+  const faults: string[] = [];
+  for (const block of claimTexts(markdown)) {
+    for (const sentence of sentences(block)) {
+      for (const pattern of boardIsPaid) {
+        if (pattern.test(sentence)) {
+          faults.push(
+            `${label}: "${sentence.slice(0, 72)}…" gates the schedule board on a plan — V353 grants scheduling.board and scheduling.constraints on every plan key`,
+          );
+        }
+      }
+      if (namesThePass.test(sentence)) continue;
+      for (const pattern of proOnlyDoor) {
+        if (pattern.test(sentence)) {
+          faults.push(
+            `${label}: "${sentence.slice(0, 72)}…" names Pro as the only way to plan several divisions together, without the Event Pass — V353 grants scheduling.multi_division to event_pass and event_pass_l, which lifts it for one competition`,
+          );
+        }
+      }
+    }
+  }
+  return faults;
+}
+
 // ── The pass's duration and credit grant, in prose ───────────────────────────
 
 /**
@@ -2257,6 +2326,114 @@ export function localePlusDifferentiatorFaults(
     if (recognised === 0) {
       faults.push(
         `${locale} ${key}: names no recognised differentiator — the ${locale} vocabulary has gone stale and this guard examined nothing`,
+      );
+    }
+  }
+  return faults;
+}
+
+/**
+ * #382 review, finding 1 — the sibling claim, pointed the other way.
+ *
+ * `localePlusDifferentiatorFaults` judges "Pro Plus adds X over the PLANS
+ * below it". This judges "Pro adds X the PASS never covers" — the upgrade
+ * page's Pro card (`upgrade.proCard.body`), shown to a community organiser
+ * with no pass, which is exactly the organiser who has just been stopped by
+ * the `scheduling.multi_division` gate and sent here to buy something.
+ *
+ * V353 made that card argue against the purchase it is sitting next to. It
+ * listed "the schedule board" among the things the pass never covers, while
+ * V353 granted `scheduling.board` to every plan AND `scheduling.multi_division`
+ * to the pass — so the $29 Event Pass shown directly above now covers, for this
+ * competition, the very capability the Pro card says it never covers.
+ * "Officials" was the same shape: `officials.marks` and `officials.roles_multi`
+ * are true on community and on the pass, and `officials.auto` is pro_plus-only,
+ * so no officials capability is a Pro-over-pass advantage at all.
+ *
+ * WHY THE GRANTS AND NOT A BANNED PHRASE, same reasoning as the sibling: if a
+ * later migration took `scheduling.board` off the pass, "the pass never covers
+ * the schedule board" becomes TRUE and this guard must fall silent.
+ *
+ * A feature with NO `event_pass` row is genuinely uncovered, not unknown: the
+ * pass overlay in `resolveFromDb` falls THROUGH to the plan row for any key the
+ * pass matrix omits, so an absent row means the pass adds nothing on that axis.
+ * That is why `stats.player` and `api.access` — neither of which has an
+ * `event_pass` row — stay in the card as real Pro advantages.
+ *
+ * Anti-vacuity, as everywhere here: a value that names no recognised capability
+ * has had this guard examine nothing, and that is itself a fault. Without it,
+ * deleting the list would pass.
+ */
+export function localePassUncoveredFaults(
+  values: LocalisedValue[],
+  grants: FeatureGrants,
+): string[] {
+  // Kept local rather than added to `LOCALE_CLAIMS`, following
+  // `aiOfficialsPlanGateFaults`: this vocabulary is scoped to ONE claim on ONE
+  // key, and the non-English halves go through `claim()` because `\b` and `\w`
+  // are ASCII-only in JavaScript (see the header over `LOCALE_CLAIMS`).
+  const vocab: Array<[feature: string, byLocale: Record<DictionaryLocale, RegExp>]> = [
+    [
+      "scheduling.board",
+      {
+        en: /\b(schedule|scheduling|multi-division)\s+board\b/i,
+        es: claim(String.raw`\btabler\w*\s+de\s+(planificaci\w+|programaci\w+|horarios)\b`),
+        fr: claim(String.raw`\btableau\s+de\s+(planification|programmation)\b`),
+        nl: claim(String.raw`\bplanningsbord\b|\bplanningsboard\b`),
+      },
+    ],
+    [
+      "officials.marks",
+      {
+        en: /\bofficials?\b|\breferees?\b/i,
+        es: claim(String.raw`\boficiales\b|\b\wrbitros\b`),
+        fr: claim(String.raw`\bofficiels\b|\barbitres\b`),
+        nl: claim(String.raw`\bofficials\b|\bscheidsrechters\b`),
+      },
+    ],
+    [
+      "stats.player",
+      {
+        en: /\bplayer\s+stat(istic)?s\b/i,
+        es: claim(String.raw`\bestad\wsticas\s+de\s+jugadores\b`),
+        fr: claim(String.raw`\bstatistiques\s+des\s+joueurs\b`),
+        nl: claim(String.raw`\bspelersstatistieken\b`),
+      },
+    ],
+    [
+      "api.access",
+      {
+        en: /\bAPI\b/i,
+        es: claim(String.raw`\bAPI\b`),
+        fr: claim(String.raw`\bAPI\b`),
+        nl: claim(String.raw`\bAPI\b`),
+      },
+    ],
+  ];
+
+  const faults: string[] = [];
+  for (const { locale, key, value } of values) {
+    let recognised = 0;
+    for (const [feature, byLocale] of vocab) {
+      if (!byLocale[locale].test(value)) continue;
+      recognised += 1;
+      const row = grants[feature];
+      if (!row) {
+        faults.push(`${locale} ${key}: names ${feature}, which has no rows in plan_entitlements`);
+        continue;
+      }
+      if (row.event_pass) {
+        faults.push(
+          `${locale} ${key}: sells ${feature} as something the Event Pass never covers, but event_pass grants it`,
+        );
+      }
+      if (!row.pro) {
+        faults.push(`${locale} ${key}: sells ${feature} as a Pro advantage, but pro does not grant it`);
+      }
+    }
+    if (recognised === 0) {
+      faults.push(
+        `${locale} ${key}: names no recognised capability — the ${locale} vocabulary has gone stale and this guard examined nothing`,
       );
     }
   }

--- a/apps/web/src/lib/feature-copy.ts
+++ b/apps/web/src/lib/feature-copy.ts
@@ -67,9 +67,18 @@ const FEATURE_REASONS: Record<string, string> = {
   "clubs.max": "You've reached your plan's club limit.",
   "teams.max": "You've reached your plan's team limit.",
   "teams.squad_max": "This squad has reached your plan's size limit.",
-  "scheduling.constraints": "The scheduling constraints solver is a Pro feature.",
-  "scheduling.board": "Editing the schedule board is a Pro feature — it stays view-only on Community.",
-  "scheduling.multi_division": "The competition-wide schedule board is a Pro feature.",
+  // V353 (#382) opened `scheduling.board` and `scheduling.constraints` to every
+  // plan, so neither of these two can be reached from the ordinary plan gates
+  // any more. They stay: an entitlement override can still switch either key
+  // off for one org, and a paywall with no reason falls back to the flat "This
+  // feature needs a plan upgrade.", which reads as a bug next to a priced
+  // button. The wording no longer claims a plan.
+  "scheduling.constraints": "The scheduling constraints solver is not available on this plan.",
+  "scheduling.board": "Editing the schedule board is not available on this plan.",
+  // Still a real paywall — and since V353 an Event Pass lifts it for one
+  // competition, which is why the key is in `PASS_FEATURES`.
+  "scheduling.multi_division":
+    "The competition-wide schedule board is a Pro feature — or an Event Pass, for one competition.",
   "officials.auto": "Auto-assigning officials (solver, phased sourcing) is a Pro Plus feature — manual assignment still works.",
   "officials.roles_multi": "Multiple official roles per fixture (judge + referee) are a Pro feature.",
   "officials.per_fixture.max": "Community includes one official per fixture — more need Pro.",

--- a/apps/web/src/lib/i18n-keys.ts
+++ b/apps/web/src/lib/i18n-keys.ts
@@ -1767,6 +1767,8 @@ export type DictionaryKey =
   | "hero.subhead"
   | "history.checkpoint.delete"
   | "history.checkpoint.empty"
+  | "history.checkpoint.evicted"
+  | "history.checkpoint.evictedHint"
   | "history.checkpoint.groupAi"
   | "history.checkpoint.groupYours"
   | "history.checkpoint.latestAi"

--- a/apps/web/src/lib/pass-features.ts
+++ b/apps/web/src/lib/pass-features.ts
@@ -34,6 +34,10 @@ export const PASS_FEATURES = new Set([
   "exports.branded",
   "sponsors.tiers",
   "sponsors.monetize",
+  // V353 (#382): the pass now lifts the competition-wide board. Community is
+  // still denied it, so this is a real paywall — and without the key here that
+  // paywall would show the Pro-only card to someone a $29 pass would clear.
+  "scheduling.multi_division",
   // scheduling.ai.runs_per_division.max retired (v17 Phase 2 Task 5, V322) —
   // the AI credit wallet meters runs on every tier now, so it no longer has a
   // plan_entitlements row for the pass to lift.

--- a/apps/web/src/server/api-v1/openapi.ts
+++ b/apps/web/src/server/api-v1/openapi.ts
@@ -219,7 +219,7 @@ export const ROUTES: RouteSpec[] = [
   { path: "/divisions/{id}/redo", method: "post", summary: "Redo the next edit (Word-like linear history)", tag: "history", request: S.HistoryStep, errors: [409, 422] },
   { path: "/divisions/{id}/history", method: "get", summary: "Ledger slice: type, actor, time, undoable/undone", tag: "history" },
   { path: "/divisions/{id}/checkpoints", method: "get", summary: "Named save points", tag: "history" },
-  { path: "/divisions/{id}/checkpoints", method: "post", summary: "Create a save point at the current watermark (quota `schedule.checkpoints.max`: 1 free / 5 Pro / unlimited Pro Plus)", tag: "history", request: S.CreateCheckpoint, status: 201, errors: [402] },
+  { path: "/divisions/{id}/checkpoints", method: "post", summary: "Create a save point at the current watermark (quota `schedule.checkpoints.max`: 2 free / 5 Pro / unlimited Pro Plus; at the cap the oldest save point is replaced)", tag: "history", request: S.CreateCheckpoint, status: 201, errors: [402] },
   { path: "/divisions/{id}/checkpoints/{checkpointId}", method: "delete", summary: "Delete a save point — frees a quota slot when the save point is manual", tag: "history", errors: [404] },
   { path: "/divisions/{id}/restore", method: "post", summary: "Undo back to a checkpoint (confirm: true; results-guarded)", tag: "history", request: S.RestoreCheckpoint, errors: [422] },
   { path: "/divisions/{id}/locks", method: "patch", summary: "Whole-division freeze + multi-site scope locks (scopes are Pro)", tag: "history", request: S.DivisionLocks, errors: [402] },

--- a/apps/web/src/server/usecases/__tests__/history.test.ts
+++ b/apps/web/src/server/usecases/__tests__/history.test.ts
@@ -481,6 +481,91 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
     await expect(createCheckpoint(auth, division.id, "three")).resolves.toBeDefined();
   });
 
+  // -------------------------------------------------------------------------
+  // #382 — AI anchors are pruned to the newest 3 per division.
+  //
+  // They are exempt from the manual quota (V303) and nothing ever deleted them:
+  // `superseded` is derived on read, not stored, and the only DELETE is the
+  // user-initiated endpoint. So they accumulated one per AI apply, for ever.
+  //
+  // Three rather than one because `CheckpointRow.superseded` calls the deeper
+  // rewind out as deliberate — "jumping back two AI runs is a real capability
+  // worth keeping". Two runs back plus the newest is exactly 3.
+  // -------------------------------------------------------------------------
+
+  it("keeps the newest 3 AI anchors per division (#382)", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    for (let i = 0; i < 6; i++) await createCheckpoint(auth, division.id, `ai-${i}`, "ai");
+    const ai = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "ai");
+    expect(ai).toHaveLength(3);
+    // listCheckpoints is newest-first.
+    expect(ai.map((r) => r.label)).toEqual(["ai-5", "ai-4", "ai-3"]);
+  });
+
+  it("the 3rd and 4th AI anchors are the boundary: 3 survive, the 4th prunes one", async () => {
+    const { auth } = await seedOrg("pro");
+    const { division } = await seedDivision(auth);
+    for (let i = 0; i < 3; i++) await createCheckpoint(auth, division.id, `ai-${i}`, "ai");
+    expect((await listCheckpoints(auth, division.id)).filter((r) => r.kind === "ai")).toHaveLength(
+      3,
+    );
+    await createCheckpoint(auth, division.id, "ai-3", "ai");
+    const ai = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "ai");
+    expect(ai.map((r) => r.label)).toEqual(["ai-3", "ai-2", "ai-1"]);
+  });
+
+  it("pruning is per division, not per org", async () => {
+    const { auth } = await seedOrg("community");
+    const a = await seedDivision(auth);
+    const b = await seedDivision(auth);
+    for (let i = 0; i < 4; i++) await createCheckpoint(auth, a.division.id, `a-${i}`, "ai");
+    await createCheckpoint(auth, b.division.id, "b-0", "ai");
+    expect(
+      (await listCheckpoints(auth, b.division.id)).filter((r) => r.kind === "ai"),
+    ).toHaveLength(1);
+    // …and A is still at its own cap of 3, not emptied by B's insert.
+    expect(
+      (await listCheckpoints(auth, a.division.id)).filter((r) => r.kind === "ai"),
+    ).toHaveLength(3);
+  });
+
+  it("the prune touches AI anchors only — manual save points survive it", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    await createCheckpoint(auth, division.id, "manual-one");
+    for (let i = 0; i < 6; i++) await createCheckpoint(auth, division.id, `ai-${i}`, "ai");
+    const rows = await listCheckpoints(auth, division.id);
+    expect(rows.filter((r) => r.kind === "manual").map((r) => r.label)).toEqual(["manual-one"]);
+    expect(rows.filter((r) => r.kind === "ai")).toHaveLength(3);
+  });
+
+  it("AI anchors still cost no manual quota", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    for (let i = 0; i < 4; i++) await createCheckpoint(auth, division.id, `ai-${i}`, "ai");
+    const first = await createCheckpoint(auth, division.id, "manual-one");
+    expect(first.evicted).toBeUndefined();
+  });
+
+  it("a pruned AI anchor costs its label, not the rewind", async () => {
+    // Same contract as a rolled manual save point: the ROW goes, the ledger
+    // does not. An anchor pruned away is no longer restorable BY ID, but undo
+    // still walks back past the watermark it named.
+    const { auth } = await seedOrg("community");
+    const { division, fixtures } = await seedDivision(auth);
+    await patchFixture(auth, fixtures[0]!.id, { scheduled_at: at(9), court_label: "C1" });
+    const oldest = await createCheckpoint(auth, division.id, "ai-0", "ai");
+    for (let i = 1; i < 4; i++) await createCheckpoint(auth, division.id, `ai-${i}`, "ai");
+
+    await expect(restoreCheckpoint(auth, division.id, oldest.id, true)).rejects.toMatchObject({
+      status: 404,
+    });
+    await undoDivision(auth, division.id);
+    const after = await divisionHistory(auth, division.id);
+    expect(Number(after.watermark)).toBeLessThan(Number(oldest.seq));
+  });
+
   it("an evicted save point costs its label, not the rewind (#382)", async () => {
     const { auth } = await seedOrg("community");
     const { division, fixtures } = await seedDivision(auth);

--- a/apps/web/src/server/usecases/__tests__/history.test.ts
+++ b/apps/web/src/server/usecases/__tests__/history.test.ts
@@ -14,6 +14,7 @@ import { createStages, generateStageFixtures } from "../stages";
 import { startDivision } from "../schedule";
 import { scoreEvent } from "../scoring";
 import { patchFixture } from "../fixtures";
+import { lockDivisions } from "../competition-schedule-apply";
 import {
   undoDivision,
   redoDivision,
@@ -479,6 +480,118 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
     await createCheckpoint(auth, division.id, "one");
     await createCheckpoint(auth, division.id, "two");
     await expect(createCheckpoint(auth, division.id, "three")).resolves.toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // #382 review, finding 2 — a quota of ZERO is a refusal, not a window of one.
+  //
+  // The roll arithmetic is `drop = n - limit + 1`, which at n=0/limit=0 asks to
+  // delete ONE row from an empty table (removing nothing) and then inserts
+  // anyway. So an org entitled to no save points at all permanently held
+  // exactly one, and `createCheckpoint`'s own stated invariant — "the
+  // post-insert count is exactly the limit" — was false on the one input where
+  // rolling cannot express the answer.
+  // -------------------------------------------------------------------------
+
+  it("a zero quota refuses the manual save rather than leaving one behind (#382)", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    // A staff override of 0 is the reachable route to limit === 0; a plan row
+    // missing from `plan_entitlements` resolves to 0 by the same door (getLimit
+    // returns 0 for an absent row), and both must behave identically.
+    await sql`
+      insert into org_entitlement_overrides (org_id, feature_key, int_value)
+      values (${auth.orgId}, 'schedule.checkpoints.max', 0)`;
+    await invalidateOrgEntitlements(auth.orgId);
+
+    await expect(createCheckpoint(auth, division.id, "should not land")).rejects.toMatchObject({
+      status: 402,
+      featureKey: "schedule.checkpoints.max",
+    });
+    // The invariant, restated as the observable: nothing landed.
+    const manual = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "manual");
+    expect(manual).toHaveLength(0);
+  });
+
+  it("a zero manual quota still lets the AI flow write its own anchor (#382)", async () => {
+    // V303's whole point: an AI apply's undo anchor is NOT one of the
+    // organiser's save points. A refusal placed outside the `manual` branch
+    // would re-break the bug that once cost a community org a paid-for AI run.
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    await sql`
+      insert into org_entitlement_overrides (org_id, feature_key, int_value)
+      values (${auth.orgId}, 'schedule.checkpoints.max', 0)`;
+    await invalidateOrgEntitlements(auth.orgId);
+
+    await expect(
+      createCheckpoint(auth, division.id, "Before AI · run 1", "ai"),
+    ).resolves.toBeTruthy();
+    const ai = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "ai");
+    expect(ai).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // #382 review, finding 3 — count-then-delete-then-insert was not serialised.
+  //
+  // The realistic race is not two admins: this product's normal shape is a
+  // single org owner, and that owner double-clicking Save is common enough to
+  // matter. Both requests read the same count, both compute the same `drop`,
+  // both target the SAME oldest row — one DELETE removes it, the other removes
+  // nothing — and both INSERTs land. The division ends at limit + 1 and one of
+  // the two organisers is never told a bookmark went.
+  // -------------------------------------------------------------------------
+
+  it("a manual save waits for the division lock rather than reading a stale count", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+
+    // The blocker takes the lock through `lockDivisions` — the SAME helper the
+    // schedule apply uses. That is the assertion that matters here: if
+    // `createCheckpoint` grew a second key scheme it would sail straight past
+    // this holder, and only a shared key keeps the two ends serialised.
+    let settled = false;
+    const holder = sql.begin(async (tx) => {
+      await lockDivisions(tx, [division.id]);
+      await new Promise((r) => setTimeout(r, 700));
+    });
+    // Let the holder actually acquire before the contender starts.
+    await new Promise((r) => setTimeout(r, 150));
+
+    const contender = createCheckpoint(auth, division.id, "waits its turn").then((v) => {
+      settled = true;
+      return v;
+    });
+    // One load-bearing sleep: long enough that an UNLOCKED createCheckpoint
+    // (a handful of queries) would certainly have finished by now.
+    await new Promise((r) => setTimeout(r, 350));
+    expect(settled, "createCheckpoint ran while another transaction held division:<id>").toBe(
+      false,
+    );
+
+    await holder;
+    await contender;
+    expect(settled).toBe(true);
+  });
+
+  it("two concurrent saves at the cap leave exactly the limit, and one is told (#382)", async () => {
+    const { auth } = await seedOrg("community"); // cap of 2 (V319)
+    const { division } = await seedDivision(auth);
+    await createCheckpoint(auth, division.id, "first"); // one below the cap
+
+    const [a, b] = await Promise.all([
+      createCheckpoint(auth, division.id, "race-a"),
+      createCheckpoint(auth, division.id, "race-b"),
+    ]);
+
+    const manual = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "manual");
+    expect(manual, "the division must not sit at limit + 1").toHaveLength(2);
+    // Serialised, the second save is the one that arrives AT the cap — so
+    // exactly one caller is told, and it names the row that actually went.
+    const notices = [a.evicted, b.evicted].filter((e) => e !== undefined);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]!.label).toBe("first");
+    expect(manual.map((r) => r.label).sort()).toEqual(["race-a", "race-b"]);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/src/server/usecases/__tests__/history.test.ts
+++ b/apps/web/src/server/usecases/__tests__/history.test.ts
@@ -95,6 +95,22 @@ async function seedDivision(auth: AuthCtx, stageCfg: Record<string, unknown> = {
 
 const at = (h: number) => new Date(Date.UTC(2026, 6, 12, h, 0, 0)).toISOString();
 
+/** Manual save points inserted DIRECTLY, bypassing `createCheckpoint`.
+ *
+ *  This is the only way to build a division sitting ABOVE its cap, which is
+ *  exactly what a plan downgrade leaves behind — and the case where "evict one"
+ *  and "evict down to the limit" give different answers. `created_at` is
+ *  explicit and spaced so the eviction order is a fact of the fixture rather
+ *  than of the clock's resolution. */
+async function seedManualCheckpoints(auth: AuthCtx, divisionId: string, n: number): Promise<void> {
+  for (let i = 0; i < n; i++) {
+    await sql`
+      insert into division_checkpoints (division_id, org_id, seq, label, kind, created_at)
+      values (${divisionId}, ${auth.orgId}, 0, ${`old-${i}`}, 'manual',
+              ${new Date(Date.UTC(2026, 0, 1, 0, i)).toISOString()})`;
+  }
+}
+
 afterAll(async () => {
   if (!HAS_DB) return;
   const globalForDb = globalThis as { _sql?: { end(): Promise<void> } };
@@ -270,15 +286,14 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
       select court_label from fixtures where id = ${fixtures[0]!.id}`;
     expect(row!.court_label).toBe("C1");
 
-    // Community: first two checkpoints free, third 402 (V319 raised the cap
-    // 1 → 2; quota, not versioning)
+    // Community holds two save points (V319 raised the cap 1 → 2). Since #382
+    // the third does not 402 — it ROLLS, dropping the oldest and naming it.
     const { auth: freeAuth } = await seedOrg("community");
     const { division: freeDiv } = await seedDivision(freeAuth);
     await createCheckpoint(freeAuth, freeDiv.id, "one");
     await createCheckpoint(freeAuth, freeDiv.id, "two");
-    await expect(createCheckpoint(freeAuth, freeDiv.id, "three")).rejects.toMatchObject({
-      featureKey: "schedule.checkpoints.max",
-    });
+    const third = await createCheckpoint(freeAuth, freeDiv.id, "three");
+    expect(third.evicted?.label).toBe("one");
   });
 
   // V303. Before this the AI accept flow's undo anchor was billed as one of the
@@ -291,11 +306,12 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
 
     await createCheckpoint(auth, division.id, "my save point");
     await createCheckpoint(auth, division.id, "my second save point");
-    await expect(createCheckpoint(auth, division.id, "another")).rejects.toMatchObject({
-      featureKey: "schedule.checkpoints.max",
-    });
+    // #382: at the cap the save ROLLS rather than 402ing — but the window is
+    // still two wide, which is what "exempt" has to mean here.
+    const rolled = await createCheckpoint(auth, division.id, "another");
+    expect(rolled.evicted?.label).toBe("my save point");
 
-    // AI applies still work — repeatedly — and never touch that quota.
+    // AI applies still work — repeatedly — and never touch that window.
     await expect(
       createCheckpoint(auth, division.id, "Before AI · run 1", "ai"),
     ).resolves.toBeTruthy();
@@ -306,10 +322,10 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
       createCheckpoint(auth, division.id, "Before AI · run 3", "ai"),
     ).resolves.toBeTruthy();
 
-    // …and the manual quota is still exactly as spent: two used, none free.
-    await expect(createCheckpoint(auth, division.id, "yet another")).rejects.toMatchObject({
-      featureKey: "schedule.checkpoints.max",
-    });
+    // …and the manual window is still exactly two wide: three AI anchors in
+    // between did not consume, free or shift a single manual slot.
+    const manual = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "manual");
+    expect(manual.map((r) => r.label)).toEqual(["another", "my second save point"]);
   });
 
   it("pro with 3 manual save points keeps its remaining 2 after AI runs", async () => {
@@ -318,12 +334,11 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
     for (let i = 1; i <= 3; i++) await createCheckpoint(auth, division.id, `manual ${i}`, "manual");
     await createCheckpoint(auth, division.id, "Before AI · run 1", "ai");
     await createCheckpoint(auth, division.id, "Before AI · run 2", "ai");
-    // 3 manual of 5 used → two more allowed, then 402. The AI rows do not count.
-    await expect(createCheckpoint(auth, division.id, "manual 4")).resolves.toBeTruthy();
-    await expect(createCheckpoint(auth, division.id, "manual 5")).resolves.toBeTruthy();
-    await expect(createCheckpoint(auth, division.id, "manual 6")).rejects.toMatchObject({
-      featureKey: "schedule.checkpoints.max",
-    });
+    // 3 manual of 5 used → two more evict nothing; the sixth rolls. The AI rows
+    // do not count towards either.
+    expect((await createCheckpoint(auth, division.id, "manual 4")).evicted).toBeUndefined();
+    expect((await createCheckpoint(auth, division.id, "manual 5")).evicted).toBeUndefined();
+    expect((await createCheckpoint(auth, division.id, "manual 6")).evicted?.label).toBe("manual 1");
   });
 
   it("only the newest AI anchor is live; older ones are superseded but still listed", async () => {
@@ -346,18 +361,20 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
 
   // The quota is per-division and nothing could reclaim a slot, so an organiser
   // who made a save point they no longer wanted was stuck with it — on
-  // community that meant permanently holding their only one.
-  it("deleting a manual save point frees its quota slot", async () => {
+  // community that meant permanently holding their only one. Since #382 the
+  // save no longer 402s at the cap, so what a delete buys is the SILENT save:
+  // the next one takes a free slot instead of evicting the survivor.
+  it("deleting a manual save point frees its slot, so the next save evicts nothing", async () => {
     const { auth } = await seedOrg("community");
     const { division } = await seedDivision(auth);
     const cp = await createCheckpoint(auth, division.id, "wrong moment");
     await createCheckpoint(auth, division.id, "second slot"); // fill to the cap of 2 (V319)
-    await expect(createCheckpoint(auth, division.id, "the one I wanted")).rejects.toMatchObject({
-      featureKey: "schedule.checkpoints.max",
-    });
 
     await deleteCheckpoint(auth, division.id, cp.id);
-    await expect(createCheckpoint(auth, division.id, "the one I wanted")).resolves.toBeTruthy();
+    const next = await createCheckpoint(auth, division.id, "the one I wanted");
+    expect(next.evicted).toBeUndefined();
+    const manual = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "manual");
+    expect(manual.map((r) => r.label)).toEqual(["the one I wanted", "second slot"]);
   });
 
   it("deleting is scoped to the division, and a missing checkpoint is 404", async () => {
@@ -377,21 +394,117 @@ describe.skipIf(!HAS_DB)("schedule undo & versioning (Jul3/03)", () => {
     ).rejects.toMatchObject({ status: 404 });
   });
 
-  it("checkpoints quota ladder: pro allows 5 then 402; pro_plus unlimited", async () => {
+  it("checkpoints window ladder: pro holds 5 then rolls; pro_plus unlimited", async () => {
     const { auth: proAuth } = await seedOrg("pro");
     const { division: proDiv } = await seedDivision(proAuth);
     for (let i = 1; i <= 5; i++) {
-      await expect(createCheckpoint(proAuth, proDiv.id, `cp${i}`)).resolves.toBeTruthy();
+      expect((await createCheckpoint(proAuth, proDiv.id, `cp${i}`)).evicted).toBeUndefined();
     }
-    await expect(createCheckpoint(proAuth, proDiv.id, "cp6")).rejects.toMatchObject({
-      featureKey: "schedule.checkpoints.max",
-    });
+    // The sixth rolls the window rather than 402ing (#382).
+    expect((await createCheckpoint(proAuth, proDiv.id, "cp6")).evicted?.label).toBe("cp1");
+    const proManual = (await listCheckpoints(proAuth, proDiv.id)).filter(
+      (r) => r.kind === "manual",
+    );
+    expect(proManual).toHaveLength(5);
 
     const { auth: plusAuth } = await seedOrg("pro_plus");
     const { division: plusDiv } = await seedDivision(plusAuth);
     for (let i = 1; i <= 6; i++) {
-      await expect(createCheckpoint(plusAuth, plusDiv.id, `cp${i}`)).resolves.toBeTruthy();
+      expect((await createCheckpoint(plusAuth, plusDiv.id, `cp${i}`)).evicted).toBeUndefined();
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // #382 — at the save-point cap, roll instead of refusing.
+  //
+  // A checkpoint is a named BOOKMARK, not the history. The ledger keeps every
+  // event and restore is "undo until the watermark reaches this seq", so
+  // dropping a save point costs the label, not the ability to rewind that far.
+  // Refusing the save, by contrast, cost the organiser the thing they were
+  // about to do.
+  // -------------------------------------------------------------------------
+
+  it("at the cap, saving evicts exactly the oldest and names it (#382)", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    await createCheckpoint(auth, division.id, "one");
+    await createCheckpoint(auth, division.id, "two");
+    const third = await createCheckpoint(auth, division.id, "three");
+
+    expect(third.evicted?.label).toBe("one");
+    const rows = await listCheckpoints(auth, division.id);
+    // listCheckpoints is newest-first.
+    expect(rows.filter((r) => r.kind === "manual").map((r) => r.label)).toEqual(["three", "two"]);
+  });
+
+  it("post-insert count equals the limit exactly, even from over the cap", async () => {
+    // Do not assume n === limit. A division can sit above the cap after a plan
+    // downgrade, and ONE save must bring it to exactly the limit — not to n,
+    // and not one below.
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    await seedManualCheckpoints(auth, division.id, 5); // over the cap of 2
+    const saved = await createCheckpoint(auth, division.id, "new");
+    // Four go; the notice names the NEWEST of them, the one most likely missed.
+    expect(saved.evicted?.label).toBe("old-3");
+
+    const manual = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "manual");
+    expect(manual).toHaveLength(2);
+    expect(manual.map((r) => r.label)).toEqual(["new", "old-4"]);
+  });
+
+  it("a division below the cap evicts nothing, and the last free slot is silent", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    // Empty set, then the boundary: one UNDER the cap must still be silent.
+    const first = await createCheckpoint(auth, division.id, "one");
+    expect(first.evicted).toBeUndefined();
+    const second = await createCheckpoint(auth, division.id, "two");
+    expect(second.evicted).toBeUndefined();
+  });
+
+  it("pro_plus has a null limit and never evicts", async () => {
+    const { auth } = await seedOrg("pro_plus");
+    const { division } = await seedDivision(auth);
+    for (let i = 0; i < 8; i++) {
+      expect((await createCheckpoint(auth, division.id, `cp${i}`)).evicted).toBeUndefined();
+    }
+    const manual = (await listCheckpoints(auth, division.id)).filter((r) => r.kind === "manual");
+    expect(manual).toHaveLength(8);
+  });
+
+  it("no longer 402s on a manual save", async () => {
+    const { auth } = await seedOrg("community");
+    const { division } = await seedDivision(auth);
+    await createCheckpoint(auth, division.id, "one");
+    await createCheckpoint(auth, division.id, "two");
+    await expect(createCheckpoint(auth, division.id, "three")).resolves.toBeDefined();
+  });
+
+  it("an evicted save point costs its label, not the rewind (#382)", async () => {
+    const { auth } = await seedOrg("community");
+    const { division, fixtures } = await seedDivision(auth);
+    await patchFixture(auth, fixtures[0]!.id, { scheduled_at: at(9), court_label: "C1" });
+    const one = await createCheckpoint(auth, division.id, "one");
+    await patchFixture(auth, fixtures[0]!.id, { scheduled_at: at(10), court_label: "C2" });
+    await createCheckpoint(auth, division.id, "two");
+    const third = await createCheckpoint(auth, division.id, "three");
+    expect(third.evicted?.label).toBe("one");
+
+    // The ROW is gone, so restore can no longer target it by id…
+    await expect(restoreCheckpoint(auth, division.id, one.id, true)).rejects.toMatchObject({
+      status: 404,
+    });
+
+    // …but the LEDGER is untouched. One undo lands back on the state the
+    // evicted save point named, and a second rewinds PAST its watermark.
+    await undoDivision(auth, division.id);
+    const [back] = await sql<{ court_label: string | null }[]>`
+      select court_label from fixtures where id = ${fixtures[0]!.id}`;
+    expect(back!.court_label).toBe("C1");
+    await undoDivision(auth, division.id);
+    const after = await divisionHistory(auth, division.id);
+    expect(Number(after.watermark)).toBeLessThan(Number(one.seq));
   });
 
   it("stale optimistic token → SEQ_CONFLICT 409 contract", async () => {

--- a/apps/web/src/server/usecases/__tests__/schedule-plus.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule-plus.test.ts
@@ -146,21 +146,26 @@ describe.skipIf(!HAS_DB)("scheduling constraints v2 (Jul3/04)", () => {
     });
   });
 
-  it("constraint fields on schedule-settings are Pro", async () => {
+  // Was "constraint fields on schedule-settings are Pro". V353 (#382) opened
+  // `scheduling.constraints` to every plan, so this asserts the OPPOSITE now.
+  // Inverted rather than deleted: the gate still stands in
+  // `putScheduleSettings`, so a migration that never ran — or an override that
+  // switches the key back off — must red something.
+  it("constraint fields on schedule-settings are open to Community (#382)", async () => {
     const { auth: freeAuth } = await seedOrg("community");
     const { division: freeDiv } = await seedDivision(freeAuth);
-    await expect(
-      putScheduleSettings(
-        freeAuth,
-        freeDiv.id,
-        PutScheduleSettings.parse({
-          config: {
-            courts: ["Court 1"],
-            constraints: { crossPersonClash: "hard" },
-          },
-          tz: "UTC",
-        }),
-      ),
-    ).rejects.toMatchObject({ featureKey: "scheduling.constraints" });
+    const saved = await putScheduleSettings(
+      freeAuth,
+      freeDiv.id,
+      PutScheduleSettings.parse({
+        config: {
+          courts: ["Court 1"],
+          constraints: { crossPersonClash: "hard" },
+        },
+        tz: "UTC",
+      }),
+    );
+    // Not merely "it did not throw" — a call that stored nothing passes that.
+    expect(saved.config.constraints).toMatchObject({ crossPersonClash: "hard" });
   });
 });

--- a/apps/web/src/server/usecases/__tests__/schedule.test.ts
+++ b/apps/web/src/server/usecases/__tests__/schedule.test.ts
@@ -8,7 +8,6 @@ import { afterAll, describe, expect, it } from "vitest";
 import { randomUUID } from "node:crypto";
 import { EngineError } from "@seazn/engine/core";
 import { sql, withTenant } from "@/lib/db";
-import { PaymentRequiredError } from "@/lib/errors";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { createCompetition } from "../competitions";
 import { createDivision } from "../divisions";
@@ -331,7 +330,13 @@ describe.skipIf(!HAS_DB)("scheduling console (doc 12, PROMPT-17)", () => {
     }
   });
 
-  it("Community org: constraints/board are 402-gated, quick-start unaffected", async () => {
+  // Was "constraints/board are 402-gated". V353 (#382) opened
+  // `scheduling.constraints` and `scheduling.board` to every plan — a community
+  // organiser could already ask the AI for a schedule and then not drag one
+  // fixture of it. INVERTED rather than deleted: both gates still stand in
+  // `putScheduleSettings`, `applySchedule` and `moveFixture`, so an unapplied
+  // migration or an override switching either key back off reds this test.
+  it("Community org: constraints/board are open, quick-start unaffected (#382)", async () => {
     const { auth } = await seedOrg("community");
     const competition = await createCompetition(auth, { name: "Club Night", visibility: "private", branding: {} });
     const division = await createDivision(auth, competition.id, {
@@ -346,19 +351,20 @@ describe.skipIf(!HAS_DB)("scheduling console (doc 12, PROMPT-17)", () => {
     ]);
     const [stage] = await createStages(auth, division.id, { seq: 1, kind: "league", name: "L", config: {} });
 
-    // Constraint solver fields → 402 scheduling.constraints (doc 12 §5).
-    await expect(
-      putScheduleSettings(auth, division.id, {
-        config: {
-          startAt: T0, matchMinutes: 30, gapMinutes: 0,
-          courts: ["C1", "C2"], // multi-court is the constraint solver
-          perEntrantMinRest: 0, blackouts: [], sessionWindows: [],
-        },
-        tz: "UTC",
-      }),
-    ).rejects.toMatchObject({ featureKey: "scheduling.constraints" });
+    // Constraint solver fields: stored, not refused (#382). Two courts is what
+    // trips `usesConstraints`, and the stored value is read back so a no-op
+    // write cannot pass this.
+    const constrained = await putScheduleSettings(auth, division.id, {
+      config: {
+        startAt: T0, matchMinutes: 30, gapMinutes: 0,
+        courts: ["C1", "C2"], // multi-court is the constraint solver
+        perEntrantMinRest: 0, blackouts: [], sessionWindows: [],
+      },
+      tz: "UTC",
+    });
+    expect(constrained.config.courts).toEqual(["C1", "C2"]);
 
-    // Basic single-court settings + basic auto are Community features.
+    // Back to a single court for the auto-schedule assertions below.
     await putScheduleSettings(auth, division.id, {
       config: {
         startAt: T0, matchMinutes: 30, gapMinutes: 0,
@@ -376,16 +382,19 @@ describe.skipIf(!HAS_DB)("scheduling console (doc 12, PROMPT-17)", () => {
       source: "auto",
     });
 
-    // Board editing (pins, manual assignment sets) is Pro (view-only board).
-    await expect(
-      patchFixture(auth, fixtures[0]!.id, { schedule_locked: true }),
-    ).rejects.toBeInstanceOf(PaymentRequiredError);
-    await expect(
-      applySchedule(auth, stage.id, {
-        assignments: [{ fixture_id: fixtures[0]!.id, scheduled_at: at(600), court_label: "C1" }],
-        source: "manual",
-      }),
-    ).rejects.toMatchObject({ featureKey: "scheduling.board" });
+    // Board editing (pins, manual assignment sets) is open too (#382). Both
+    // `scheduling.board` branches are exercised — the pin on `moveFixture` and
+    // `source: "manual"` on `applySchedule` — and each is read back, so a call
+    // that returned quietly without writing cannot pass.
+    await patchFixture(auth, fixtures[0]!.id, { schedule_locked: true });
+    await applySchedule(auth, stage.id, {
+      assignments: [{ fixture_id: fixtures[0]!.id, scheduled_at: at(600), court_label: "C1" }],
+      source: "manual",
+    });
+    const [pinned] = await sql<{ schedule_locked: boolean; court_label: string | null }[]>`
+      select schedule_locked, court_label from fixtures where id = ${fixtures[0]!.id}`;
+    expect(pinned!.schedule_locked).toBe(true);
+    expect(pinned!.court_label).toBe("C1");
 
     // Quick-start unaffected: start opens scoring immediately.
     const started = await startDivision(auth, division.id);

--- a/apps/web/src/server/usecases/competition-schedule-ai.ts
+++ b/apps/web/src/server/usecases/competition-schedule-ai.ts
@@ -2349,7 +2349,10 @@ async function planForCompetition(
     throw new HttpError(403, "AI scheduling is currently turned off", "FEATURE_DISABLED");
   }
   await requireFeature(auth.orgId, "scheduling.ai");
-  await requireFeature(auth.orgId, "scheduling.multi_division");
+  // Competition-scoped since V353 (#382): an Event Pass now lifts
+  // `scheduling.multi_division`, and a pass covers ONE competition — the
+  // competition being planned is the only honest scope to ask about.
+  await requireFeature(auth.orgId, "scheduling.multi_division", competitionId);
 
   const requested = [...new Set(input.division_ids)];
   if (requested.length < 2) throw singleDivision();

--- a/apps/web/src/server/usecases/competition-schedule-apply.ts
+++ b/apps/web/src/server/usecases/competition-schedule-apply.ts
@@ -301,7 +301,10 @@ export async function applyCompetitionSchedule(
   // The capability gate, ahead of every read, every lock and every write — see
   // the module header on why this endpoint needs one of its own and why it is
   // this key rather than `scheduling.ai`.
-  await requireFeature(auth.orgId, "scheduling.multi_division");
+  //
+  // Competition-scoped since V353 (#382): an Event Pass now lifts this key, and
+  // a pass covers ONE competition — the one being written.
+  await requireFeature(auth.orgId, "scheduling.multi_division", competitionId);
 
   if (input.divisions.length === 0) {
     throw new HttpError(400, "no divisions to apply", "SCHEDULE_APPLY_NO_DIVISIONS");

--- a/apps/web/src/server/usecases/history.ts
+++ b/apps/web/src/server/usecases/history.ts
@@ -402,6 +402,29 @@ export async function createCheckpoint(
       insert into division_checkpoints (division_id, seq, label, kind, created_by)
       values (${divisionId}, ${wm}, ${label}, ${kind}, ${auth.userId})
       returning id, seq, label, kind, created_at`;
+    // #382: AI anchors are exempt from the manual quota and nothing ever deleted
+    // them, so they accumulated one per AI apply, for ever — `superseded` is
+    // derived on read, not stored, and the only other DELETE is the organiser's
+    // own. Keep the newest 3.
+    //
+    // Three, not one: `CheckpointRow.superseded` exists because jumping back
+    // two AI runs is a capability worth keeping, and two runs back plus the
+    // newest is exactly 3. No notice for these — the organiser did not name
+    // them and the panel already strikes the superseded ones through.
+    //
+    // AFTER the insert, so the row just created is always among the survivors.
+    // Same ordering exemption as the manual eviction above: selection input.
+    // The V303 index (division_id, kind, created_at desc) already serves it.
+    if (kind === "ai") {
+      await tx`
+        delete from division_checkpoints
+         where id in (
+           select id from division_checkpoints
+            where division_id = ${divisionId} and kind = 'ai'
+            order by created_at desc, seq desc, id desc
+            offset 3
+         )`;
+    }
     return { ...row!, ...(evicted ? { evicted } : {}) };
   });
 }

--- a/apps/web/src/server/usecases/history.ts
+++ b/apps/web/src/server/usecases/history.ts
@@ -20,9 +20,10 @@ import {
 } from "@seazn/engine/history";
 import { EngineError } from "@seazn/engine/core";
 import { withTenant } from "@/lib/db";
-// PaymentRequiredError is no longer thrown here: since #382 a manual save at
-// the cap rolls the window instead of refusing (see `createCheckpoint`).
-import { HttpError } from "@/lib/errors";
+// Since #382 a manual save AT THE CAP rolls the window instead of refusing, so
+// PaymentRequiredError survives here for one case only: a quota that resolves
+// below 1, where there is no window to roll (see `createCheckpoint`).
+import { HttpError, PaymentRequiredError } from "@/lib/errors";
 import { requireFeature, withinLimit } from "@/lib/entitlements";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { generateStageFixtures } from "./stages";
@@ -334,6 +335,28 @@ export async function createCheckpoint(
   kind: CheckpointKind = "manual",
 ): Promise<CheckpointRow> {
   return withTenant(auth.orgId, async (tx) => {
+    // #382 review, finding 3: the roll below is count → delete → insert, and
+    // without this lock those three steps are not serialised. Two saves landing
+    // together (the realistic shape is one owner double-clicking Save, not two
+    // admins) both read the same count, both compute the same `drop`, and both
+    // target the SAME oldest row — one DELETE takes it, the other takes nothing
+    // and so reports no `evicted` — while both INSERTs land. The division ends
+    // at limit + 1 and one organiser is never told a bookmark went. It
+    // self-corrects on the next save, which is exactly why it went unnoticed.
+    //
+    // The key is `division:<id>`, byte-identical to `lockDivisions`
+    // (competition-schedule-apply.ts) and to `step`/`restoreCheckpoint` below:
+    // the checkpoint window is a fact ABOUT a division, so it must serialise
+    // against every other writer of that division's plan, not just against
+    // other checkpoint saves. A private key would leave an apply free to move
+    // the watermark this insert is about to read.
+    //
+    // Safe to take here because `createCheckpoint` is a LEAF — the checkpoints
+    // route is its only caller — so this transaction never holds
+    // `division:<id>` while some nested call waits for the same key on another
+    // connection. `pg_advisory_xact_lock` releases at commit or rollback, so
+    // nothing survives the transaction either.
+    await tx`select pg_advisory_xact_lock(hashtext(${"division:" + divisionId}))`;
     const meta = await divisionMeta(tx, divisionId);
     // Jul3/03 §7 → V290: save points are a per-plan quota (community 1,
     // pro 5, pro_plus unlimited). schedule.versioning still gates scope locks.
@@ -356,6 +379,29 @@ export async function createCheckpoint(
         select count(*)::int as n from division_checkpoints
         where division_id = ${divisionId} and kind = 'manual'`;
       const { limit } = await withinLimit(auth.orgId, "schedule.checkpoints.max", n + 1);
+      // #382 review, finding 2: a quota below 1 has NO window to roll, so the
+      // rolling branch cannot express it. `drop = n - limit + 1` at n=0/limit=0
+      // asks to delete one row from an empty table — the delete removes nothing
+      // and the insert lands anyway, leaving an org entitled to zero save points
+      // permanently holding one, with the "post-insert count is exactly the
+      // limit" invariant broken on the one input where it mattered.
+      //
+      // Refusing is a quota refusal, so it is `PaymentRequiredError` with the
+      // feature key, the shape every other quota gate in usecases/ uses
+      // (clubs.ts, divisions.ts, entrants.ts, competitions.ts).
+      //
+      // Zero is reachable two ways and this deliberately does not distinguish
+      // them: a staff override with `int_value = 0`, and a MISSING
+      // `plan_entitlements` row, which `getLimit` also resolves to 0. The
+      // override is a deliberate grant of nothing and must be honoured. The
+      // missing row is a mis-seeded database — and there, refusing is still the
+      // better answer than the old behaviour, which silently held one save point
+      // and lied about the count. All three real plan keys (community 2, pro 5,
+      // pro_plus unlimited) carry a row, so a correctly migrated database cannot
+      // reach this by accident; `event_pass`/`event_pass_l` have no row, but
+      // they are pass keys, never an org's plan key, and this read passes no
+      // competition so no pass overlay applies.
+      if (limit !== null && limit < 1) throw new PaymentRequiredError("schedule.checkpoints.max");
       // A null limit is unlimited (pro_plus) — never evict.
       if (limit !== null && n >= limit) {
         // Delete n - limit + 1, so the POST-INSERT count is exactly the limit.

--- a/apps/web/src/server/usecases/history.ts
+++ b/apps/web/src/server/usecases/history.ts
@@ -20,7 +20,9 @@ import {
 } from "@seazn/engine/history";
 import { EngineError } from "@seazn/engine/core";
 import { withTenant } from "@/lib/db";
-import { HttpError, PaymentRequiredError } from "@/lib/errors";
+// PaymentRequiredError is no longer thrown here: since #382 a manual save at
+// the cap rolls the window instead of refusing (see `createCheckpoint`).
+import { HttpError } from "@/lib/errors";
 import { requireFeature, withinLimit } from "@/lib/entitlements";
 import type { AuthCtx } from "@/server/api-v1/auth";
 import { generateStageFixtures } from "./stages";
@@ -297,6 +299,14 @@ export interface CheckpointRow {
    *  through. They stay restorable: the ledger can rewind to any watermark, and
    *  jumping back two AI runs is a real capability worth keeping. */
   superseded?: boolean;
+  /** #382 — set on the row RETURNED BY A CREATE, never by a list: the save
+   *  point this one pushed out of the plan's rolling window. The panel names it
+   *  in a non-blocking notice, so the organiser learns which label they lost
+   *  rather than discovering it missing later.
+   *
+   *  Present only when something was actually dropped. One name, even when a
+   *  downgrade drops several — see `createCheckpoint`. */
+  evicted?: { id: string; label: string };
 }
 
 export async function listCheckpoints(auth: AuthCtx, divisionId: string): Promise<CheckpointRow[]> {
@@ -332,12 +342,59 @@ export async function createCheckpoint(
     // flow's own undo anchor is what previously blocked a community org that
     // already held one save point from applying an AI schedule at all — the
     // create 402'd, the apply aborted, and the AI generation was already spent.
+    //
+    // #382: at the cap this used to throw PaymentRequiredError. It now ROLLS.
+    // A checkpoint is a named bookmark, not the history — the ledger keeps
+    // every event and restore is "undo until the watermark reaches this seq",
+    // so dropping a save point costs the LABEL, not the ability to rewind that
+    // far. Refusing the save cost the organiser the thing they were doing, in
+    // the middle of doing it, which is a far worse trade than losing the oldest
+    // bookmark. The quota still means something: it is the width of the window.
+    let evicted: { id: string; label: string } | undefined;
     if (kind === "manual") {
       const [{ n }] = await tx<{ n: number }[]>`
         select count(*)::int as n from division_checkpoints
         where division_id = ${divisionId} and kind = 'manual'`;
-      const quota = await withinLimit(auth.orgId, "schedule.checkpoints.max", n + 1);
-      if (!quota.ok) throw new PaymentRequiredError("schedule.checkpoints.max");
+      const { limit } = await withinLimit(auth.orgId, "schedule.checkpoints.max", n + 1);
+      // A null limit is unlimited (pro_plus) — never evict.
+      if (limit !== null && n >= limit) {
+        // Delete n - limit + 1, so the POST-INSERT count is exactly the limit.
+        // Do not assume n === limit: a plan downgrade can leave a division above
+        // the cap, and one save must bring it back to the limit, not to n.
+        //
+        // Order: created_at asc, seq asc, id asc. The `id` tie-break is a UUID,
+        // which the determinism rule normally forbids — acceptable here because
+        // this is SELECTION INPUT, not output ordering, the same exemption
+        // advisory-lock ordering gets. Do not "fix" it.
+        const drop = n - limit + 1;
+        const gone = await tx<
+          { id: string; label: string; created_at: Date | string; seq: string | number }[]
+        >`
+          delete from division_checkpoints
+           where id in (
+             select id from division_checkpoints
+              where division_id = ${divisionId} and kind = 'manual'
+              order by created_at asc, seq asc, id asc
+              limit ${drop}
+           )
+           returning id, label, created_at, seq`;
+        // RETURNING does NOT preserve the subquery's ORDER BY — Postgres hands
+        // back deleted rows in whatever order it removed them. Re-apply the
+        // same ordering here rather than trusting the array's shape.
+        //
+        // The notice names ONE save point; when several go (a downgrade), name
+        // the newest of them — it is the one the organiser is likeliest to miss.
+        const newest = gone
+          .slice()
+          .sort(
+            (a, b) =>
+              new Date(a.created_at).getTime() - new Date(b.created_at).getTime() ||
+              Number(a.seq) - Number(b.seq) ||
+              (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+          )
+          .at(-1);
+        if (newest) evicted = { id: newest.id, label: newest.label };
+      }
     }
     const ledger = await loadLedger(tx, divisionId);
     const wm = meta.edit_watermark ?? (ledger[ledger.length - 1]?.seq ?? 0);
@@ -345,7 +402,7 @@ export async function createCheckpoint(
       insert into division_checkpoints (division_id, seq, label, kind, created_by)
       values (${divisionId}, ${wm}, ${label}, ${kind}, ${auth.userId})
       returning id, seq, label, kind, created_at`;
-    return row!;
+    return { ...row!, ...(evicted ? { evicted } : {}) };
   });
 }
 

--- a/apps/web/src/server/usecases/schedule-ai-preview.ts
+++ b/apps/web/src/server/usecases/schedule-ai-preview.ts
@@ -407,7 +407,11 @@ export async function previewScheduleAi(
     throw new HttpError(403, "AI scheduling is currently turned off", "FEATURE_DISABLED");
   }
   await requireFeature(auth.orgId, "scheduling.ai");
-  if (scope.kind === "competition") await requireFeature(auth.orgId, "scheduling.multi_division");
+  // Competition-scoped since V353 (#382): an Event Pass lifts this key, and a
+  // pass covers ONE competition — `scope.id` IS that competition here.
+  if (scope.kind === "competition") {
+    await requireFeature(auth.orgId, "scheduling.multi_division", scope.id);
+  }
 
   const resolved =
     scope.kind === "division"

--- a/apps/web/src/server/usecases/schedule.ts
+++ b/apps/web/src/server/usecases/schedule.ts
@@ -755,8 +755,11 @@ export async function applySchedule(
   stageId: string,
   input: ApplyScheduleRequest,
 ): Promise<ApplyScheduleOut> {
-  // Manual assignment sets and pin changes are board editing — Pro (doc 12 §5;
-  // Community keeps the basic auto flow).
+  // Manual assignment sets and pin changes are board editing. The gate stays,
+  // but since V353 (#382) `scheduling.board` is granted on EVERY plan — an
+  // organiser who could ask the AI for a schedule could not then drag one
+  // fixture of it, which was backwards. The key is kept rather than deleted:
+  // it is still what an entitlement override or a future tier moves.
   if (input.source === "manual" || input.assignments.some((a) => a.schedule_locked !== undefined)) {
     await requireFeature(auth.orgId, "scheduling.board");
   }

--- a/db/migration/deltas/V353__open_scheduling_entitlements.sql
+++ b/db/migration/deltas/V353__open_scheduling_entitlements.sql
@@ -1,0 +1,30 @@
+-- V353 — division scheduling is open to every plan; multi-division stays paid.
+--
+-- #382. `scheduling.ai` was already open to every plan: V322 retired
+-- `scheduling.ai.runs_per_division.max` because the AI credit wallet meters runs
+-- on every tier, so AI scheduling is credit-gated, not plan-gated. What was
+-- still gated is the ordinary board and constraints — the non-AI scheduling an
+-- organiser does by hand. An organiser who could ask the AI for a schedule then
+-- could not drag one fixture of it is the shape this removes.
+--
+-- Event Pass carried NO ROW for any of the three. `hasFeature` reads
+-- `row?.bool_value === true`, so a missing row is false: an Event Pass org got
+-- none of them. These are inserts, not flips.
+--
+-- After this, `scheduling.multi_division` is the only scheduling paywall left.
+--
+-- Corrects V303's header while here: that comment states the save-point quota
+-- as "1 free / 5 Pro", which V319 superseded — community has been 2 since. The
+-- migration file itself is left untouched (Flyway validates its checksum); the
+-- live numbers are `schedule.checkpoints.max` in this table, which as of V353
+-- read community 2 / pro 5 / pro_plus unlimited.
+insert into plan_entitlements (plan_key, feature_key, bool_value) values
+  ('community',    'scheduling.board',          true),
+  ('event_pass',   'scheduling.board',          true),
+  ('event_pass_l', 'scheduling.board',          true),
+  ('community',    'scheduling.constraints',    true),
+  ('event_pass',   'scheduling.constraints',    true),
+  ('event_pass_l', 'scheduling.constraints',    true),
+  ('event_pass',   'scheduling.multi_division', true),
+  ('event_pass_l', 'scheduling.multi_division', true)
+on conflict (plan_key, feature_key) do update set bool_value = excluded.bool_value;

--- a/openapi/v1.json
+++ b/openapi/v1.json
@@ -55878,7 +55878,7 @@
         ]
       },
       "post": {
-        "summary": "Create a save point at the current watermark (quota `schedule.checkpoints.max`: 1 free / 5 Pro / unlimited Pro Plus)",
+        "summary": "Create a save point at the current watermark (quota `schedule.checkpoints.max`: 2 free / 5 Pro / unlimited Pro Plus; at the cap the oldest save point is replaced)",
         "tags": [
           "history"
         ],

--- a/openapi/v1.public.json
+++ b/openapi/v1.public.json
@@ -40107,7 +40107,7 @@
         ]
       },
       "post": {
-        "summary": "Create a save point at the current watermark (quota `schedule.checkpoints.max`: 1 free / 5 Pro / unlimited Pro Plus)",
+        "summary": "Create a save point at the current watermark (quota `schedule.checkpoints.max`: 2 free / 5 Pro / unlimited Pro Plus; at the cap the oldest save point is replaced)",
         "tags": [
           "history"
         ],

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -8282,24 +8282,33 @@ async function proPlusSuite(): Promise<void> {
     officialsAllowed.status === 200,
   );
 
-  // (a) Community: save points — community's cap is 2 (V319), so the 1st and
-  // 2nd land and the 3rd 402s.
+  // (a) Community: save points — community's window is 2 wide (V319). The 1st
+  // and 2nd land silently; since #382 the 3rd ROLLS rather than 402ing, and the
+  // response names the label it replaced.
+  const cp1Label = `plus 1 ${tag}`;
   const cp1 = await v1(owner, `/api/v1/divisions/${div.id}/checkpoints`, "POST", {
-    label: `plus 1 ${tag}`,
+    label: cp1Label,
   });
   check("pp: community's first save point is free", cp1.status === 201);
   const cp2 = await v1(owner, `/api/v1/divisions/${div.id}/checkpoints`, "POST", {
     label: `plus 2 ${tag}`,
   });
   check("pp: community's second save point is free (cap is 2)", cp2.status === 201);
-  const cp3Denied = await v1(owner, `/api/v1/divisions/${div.id}/checkpoints`, "POST", {
-    label: `plus 3 denied ${tag}`,
+  const cp3Rolled = await v1(owner, `/api/v1/divisions/${div.id}/checkpoints`, "POST", {
+    label: `plus 3 ${tag}`,
   });
   check(
-    "pp: community 402s a 3rd save point (schedule.checkpoints.max)",
-    cp3Denied.status === 402 &&
-      (cp3Denied.json.error as { feature_key?: string } | undefined)?.feature_key ===
-        "schedule.checkpoints.max",
+    "pp: community's 3rd save point rolls the window and names what it replaced (#382)",
+    cp3Rolled.status === 201 &&
+      (cp3Rolled.json.data as { evicted?: { label?: string } } | undefined)?.evicted?.label ===
+        cp1Label,
+  );
+  const cpList = await v1(owner, `/api/v1/divisions/${div.id}/checkpoints`, "GET");
+  check(
+    "pp: community holds exactly 2 manual save points after the roll",
+    ((cpList.json.data as { kind?: string }[] | undefined) ?? []).filter(
+      (r) => (r.kind ?? "manual") === "manual",
+    ).length === 2,
   );
 
   // (b) Pro: read-only keys stay free (api.access), but a score- or


### PR DESCRIPTION
Closes #382.

> **Stacked on #476** (`ai-gap-a-quote-integrity`). Based on A rather than `main` because both regenerate `i18n-keys.ts` and branching from `main` would guarantee a conflict at merge. Merge #476 first; this retargets to `main` automatically.

## What ships

**V353 opens the schedule board and the constraints editor to every plan.** The multi-division board stays paid — that is the one scheduling paywall left, and the PR asserts its continued presence rather than only asserting the absence of the others.

**At the save-point cap, the window rolls instead of refusing.** The organiser is told which save point was replaced, in a notice rather than a paywall — nothing was refused.

**AI restore anchors prune to the newest 3 per division.**

**Stale checkpoint-quota copy corrected.**

## Five plan corrections, each verified against the code

- The issue specified migration **V344**; it is taken. This is **V353**.
- The plan wanted an edit to **V303**. Impossible — Flyway validates checksums here with no `validateOnMigrate=false`, proven by a comment-only change failing `Migration checksum mismatch for migration version 303`. The correction went into V353's header instead, per the plan's own fallback.
- `listCheckpoints` is **newest-first**, so every ordering assertion the plan wrote was reversed.
- `RETURNING` does not preserve a subquery's `ORDER BY`, so the plan's `gone.at(-1)` picks an arbitrary row. The code returns `created_at, seq` and re-sorts.
- **The one that mattered:** granting `scheduling.multi_division` to Event Pass makes it a pass-lifted key, and the repo's own `pass-scoping-guard` flagged **four gate sites still resolving it org-wide**. An Event Pass holder would have paid $29 and still been denied the competition-wide board. All four now resolve the competition in scope, and the key had to enter `PASS_FEATURES` or the paywall would show a Pro-only card to someone the pass already clears.

## Review found one important defect, fixed here

`upgrade.proCard.body` told the organiser that Pro "adds the schedule board … the pass never covers" — rendered to a community org with no pass, i.e. **exactly** the person who just hit the multi-division gate. Since V353 the pass does cover it. The card was arguing against the purchase `PASS_FEATURES` had just been extended to offer. Reworded in all four locales, and the same lost-sale sentence fixed in the help article.

Also fixed: a zero save-point quota now refuses rather than silently holding one save point and misreporting the count, and `createCheckpoint` takes the division advisory lock so two concurrent saves at the cap cannot leave `limit + 1` rows with nobody told.

## Tests that were inverted, not deleted

Three suites and one smoke check encoded the removed paywall. Each was inverted with the assertion **reading the stored value back** — an inversion that asserts a constant is worse than a deleted test.

## Verification

Unit 5523 passed / 0 failed / 0 failed suites / 624 suites / 0 foreign. **e2e 18/18** against a real standalone prod build, re-run after the `history.ts` change rather than assumed. The eviction notice is asserted at **375px** with a document-level horizontal-scroll check. Every change mutation-proved; the concurrency test is deterministic at 5/5 red without the lock and 5/5 green with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)