### PR TITLE
fix(docker): cap the build heap, and print the fly builder's real capacity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,25 @@ ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 
 # tsc gates types in CI; the in-build checker (the 6 GB-heap worker that
 # SIGKILLed on builder VMs) is skipped here.
-RUN SKIP_TYPECHECK=1 npm run build --workspace apps/web
+#
+# The heap cap is not cargo-cult. After #480 moved this stage to node:26-alpine
+# the fly Depot builder began OOM-killing `next build` deterministically —
+# SIGKILL (the kernel, on the container's memory limit), not V8's own
+# "Ineffective mark-compacts", at 80s/88s/117s across two runs. The identical
+# stage builds on a GitHub runner (16 GB) in ~2m, which is why nothing catches
+# it before deploy: `docker build --target builder` is green in CI.
+#
+# Node picks its default old-space from the HOST's memory, not from the
+# container's cgroup limit, so on a big builder V8 will happily grow past what
+# the container is allowed and get killed rather than collecting. Capping it
+# makes V8 collect first. The size is deliberately well under any plausible
+# builder limit — Turbopack's Rust side needs headroom outside the JS heap.
+#
+# The capacity line is a permanent diagnostic: it prints in both the fly build
+# log and CI's docker job, so the next time this moves we read the builder's
+# real limit instead of inferring it.
+RUN echo "builder capacity: nproc=$(nproc) memory.max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo unknown)" \
+ && SKIP_TYPECHECK=1 NODE_OPTIONS=--max-old-space-size=2048 npm run build --workspace apps/web
 
 # ── Stage 2: minimal production image ────────────────────────────────────────
 FROM node:26-alpine AS runner


### PR DESCRIPTION
## The break

Staging has not deployed since #480. With #481 merged the deploy clears `Sync sport catalog` and dies one step later:

```
#14 79.94 npm error signal SIGKILL
#14 ERROR: process "/bin/sh -c SKIP_TYPECHECK=1 npm run build --workspace apps/web"
      did not complete successfully: exit code: 1
```

Deterministic — three kills across two runs, at 80s / 88s / 117s. `SIGKILL` is the kernel on a container memory limit, not V8's own `Ineffective mark-compacts`.

## Why nothing caught it

CI's `docker build + TS 7 musl exec` job builds the identical `--target builder` stage on a GitHub runner (16 GB) and is green in ~2m. The first signal is a failed staging deploy on `main`.

#480 moved this stage from `node:22-alpine` to `node:26-alpine`, and that image has never completed a fly build — #480's own deploy died earlier, at `sync:sports`, so the Docker change was never exercised end to end.

## What this does

1. **Caps the JS heap.** Node sizes its default old-space from the *host's* memory, not the container's cgroup limit, so on a large builder V8 grows past what the container allows and is killed rather than collecting.
2. **Prints the builder's capacity** — `nproc` and `memory.max` — immediately before the build. It lands in both the fly build log and CI's docker job.

## What I measured, and what I did not

Locally, with the cap:

```
SKIP_TYPECHECK=1 NODE_OPTIONS=--max-old-space-size=2048 npm run build --workspace apps/web
→ exit 0,  maximum resident set size 3.83 GB
```

So the build completes under a 2 GB JS heap — but total RSS is still 3.83 GB, meaning the JS heap is **not** the whole footprint and Turbopack's native side needs headroom outside it. That is why the cap sits well below any plausible builder limit rather than close to it.

I could not reproduce the OOM itself: there is no Docker on this machine, and `flyctl` here is unauthenticated, so the Depot builder is unreachable outside CI.

This is therefore a fix that is also an instrument. Three outcomes, all informative:

- **Deploy goes green** — the JS heap was the binding constraint.
- **Fails with a V8 heap-limit error** instead of SIGKILL — JS is the hog and the cap is simply too low.
- **Still SIGKILLs at a similar time** — the native side is the hog, and the printed `nproc` tells us whether Turbopack is spawning a thread pool sized for a builder far wider than its memory allowance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)