### PR TITLE
fix(engine): declare zod as a runtime dependency — unbreak the staging deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,12 @@ jobs:
       # @seazn/engine/sports from the repo ROOT, so those three are root
       # PRODUCTION dependencies — --prod honours the section, unlike npm ci
       # --omit=dev which used to find them hoisted out of apps/web.
+      #
+      # That reasoning is TRANSITIVE: @seazn/engine's own runtime imports must
+      # be in ITS `dependencies` too. pnpm gives no walk-up to a hoisted copy,
+      # so a devDependency-only entry resolves in every other job and dies with
+      # ERR_MODULE_NOT_FOUND here alone. packages/engine/test/runtime-deps.test.ts
+      # is the gate; it is why zod sits in dependencies, not devDependencies.
       - run: pnpm install --frozen-lockfile --prod
 
       - name: Cache Flyway CLI

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -32,7 +32,8 @@
     "zod": "^4.4.3"
   },
   "dependencies": {
-    "z3-solver": "5.0.0"
+    "z3-solver": "5.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^9",
@@ -42,7 +43,6 @@
     "typescript-eslint": "^8",
     "typescript": "6.0.3",
     "typescript-native": "npm:typescript@7.0.2",
-    "vitest": "^4.1.9",
-    "zod": "^4.4.3"
+    "vitest": "^4.1.9"
   }
 }

--- a/packages/engine/test/runtime-deps.test.ts
+++ b/packages/engine/test/runtime-deps.test.ts
@@ -1,0 +1,77 @@
+// The staging deploy installs with `pnpm install --frozen-lockfile --prod`,
+// which drops devDependencies. pnpm's isolated node_modules gives no walk-up
+// to a hoisted copy the way npm's flat tree did, so every package the engine
+// imports at RUNTIME must sit in `dependencies` — a devDependency-only entry
+// resolves fine in every local run and in every CI job that installs dev deps,
+// then dies with ERR_MODULE_NOT_FOUND on the deploy job alone.
+//
+// src/testkit/** is excluded: it is a test harness, imported only from a
+// consumer's own test files, so vitest/fast-check stay devDependencies.
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const SRC = new URL("../src", import.meta.url).pathname;
+const MANIFEST = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url).pathname, "utf8"),
+) as { dependencies?: Record<string, string> };
+
+/** `import … from "x"`, `export … from "x"`, bare `import "x"`, `import("x")`. */
+const SPECIFIER =
+  /(?:^|\n)\s*(?:import|export)[\s\S]*?from\s*["']([^"']+)["']|(?:^|\n)\s*import\s*["']([^"']+)["']|\bimport\(\s*["']([^"']+)["']\s*\)/g;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry !== "testkit") walk(full, out);
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Comments first: prose in this repo contains phrases like `tell "worse" from
+ * "better"`, which the multi-line import pattern below would otherwise read as
+ * an import of a package named `better`.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:"'`])\/\/.*$/gm, "$1");
+}
+
+/** Bare package name: "zod/v4" → "zod", "@scope/pkg/sub" → "@scope/pkg". */
+function packageOf(specifier: string): string {
+  const parts = specifier.split("/");
+  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
+}
+
+function runtimeImports(): Map<string, string> {
+  const found = new Map<string, string>(); // package -> first file that imports it
+  for (const file of walk(SRC)) {
+    const source = stripComments(readFileSync(file, "utf8"));
+    for (const match of source.matchAll(SPECIFIER)) {
+      const specifier = match[1] ?? match[2] ?? match[3]!;
+      if (specifier.startsWith(".") || specifier.startsWith("node:")) continue;
+      const pkg = packageOf(specifier);
+      if (!found.has(pkg)) found.set(pkg, file.slice(SRC.length + 1));
+    }
+  }
+  return found;
+}
+
+describe("engine runtime dependencies", () => {
+  it("declares every runtime import in `dependencies`, not `devDependencies`", () => {
+    const declared = new Set(Object.keys(MANIFEST.dependencies ?? {}));
+    const missing = [...runtimeImports()]
+      .filter(([pkg]) => !declared.has(pkg))
+      .map(([pkg, file]) => `${pkg} (imported from src/${file})`);
+    expect(missing).toEqual([]);
+  });
+
+  it("finds the imports it is meant to be guarding", () => {
+    // A regex that silently matched nothing would make the gate above vacuous.
+    expect([...runtimeImports().keys()].sort()).toEqual(["z3-solver", "zod"]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,9 @@ importers:
       z3-solver:
         specifier: 5.0.0
         version: 5.0.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^9
@@ -251,9 +254,6 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/coverage-v8@4.1.9)(vite@8.1.1(@types/node@26.1.2)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
-      zod:
-        specifier: ^4.4.3
-        version: 4.4.3
 
 packages:
 


### PR DESCRIPTION
## The break

`main` cannot deploy. The `Sync sport catalog` step of the staging deploy job fails:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'zod' imported from
  packages/engine/src/sports/football/football.ts
```

([run 31020881395](https://github.com/ashokhein/seazn.club/actions/runs/31020881395))

## Why

The deploy job installs with `pnpm install --frozen-lockfile --prod`, which drops devDependencies. `packages/engine` declared `zod` only in **peerDependencies + devDependencies**, so the engine had no resolvable `zod` in that job.

Under npm this worked by accident — `zod` is a real dependency of `apps/web`, npm hoisted it to the root `node_modules`, and Node's walk-up from `packages/engine/src/…` found it there. pnpm's isolated `node_modules` removes that walk-up, so #480 turned a latent misdeclaration into a broken deploy.

The same reasoning already moved `postgres`/`stripe`/`@seazn/engine` to root production dependencies (ci.yml comment) — it was never applied *transitively* to the engine's own imports.

## The fix

`zod` moves to `packages/engine`'s `dependencies`. It is a genuine runtime import (every sport module's event schema). `peerDependencies` stays as the version-alignment declaration. The lockfile diff is the section move and nothing else — no version drift.

## The gate

`packages/engine/test/runtime-deps.test.ts` scans every non-test file under `src/` (excluding the `testkit` harness, whose vitest/fast-check imports are legitimately a consumer's dev deps) for bare import specifiers and asserts each is declared in `dependencies`. A second assertion pins the set it finds, so a regex that silently matched nothing cannot make the gate vacuous.

This class of bug is invisible to every other job — a devDependency-only entry resolves fine wherever dev deps are installed, and only the `--prod` deploy sees it.

## Verification

- `pnpm install --frozen-lockfile --prod` in a clean worktree now links `packages/engine/node_modules/zod` (→ `.pnpm/zod@4.4.3`).
- `scripts/sync-sports.ts` under that prod-only install reaches its database connection (`connect ECONNREFUSED` against a dummy DSN) instead of failing module resolution.
- Engine suite: **2329 passed / 2330 total (1 skipped), 0 failed**.
- The new test fails on the previous manifest (`1 passed / 1 failed`) and passes on this one (`2 passed / 0 failed`).

## Not in scope

Two e2e tests are also red on `main`, both predating #480 (`board-v3` payload budget, from #479; `ai-architect` mobile officials step, from #476). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)