### PR TITLE
test(e2e): unbreak main — officials run button + stop budgeting the i18n dictionary

### DIFF
--- a/apps/web/e2e/ai-architect.spec.ts
+++ b/apps/web/e2e/ai-architect.spec.ts
@@ -1359,7 +1359,13 @@ test.describe("mobile viewport", () => {
     await expect(page.locator("[data-ghost-id]")).toHaveCount(0);
     await shot(page, "08-mobile-schedule");
 
+    // #383: arriving at the officials step no longer drafts anything, so the
+    // grid is absent until the organiser presses the run button — and the
+    // confirm card that stands in its place must fit the phone too.
     await page.getByRole("button", { name: "Assign officials" }).click();
+    await expect(page.getByLabel("Officials by fixture")).toHaveCount(0);
+    await expect(page.getByRole("region", { name: "What this run costs" })).toBeVisible();
+    await page.getByRole("button", { name: /Draft the duty spread.*1 credit\b/ }).click();
     await expect(page.getByLabel("Officials by fixture")).toBeVisible({ timeout: 20_000 });
 
     await page.getByRole("button", { name: "Review & apply" }).click();

--- a/apps/web/e2e/board-v3.spec.ts
+++ b/apps/web/e2e/board-v3.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
 import {
   TAG,
@@ -149,17 +151,35 @@ test.describe.serial("board v3 (PROMPT-33)", () => {
     // the document (the dev-mode HTML around them carries HMR/dev overhead
     // that never ships). Parse the response body: hydration may have drained
     // the runtime __next_f array by the time we could evaluate.
-    // Budget raised 250K→420K in the v5 i18n merge (c7a0527): every /o console
-    // page now serialises the full ui dictionary (~110KB) into its flight via
-    // DictProvider — a fixed overhead on top of the 5×66 fixture blocks. The
-    // guard still catches genuine per-fixture bloat regressions.
     const html = (await resp!.body()).toString("utf8");
     const flightBytes = [...html.matchAll(/__next_f\.push\((\[[\s\S]*?\])\)<\/script>/g)].reduce(
       (n, m) => n + m[1]!.length,
       0,
     );
     expect(flightBytes).toBeGreaterThan(0);
-    expect(flightBytes).toBeLessThan(420_000);
+
+    // The dictionary is subtracted, not budgeted. Every /o console page
+    // serialises the WHOLE ui dictionary into its flight via DictProvider
+    // (o/[orgSlug]/layout.tsx) — one copy per document, ~190KB escaped, and it
+    // grows with every locale key added anywhere in the app. Budgeting the raw
+    // total made this guard an i18n tripwire: it was raised 250K→420K in the
+    // v5 i18n merge (c7a0527), then reds again the moment six `board.ai.joint.
+    // undo*` keys landed in #479 (+639B, at 420098 against a 420000 ceiling) —
+    // a board test failing for a commit that touched no board payload.
+    //
+    // What gap 15 actually budgets is the per-fixture cost of a 5×66 board, so
+    // that is what is asserted: the flight MINUS the dictionary it carries.
+    // A genuine per-fixture regression is tens of KB and still trips this;
+    // adding locale strings no longer does.
+    const uiDict = readFileSync(
+      fileURLToPath(new URL("../src/dictionaries/en/ui.json", import.meta.url)),
+      "utf8",
+    );
+    // As the flight carries it: minified, then JSON-string-escaped (the outer
+    // quotes are not part of the payload).
+    const dictBytes = JSON.stringify(JSON.stringify(JSON.parse(uiDict))).length - 2;
+    expect(flightBytes).toBeGreaterThan(dictBytes); // the dict IS in there
+    expect(flightBytes - dictBytes).toBeLessThan(250_000);
   });
 
   test("legend filters to two divisions in two taps; the URL is shareable", async ({ page }) => {


### PR DESCRIPTION
Two e2e specs have been red on `main` since **before** the pnpm migration. Neither is a product defect.

| first red | commit | test |
|---|---|---|
| 14:46 | 5d6f0b2c (#476) | `ai-architect.spec.ts` mobile happy flow |
| 15:07 | bfc56b17 (#479) | `board-v3.spec.ts` payload budget |

## 1. Officials grid never mounts (mobile happy flow)

#383 removed the officials auto-draft that used to fire on entering the step — arriving is free now, and the grid stays unmounted until the organiser presses **"Draft the duty spread … 1 credit"**. Two of the three call sites were updated with that press; the mobile one was missed, so it waited 20s for a grid that was never going to render.

The absence is now asserted explicitly, along with the confirm card that stands in its place — which also has to fit a 390px phone, and this is the test that checks that.

## 2. Payload budget was measuring the dictionary

Six new `board.ai.joint.undo*` locale keys added **639 bytes** to every `/o` console page's flight. The raw total was already within 0.6K of the ceiling — **420098 against 420000**. The commit touched no board payload, no server component, no fixture serialisation.

Every `/o` page serialises the *whole* ui dictionary via `DictProvider` (one copy per document, ~190KB escaped), and it grows with any locale key added anywhere in the app. Budgeting the raw total made a board test into an i18n tripwire — it had already been raised 250K→420K once for the v5 i18n merge.

So the dictionary is **subtracted rather than budgeted**, and what gap 15 actually cares about is what gets asserted: the per-fixture cost of a 5×66 board (`< 250_000`, ~9% headroom on the observed CI figure). A genuine per-fixture regression is tens of KB and still trips it; adding locale strings no longer does.

`expect(flightBytes).toBeGreaterThan(dictBytes)` keeps the subtraction honest — if the dictionary ever stops being in the flight, the guard fails rather than silently passing.

## Verification

Local run against a **standalone production build** (the serving path CI uses, not `next start`) on a fresh migrated + sport-synced database:

```
21 passed (1.2m)   exit 0
✓ board-v3.spec.ts:139 › seed: five divisions × ~66 fixtures land under the payload budget (gap 15)
✓ ai-architect.spec.ts:1334 › mobile viewport › the happy flow runs at 390px with no horizontal scroll
```

`npx eslint` on both specs: exit 0. `tsc --noEmit` for apps/web: exit 0.

Stacks on #481 (the `zod` deploy fix) — independent files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)