### PR TITLE
fix(ci): build the staging image on the runner, deploy it by tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,9 +616,70 @@ jobs:
         if: env.STAGING_STRIPE_SECRET_KEY == ''
         run: echo "::warning::STAGING_STRIPE_SECRET_KEY not set — Stripe prices not synced; checkout will 503 until 'npm run stripe:sync' runs against staging."
 
+      # The image is built HERE, on the runner, and pushed to fly's registry —
+      # `flyctl deploy` then only ships a digest it already has.
+      #
+      # `flyctl deploy --remote-only` builds on a fly Depot builder, and that
+      # builder cannot hold this build: it reports nproc=4 and NO cgroup memory
+      # limit, so nothing bounds `next build` until the VM runs out and the
+      # kernel SIGKILLs it. That happened deterministically once #480 moved the
+      # builder stage to node:26-alpine — 80s/88s/117s across three attempts —
+      # and capping the JS heap did not help, because the 3.83 GB peak is mostly
+      # Turbopack's native side, outside anything NODE_OPTIONS bounds. A runner
+      # has 16 GB and already proves this exact stage builds (the PR-only
+      # `docker build --target builder` job).
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy -c fly.stg.toml --remote-only --build-arg SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN"
+
+      # fly.stg.toml's [build.args] are read by flyctl's own builder, which is
+      # no longer doing the build — so they are parsed out and handed to
+      # `docker build` instead. Parsed rather than duplicated into this file:
+      # NEXT_PUBLIC_* vars are baked into the client bundle at build time, and a
+      # copy that silently drifted from fly.stg.toml would ship a bundle
+      # pointing at the wrong Supabase/Stripe/base URL with nothing failing.
+      - name: Read app name and build args from fly.stg.toml
+        id: flycfg
+        run: |
+          node -e '
+            const fs = require("fs");
+            const toml = fs.readFileSync("fly.stg.toml", "utf8");
+            const app = toml.match(/^\s*app\s*=\s*"([^"]+)"/m)?.[1];
+            if (!app) { console.error("::error::no app name in fly.stg.toml"); process.exit(1); }
+            const section = toml.split(/^\s*\[build\.args\]\s*$/m)[1] ?? "";
+            const args = [];
+            for (const line of section.split(/\r?\n/)) {
+              if (/^\s*\[/.test(line)) break;
+              const m = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*"([^"]*)"\s*$/);
+              if (m) args.push(m[1] + "=" + m[2]);
+            }
+            if (!args.length) { console.error("::error::no [build.args] in fly.stg.toml"); process.exit(1); }
+            console.log("app=" + app + ", " + args.length + " build args");
+            fs.appendFileSync(process.env.GITHUB_OUTPUT,
+              "app=" + app + "\nargs<<FLYARGS\n" + args.join("\n") + "\nFLYARGS\n");
+          '
+
+      - name: Authenticate Docker against the fly registry
+        run: flyctl auth docker
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}
-          # Source-map upload only (next.config.js). Secret — never in fly.stg.toml.
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and push the image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: registry.fly.io/${{ steps.flycfg.outputs.app }}:${{ github.sha }}
+          # SENTRY_AUTH_TOKEN is a secret and stays out of fly.stg.toml; it is
+          # passed the same way flyctl passed it (--build-arg), so its exposure
+          # in image history is unchanged from before.
+          build-args: |
+            ${{ steps.flycfg.outputs.args }}
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # --image, so no builder is involved at all: fly pulls the digest above.
+      - name: Deploy the pushed image
+        run: flyctl deploy -c fly.stg.toml --image registry.fly.io/${{ steps.flycfg.outputs.app }}:${{ github.sha }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,24 +49,19 @@ ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 # tsc gates types in CI; the in-build checker (the 6 GB-heap worker that
 # SIGKILLed on builder VMs) is skipped here.
 #
-# The heap cap is not cargo-cult. After #480 moved this stage to node:26-alpine
-# the fly Depot builder began OOM-killing `next build` deterministically —
-# SIGKILL (the kernel, on the container's memory limit), not V8's own
-# "Ineffective mark-compacts", at 80s/88s/117s across two runs. The identical
-# stage builds on a GitHub runner (16 GB) in ~2m, which is why nothing catches
-# it before deploy: `docker build --target builder` is green in CI.
+# This step needs roughly 4 GB: measured peak RSS is 3.83 GB, and most of it is
+# NOT the JS heap — a 2 GB `--max-old-space-size` cap changed nothing, the
+# build was still SIGKILLed at the same point. Turbopack's native side is the
+# bulk, and it sits outside anything NODE_OPTIONS can bound.
 #
-# Node picks its default old-space from the HOST's memory, not from the
-# container's cgroup limit, so on a big builder V8 will happily grow past what
-# the container is allowed and get killed rather than collecting. Capping it
-# makes V8 collect first. The size is deliberately well under any plausible
-# builder limit — Turbopack's Rust side needs headroom outside the JS heap.
+# That is why the image is built on a CI runner and pushed to registry.fly.io
+# rather than built by `flyctl deploy` (see the deploy job in ci.yml). The fly
+# Depot builder reports nproc=4 and NO cgroup memory limit, so nothing bounds
+# the build until the VM itself runs out and the kernel kills it — which it did
+# deterministically, at 80s/88s/117s across three attempts, once #480 moved
+# this stage to node:26-alpine.
 #
-# The capacity line is a permanent diagnostic: it prints in both the fly build
-# log and CI's docker job, so the next time this moves we read the builder's
-# real limit instead of inferring it.
-RUN echo "builder capacity: nproc=$(nproc) memory.max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null || echo unknown)" \
- && SKIP_TYPECHECK=1 NODE_OPTIONS=--max-old-space-size=2048 npm run build --workspace apps/web
+RUN SKIP_TYPECHECK=1 npm run build --workspace apps/web
 
 # ── Stage 2: minimal production image ────────────────────────────────────────
 FROM node:26-alpine AS runner


### PR DESCRIPTION
## Why

`flyctl deploy --remote-only` cannot build this app any more. The capacity probe from #483 answered it:

```
builder capacity: nproc=4 memory.max=9223372036854771712
```

**No cgroup memory limit** — so nothing bounds `next build` until the VM itself runs out and the kernel SIGKILLs it. Deterministic since #480 moved the builder stage to `node:26-alpine`: 80s / 88s / 117s across three attempts. Staging has not deployed since.

Capping the JS heap (#483) did not help, and that is the useful finding: peak RSS is **3.83 GB** and most of it is Turbopack's native side, outside anything `NODE_OPTIONS` can bound. There is no heap number that fixes this — the build needs a machine with ~4 GB.

## What changes

A GitHub runner has 16 GB and already proves this exact stage builds — the PR-only `docker build --target builder` job does it in ~2m. So:

1. The image is built on the runner and pushed to `registry.fly.io` (`flyctl auth docker`, existing `FLY_TOKEN`).
2. `flyctl deploy --image registry.fly.io/<app>:<sha>` ships a digest fly already has. **No builder is involved in the deploy at all.**
3. Layer cache moves to `type=gha`.

## The build args

`fly.stg.toml`'s `[build.args]` were consumed by flyctl's builder, which no longer does the build — so they are **parsed out of that same file** and handed to `docker build`.

Parsed rather than copied into the workflow on purpose: `NEXT_PUBLIC_*` vars are baked into the client bundle at build time, so a duplicate that drifted from `fly.stg.toml` would ship a bundle pointing at the wrong Supabase / Stripe / base URL **with nothing failing**. The step fails loudly if the app name or the `[build.args]` table is missing.

Verified the parser against the real file: `app=seazn-club-stg` plus all 9 args (`NEXT_PUBLIC_SUPABASE_URL`, `…ANON_KEY`, `…STRIPE_PUBLISHABLE_KEY`, `…BASE_URL`, `…POSTHOG_KEY`, `…POSTHOG_HOST`, `…SENTRY_DSN`, `SENTRY_ORG`, `SENTRY_PROJECT`). Workflow YAML parses; the deploy job's last six steps are in the intended order.

`SENTRY_AUTH_TOKEN` is still passed as a `--build-arg`, exactly as flyctl passed it, so its exposure in image history is unchanged.

## Also

Drops the capacity probe from #483 — it did its job, and once the build runs on a runner of known size it is only noise. The finding is recorded in the Dockerfile comment instead.

## Verification limits

The deploy job runs on `push: main` only, so this path cannot execute on a PR — the first real exercise is the merge. What is checked here: the parser against the live `fly.stg.toml`, the YAML, and the unchanged `docker build --target builder` job in this PR's own checks.

Pre-existing and untouched: the Dockerfile declares no `ARG` for `NEXT_PUBLIC_POSTHOG_KEY` / `NEXT_PUBLIC_POSTHOG_HOST`, so those two are passed but not consumed — that was equally true under flyctl. Docker will now say so in a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)